### PR TITLE
Add memhub session-continuity context files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.memhub/
+agent_docs/PROJECT.md
+agent_docs/PROJECT_LEDGER.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Orch
+
+A cross-host development orchestrator for the Codex CLI and Claude Code CLI.
+
+## Session Continuity
+
+memhub is the source of truth at `.memhub/project.sqlite`. The rendered files
+under `.memhub/rendered/` are the local human-readable view — generated from
+the DB and gitignored by default. Re-render after `/wrap-up` with
+`memhub render`. Read PROJECT.md at session start before acting.
+
+## Build / test / run
+
+None yet — the shared-core language/runtime is undecided (PRD §24).
+See Architecture in `.memhub/rendered/PROJECT.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# Orch
+
+A cross-host development orchestrator for the Codex CLI and Claude Code CLI.
+
+## Session Continuity
+
+memhub is the source of truth at `.memhub/project.sqlite`. The rendered files
+under `.memhub/rendered/` are the local human-readable view — generated from
+the DB and gitignored by default. Re-render after `/wrap-up` with
+`memhub render`. Read PROJECT.md at session start before acting.
+
+## Build / test / run
+
+None yet — the shared-core language/runtime is undecided (PRD §24).
+See Architecture in `.memhub/rendered/PROJECT.md`.


### PR DESCRIPTION
## What

Adds memhub as this repo''s project-memory / session-continuity system and the tracked files that support it:

- **`.gitignore`** — ignores the local memhub store (`.memhub/`) and the legacy `agent_docs/` render paths. The SQLite DB and generated `PROJECT.md` / `PROJECT_LEDGER.md` stay machine-local by design.
- **`CLAUDE.md`** and **`AGENTS.md`** — minimal root context files that point agents at the memhub store and its rendered views for session continuity. Identical bodies, one per supported host (Claude Code and Codex), matching Orch''s cross-host goal.

## Why

Orch is currently a PRD-only repo. Establishing memhub now gives every future session a durable, queryable memory of decisions and state instead of re-deriving context from scratch. The `.gitignore` split keeps durable knowledge (the DB) reproducible while excluding machine-local generated output from version control.

## Notes

- No source/build changes — the shared-core language/runtime is still undecided per PRD §24.
- The memhub DB and rendered files are intentionally **not** committed (local-vs-shared boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)