### PR TITLE
Add internal/paths containment primitives

### DIFF
--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -1,0 +1,133 @@
+// Package paths provides the safe-path and containment primitives
+// (PRD §6, §15) the orchestration core builds on: canonical absolute
+// paths with symlinks resolved, segment-aware containment checks for
+// worktree enforcement, and discovery of the repository root that
+// holds .orchestrator/. Every helper fails closed: a path that cannot
+// be verified yields an error, never a permissive default.
+package paths
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// OrchestratorDir is the name of the repo-root directory Orch owns.
+const OrchestratorDir = ".orchestrator"
+
+// ErrNotFound reports that no ancestor directory contains
+// .orchestrator/. Callers test for it with errors.Is.
+var ErrNotFound = errors.New("no " + OrchestratorDir + " directory found")
+
+// foldCase reports whether path comparison ignores case on this OS.
+// Windows and macOS default filesystems are case-insensitive;
+// per-volume overrides (case-sensitive APFS, case-insensitive ext4)
+// are not detected.
+var foldCase = runtime.GOOS == "windows" || runtime.GOOS == "darwin"
+
+// Canonical returns path as an absolute, symlink-resolved, cleaned
+// path. The target need not exist: the deepest existing ancestor is
+// resolved and the remaining components are appended lexically, so a
+// write destination can be checked before anything creates it. Any
+// failure other than non-existence (for example permission denied)
+// is an error so callers fail closed.
+func Canonical(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize %s: %w", path, err)
+	}
+	// Abs cleans the path, so the components popped into rest below
+	// never contain "." or "..".
+	dir := abs
+	var rest []string
+	for {
+		resolved, err := filepath.EvalSymlinks(dir)
+		if err == nil {
+			for i := len(rest) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, rest[i])
+			}
+			return filepath.Clean(resolved), nil
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("canonicalize %s: %w", path, err)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			// Even the volume root failed to resolve.
+			return "", fmt.Errorf("canonicalize %s: %w", path, err)
+		}
+		rest = append(rest, filepath.Base(dir))
+		dir = parent
+	}
+}
+
+// Inside reports whether path is contained in root; path equal to
+// root counts as inside. Both arguments are canonicalized first, so
+// a symlink cannot smuggle a path out of root and ".." segments
+// cannot fake containment. The comparison is segment-aware: /repo-2
+// is not inside /repo. An unverifiable path is an error, and callers
+// must treat it as "deny".
+func Inside(root, path string) (bool, error) {
+	canonRoot, err := Canonical(root)
+	if err != nil {
+		return false, err
+	}
+	canonPath, err := Canonical(path)
+	if err != nil {
+		return false, err
+	}
+	return inside(canonRoot, canonPath, foldCase), nil
+}
+
+// inside compares two canonical paths. Case folding uses ToLower as
+// an approximation of the Windows/macOS folding rules; both sides
+// fold identically so containment stays consistent.
+func inside(root, path string, fold bool) bool {
+	if fold {
+		root = strings.ToLower(root)
+		path = strings.ToLower(path)
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		// Different volumes or otherwise incomparable: not inside.
+		return false
+	}
+	if rel == "." {
+		return true
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// FindRoot walks from startDir toward the filesystem root and returns
+// the first directory containing an .orchestrator directory. It
+// returns an error wrapping ErrNotFound when no ancestor qualifies,
+// and fails closed on anything it cannot trust: an unreadable
+// ancestor, or an .orchestrator entry that is not a real directory
+// (a symlink does not count).
+func FindRoot(startDir string) (string, error) {
+	dir, err := Canonical(startDir)
+	if err != nil {
+		return "", err
+	}
+	for {
+		candidate := filepath.Join(dir, OrchestratorDir)
+		info, err := os.Lstat(candidate)
+		switch {
+		case err == nil && info.IsDir():
+			return dir, nil
+		case err == nil:
+			return "", fmt.Errorf("%s exists but is not a real directory", candidate)
+		case !errors.Is(err, fs.ErrNotExist):
+			return "", fmt.Errorf("find repo root: %w", err)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("%w in %s or any parent", ErrNotFound, startDir)
+		}
+		dir = parent
+	}
+}

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -1,0 +1,191 @@
+package paths
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// symlink creates newname pointing at oldname, skipping the test on
+// platforms where symlink creation is unavailable (Windows without
+// Developer Mode or elevation).
+func symlink(t *testing.T, oldname, newname string) {
+	t.Helper()
+	if err := os.Symlink(oldname, newname); err != nil {
+		t.Skipf("cannot create symlinks here: %v", err)
+	}
+}
+
+// canonical is Canonical with the error turned into a test failure.
+func canonical(t *testing.T, path string) string {
+	t.Helper()
+	c, err := Canonical(path)
+	if err != nil {
+		t.Fatalf("Canonical(%s): %v", path, err)
+	}
+	return c
+}
+
+func TestCanonicalExistingDir(t *testing.T) {
+	root := t.TempDir()
+	got := canonical(t, root)
+	// Canonicalizing an already-canonical path is a fixed point.
+	if again := canonical(t, got); again != got {
+		t.Errorf("Canonical not idempotent: %s then %s", got, again)
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("Canonical(%s) = %s, want absolute", root, got)
+	}
+}
+
+func TestCanonicalMissingTail(t *testing.T) {
+	root := t.TempDir()
+	got := canonical(t, filepath.Join(root, "a", "b.txt"))
+	want := filepath.Join(canonical(t, root), "a", "b.txt")
+	if got != want {
+		t.Errorf("Canonical = %s, want %s", got, want)
+	}
+}
+
+func TestCanonicalRelative(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	got := canonical(t, filepath.Join("sub", "file.go"))
+	want := filepath.Join(canonical(t, root), "sub", "file.go")
+	if got != want {
+		t.Errorf("Canonical = %s, want %s", got, want)
+	}
+}
+
+func TestCanonicalResolvesSymlink(t *testing.T) {
+	base := t.TempDir()
+	real := filepath.Join(base, "real")
+	if err := os.Mkdir(real, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(base, "link")
+	symlink(t, real, link)
+
+	// The tail does not exist; the symlinked ancestor must still resolve.
+	got := canonical(t, filepath.Join(link, "new.txt"))
+	want := filepath.Join(canonical(t, real), "new.txt")
+	if got != want {
+		t.Errorf("Canonical = %s, want %s", got, want)
+	}
+}
+
+func TestInside(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "repo")
+	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Sibling whose name extends the root's ("repo2" vs "repo").
+	if err := os.Mkdir(filepath.Join(base, "repo2"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := map[string]struct {
+		path string
+		want bool
+	}{
+		"root itself":         {root, true},
+		"direct child":        {filepath.Join(root, "a.go"), true},
+		"nested child":        {filepath.Join(root, "sub", "b.go"), true},
+		"missing deep child":  {filepath.Join(root, "no", "such", "c.go"), true},
+		"parent":              {base, false},
+		"sibling name prefix": {filepath.Join(base, "repo2"), false},
+		"dotdot escape":       {filepath.Join(root, "..", "repo2", "d.go"), false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := Inside(root, tc.path)
+			if err != nil {
+				t.Fatalf("Inside: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("Inside(%s, %s) = %v, want %v", root, tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInsideSymlinkCannotEscape(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "repo")
+	outside := filepath.Join(base, "outside")
+	for _, dir := range []string{root, outside} {
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	symlink(t, outside, filepath.Join(root, "link"))
+
+	got, err := Inside(root, filepath.Join(root, "link", "e.go"))
+	if err != nil {
+		t.Fatalf("Inside: %v", err)
+	}
+	if got {
+		t.Error("Inside = true for a symlink that points outside the root")
+	}
+}
+
+func TestInsideCaseFolding(t *testing.T) {
+	root := filepath.FromSlash("/Repo")
+	path := filepath.FromSlash("/repo/sub/f.go")
+	if !inside(root, path, true) {
+		t.Error("inside(fold=true) = false, want true for case-differing paths")
+	}
+	// On Windows filepath.Rel itself folds case, so the unfolded
+	// comparison is only observable elsewhere (notably macOS, where
+	// Rel is case-sensitive but the default filesystem is not —
+	// which is what the explicit fold is for).
+	if runtime.GOOS != "windows" && inside(root, path, false) {
+		t.Error("inside(fold=false) = true, want false for case-differing paths")
+	}
+}
+
+func TestFindRoot(t *testing.T) {
+	root := t.TempDir()
+	deep := filepath.Join(root, "a", "b")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, OrchestratorDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := FindRoot(deep)
+	if err != nil {
+		t.Fatalf("FindRoot: %v", err)
+	}
+	if want := canonical(t, root); got != want {
+		t.Errorf("FindRoot = %s, want %s", got, want)
+	}
+}
+
+func TestFindRootNotFound(t *testing.T) {
+	got, err := FindRoot(t.TempDir())
+	if err == nil {
+		// A real ancestor of the temp dir happens to be initialized;
+		// the not-found case cannot be exercised on this machine.
+		t.Skipf("ancestor %s contains %s", got, OrchestratorDir)
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("FindRoot error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestFindRootRejectsNonDirectory(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, OrchestratorDir), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := FindRoot(root)
+	if err == nil || !strings.Contains(err.Error(), "not a real directory") {
+		t.Errorf("FindRoot error = %v, want 'not a real directory'", err)
+	}
+}


### PR DESCRIPTION
## What

New `internal/paths` package — the safe-path and containment primitives (PRD §6, §15) that `internal/gitops` and the future `orch guard` command build on:

- **`Canonical`** — absolute, symlink-resolved, cleaned paths. Works for write targets that don't exist yet: the deepest existing ancestor is resolved, the missing tail is joined lexically.
- **`Inside`** — segment-aware containment (`/repo-2` is not inside `/repo`), immune to `..` and symlink escapes because both sides are canonicalized first. Case-folded on Windows/macOS.
- **`FindRoot`** — walks up from any directory to the repo root containing `.orchestrator/`; rejects a symlinked or non-directory `.orchestrator` entry.

## Why

First package of roadmap Phase 1 (memhub task 6). Worktree write-enforcement and git worktree management both reduce to "is this path provably inside that root" — that check has to exist once, fail closed, and behave identically on all three OSes before anything builds on it.

Fail-closed contract throughout: any path that cannot be verified (permission error, unreadable ancestor) returns an error, never a permissive default; callers must treat errors as deny.

## Notes

- No consumers yet by design — gitops (task 7) and guard (task 12) land on top of it.
- Symlink tests skip on Windows runners without symlink privilege.
- On Windows `filepath.Rel` already folds case; the explicit fold exists for macOS, where `Rel` is case-sensitive but the default filesystem is not. Per-volume sensitivity overrides (case-sensitive APFS, case-insensitive ext4) are documented as not detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)