### PR TITLE
Add Assist/Delivery state machine and cross-host Delivery lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ coverage.html
 
 # Orch machine-local overrides (PRD §17)
 .orchestrator/config.local.toml
+
+# Orch machine-local state and lock (PRD §7, §14)
+.orchestrator/state.json
+.orchestrator/delivery.lock

--- a/internal/cli/abort.go
+++ b/internal/cli/abort.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// runAbort returns the repository to Assist without deleting any work
+// (PRD §15). Releasing a lock held by another owner is deliberate:
+// abort is the explicit human takeover, and the released owner is
+// printed so the takeover is visible.
+func runAbort(env Env) error {
+	if _, err := config.Load(env.RepoRoot); err != nil {
+		return err
+	}
+	res, err := state.Abort(env.RepoRoot)
+	if err != nil {
+		return err
+	}
+
+	if res.LockOwner != nil {
+		fmt.Fprintf(env.Stdout, "released delivery lock held by %s on %s (pid %d)\n",
+			res.LockOwner.Host, res.LockOwner.Hostname, res.LockOwner.PID)
+	} else if res.LockCleared {
+		fmt.Fprintln(env.Stdout, "cleared unreadable delivery lock")
+	}
+
+	switch {
+	case res.PriorRun != nil:
+		fmt.Fprintf(env.Stdout, "aborted delivery run %s; returned to assist (branches and worktrees preserved)\n", res.PriorRun.ID)
+	case res.StateReset:
+		fmt.Fprintln(env.Stdout, "reset unreadable state file to assist")
+	case !res.LockCleared:
+		fmt.Fprintln(env.Stdout, "already in assist; nothing to abort")
+	}
+	return nil
+}

--- a/internal/cli/abort_test.go
+++ b/internal/cli/abort_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+func TestAbortNotInitialized(t *testing.T) {
+	env, _, stderr := testEnv(t)
+	if code := Run([]string{"abort"}, env); code != ExitError {
+		t.Errorf("exit = %d, want %d", code, ExitError)
+	}
+	if !strings.Contains(stderr.String(), "not initialized") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestAbortDeliveryRun(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	st, err := state.EnterDelivery(env.RepoRoot, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code := Run([]string{"abort"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d", code, ExitOK)
+	}
+	out := stdout.String()
+	for _, want := range []string{"aborted delivery run " + st.Run.ID, "released delivery lock", "preserved"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	if o, err := lockfile.Inspect(env.RepoRoot); o != nil || err != nil {
+		t.Errorf("lock still present after abort: %+v, %v", o, err)
+	}
+}
+
+func TestAbortIdempotent(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	if _, err := state.EnterDelivery(env.RepoRoot, "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if code := Run([]string{"abort"}, env); code != ExitOK {
+		t.Fatalf("first abort exit = %d", code)
+	}
+	stdout.Reset()
+	if code := Run([]string{"abort"}, env); code != ExitOK {
+		t.Fatalf("second abort exit = %d", code)
+	}
+	if !strings.Contains(stdout.String(), "nothing to abort") {
+		t.Errorf("second abort output = %q", stdout.String())
+	}
+}
+
+func TestAbortClearsOrphanedLock(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	err := lockfile.Acquire(env.RepoRoot, lockfile.Owner{RunID: "run-orphan", Host: "codex", Hostname: "elsewhere", PID: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code := Run([]string{"abort"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d", code, ExitOK)
+	}
+	out := stdout.String()
+	// The released owner is printed so a takeover is visible.
+	for _, want := range []string{"released delivery lock", "codex", "elsewhere"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -41,7 +41,7 @@ func commands() []command {
 		{"configure", "Change committed configuration (not implemented)", notImplemented("configure")},
 		{"configure-local", "Change machine-local overrides (not implemented)", notImplemented("configure-local")},
 		{"resume", "Resume an interrupted Delivery run (not implemented)", notImplemented("resume")},
-		{"abort", "Stop dispatch and return to Assist (not implemented)", notImplemented("abort")},
+		{"abort", "Stop dispatch and return to Assist", runAbort},
 		{"metrics", "Show local metrics (not implemented)", notImplemented("metrics")},
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -109,7 +109,7 @@ func TestRunUnexpectedArgument(t *testing.T) {
 }
 
 func TestNotImplementedCommandsFailClosed(t *testing.T) {
-	for _, name := range []string{"init", "configure", "configure-local", "resume", "abort", "metrics"} {
+	for _, name := range []string{"init", "configure", "configure-local", "resume", "metrics"} {
 		t.Run(name, func(t *testing.T) {
 			env, _, stderr := testEnv(t)
 			if code := Run([]string{name}, env); code != ExitError {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -3,8 +3,11 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/state"
 )
 
 func runDoctor(env Env) error {
@@ -29,6 +32,22 @@ func runDoctor(env Env) error {
 
 	if config.HasLocalOverride(env.RepoRoot) {
 		fmt.Fprintf(env.Stdout, "note  %s present; overrides are not yet applied\n", config.LocalOverridePath)
+	}
+
+	st, stErr := state.Load(env.RepoRoot)
+	check("state file", stErr)
+
+	owner, lockErr := lockfile.Inspect(env.RepoRoot)
+	check("delivery lock", lockErr)
+
+	if stErr == nil && lockErr == nil {
+		check("state/lock consistency", state.CheckConsistent(st, owner))
+	}
+
+	if owner != nil {
+		if hostname, err := os.Hostname(); err == nil && owner.Hostname == hostname && !lockfile.PIDAlive(owner.PID) {
+			fmt.Fprintf(env.Stdout, "note  delivery lock: acquiring process (pid %d) is no longer running — normal between commands; if no Delivery run is active, run `orch abort`\n", owner.PID)
+		}
 	}
 
 	if failed {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -2,9 +2,14 @@ package cli
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/state"
 )
 
 func TestDoctorAllChecksPass(t *testing.T) {
@@ -52,6 +57,101 @@ func TestDoctorMissingConfig(t *testing.T) {
 	if !strings.Contains(stdout.String(), "FAIL  configuration") {
 		t.Errorf("stdout missing configuration failure:\n%s", stdout.String())
 	}
+}
+
+func TestDoctorConsistentDeliveryPasses(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	if _, err := state.EnterDelivery(env.RepoRoot, "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"ok    state file", "ok    delivery lock", "ok    state/lock consistency"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestDoctorOrphanedLockFails(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	err := lockfile.Acquire(env.RepoRoot, lockfile.Owner{RunID: "run-orphan", Host: "codex", Hostname: "h", PID: 1, AcquiredAt: time.Now().UTC()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code := Run([]string{"doctor"}, env); code != ExitError {
+		t.Errorf("exit = %d, want %d", code, ExitError)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "FAIL  state/lock consistency") {
+		t.Errorf("output missing consistency failure:\n%s", out)
+	}
+	if !strings.Contains(out, "orch abort") {
+		t.Errorf("output missing abort remediation:\n%s", out)
+	}
+}
+
+func TestDoctorCorruptLockFails(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	if err := os.WriteFile(filepath.Join(env.RepoRoot, ".orchestrator", "delivery.lock"), []byte("{broken"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if code := Run([]string{"doctor"}, env); code != ExitError {
+		t.Errorf("exit = %d, want %d", code, ExitError)
+	}
+	if !strings.Contains(stdout.String(), "FAIL  delivery lock") {
+		t.Errorf("output missing lock failure:\n%s", stdout.String())
+	}
+}
+
+func TestDoctorNotesDeadAcquirer(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	hostname, err := os.Hostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, err := state.EnterDelivery(env.RepoRoot, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Rewrite the lock with an exited process's PID and this hostname.
+	if err := lockfile.Release(env.RepoRoot); err != nil {
+		t.Fatal(err)
+	}
+	err = lockfile.Acquire(env.RepoRoot, lockfile.Owner{
+		RunID: st.Run.ID, Host: "claude", Hostname: hostname,
+		PID: exitedPID(t), AcquiredAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (a dead acquirer is normal between commands)\n%s", code, ExitOK, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "no longer running") {
+		t.Errorf("output missing dead-acquirer note:\n%s", stdout.String())
+	}
+}
+
+// exitedPID runs this test binary with no matching tests so it exits
+// immediately, returning its (now dead) PID.
+func exitedPID(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=TestNoSuchTestExists")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cannot start helper process: %v", err)
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("helper process: %v", err)
+	}
+	return pid
 }
 
 func TestDoctorNotesLocalOverride(t *testing.T) {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -3,8 +3,11 @@ package cli
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/state"
 )
 
 func runStatus(env Env) error {
@@ -12,8 +15,31 @@ func runStatus(env Env) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(env.Stdout, "mode:   assist (state machine not yet implemented)")
+	st, err := state.Load(env.RepoRoot)
+	if err != nil {
+		return err
+	}
+	owner, err := lockfile.Inspect(env.RepoRoot)
+	if err != nil {
+		return err
+	}
+
+	if st.Mode == state.ModeDelivery {
+		fmt.Fprintf(env.Stdout, "mode:   delivery (run %s, host %s, started %s)\n",
+			st.Run.ID, st.Run.Host, st.Run.StartedAt.Format(time.RFC3339))
+	} else {
+		fmt.Fprintln(env.Stdout, "mode:   assist")
+	}
+	if owner != nil {
+		fmt.Fprintf(env.Stdout, "lock:   held by %s on %s (pid %d, acquired %s)\n",
+			owner.Host, owner.Hostname, owner.PID, owner.AcquiredAt.Format(time.RFC3339))
+	}
 	fmt.Fprintf(env.Stdout, "config: %s (schema %d, revision %q)\n", config.Path, cfg.SchemaVersion, cfg.ConfigRevision)
 	fmt.Fprintf(env.Stdout, "hosts:  %s\n", strings.Join(cfg.EnabledHosts(), ", "))
+
+	// Status inspects and reports; doctor is the check that fails.
+	if err := state.CheckConsistent(st, owner); err != nil {
+		fmt.Fprintf(env.Stdout, "warning: %v\n", err)
+	}
 	return nil
 }

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -1,8 +1,14 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/state"
 )
 
 func TestStatusNotInitialized(t *testing.T) {
@@ -26,6 +32,56 @@ func TestStatusValidConfig(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q:\n%s", want, out)
 		}
+	}
+}
+
+func TestStatusDeliveryShowsRunAndLock(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	st, err := state.EnterDelivery(env.RepoRoot, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code := Run([]string{"status"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d", code, ExitOK)
+	}
+	out := stdout.String()
+	for _, want := range []string{"mode:   delivery", st.Run.ID, "lock:   held by claude"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "warning:") {
+		t.Errorf("unexpected warning on consistent state:\n%s", out)
+	}
+}
+
+func TestStatusCorruptState(t *testing.T) {
+	env, _, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	if err := os.WriteFile(filepath.Join(env.RepoRoot, ".orchestrator", "state.json"), []byte("{broken"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if code := Run([]string{"status"}, env); code != ExitError {
+		t.Errorf("exit = %d, want %d", code, ExitError)
+	}
+	if !strings.Contains(stderr.String(), "state.json") {
+		t.Errorf("stderr does not name the state file: %q", stderr.String())
+	}
+}
+
+func TestStatusOrphanedLockWarnsButSucceeds(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	err := lockfile.Acquire(env.RepoRoot, lockfile.Owner{RunID: "run-orphan", Host: "codex", Hostname: "h", PID: 1, AcquiredAt: time.Now().UTC()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code := Run([]string{"status"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (status inspects; doctor enforces)", code, ExitOK)
+	}
+	if !strings.Contains(stdout.String(), "warning:") {
+		t.Errorf("output missing consistency warning:\n%s", stdout.String())
 	}
 }
 

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -1,0 +1,121 @@
+// Package lockfile implements the exclusive cross-host Delivery lock
+// (PRD §14): one active Delivery coordinator per repository across both
+// hosts. The lock is the existence of .orchestrator/delivery.lock,
+// created with O_EXCL so acquisition is atomic on every supported OS.
+//
+// The lock deliberately outlives the acquiring process: a Delivery run
+// spans many short-lived orch invocations plus a host agent session, so
+// the recorded PID is advisory and its death is never treated as
+// staleness. There is no automatic takeover; recovery is always the
+// explicit human action `orch abort` (PRD §15). A lock file that exists
+// but cannot be read still denies acquisition (fail closed).
+package lockfile
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Path is the repo-relative location of the Delivery lock file.
+const Path = ".orchestrator/delivery.lock"
+
+// SchemaVersion is the lock-file schema this build reads and writes.
+const SchemaVersion = 1
+
+// ErrHeld reports that the Delivery lock is already held. Callers test
+// for it with errors.Is.
+var ErrHeld = errors.New("delivery lock is already held")
+
+// Owner identifies who acquired the lock. Hostname and PID exist for
+// audit and diagnostics only: the acquiring process is expected to exit
+// while its Delivery run legitimately continues.
+type Owner struct {
+	SchemaVersion int       `json:"schema_version"`
+	RunID         string    `json:"run_id"`
+	Host          string    `json:"host"` // "claude" or "codex"
+	Hostname      string    `json:"hostname"`
+	PID           int       `json:"pid"`
+	AcquiredAt    time.Time `json:"acquired_at"`
+}
+
+func lockPath(repoRoot string) string {
+	return filepath.Join(repoRoot, filepath.FromSlash(Path))
+}
+
+// Acquire atomically creates the lock file recording o. If the lock
+// already exists — even unreadable — it returns an error wrapping
+// ErrHeld and changes nothing.
+func Acquire(repoRoot string, o Owner) error {
+	f, err := os.OpenFile(lockPath(repoRoot), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if errors.Is(err, fs.ErrExist) {
+		return heldError(repoRoot)
+	}
+	if err != nil {
+		return fmt.Errorf("create %s: %w", Path, err)
+	}
+	o.SchemaVersion = SchemaVersion
+	data, err := json.MarshalIndent(o, "", "  ")
+	if err == nil {
+		_, err = f.Write(append(data, '\n'))
+	}
+	if err == nil {
+		err = f.Sync()
+	}
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		_ = os.Remove(lockPath(repoRoot)) // best effort; a leftover corrupt lock still fails closed
+		return fmt.Errorf("write %s: %w", Path, err)
+	}
+	return nil
+}
+
+func heldError(repoRoot string) error {
+	cur, err := Inspect(repoRoot)
+	if err != nil {
+		return fmt.Errorf("%w and unreadable (%v); run `orch abort` to clear it", ErrHeld, err)
+	}
+	if cur == nil {
+		// The holder released between our failed create and this read.
+		return fmt.Errorf("%w (released concurrently; retry)", ErrHeld)
+	}
+	return fmt.Errorf("%w by %s on %s (pid %d, acquired %s)",
+		ErrHeld, cur.Host, cur.Hostname, cur.PID, cur.AcquiredAt.Format(time.RFC3339))
+}
+
+// Inspect returns the current owner, (nil, nil) when no lock exists, or
+// an error when the lock exists but cannot be trusted. Callers must
+// treat an error as "cannot verify, deny" (fail closed).
+func Inspect(repoRoot string) (*Owner, error) {
+	data, err := os.ReadFile(lockPath(repoRoot))
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", Path, err)
+	}
+	var o Owner
+	if err := json.Unmarshal(data, &o); err != nil {
+		return nil, fmt.Errorf("parse %s: %v (run `orch abort` to clear a broken lock)", Path, err)
+	}
+	if o.SchemaVersion != SchemaVersion {
+		return nil, fmt.Errorf("%s: unsupported schema_version %d (this build understands %d)", Path, o.SchemaVersion, SchemaVersion)
+	}
+	return &o, nil
+}
+
+// Release removes the lock file. A missing lock is not an error, so
+// Release is idempotent.
+func Release(repoRoot string) error {
+	err := os.Remove(lockPath(repoRoot))
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove %s: %w", Path, err)
+	}
+	return nil
+}

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -1,0 +1,175 @@
+package lockfile
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// lockDir returns a temp repo root containing .orchestrator/.
+func lockDir(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".orchestrator"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func testOwner() Owner {
+	return Owner{
+		RunID:      "run-20260710T120000Z-deadbeef",
+		Host:       "claude",
+		Hostname:   "testhost",
+		PID:        os.Getpid(),
+		AcquiredAt: time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestAcquireInspectRoundTrip(t *testing.T) {
+	root := lockDir(t)
+	want := testOwner()
+	if err := Acquire(root, want); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	got, err := Inspect(root)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	want.SchemaVersion = SchemaVersion
+	if got == nil || *got != want {
+		t.Errorf("Inspect = %+v, want %+v", got, want)
+	}
+}
+
+func TestAcquireHeldNamesOwner(t *testing.T) {
+	root := lockDir(t)
+	if err := Acquire(root, testOwner()); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	err := Acquire(root, testOwner())
+	if !errors.Is(err, ErrHeld) {
+		t.Fatalf("second Acquire = %v, want ErrHeld", err)
+	}
+	for _, want := range []string{"claude", "testhost"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name %q", err, want)
+		}
+	}
+}
+
+func TestAcquireOverCorruptLockDenied(t *testing.T) {
+	root := lockDir(t)
+	if err := os.WriteFile(filepath.Join(root, ".orchestrator", "delivery.lock"), []byte("{broken"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := Acquire(root, testOwner())
+	if !errors.Is(err, ErrHeld) {
+		t.Fatalf("Acquire over corrupt lock = %v, want ErrHeld", err)
+	}
+	if !strings.Contains(err.Error(), "orch abort") {
+		t.Errorf("error %q missing abort remediation", err)
+	}
+}
+
+func TestInspect(t *testing.T) {
+	t.Run("absent", func(t *testing.T) {
+		o, err := Inspect(lockDir(t))
+		if o != nil || err != nil {
+			t.Errorf("Inspect = %+v, %v; want nil, nil", o, err)
+		}
+	})
+	for name, content := range map[string]string{
+		"corrupt":      "not json",
+		"wrong schema": `{"schema_version": 99, "run_id": "r", "host": "claude"}`,
+		"empty":        "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			root := lockDir(t)
+			if err := os.WriteFile(filepath.Join(root, ".orchestrator", "delivery.lock"), []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Inspect(root); err == nil {
+				t.Error("Inspect succeeded on untrustworthy lock; want error")
+			}
+		})
+	}
+}
+
+func TestReleaseIdempotent(t *testing.T) {
+	root := lockDir(t)
+	if err := Acquire(root, testOwner()); err != nil {
+		t.Fatal(err)
+	}
+	if err := Release(root); err != nil {
+		t.Fatalf("first Release: %v", err)
+	}
+	if err := Release(root); err != nil {
+		t.Fatalf("second Release: %v", err)
+	}
+	if o, err := Inspect(root); o != nil || err != nil {
+		t.Errorf("lock still present after Release: %+v, %v", o, err)
+	}
+}
+
+func TestAcquireExactlyOneWinner(t *testing.T) {
+	root := lockDir(t)
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := range errs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = Acquire(root, testOwner())
+		}()
+	}
+	wg.Wait()
+	wins := 0
+	for _, err := range errs {
+		switch {
+		case err == nil:
+			wins++
+		case errors.Is(err, ErrHeld):
+		default:
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+	if wins != 1 {
+		t.Errorf("%d goroutines acquired the lock, want exactly 1", wins)
+	}
+}
+
+func TestPIDAlive(t *testing.T) {
+	if !PIDAlive(os.Getpid()) {
+		t.Error("PIDAlive(self) = false, want true")
+	}
+	if PIDAlive(0) || PIDAlive(-1) {
+		t.Error("PIDAlive(non-positive) = true, want false")
+	}
+	if pid, ok := exitedPID(t); ok && PIDAlive(pid) {
+		t.Errorf("PIDAlive(%d) = true for an exited process, want false", pid)
+	}
+}
+
+// exitedPID runs this test binary with no matching tests so it exits
+// immediately, returning its (now dead) PID.
+func exitedPID(t *testing.T) (int, bool) {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=TestNoSuchTestExists")
+	if err := cmd.Start(); err != nil {
+		t.Logf("cannot start helper process: %v", err)
+		return 0, false
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		t.Logf("helper process: %v", err)
+		return 0, false
+	}
+	return pid, true
+}

--- a/internal/lockfile/pid_unix.go
+++ b/internal/lockfile/pid_unix.go
@@ -1,0 +1,25 @@
+//go:build unix
+
+package lockfile
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// PIDAlive reports whether a process with the given PID currently
+// exists. EPERM counts as alive: the process exists but belongs to
+// another user. Advisory only — PIDs are reused, and the acquiring
+// orch process is expected to exit during a healthy Delivery run.
+func PIDAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = p.Signal(syscall.Signal(0))
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/internal/lockfile/pid_windows.go
+++ b/internal/lockfile/pid_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package lockfile
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// PIDAlive reports whether a process with the given PID currently
+// exists. On Windows os.FindProcess opens a real handle, so it fails
+// when no such process exists; access-denied counts as alive (the
+// process exists but is not openable). Advisory only — PIDs are
+// reused, and the acquiring orch process is expected to exit during a
+// healthy Delivery run.
+func PIDAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return errors.Is(err, syscall.ERROR_ACCESS_DENIED)
+	}
+	_ = p.Release()
+	return true
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,0 +1,112 @@
+// Package state persists the Assist/Delivery operating mode (PRD §7)
+// in .orchestrator/state.json, machine-local and gitignored. A missing
+// file means Assist; a file that cannot be read, parsed, or recognized
+// is an error so callers fail closed (PRD §15).
+package state
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Path is the repo-relative location of the state file.
+const Path = ".orchestrator/state.json"
+
+// SchemaVersion is the state-file schema this build reads and writes.
+const SchemaVersion = 1
+
+// Mode is the operating mode (PRD §7).
+type Mode string
+
+const (
+	ModeAssist   Mode = "assist"
+	ModeDelivery Mode = "delivery"
+)
+
+// Run describes the active Delivery run.
+type Run struct {
+	ID        string    `json:"id"`
+	Host      string    `json:"host"` // "claude" or "codex"
+	StartedAt time.Time `json:"started_at"`
+}
+
+// State is the persisted operating state.
+type State struct {
+	SchemaVersion int       `json:"schema_version"`
+	Mode          Mode      `json:"mode"`
+	Run           *Run      `json:"run,omitempty"` // non-nil iff Mode is delivery
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+func statePath(repoRoot string) string {
+	return filepath.Join(repoRoot, filepath.FromSlash(Path))
+}
+
+// Load reads the state under repoRoot. A missing file is Assist, not an
+// error. Anything unreadable or inconsistent is an error naming the
+// file so the caller can deny and the human can act.
+func Load(repoRoot string) (*State, error) {
+	data, err := os.ReadFile(statePath(repoRoot))
+	if errors.Is(err, fs.ErrNotExist) {
+		return &State{SchemaVersion: SchemaVersion, Mode: ModeAssist}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", Path, err)
+	}
+
+	var st State
+	if err := json.Unmarshal(data, &st); err != nil {
+		return nil, fmt.Errorf("parse %s: %v (run `orch abort` to reset to assist)", Path, err)
+	}
+	if st.SchemaVersion != SchemaVersion {
+		return nil, fmt.Errorf("%s: unsupported schema_version %d (this build understands %d)", Path, st.SchemaVersion, SchemaVersion)
+	}
+	switch st.Mode {
+	case ModeAssist:
+		if st.Run != nil {
+			return nil, fmt.Errorf("%s: assist mode with a recorded run (run `orch abort` to reset)", Path)
+		}
+	case ModeDelivery:
+		if st.Run == nil {
+			return nil, fmt.Errorf("%s: delivery mode without a recorded run (run `orch abort` to reset)", Path)
+		}
+	default:
+		return nil, fmt.Errorf("%s: unknown mode %q (run `orch abort` to reset)", Path, st.Mode)
+	}
+	return &st, nil
+}
+
+// write atomically replaces the state file: temp file in the same
+// directory, sync, then rename (which replaces on Windows too).
+func write(repoRoot string, st *State) error {
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode %s: %w", Path, err)
+	}
+	dir := filepath.Dir(statePath(repoRoot))
+	f, err := os.CreateTemp(dir, "state-*.tmp")
+	if err != nil {
+		return fmt.Errorf("write %s: %w", Path, err)
+	}
+	tmp := f.Name()
+	_, err = f.Write(append(data, '\n'))
+	if err == nil {
+		err = f.Sync()
+	}
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	if err == nil {
+		err = os.Rename(tmp, statePath(repoRoot))
+	}
+	if err != nil {
+		_ = os.Remove(tmp) // best effort; the real state file is untouched
+		return fmt.Errorf("write %s: %w", Path, err)
+	}
+	return nil
+}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,0 +1,261 @@
+package state
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/lockfile"
+)
+
+// stateDir returns a temp repo root containing .orchestrator/.
+func stateDir(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".orchestrator"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func writeState(t *testing.T, root, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, ".orchestrator", "state.json"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadMissingFileIsAssist(t *testing.T) {
+	st, err := Load(stateDir(t))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if st.Mode != ModeAssist || st.Run != nil {
+		t.Errorf("Load = %+v, want assist with no run", st)
+	}
+}
+
+func TestLoadRejectsBadState(t *testing.T) {
+	cases := map[string]struct {
+		content string
+		wantMsg string
+	}{
+		"corrupt json":    {"{broken", "parse"},
+		"wrong schema":    {`{"schema_version": 99, "mode": "assist"}`, "schema_version 99"},
+		"unknown mode":    {`{"schema_version": 1, "mode": "turbo"}`, `unknown mode "turbo"`},
+		"delivery no run": {`{"schema_version": 1, "mode": "delivery"}`, "without a recorded run"},
+		"assist with run": {`{"schema_version": 1, "mode": "assist", "run": {"id": "r", "host": "claude", "started_at": "2026-07-10T12:00:00Z"}}`, "assist mode with a recorded run"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			root := stateDir(t)
+			writeState(t, root, tc.content)
+			_, err := Load(root)
+			if err == nil {
+				t.Fatal("Load succeeded, want error")
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error %q missing %q", err, tc.wantMsg)
+			}
+		})
+	}
+}
+
+func TestWriteReplacesExistingState(t *testing.T) {
+	root := stateDir(t)
+	first := &State{SchemaVersion: SchemaVersion, Mode: ModeAssist, UpdatedAt: time.Now().UTC()}
+	if err := write(root, first); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	second := &State{
+		SchemaVersion: SchemaVersion,
+		Mode:          ModeDelivery,
+		Run:           &Run{ID: "run-x", Host: "claude", StartedAt: time.Now().UTC()},
+		UpdatedAt:     time.Now().UTC(),
+	}
+	// Rename over an existing file must work on Windows too.
+	if err := write(root, second); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	got, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Mode != ModeDelivery || got.Run == nil || got.Run.ID != "run-x" {
+		t.Errorf("Load = %+v, want delivery run-x", got)
+	}
+	leftovers, err := filepath.Glob(filepath.Join(root, ".orchestrator", "state-*.tmp"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leftovers) > 0 {
+		t.Errorf("temp files left behind: %v", leftovers)
+	}
+}
+
+func TestEnterDelivery(t *testing.T) {
+	root := stateDir(t)
+	st, err := EnterDelivery(root, "claude")
+	if err != nil {
+		t.Fatalf("EnterDelivery: %v", err)
+	}
+	if st.Mode != ModeDelivery || st.Run == nil {
+		t.Fatalf("EnterDelivery state = %+v", st)
+	}
+	owner, err := lockfile.Inspect(root)
+	if err != nil || owner == nil {
+		t.Fatalf("Inspect = %+v, %v", owner, err)
+	}
+	if owner.RunID != st.Run.ID {
+		t.Errorf("lock run %s != state run %s", owner.RunID, st.Run.ID)
+	}
+	if err := CheckConsistent(st, owner); err != nil {
+		t.Errorf("CheckConsistent: %v", err)
+	}
+}
+
+func TestEnterDeliveryRejectsUnknownHost(t *testing.T) {
+	if _, err := EnterDelivery(stateDir(t), "emacs"); err == nil {
+		t.Error("EnterDelivery accepted unknown host")
+	}
+}
+
+func TestEnterDeliveryContentionLeavesStateUntouched(t *testing.T) {
+	root := stateDir(t)
+	if _, err := EnterDelivery(root, "claude"); err != nil {
+		t.Fatal(err)
+	}
+	before, err := Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = EnterDelivery(root, "codex")
+	if !errors.Is(err, lockfile.ErrHeld) {
+		t.Fatalf("second EnterDelivery = %v, want ErrHeld", err)
+	}
+	after, err := Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Run.ID != before.Run.ID {
+		t.Errorf("state changed on contention: %s -> %s", before.Run.ID, after.Run.ID)
+	}
+}
+
+func TestAbortFromDelivery(t *testing.T) {
+	root := stateDir(t)
+	st, err := EnterDelivery(root, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := Abort(root)
+	if err != nil {
+		t.Fatalf("Abort: %v", err)
+	}
+	if res.PriorRun == nil || res.PriorRun.ID != st.Run.ID {
+		t.Errorf("PriorRun = %+v, want run %s", res.PriorRun, st.Run.ID)
+	}
+	if res.LockOwner == nil || !res.LockCleared {
+		t.Errorf("lock not reported released: %+v", res)
+	}
+	after, err := Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Mode != ModeAssist {
+		t.Errorf("mode after abort = %s, want assist", after.Mode)
+	}
+	if o, err := lockfile.Inspect(root); o != nil || err != nil {
+		t.Errorf("lock still present after abort: %+v, %v", o, err)
+	}
+}
+
+func TestAbortIdempotentFromAssist(t *testing.T) {
+	root := stateDir(t)
+	res, err := Abort(root)
+	if err != nil {
+		t.Fatalf("Abort: %v", err)
+	}
+	if res.PriorRun != nil || res.LockCleared || res.StateReset {
+		t.Errorf("Abort on clean assist did something: %+v", res)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".orchestrator", "state.json")); !errors.Is(err, os.ErrNotExist) {
+		t.Error("Abort on clean assist created a state file")
+	}
+}
+
+func TestAbortClearsOrphanedLock(t *testing.T) {
+	root := stateDir(t)
+	err := lockfile.Acquire(root, lockfile.Owner{RunID: "run-orphan", Host: "codex", Hostname: "h", PID: 1, AcquiredAt: time.Now().UTC()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := Abort(root)
+	if err != nil {
+		t.Fatalf("Abort: %v", err)
+	}
+	if !res.LockCleared || res.LockOwner == nil || res.LockOwner.RunID != "run-orphan" {
+		t.Errorf("orphaned lock not reported: %+v", res)
+	}
+	if o, _ := lockfile.Inspect(root); o != nil {
+		t.Error("orphaned lock still present after abort")
+	}
+}
+
+func TestAbortResetsCorruptState(t *testing.T) {
+	root := stateDir(t)
+	writeState(t, root, "{broken")
+	res, err := Abort(root)
+	if err != nil {
+		t.Fatalf("Abort: %v", err)
+	}
+	if !res.StateReset {
+		t.Errorf("StateReset = false: %+v", res)
+	}
+	after, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load after abort: %v", err)
+	}
+	if after.Mode != ModeAssist {
+		t.Errorf("mode = %s, want assist", after.Mode)
+	}
+}
+
+func TestCheckConsistent(t *testing.T) {
+	run := &Run{ID: "run-a", Host: "claude", StartedAt: time.Now().UTC()}
+	assist := &State{SchemaVersion: SchemaVersion, Mode: ModeAssist}
+	delivery := &State{SchemaVersion: SchemaVersion, Mode: ModeDelivery, Run: run}
+	owner := &lockfile.Owner{SchemaVersion: lockfile.SchemaVersion, RunID: "run-a"}
+	otherOwner := &lockfile.Owner{SchemaVersion: lockfile.SchemaVersion, RunID: "run-b"}
+
+	cases := map[string]struct {
+		st     *State
+		owner  *lockfile.Owner
+		wantOK bool
+	}{
+		"assist no lock":    {assist, nil, true},
+		"delivery matching": {delivery, owner, true},
+		"assist with lock":  {assist, owner, false},
+		"delivery no lock":  {delivery, nil, false},
+		"run id mismatch":   {delivery, otherOwner, false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := CheckConsistent(tc.st, tc.owner)
+			if tc.wantOK && err != nil {
+				t.Errorf("CheckConsistent = %v, want nil", err)
+			}
+			if !tc.wantOK {
+				if err == nil {
+					t.Fatal("CheckConsistent = nil, want error")
+				}
+				if !strings.Contains(err.Error(), "orch abort") {
+					t.Errorf("error %q missing abort remediation", err)
+				}
+			}
+		})
+	}
+}

--- a/internal/state/transition.go
+++ b/internal/state/transition.go
@@ -1,0 +1,132 @@
+package state
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/lockfile"
+)
+
+// EnterDelivery acquires the cross-host Delivery lock and records a new
+// delivery run. Ordering matters for crash safety: lock first, state
+// second — a crash between the two leaves an orphaned lock, which
+// denies every new run (fail closed) until `orch abort` clears it. The
+// reverse order could leave delivery state without a lock, letting a
+// second host acquire.
+//
+// In this slice only tests call EnterDelivery; the plan gate that will
+// invoke it is future work (PRD §22: no manual delivery command).
+func EnterDelivery(repoRoot, host string) (*State, error) {
+	if host != "claude" && host != "codex" {
+		return nil, fmt.Errorf("unknown host %q (want claude or codex)", host)
+	}
+	now := time.Now().UTC()
+	runID, err := newRunID(now)
+	if err != nil {
+		return nil, err
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "unknown"
+	}
+	if err := lockfile.Acquire(repoRoot, lockfile.Owner{
+		RunID:      runID,
+		Host:       host,
+		Hostname:   hostname,
+		PID:        os.Getpid(),
+		AcquiredAt: now,
+	}); err != nil {
+		return nil, err
+	}
+	st := &State{
+		SchemaVersion: SchemaVersion,
+		Mode:          ModeDelivery,
+		Run:           &Run{ID: runID, Host: host, StartedAt: now},
+		UpdatedAt:     now,
+	}
+	if err := write(repoRoot, st); err != nil {
+		_ = lockfile.Release(repoRoot) // best effort; a leftover lock still fails closed
+		return nil, err
+	}
+	return st, nil
+}
+
+// AbortResult describes what Abort found and did.
+type AbortResult struct {
+	// PriorRun is the delivery run the state file recorded, if any.
+	PriorRun *Run
+	// LockOwner is the readable owner of a released lock, if any.
+	LockOwner *lockfile.Owner
+	// LockCleared reports that a lock file (readable or not) was removed.
+	LockCleared bool
+	// StateReset reports that an unreadable or inconsistent state file
+	// was overwritten with assist.
+	StateReset bool
+}
+
+// Abort returns the repository to Assist and releases the Delivery
+// lock (PRD §15). It is the explicit human recovery path, so it also
+// clears corrupt state files and orphaned or unreadable locks, and it
+// is idempotent. It never touches branches or worktrees. Ordering
+// matters for crash safety: state first, lock second — see
+// EnterDelivery.
+func Abort(repoRoot string) (*AbortResult, error) {
+	res := &AbortResult{}
+
+	st, err := Load(repoRoot)
+	if err != nil {
+		res.StateReset = true
+	} else if st.Mode == ModeDelivery {
+		res.PriorRun = st.Run
+	}
+
+	owner, inspectErr := lockfile.Inspect(repoRoot)
+	res.LockOwner = owner
+	res.LockCleared = owner != nil || inspectErr != nil
+
+	if res.PriorRun == nil && !res.StateReset && !res.LockCleared {
+		return res, nil // already assist, nothing to change
+	}
+
+	if res.PriorRun != nil || res.StateReset {
+		assist := &State{SchemaVersion: SchemaVersion, Mode: ModeAssist, UpdatedAt: time.Now().UTC()}
+		if err := write(repoRoot, assist); err != nil {
+			return nil, err
+		}
+	}
+	if res.LockCleared {
+		if err := lockfile.Release(repoRoot); err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+// CheckConsistent verifies the invariant that delivery mode and the
+// Delivery lock exist together and describe the same run. st and owner
+// come from Load and lockfile.Inspect.
+func CheckConsistent(st *State, owner *lockfile.Owner) error {
+	switch {
+	case st.Mode == ModeAssist && owner == nil:
+		return nil
+	case st.Mode == ModeAssist:
+		return fmt.Errorf("delivery lock exists (run %s) but state is assist; run `orch abort` to clear the orphaned lock", owner.RunID)
+	case owner == nil:
+		return fmt.Errorf("state records delivery run %s but no delivery lock exists; run `orch abort` to reset", st.Run.ID)
+	case st.Run.ID != owner.RunID:
+		return fmt.Errorf("state run %s does not match lock run %s; run `orch abort` to reset", st.Run.ID, owner.RunID)
+	}
+	return nil
+}
+
+// newRunID builds a sortable, collision-resistant run identifier:
+// UTC timestamp plus random hex.
+func newRunID(now time.Time) (string, error) {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("generate run id: %w", err)
+	}
+	return fmt.Sprintf("run-%s-%x", now.Format("20060102T150405Z"), b), nil
+}


### PR DESCRIPTION
## What

Implements the next PRD slice after the skeleton (#2): the operating-mode state machine (`internal/state`) and the exclusive cross-host Delivery lock (`internal/lockfile`), wired into `orch status`, `orch doctor`, and a now-implemented `orch abort`.

- **`internal/lockfile`** — the lock is the existence of `.orchestrator/delivery.lock`, created with `O_CREATE|O_EXCL` (atomic on all three OSes). Owner metadata (host, hostname, PID, run id, acquired-at) is audit/diagnostic only. No automatic staleness takeover: the acquiring process is *expected* to exit while a Delivery run continues, so PID death is never a steal signal; recovery is always the explicit human action `orch abort`. Unreadable lock = deny (fail closed).
- **`internal/state`** — Assist/Delivery mode persisted as schema-versioned JSON at `.orchestrator/state.json` (machine-local, gitignored), atomic temp+rename writes. Missing file = Assist; corrupt/inconsistent = fail closed with remediation. Crash-safe transition ordering (lock before state on enter, state before lock on abort) means either crash window leaves an orphaned lock that denies new runs rather than ever allowing two coordinators.
- **CLI** — `status` shows real mode/run/lock and warns on inconsistency (exit 0 — it inspects); `doctor` enforces with three new checks plus a dead-acquirer advisory note; `abort` returns to Assist, clears orphaned/corrupt locks and state, prints any released owner so takeover is visible, and is idempotent.

## Why

PRD §7 (modes), §14 (one active Delivery coordinator per repo across both hosts), §15 (fail closed; abort preserves work). This also settles two §24 deferrals — state-storage format (JSON) and cross-platform locking primitive (O_EXCL lock file) — chosen because a Delivery "hold" spans many short-lived `orch` invocations plus a host agent session, which rules out kernel locks bound to an open handle.

`EnterDelivery` is exercised only by tests in this slice; the plan gate that will invoke it is future work (PRD §22: no manual delivery command).

## Testing

- Unit: lock acquire/inspect/release incl. 8-goroutine race (exactly one winner), corrupt-lock denial, PID-liveness with a real exited process; state load/reject matrix, Windows rename-over-existing, contention leaves state untouched, abort idempotence; CLI status/doctor/abort coverage.
- End-to-end on Windows: fresh repo → `status` assist; hand-planted orphaned lock → `doctor` FAILs with `orch abort` remediation; `abort` releases and prints the foreign owner; second `abort` no-ops; `status` clean.
- `go build/vet/test`, `gofmt` all green locally; 3-OS CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)