### PR TITLE
Add Go project skeleton with config validation and CLI stubs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto
+*.go text eol=lf
+*.toml text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.md text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - run: go build ./...
+      - run: go vet ./...
+      - run: go test ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Check gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "gofmt required on:"
+            echo "$unformatted"
+            exit 1
+          fi
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
 .memhub/
 agent_docs/PROJECT.md
 agent_docs/PROJECT_LEDGER.md
+
+# Go build/test artifacts
+/orch
+/orch.exe
+/bin/
+*.test
+*.out
+coverage.html
+
+# Orch machine-local overrides (PRD §17)
+.orchestrator/config.local.toml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,19 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - unused
+  settings:
+    errcheck:
+      # Best-effort human-facing output to injected writers; failures
+      # there are not actionable.
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,5 +11,12 @@ the DB and gitignored by default. Re-render after `/wrap-up` with
 
 ## Build / test / run
 
-None yet — the shared-core language/runtime is undecided (PRD §24).
-See Architecture in `.memhub/rendered/PROJECT.md`.
+Shared core is Go (module `github.com/kninetimmy/orch`, Go 1.26+).
+
+- Build:  `go build ./...`
+- Test:   `go test ./...`
+- Vet:    `go vet ./...`
+- Format: `gofmt -w .` (CI fails on unformatted files)
+- Run:    `go run ./cmd/orch status` (or `doctor`, `help`)
+
+Host adapters under `adapters/` are non-Go artifacts (not implemented yet).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,5 +11,12 @@ the DB and gitignored by default. Re-render after `/wrap-up` with
 
 ## Build / test / run
 
-None yet — the shared-core language/runtime is undecided (PRD §24).
-See Architecture in `.memhub/rendered/PROJECT.md`.
+Shared core is Go (module `github.com/kninetimmy/orch`, Go 1.26+).
+
+- Build:  `go build ./...`
+- Test:   `go test ./...`
+- Vet:    `go vet ./...`
+- Format: `gofmt -w .` (CI fails on unformatted files)
+- Run:    `go run ./cmd/orch status` (or `doctor`, `help`)
+
+Host adapters under `adapters/` are non-Go artifacts (not implemented yet).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Orch
+
+Orch is a cross-host development orchestrator for the Codex CLI and
+Claude Code CLI. It keeps a frontier model in the Architect role
+(planning, architecture, routing, final review) and delegates
+exploration, implementation, specialist work, and review to explicitly
+configured models at appropriate reasoning-effort levels — without
+weakening delivery discipline. Every tracked-file mutation flows
+through an issue, an isolated feature worktree, a PR, independent
+review, verification/CI, and a human-approved merge.
+
+The full product definition lives in [ORCH-PRD.md](ORCH-PRD.md).
+
+**Status: pre-alpha.** The repo contains the project skeleton plus one
+thin vertical slice: strict parsing/validation of the committed
+configuration (`.orchestrator/config.toml`) and stub `orch status` /
+`orch doctor` commands. No orchestration behavior exists yet; the
+remaining commands fail closed with explicit not-implemented errors.
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| `cmd/orch/` | CLI entry point |
+| `internal/config/` | Committed-configuration schema, loading, fail-closed validation |
+| `internal/cli/` | Command dispatch, `status`, `doctor` |
+| `adapters/claude/`, `adapters/codex/` | Future host-adapter artifacts (skills, hooks, templates) |
+| `ORCH-PRD.md` | Product requirements — source of truth for v1 |
+
+## Build / test / run
+
+Requires Go 1.26+.
+
+```sh
+go build ./...            # build everything
+go test ./...             # run the test suite
+go vet ./...              # static checks
+gofmt -l .                # list unformatted files (CI fails on any)
+go run ./cmd/orch status  # or: doctor, help
+```
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/adapters/claude/README.md
+++ b/adapters/claude/README.md
@@ -1,0 +1,8 @@
+# Claude Code adapter
+
+This directory will hold the Claude Code host adapter: the non-Go
+artifacts (skills, hooks, Architect instruction templates, and managed
+instruction-block content per PRD §19) that integrate Claude Code with
+the shared core by invoking the `orch` binary.
+
+Nothing is implemented yet.

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -1,0 +1,8 @@
+# Codex CLI adapter
+
+This directory will hold the Codex CLI host adapter: the non-Go
+artifacts (prompts, hooks, Architect instruction templates, and managed
+instruction-block content per PRD §19) that integrate Codex CLI with
+the shared core by invoking the `orch` binary.
+
+Nothing is implemented yet.

--- a/cmd/orch/main.go
+++ b/cmd/orch/main.go
@@ -1,0 +1,24 @@
+// Command orch is the shared-core CLI for the Orch development
+// orchestrator (see ORCH-PRD.md). Host adapters invoke this binary;
+// it never runs interactive dialogs itself.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kninetimmy/orch/internal/cli"
+)
+
+func main() {
+	root, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "orch: %v\n", err)
+		os.Exit(cli.ExitError)
+	}
+	os.Exit(cli.Run(os.Args[1:], cli.Env{
+		RepoRoot: root,
+		Stdout:   os.Stdout,
+		Stderr:   os.Stderr,
+	}))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/kninetimmy/orch
+
+go 1.26.0

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/kninetimmy/orch
 
 go 1.26.0
+
+require github.com/BurntSushi/toml v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,0 +1,95 @@
+// Package cli implements the orch command surface (PRD §22). Commands
+// without an implementation yet fail closed with an explicit error.
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+)
+
+// Exit codes returned by Run.
+const (
+	ExitOK    = 0
+	ExitError = 1
+	ExitUsage = 2
+)
+
+// Env carries the invocation context so commands stay testable.
+type Env struct {
+	// RepoRoot is the directory containing .orchestrator/.
+	RepoRoot string
+	Stdout   io.Writer
+	Stderr   io.Writer
+	// LookPath resolves an executable name; defaults to exec.LookPath.
+	LookPath func(string) (string, error)
+}
+
+type command struct {
+	name    string
+	summary string
+	run     func(Env) error
+}
+
+// commands lists the full PRD §22 surface in documentation order, so
+// `orch help` always shows every logical command even before it works.
+func commands() []command {
+	return []command{
+		{"init", "Interview and bootstrap this repository (not implemented)", notImplemented("init")},
+		{"status", "Show mode and configuration summary", runStatus},
+		{"doctor", "Check environment and configuration health", runDoctor},
+		{"configure", "Change committed configuration (not implemented)", notImplemented("configure")},
+		{"configure-local", "Change machine-local overrides (not implemented)", notImplemented("configure-local")},
+		{"resume", "Resume an interrupted Delivery run (not implemented)", notImplemented("resume")},
+		{"abort", "Stop dispatch and return to Assist (not implemented)", notImplemented("abort")},
+		{"metrics", "Show local metrics (not implemented)", notImplemented("metrics")},
+	}
+}
+
+func notImplemented(name string) func(Env) error {
+	return func(Env) error {
+		return fmt.Errorf("%s is not implemented yet", name)
+	}
+}
+
+// Run dispatches args (without the program name) and returns a process
+// exit code.
+func Run(args []string, env Env) int {
+	if env.LookPath == nil {
+		env.LookPath = exec.LookPath
+	}
+	if len(args) == 0 {
+		usage(env.Stderr)
+		return ExitUsage
+	}
+	if args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
+		usage(env.Stdout)
+		return ExitOK
+	}
+	for _, c := range commands() {
+		if c.name != args[0] {
+			continue
+		}
+		if len(args) > 1 {
+			fmt.Fprintf(env.Stderr, "orch %s: unexpected argument %q\n", c.name, args[1])
+			return ExitUsage
+		}
+		if err := c.run(env); err != nil {
+			fmt.Fprintf(env.Stderr, "orch %s: %v\n", c.name, err)
+			return ExitError
+		}
+		return ExitOK
+	}
+	fmt.Fprintf(env.Stderr, "orch: unknown command %q\n\n", args[0])
+	usage(env.Stderr)
+	return ExitUsage
+}
+
+func usage(w io.Writer) {
+	fmt.Fprintln(w, "usage: orch <command>")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "commands:")
+	for _, c := range commands() {
+		fmt.Fprintf(w, "  %-16s %s\n", c.name, c.summary)
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// validTOML is a minimal valid configuration (one host, defaults).
+const validTOML = `
+schema_version  = 1
+config_revision = "r1"
+
+[memhub]
+mode = "off"
+
+[hosts.claude.roles.architect]
+model  = "claude-opus-4-8"
+effort = "xhigh"
+
+[hosts.claude.roles.scout]
+model  = "claude-sonnet-5"
+effort = "low"
+
+[hosts.claude.roles.implementer]
+model  = "claude-sonnet-5"
+effort = "xhigh"
+
+[hosts.claude.roles.specialist]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.reviewer]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.review_downgrade]
+model  = "claude-sonnet-5"
+effort = "high"
+`
+
+// testEnv returns an Env writing to fresh buffers, rooted in an empty
+// temp dir, with every PATH lookup succeeding.
+func testEnv(t *testing.T) (Env, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	env := Env{
+		RepoRoot: t.TempDir(),
+		Stdout:   &stdout,
+		Stderr:   &stderr,
+		LookPath: func(name string) (string, error) { return "/fake/" + name, nil },
+	}
+	return env, &stdout, &stderr
+}
+
+func writeConfig(t *testing.T, root, content string) {
+	t.Helper()
+	if err := os.Mkdir(filepath.Join(root, ".orchestrator"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".orchestrator", "config.toml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunNoArgs(t *testing.T) {
+	env, _, stderr := testEnv(t)
+	if code := Run(nil, env); code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+	if !strings.Contains(stderr.String(), "usage: orch") {
+		t.Errorf("stderr missing usage text: %q", stderr.String())
+	}
+}
+
+func TestRunHelpListsAllCommands(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	if code := Run([]string{"help"}, env); code != ExitOK {
+		t.Errorf("exit = %d, want %d", code, ExitOK)
+	}
+	for _, name := range []string{"init", "status", "doctor", "configure", "configure-local", "resume", "abort", "metrics"} {
+		if !strings.Contains(stdout.String(), name) {
+			t.Errorf("help output missing command %q", name)
+		}
+	}
+}
+
+func TestRunUnknownCommand(t *testing.T) {
+	env, _, stderr := testEnv(t)
+	if code := Run([]string{"deploy"}, env); code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+	if !strings.Contains(stderr.String(), `unknown command "deploy"`) {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunUnexpectedArgument(t *testing.T) {
+	env, _, stderr := testEnv(t)
+	if code := Run([]string{"status", "--verbose"}, env); code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+	if !strings.Contains(stderr.String(), "unexpected argument") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestNotImplementedCommandsFailClosed(t *testing.T) {
+	for _, name := range []string{"init", "configure", "configure-local", "resume", "abort", "metrics"} {
+		t.Run(name, func(t *testing.T) {
+			env, _, stderr := testEnv(t)
+			if code := Run([]string{name}, env); code != ExitError {
+				t.Errorf("exit = %d, want %d", code, ExitError)
+			}
+			if !strings.Contains(stderr.String(), "not implemented") {
+				t.Errorf("stderr = %q", stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunDefaultsLookPath(t *testing.T) {
+	// Run must not panic when LookPath is nil (main.go passes none).
+	var stdout, stderr bytes.Buffer
+	env := Env{RepoRoot: t.TempDir(), Stdout: &stdout, Stderr: &stderr}
+	if code := Run([]string{"help"}, env); code != ExitOK {
+		t.Errorf("exit = %d, want %d", code, ExitOK)
+	}
+}
+
+var errNotFound = errors.New("executable file not found")

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/kninetimmy/orch/internal/config"
+)
+
+func runDoctor(env Env) error {
+	failed := false
+	check := func(name string, err error) {
+		if err != nil {
+			failed = true
+			fmt.Fprintf(env.Stdout, "FAIL  %s: %v\n", name, err)
+			return
+		}
+		fmt.Fprintf(env.Stdout, "ok    %s\n", name)
+	}
+
+	_, gitErr := env.LookPath("git")
+	check("git on PATH", gitErr)
+
+	_, ghErr := env.LookPath("gh")
+	check("gh on PATH", ghErr)
+
+	_, cfgErr := config.Load(env.RepoRoot)
+	check("configuration", cfgErr)
+
+	if config.HasLocalOverride(env.RepoRoot) {
+		fmt.Fprintf(env.Stdout, "note  %s present; overrides are not yet applied\n", config.LocalOverridePath)
+	}
+
+	if failed {
+		return errors.New("one or more checks failed")
+	}
+	return nil
+}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDoctorAllChecksPass(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"ok    git on PATH", "ok    gh on PATH", "ok    configuration"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestDoctorMissingTool(t *testing.T) {
+	env, stdout, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	env.LookPath = func(name string) (string, error) {
+		if name == "gh" {
+			return "", errNotFound
+		}
+		return "/fake/" + name, nil
+	}
+	if code := Run([]string{"doctor"}, env); code != ExitError {
+		t.Errorf("exit = %d, want %d", code, ExitError)
+	}
+	if !strings.Contains(stdout.String(), "FAIL  gh on PATH") {
+		t.Errorf("stdout missing gh failure:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "ok    git on PATH") {
+		t.Errorf("doctor stopped at first failure instead of running all checks:\n%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "one or more checks failed") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestDoctorMissingConfig(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	if code := Run([]string{"doctor"}, env); code != ExitError {
+		t.Errorf("exit = %d, want %d", code, ExitError)
+	}
+	if !strings.Contains(stdout.String(), "FAIL  configuration") {
+		t.Errorf("stdout missing configuration failure:\n%s", stdout.String())
+	}
+}
+
+func TestDoctorNotesLocalOverride(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	if err := os.WriteFile(filepath.Join(env.RepoRoot, ".orchestrator", "config.local.toml"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d", code, ExitOK)
+	}
+	if !strings.Contains(stdout.String(), "overrides are not yet applied") {
+		t.Errorf("stdout missing local-override note:\n%s", stdout.String())
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kninetimmy/orch/internal/config"
+)
+
+func runStatus(env Env) error {
+	cfg, err := config.Load(env.RepoRoot)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(env.Stdout, "mode:   assist (state machine not yet implemented)")
+	fmt.Fprintf(env.Stdout, "config: %s (schema %d, revision %q)\n", config.Path, cfg.SchemaVersion, cfg.ConfigRevision)
+	fmt.Fprintf(env.Stdout, "hosts:  %s\n", strings.Join(cfg.EnabledHosts(), ", "))
+	return nil
+}

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStatusNotInitialized(t *testing.T) {
+	env, _, stderr := testEnv(t)
+	if code := Run([]string{"status"}, env); code != ExitError {
+		t.Errorf("exit = %d, want %d", code, ExitError)
+	}
+	if !strings.Contains(stderr.String(), "not initialized") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestStatusValidConfig(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	if code := Run([]string{"status"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d", code, ExitOK)
+	}
+	out := stdout.String()
+	for _, want := range []string{"mode:   assist", `revision "r1"`, "hosts:  claude"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestStatusInvalidConfig(t *testing.T) {
+	env, _, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML+"\nbogus_key = true\n")
+	if code := Run([]string{"status"}, env); code != ExitError {
+		t.Errorf("exit = %d, want %d", code, ExitError)
+	}
+	if !strings.Contains(stderr.String(), "bogus_key") {
+		t.Errorf("stderr does not name the unknown key: %q", stderr.String())
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,76 @@
+// Package config parses and validates the committed Orch configuration
+// at .orchestrator/config.toml (PRD §17). Machine-local overrides in
+// config.local.toml are detected but not yet applied.
+package config
+
+// Config is the root of the committed configuration schema.
+type Config struct {
+	SchemaVersion  int         `toml:"schema_version"`
+	ConfigRevision string      `toml:"config_revision"`
+	Concurrency    Concurrency `toml:"concurrency"`
+	Merge          Merge       `toml:"merge"`
+	Memhub         Memhub      `toml:"memhub"`
+	Metrics        Metrics     `toml:"metrics"`
+	Hosts          Hosts       `toml:"hosts"`
+}
+
+// Concurrency caps concurrent subagents (PRD §14; default 3).
+type Concurrency struct {
+	MaxSubagents int `toml:"max_subagents"`
+}
+
+// Merge selects the repository merge strategy (PRD §16; default squash).
+type Merge struct {
+	Strategy string `toml:"strategy"`
+}
+
+// Memhub selects the integration mode (PRD §20). There is no default:
+// the mode is policy-bearing and must be chosen explicitly.
+type Memhub struct {
+	Mode string `toml:"mode"`
+}
+
+// Metrics enables optional local metrics (PRD §21; off by default).
+type Metrics struct {
+	Enabled bool `toml:"enabled"`
+}
+
+// Hosts holds one profile per enabled host. A nil host is not enabled.
+type Hosts struct {
+	Codex  *Host `toml:"codex"`
+	Claude *Host `toml:"claude"`
+}
+
+// Host is a per-host model/effort profile (PRD §10).
+type Host struct {
+	Roles Roles `toml:"roles"`
+}
+
+// Roles maps every PRD §9 role, plus the safe review downgrade, to an
+// exact model and effort. All six are required for an enabled host.
+type Roles struct {
+	Architect       RoleProfile `toml:"architect"`
+	Scout           RoleProfile `toml:"scout"`
+	Implementer     RoleProfile `toml:"implementer"`
+	Specialist      RoleProfile `toml:"specialist"`
+	Reviewer        RoleProfile `toml:"reviewer"`
+	ReviewDowngrade RoleProfile `toml:"review_downgrade"`
+}
+
+// RoleProfile pins an exact model version and reasoning effort.
+type RoleProfile struct {
+	Model  string `toml:"model"`
+	Effort string `toml:"effort"`
+}
+
+// EnabledHosts returns the names of the configured hosts in stable order.
+func (c *Config) EnabledHosts() []string {
+	var names []string
+	if c.Hosts.Claude != nil {
+		names = append(names, "claude")
+	}
+	if c.Hosts.Codex != nil {
+		names = append(names, "codex")
+	}
+	return names
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// loadFixture copies a testdata file into a temp repo layout and loads it.
+func loadFixture(t *testing.T, name string) (*Config, error) {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".orchestrator"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join("testdata", filepath.FromSlash(name)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".orchestrator", "config.toml"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return Load(root)
+}
+
+func TestLoadMinimalAppliesDefaults(t *testing.T) {
+	cfg, err := loadFixture(t, "valid/minimal.toml")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Concurrency.MaxSubagents; got != 3 {
+		t.Errorf("MaxSubagents default = %d, want 3", got)
+	}
+	if got := cfg.Merge.Strategy; got != "squash" {
+		t.Errorf("Merge.Strategy default = %q, want squash", got)
+	}
+	if got := cfg.EnabledHosts(); len(got) != 1 || got[0] != "claude" {
+		t.Errorf("EnabledHosts = %v, want [claude]", got)
+	}
+	if cfg.Metrics.Enabled {
+		t.Error("Metrics.Enabled = true, want false by default")
+	}
+}
+
+func TestLoadFull(t *testing.T) {
+	cfg, err := loadFixture(t, "valid/full.toml")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.EnabledHosts(); len(got) != 2 || got[0] != "claude" || got[1] != "codex" {
+		t.Errorf("EnabledHosts = %v, want [claude codex]", got)
+	}
+	if got := cfg.Hosts.Codex.Roles.Architect.Model; got != "gpt-5.6-sol" {
+		t.Errorf("codex architect model = %q, want gpt-5.6-sol", got)
+	}
+	if got := cfg.Hosts.Claude.Roles.ReviewDowngrade.Effort; got != "high" {
+		t.Errorf("claude review_downgrade effort = %q, want high", got)
+	}
+	if got := cfg.Memhub.Mode; got != "required" {
+		t.Errorf("memhub.mode = %q, want required", got)
+	}
+}
+
+func TestLoadInvalid(t *testing.T) {
+	tests := []struct {
+		fixture   string
+		wantInErr string
+	}{
+		{"invalid/unknown_key.toml", "bogus_key"},
+		{"invalid/bad_schema_version.toml", "schema_version"},
+		{"invalid/missing_revision.toml", "config_revision"},
+		{"invalid/bad_effort.toml", `"ultra"`},
+		{"invalid/bad_merge_strategy.toml", `"fast-forward"`},
+		{"invalid/bad_memhub_mode.toml", `"maybe"`},
+		{"invalid/no_hosts.toml", "at least one of hosts.codex or hosts.claude"},
+		{"invalid/missing_role.toml", "hosts.claude.roles.reviewer.model"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.fixture, func(t *testing.T) {
+			cfg, err := loadFixture(t, tt.fixture)
+			if err == nil {
+				t.Fatal("Load succeeded, want error")
+			}
+			if cfg != nil {
+				t.Error("Load returned a partial Config alongside an error")
+			}
+			if !strings.Contains(err.Error(), tt.wantInErr) {
+				t.Errorf("error %q does not mention %q", err, tt.wantInErr)
+			}
+		})
+	}
+}
+
+func TestLoadMissingConfig(t *testing.T) {
+	cfg, err := Load(t.TempDir())
+	if !errors.Is(err, ErrNotInitialized) {
+		t.Fatalf("Load err = %v, want ErrNotInitialized", err)
+	}
+	if cfg != nil {
+		t.Error("Load returned a Config for a missing file")
+	}
+}
+
+func TestHasLocalOverride(t *testing.T) {
+	root := t.TempDir()
+	if HasLocalOverride(root) {
+		t.Error("HasLocalOverride = true in empty repo")
+	}
+	if err := os.Mkdir(filepath.Join(root, ".orchestrator"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".orchestrator", "config.local.toml"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !HasLocalOverride(root) {
+		t.Error("HasLocalOverride = false with override file present")
+	}
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Path is the repo-relative location of the committed configuration.
+const Path = ".orchestrator/config.toml"
+
+// LocalOverridePath is the repo-relative location of the machine-local
+// override file. It is detected but not yet applied (PRD §17).
+const LocalOverridePath = ".orchestrator/config.local.toml"
+
+// ErrNotInitialized reports a missing committed configuration file.
+var ErrNotInitialized = errors.New("not initialized: " + Path + " not found (orch init is not yet implemented)")
+
+// Load reads, parses, and validates the committed configuration under
+// repoRoot. It never returns a partial Config: on any parse or
+// validation failure the returned Config is nil.
+func Load(repoRoot string) (*Config, error) {
+	data, err := os.ReadFile(filepath.Join(repoRoot, filepath.FromSlash(Path)))
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, ErrNotInitialized
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", Path, err)
+	}
+
+	var cfg Config
+	md, err := toml.Decode(string(data), &cfg)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", Path, err)
+	}
+	if undecoded := md.Undecoded(); len(undecoded) > 0 {
+		keys := make([]string, len(undecoded))
+		for i, k := range undecoded {
+			keys[i] = k.String()
+		}
+		return nil, fmt.Errorf("%s: unknown keys: %s", Path, strings.Join(keys, ", "))
+	}
+
+	applyDefaults(&cfg, md)
+	if err := cfg.validate(); err != nil {
+		return nil, fmt.Errorf("%s: %w", Path, err)
+	}
+	return &cfg, nil
+}
+
+// applyDefaults fills PRD-specified defaults for keys the file omits.
+// Only keys with an explicit PRD default get one; everything else must
+// be stated in the file (fail closed).
+func applyDefaults(cfg *Config, md toml.MetaData) {
+	if !md.IsDefined("concurrency", "max_subagents") {
+		cfg.Concurrency.MaxSubagents = 3
+	}
+	if !md.IsDefined("merge", "strategy") {
+		cfg.Merge.Strategy = "squash"
+	}
+}
+
+// HasLocalOverride reports whether the machine-local override file
+// exists under repoRoot.
+func HasLocalOverride(repoRoot string) bool {
+	_, err := os.Stat(filepath.Join(repoRoot, filepath.FromSlash(LocalOverridePath)))
+	return err == nil
+}

--- a/internal/config/testdata/invalid/bad_effort.toml
+++ b/internal/config/testdata/invalid/bad_effort.toml
@@ -1,0 +1,30 @@
+# "ultra" is not a valid Claude effort level.
+schema_version  = 1
+config_revision = "r1"
+
+[memhub]
+mode = "off"
+
+[hosts.claude.roles.architect]
+model  = "claude-opus-4-8"
+effort = "ultra"
+
+[hosts.claude.roles.scout]
+model  = "claude-sonnet-5"
+effort = "low"
+
+[hosts.claude.roles.implementer]
+model  = "claude-sonnet-5"
+effort = "xhigh"
+
+[hosts.claude.roles.specialist]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.reviewer]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.review_downgrade]
+model  = "claude-sonnet-5"
+effort = "high"

--- a/internal/config/testdata/invalid/bad_memhub_mode.toml
+++ b/internal/config/testdata/invalid/bad_memhub_mode.toml
@@ -1,0 +1,30 @@
+# memhub.mode must be required, best-effort, or off.
+schema_version  = 1
+config_revision = "r1"
+
+[memhub]
+mode = "maybe"
+
+[hosts.claude.roles.architect]
+model  = "claude-opus-4-8"
+effort = "xhigh"
+
+[hosts.claude.roles.scout]
+model  = "claude-sonnet-5"
+effort = "low"
+
+[hosts.claude.roles.implementer]
+model  = "claude-sonnet-5"
+effort = "xhigh"
+
+[hosts.claude.roles.specialist]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.reviewer]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.review_downgrade]
+model  = "claude-sonnet-5"
+effort = "high"

--- a/internal/config/testdata/invalid/bad_merge_strategy.toml
+++ b/internal/config/testdata/invalid/bad_merge_strategy.toml
@@ -1,0 +1,33 @@
+# Only squash, rebase, and merge-commit are valid strategies.
+schema_version  = 1
+config_revision = "r1"
+
+[merge]
+strategy = "fast-forward"
+
+[memhub]
+mode = "off"
+
+[hosts.claude.roles.architect]
+model  = "claude-opus-4-8"
+effort = "xhigh"
+
+[hosts.claude.roles.scout]
+model  = "claude-sonnet-5"
+effort = "low"
+
+[hosts.claude.roles.implementer]
+model  = "claude-sonnet-5"
+effort = "xhigh"
+
+[hosts.claude.roles.specialist]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.reviewer]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.review_downgrade]
+model  = "claude-sonnet-5"
+effort = "high"

--- a/internal/config/testdata/invalid/bad_schema_version.toml
+++ b/internal/config/testdata/invalid/bad_schema_version.toml
@@ -1,0 +1,30 @@
+# Only schema_version = 1 is supported.
+schema_version  = 2
+config_revision = "r1"
+
+[memhub]
+mode = "off"
+
+[hosts.claude.roles.architect]
+model  = "claude-opus-4-8"
+effort = "xhigh"
+
+[hosts.claude.roles.scout]
+model  = "claude-sonnet-5"
+effort = "low"
+
+[hosts.claude.roles.implementer]
+model  = "claude-sonnet-5"
+effort = "xhigh"
+
+[hosts.claude.roles.specialist]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.reviewer]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.review_downgrade]
+model  = "claude-sonnet-5"
+effort = "high"

--- a/internal/config/testdata/invalid/missing_revision.toml
+++ b/internal/config/testdata/invalid/missing_revision.toml
@@ -1,0 +1,29 @@
+# config_revision is required and non-empty.
+schema_version = 1
+
+[memhub]
+mode = "off"
+
+[hosts.claude.roles.architect]
+model  = "claude-opus-4-8"
+effort = "xhigh"
+
+[hosts.claude.roles.scout]
+model  = "claude-sonnet-5"
+effort = "low"
+
+[hosts.claude.roles.implementer]
+model  = "claude-sonnet-5"
+effort = "xhigh"
+
+[hosts.claude.roles.specialist]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.reviewer]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.review_downgrade]
+model  = "claude-sonnet-5"
+effort = "high"

--- a/internal/config/testdata/invalid/missing_role.toml
+++ b/internal/config/testdata/invalid/missing_role.toml
@@ -1,0 +1,27 @@
+# An enabled host must define all six role profiles; reviewer is
+# missing here.
+schema_version  = 1
+config_revision = "r1"
+
+[memhub]
+mode = "off"
+
+[hosts.claude.roles.architect]
+model  = "claude-opus-4-8"
+effort = "xhigh"
+
+[hosts.claude.roles.scout]
+model  = "claude-sonnet-5"
+effort = "low"
+
+[hosts.claude.roles.implementer]
+model  = "claude-sonnet-5"
+effort = "xhigh"
+
+[hosts.claude.roles.specialist]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.review_downgrade]
+model  = "claude-sonnet-5"
+effort = "high"

--- a/internal/config/testdata/invalid/no_hosts.toml
+++ b/internal/config/testdata/invalid/no_hosts.toml
@@ -1,0 +1,6 @@
+# At least one host profile must be configured.
+schema_version  = 1
+config_revision = "r1"
+
+[memhub]
+mode = "off"

--- a/internal/config/testdata/invalid/unknown_key.toml
+++ b/internal/config/testdata/invalid/unknown_key.toml
@@ -1,0 +1,31 @@
+# A key outside the schema must be rejected by name.
+schema_version  = 1
+config_revision = "r1"
+bogus_key       = true
+
+[memhub]
+mode = "off"
+
+[hosts.claude.roles.architect]
+model  = "claude-opus-4-8"
+effort = "xhigh"
+
+[hosts.claude.roles.scout]
+model  = "claude-sonnet-5"
+effort = "low"
+
+[hosts.claude.roles.implementer]
+model  = "claude-sonnet-5"
+effort = "xhigh"
+
+[hosts.claude.roles.specialist]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.reviewer]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.review_downgrade]
+model  = "claude-sonnet-5"
+effort = "high"

--- a/internal/config/testdata/valid/full.toml
+++ b/internal/config/testdata/valid/full.toml
@@ -1,0 +1,64 @@
+# Every section explicit, both hosts enabled, values matching the
+# PRD §10 default model profiles.
+schema_version  = 1
+config_revision = "r1"
+
+[concurrency]
+max_subagents = 3
+
+[merge]
+strategy = "squash"
+
+[memhub]
+mode = "required"
+
+[metrics]
+enabled = false
+
+[hosts.codex.roles.architect]
+model  = "gpt-5.6-sol"
+effort = "high"
+
+[hosts.codex.roles.scout]
+model  = "gpt-5.6-terra"
+effort = "low"
+
+[hosts.codex.roles.implementer]
+model  = "gpt-5.6-terra"
+effort = "high"
+
+[hosts.codex.roles.specialist]
+model  = "gpt-5.6-sol"
+effort = "medium"
+
+[hosts.codex.roles.reviewer]
+model  = "gpt-5.6-sol"
+effort = "medium"
+
+[hosts.codex.roles.review_downgrade]
+model  = "gpt-5.6-terra"
+effort = "high"
+
+[hosts.claude.roles.architect]
+model  = "claude-opus-4-8"
+effort = "xhigh"
+
+[hosts.claude.roles.scout]
+model  = "claude-sonnet-5"
+effort = "low"
+
+[hosts.claude.roles.implementer]
+model  = "claude-sonnet-5"
+effort = "xhigh"
+
+[hosts.claude.roles.specialist]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.reviewer]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.review_downgrade]
+model  = "claude-sonnet-5"
+effort = "high"

--- a/internal/config/testdata/valid/minimal.toml
+++ b/internal/config/testdata/valid/minimal.toml
@@ -1,0 +1,32 @@
+# Smallest valid configuration: one host, PRD defaults for
+# concurrency (3) and merge strategy (squash). memhub.mode has no
+# default and must be explicit.
+schema_version  = 1
+config_revision = "r1"
+
+[memhub]
+mode = "off"
+
+[hosts.claude.roles.architect]
+model  = "claude-opus-4-8"
+effort = "xhigh"
+
+[hosts.claude.roles.scout]
+model  = "claude-sonnet-5"
+effort = "low"
+
+[hosts.claude.roles.implementer]
+model  = "claude-sonnet-5"
+effort = "xhigh"
+
+[hosts.claude.roles.specialist]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.reviewer]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.review_downgrade]
+model  = "claude-sonnet-5"
+effort = "high"

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var mergeStrategies = map[string]bool{"squash": true, "rebase": true, "merge-commit": true}
+
+var memhubModes = map[string]bool{"required": true, "best-effort": true, "off": true}
+
+// effortsByHost lists the reasoning-effort levels each host accepts
+// (PRD §10 model tables).
+var effortsByHost = map[string]map[string]bool{
+	"codex":  {"low": true, "medium": true, "high": true},
+	"claude": {"low": true, "medium": true, "high": true, "xhigh": true},
+}
+
+// validate collects every violation and reports them together in one
+// error; it never stops at the first problem.
+func (c *Config) validate() error {
+	var problems []string
+	fail := func(format string, args ...any) {
+		problems = append(problems, fmt.Sprintf(format, args...))
+	}
+
+	if c.SchemaVersion != 1 {
+		fail("schema_version: unsupported version %d (this build supports 1)", c.SchemaVersion)
+	}
+	if c.ConfigRevision == "" {
+		fail("config_revision: must be a non-empty revision identifier")
+	}
+	if c.Concurrency.MaxSubagents < 1 {
+		fail("concurrency.max_subagents: must be >= 1, got %d", c.Concurrency.MaxSubagents)
+	}
+	if !mergeStrategies[c.Merge.Strategy] {
+		fail("merge.strategy: %q is not one of squash, rebase, merge-commit", c.Merge.Strategy)
+	}
+	if !memhubModes[c.Memhub.Mode] {
+		fail("memhub.mode: %q is not one of required, best-effort, off", c.Memhub.Mode)
+	}
+
+	if c.Hosts.Codex == nil && c.Hosts.Claude == nil {
+		fail("hosts: at least one of hosts.codex or hosts.claude must be configured")
+	}
+	if c.Hosts.Codex != nil {
+		validateHost("codex", c.Hosts.Codex, fail)
+	}
+	if c.Hosts.Claude != nil {
+		validateHost("claude", c.Hosts.Claude, fail)
+	}
+
+	if len(problems) > 0 {
+		return errors.New("invalid configuration:\n  - " + strings.Join(problems, "\n  - "))
+	}
+	return nil
+}
+
+func validateHost(name string, h *Host, fail func(string, ...any)) {
+	roles := []struct {
+		key     string
+		profile RoleProfile
+	}{
+		{"architect", h.Roles.Architect},
+		{"scout", h.Roles.Scout},
+		{"implementer", h.Roles.Implementer},
+		{"specialist", h.Roles.Specialist},
+		{"reviewer", h.Roles.Reviewer},
+		{"review_downgrade", h.Roles.ReviewDowngrade},
+	}
+	for _, r := range roles {
+		prefix := "hosts." + name + ".roles." + r.key
+		if r.profile.Model == "" {
+			fail("%s.model: must be an exact model version", prefix)
+		}
+		if !effortsByHost[name][r.profile.Effort] {
+			fail("%s.effort: %q is not one of %s", prefix, r.profile.Effort, effortList(name))
+		}
+	}
+}
+
+func effortList(host string) string {
+	if host == "claude" {
+		return "low, medium, high, xhigh"
+	}
+	return "low, medium, high"
+}


### PR DESCRIPTION
## What

Scaffolds the repo from the PRD: Go module (`github.com/kninetimmy/orch`, Go 1.26), cross-platform CI, lint gate, and one thin vertical slice — strict parsing/validation of `.orchestrator/config.toml` (PRD §17/§10) wired into stub `orch status` and `orch doctor` commands. The other six PRD §22 commands are registered but fail closed with explicit not-implemented errors.

## Why

PRD §24 deferred the stack choice to the implementation plan. Planning resolved it to **Go**: single static binary per OS (host adapters' hooks/skills invoke it), trivial cross-compilation for the Win/mac/Linux parity CI the PRD's acceptance criteria require, strong stdlib for the future cross-host Delivery lock, and an official MCP Go SDK when adapters need it. The thin slice gives CI and the test harness real behavior to exercise from day one instead of an empty skeleton.

Notable decisions:
- **Only dependency: `BurntSushi/toml`** — its `MetaData.Undecoded()` reports *every* unknown key, so validation fails closed with a complete error list (all violations collected in one pass; no partial `Config` ever returned).
- **No CLI framework** — eight flat subcommands don't justify cobra; the dispatcher is stdlib-only with an explicit exit-code contract (0 ok, 1 failure, 2 usage).
- **`config.local.toml` merge deliberately excluded** — PRD §17's "overrides never weaken policy" needs a policy-classification layer first; merging without it would be fail-open. `doctor` reports the file's presence so nothing is silently ignored.
- CI: build/vet/test matrix on ubuntu/windows/macos (`fail-fast: false`), plus a gofmt + golangci-lint v2.12.2 gate (errcheck enforces fail-loudly error handling).

## Verification

- `go test ./...` green locally; gofmt/vet/golangci-lint clean.
- Binary smoke-tested on Windows: `status` with no config → "not initialized" exit 1; valid config → summary exit 0; `doctor` → all checks ok; appended unknown key → named in error, exit 1; `resume` → not-implemented, exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)