### PR TITLE
Add internal/gitops and internal/execx: git operations behind an injectable runner

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+
+	"github.com/kninetimmy/orch/internal/execx"
 )
 
 // Exit codes returned by Run.
@@ -23,6 +25,9 @@ type Env struct {
 	Stderr   io.Writer
 	// LookPath resolves an executable name; defaults to exec.LookPath.
 	LookPath func(string) (string, error)
+	// Runner executes external commands (git, gh); defaults to
+	// execx.Local resolving through LookPath.
+	Runner execx.Runner
 }
 
 type command struct {
@@ -57,6 +62,9 @@ func notImplemented(name string) func(Env) error {
 func Run(args []string, env Env) int {
 	if env.LookPath == nil {
 		env.LookPath = exec.LookPath
+	}
+	if env.Runner == nil {
+		env.Runner = execx.Local{LookPath: env.LookPath}
 	}
 	if len(args) == 0 {
 		usage(env.Stderr)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2,11 +2,14 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx"
 )
 
 // validTOML is a minimal valid configuration (one host, defaults).
@@ -43,17 +46,36 @@ effort = "high"
 `
 
 // testEnv returns an Env writing to fresh buffers, rooted in an empty
-// temp dir, with every PATH lookup succeeding.
+// temp dir, with every PATH lookup succeeding and a Runner that
+// reports the repo root as a healthy git top level.
 func testEnv(t *testing.T) (Env, *bytes.Buffer, *bytes.Buffer) {
 	t.Helper()
 	var stdout, stderr bytes.Buffer
+	root := t.TempDir()
 	env := Env{
-		RepoRoot: t.TempDir(),
+		RepoRoot: root,
 		Stdout:   &stdout,
 		Stderr:   &stderr,
 		LookPath: func(name string) (string, error) { return "/fake/" + name, nil },
+		Runner:   fakeGitRunner{toplevel: root},
 	}
 	return env, &stdout, &stderr
+}
+
+// fakeGitRunner answers `git rev-parse --show-toplevel` (the doctor
+// repository probe) with a fixed top level; exit carries a scripted
+// failure.
+type fakeGitRunner struct {
+	toplevel string
+	exit     int
+	stderr   string
+}
+
+func (f fakeGitRunner) Run(context.Context, execx.Cmd) (execx.Result, error) {
+	if f.exit != 0 {
+		return execx.Result{Stderr: f.stderr, ExitCode: f.exit}, nil
+	}
+	return execx.Result{Stdout: f.toplevel + "\n"}, nil
 }
 
 func writeConfig(t *testing.T, root, content string) {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1,11 +1,13 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 
 	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/gitops"
 	"github.com/kninetimmy/orch/internal/lockfile"
 	"github.com/kninetimmy/orch/internal/state"
 )
@@ -23,6 +25,13 @@ func runDoctor(env Env) error {
 
 	_, gitErr := env.LookPath("git")
 	check("git on PATH", gitErr)
+
+	if gitErr == nil {
+		// gitops.Open also verifies .orchestrator/ sits at the git
+		// top level, which the containment guarantees depend on.
+		_, repoErr := gitops.Open(context.Background(), env.Runner, env.RepoRoot)
+		check("git repository", repoErr)
+	}
 
 	_, ghErr := env.LookPath("gh")
 	check("gh on PATH", ghErr)

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -19,10 +19,43 @@ func TestDoctorAllChecksPass(t *testing.T) {
 		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
 	}
 	out := stdout.String()
-	for _, want := range []string{"ok    git on PATH", "ok    gh on PATH", "ok    configuration"} {
+	for _, want := range []string{"ok    git on PATH", "ok    git repository", "ok    gh on PATH", "ok    configuration"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q:\n%s", want, out)
 		}
+	}
+}
+
+func TestDoctorNotAGitRepo(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	env.Runner = fakeGitRunner{exit: 128, stderr: "fatal: not a git repository"}
+	if code := Run([]string{"doctor"}, env); code != ExitError {
+		t.Errorf("exit = %d, want %d", code, ExitError)
+	}
+	if !strings.Contains(stdout.String(), "FAIL  git repository") {
+		t.Errorf("stdout missing repository failure:\n%s", stdout.String())
+	}
+}
+
+func TestDoctorSkipsRepoCheckWithoutGit(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	env.LookPath = func(name string) (string, error) {
+		if name == "git" {
+			return "", errNotFound
+		}
+		return "/fake/" + name, nil
+	}
+	if code := Run([]string{"doctor"}, env); code != ExitError {
+		t.Errorf("exit = %d, want %d", code, ExitError)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "FAIL  git on PATH") {
+		t.Errorf("stdout missing git failure:\n%s", out)
+	}
+	if strings.Contains(out, "git repository") {
+		t.Errorf("repository check ran without git on PATH:\n%s", out)
 	}
 }
 

--- a/internal/execx/execx.go
+++ b/internal/execx/execx.go
@@ -1,0 +1,107 @@
+// Package execx defines the injectable external-command runner the
+// orchestration core uses for git and gh (PRD §5, §12). Commands are
+// always argument vectors — never shell strings — so external input
+// can never be shell-interpreted. A non-zero exit is data in Result,
+// not an error: callers that need exit codes as information (PRD §16
+// reproduce-on-base) read them directly, and callers for whom
+// non-zero means failure convert it themselves.
+package execx
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// Cmd describes one external command invocation.
+type Cmd struct {
+	// Name is the executable name; the runner resolves it on PATH.
+	Name string
+	// Args is the argument vector. It is passed verbatim to the
+	// process and never shell-interpreted.
+	Args []string
+	// Dir is the working directory. It is required: an implicit
+	// inherited cwd would make command behavior depend on ambient
+	// process state, so an empty Dir is an error (fail closed).
+	Dir string
+	// Env holds KEY=VALUE pairs appended to os.Environ(). Later
+	// entries win, so callers can override inherited variables.
+	// nil adds nothing.
+	Env []string
+	// Stdin is the process input; nil means no input.
+	Stdin io.Reader
+}
+
+// Result carries everything a caller needs to interpret an invocation
+// that ran to completion.
+type Result struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+// Runner runs external commands. Run returns a non-nil error only
+// when the command could not be executed at all (executable missing,
+// context canceled, spawn failure); a command that ran and exited
+// non-zero returns a nil error with the exit code in Result.
+type Runner interface {
+	Run(ctx context.Context, cmd Cmd) (Result, error)
+}
+
+// Local is the production Runner backed by os/exec.
+type Local struct {
+	// LookPath resolves an executable name; defaults to exec.LookPath.
+	LookPath func(string) (string, error)
+}
+
+// waitDelay bounds how long Run waits for I/O after the context is
+// canceled: a grandchild process holding the inherited pipes must not
+// keep Wait blocked forever.
+const waitDelay = 10 * time.Second
+
+// Run executes c and captures its output. The executable is resolved
+// first so a missing binary yields an actionable error instead of a
+// spawn failure.
+func (l Local) Run(ctx context.Context, c Cmd) (Result, error) {
+	if c.Dir == "" {
+		return Result{}, fmt.Errorf("run %s: working directory not set", c.Name)
+	}
+	lookPath := l.LookPath
+	if lookPath == nil {
+		lookPath = exec.LookPath
+	}
+	path, err := lookPath(c.Name)
+	if err != nil {
+		return Result{}, fmt.Errorf("%s not found on PATH; install it or adjust PATH: %w", c.Name, err)
+	}
+
+	cmd := exec.CommandContext(ctx, path, c.Args...)
+	cmd.Dir = c.Dir
+	cmd.Env = append(os.Environ(), c.Env...)
+	cmd.Stdin = c.Stdin
+	cmd.WaitDelay = waitDelay
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+	res := Result{Stdout: stdout.String(), Stderr: stderr.String()}
+	var exitErr *exec.ExitError
+	switch {
+	case err == nil:
+		return res, nil
+	case errors.As(err, &exitErr) && ctx.Err() == nil:
+		// The command ran and exited non-zero: that is data, not an
+		// error. A cancellation-induced kill is reported as an error
+		// instead, because the caller did not get a real exit status.
+		res.ExitCode = exitErr.ExitCode()
+		return res, nil
+	default:
+		return Result{}, fmt.Errorf("run %s: %w", c.Name, err)
+	}
+}

--- a/internal/execx/execx_test.go
+++ b/internal/execx/execx_test.go
@@ -1,0 +1,144 @@
+package execx
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// requireGit skips the test when git is unavailable; CI has it on all
+// three OSes, so a skip only happens on unusual developer machines.
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("git not on PATH: %v", err)
+	}
+}
+
+func TestRunSuccess(t *testing.T) {
+	requireGit(t)
+	res, err := Local{}.Run(context.Background(), Cmd{
+		Name: "git",
+		Args: []string{"--version"},
+		Dir:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Errorf("exit code = %d, want 0 (stderr: %s)", res.ExitCode, res.Stderr)
+	}
+	if !strings.Contains(res.Stdout, "git version") {
+		t.Errorf("stdout = %q, want git version banner", res.Stdout)
+	}
+}
+
+func TestRunNonZeroExitIsData(t *testing.T) {
+	requireGit(t)
+	res, err := Local{}.Run(context.Background(), Cmd{
+		Name: "git",
+		Args: []string{"definitely-not-a-subcommand"},
+		Dir:  t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v (non-zero exit must not be an error)", err)
+	}
+	if res.ExitCode == 0 {
+		t.Error("exit code = 0, want non-zero")
+	}
+	if res.Stderr == "" {
+		t.Error("stderr empty, want git's complaint")
+	}
+}
+
+func TestRunMissingExecutable(t *testing.T) {
+	_, err := Local{}.Run(context.Background(), Cmd{
+		Name: "orch-no-such-binary",
+		Dir:  t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("Run succeeded, want error for missing executable")
+	}
+	if !strings.Contains(err.Error(), "orch-no-such-binary") {
+		t.Errorf("error %q does not name the executable", err)
+	}
+}
+
+func TestRunEmptyDirFailsClosed(t *testing.T) {
+	_, err := Local{}.Run(context.Background(), Cmd{Name: "git", Args: []string{"--version"}})
+	if err == nil || !strings.Contains(err.Error(), "working directory") {
+		t.Fatalf("Run with empty Dir: err = %v, want working-directory error", err)
+	}
+}
+
+func TestRunCanceledContext(t *testing.T) {
+	requireGit(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := Local{}.Run(ctx, Cmd{Name: "git", Args: []string{"--version"}, Dir: t.TempDir()})
+	if err == nil {
+		t.Fatal("Run with canceled context succeeded, want error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error %v does not wrap context.Canceled", err)
+	}
+}
+
+func TestRunLookPathInjection(t *testing.T) {
+	sentinel := errors.New("lookup refused")
+	_, err := Local{LookPath: func(string) (string, error) { return "", sentinel }}.Run(
+		context.Background(), Cmd{Name: "git", Dir: t.TempDir()})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want wrapped injected LookPath error", err)
+	}
+}
+
+func TestRunEnvAndDirPropagate(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "gitconfig")
+	if err := os.WriteFile(cfg, []byte("[orch]\n\tprobe = value\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err := Local{}.Run(context.Background(), Cmd{
+		Name: "git",
+		Args: []string{"config", "--global", "--get", "orch.probe"},
+		Dir:  dir,
+		Env:  []string{"GIT_CONFIG_GLOBAL=" + cfg, "GIT_CONFIG_NOSYSTEM=1"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if strings.TrimSpace(res.Stdout) != "value" {
+		t.Errorf("stdout = %q, want %q (env not propagated?)", res.Stdout, "value")
+	}
+
+	// Dir propagation: rev-parse resolves the toplevel of the repo
+	// that contains the working directory.
+	if _, err := (Local{}).Run(context.Background(), Cmd{
+		Name: "git", Args: []string{"init"}, Dir: dir,
+	}); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	res, err = Local{}.Run(context.Background(), Cmd{
+		Name: "git", Args: []string{"rev-parse", "--show-toplevel"}, Dir: dir,
+	})
+	if err != nil || res.ExitCode != 0 {
+		t.Fatalf("rev-parse: err=%v exit=%d stderr=%s", err, res.ExitCode, res.Stderr)
+	}
+	got, err := filepath.EvalSymlinks(filepath.FromSlash(strings.TrimSpace(res.Stdout)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.EqualFold(got, want) {
+		t.Errorf("toplevel = %q, want %q (dir not propagated?)", got, want)
+	}
+}

--- a/internal/execx/execxtest/script.go
+++ b/internal/execx/execxtest/script.go
@@ -1,0 +1,81 @@
+// Package execxtest provides a scripted fake execx.Runner for
+// transcript tests: each expected call is asserted in order and
+// answered with a recorded result, so tests pin the exact argument
+// vectors the core sends to git and gh without running either.
+package execxtest
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx"
+)
+
+// Call is one expected invocation and its scripted response.
+type Call struct {
+	// Name is the expected Cmd.Name, for example "git".
+	Name string
+	// Args is the expected exact argument vector.
+	Args []string
+	// Dir is the expected Cmd.Dir; empty skips the check because
+	// many tests build paths from t.TempDir().
+	Dir string
+	// Env, when non-nil, is the expected exact Cmd.Env.
+	Env []string
+
+	// Stdout, Stderr, and Exit form the scripted Result.
+	Stdout string
+	Stderr string
+	Exit   int
+	// Err, when non-nil, is returned instead of a Result, modeling
+	// a command that could not run at all.
+	Err error
+}
+
+// Script is a Runner that fails the test on any call that deviates
+// from the recorded transcript.
+type Script struct {
+	T     *testing.T
+	Calls []Call
+
+	next int
+}
+
+// Run asserts that c matches the next scripted call and returns its
+// recorded response.
+func (s *Script) Run(_ context.Context, c execx.Cmd) (execx.Result, error) {
+	s.T.Helper()
+	if s.next >= len(s.Calls) {
+		s.T.Fatalf("unexpected call %d: %s %v (script has %d calls)", s.next+1, c.Name, c.Args, len(s.Calls))
+	}
+	want := s.Calls[s.next]
+	s.next++
+	if c.Name != want.Name {
+		s.T.Fatalf("call %d: got command %q, want %q", s.next, c.Name, want.Name)
+	}
+	if !slices.Equal(c.Args, want.Args) {
+		s.T.Fatalf("call %d: %s args\ngot  %q\nwant %q", s.next, c.Name, c.Args, want.Args)
+	}
+	if want.Dir != "" && c.Dir != want.Dir {
+		s.T.Fatalf("call %d: %s dir\ngot  %q\nwant %q", s.next, c.Name, c.Dir, want.Dir)
+	}
+	if want.Env != nil && !slices.Equal(c.Env, want.Env) {
+		s.T.Fatalf("call %d: %s env\ngot  %q\nwant %q", s.next, c.Name, c.Env, want.Env)
+	}
+	if want.Err != nil {
+		return execx.Result{}, want.Err
+	}
+	return execx.Result{Stdout: want.Stdout, Stderr: want.Stderr, ExitCode: want.Exit}, nil
+}
+
+// AssertExhausted fails the test unless every scripted call was
+// consumed. Tests use it to prove fail-closed short circuits: an
+// operation that must be denied before touching git leaves an empty
+// script untouched.
+func (s *Script) AssertExhausted() {
+	s.T.Helper()
+	if s.next != len(s.Calls) {
+		s.T.Fatalf("script not exhausted: %d of %d calls made", s.next, len(s.Calls))
+	}
+}

--- a/internal/gitops/base.go
+++ b/internal/gitops/base.go
@@ -1,0 +1,46 @@
+package gitops
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/kninetimmy/orch/internal/paths"
+)
+
+// WithBaseWorktree checks ref out into a disposable detached worktree
+// and calls fn with its directory, then always removes it. It is the
+// substrate for PRD §16's "a failure is pre-existing only when
+// reproduced on the base branch": the run engine runs the failing
+// verification command inside fn and interprets the exit code; gitops
+// only provides the checkout.
+//
+// Cleanup is the one place gitops uses `worktree remove --force`:
+// reproduction commands legitimately leave untracked build artifacts,
+// and the checkout is disposable by construction — detached, holding
+// no branch and no user work, at a path this function generated — so
+// forced removal cannot destroy work (PRD §15 still holds). A cleanup
+// failure is joined with fn's error, never swallowed (PRD §16:
+// cleanup failures keep the run incomplete).
+func (g *Git) WithBaseWorktree(ctx context.Context, ref string, fn func(dir string) error) (err error) {
+	tmp, err := os.MkdirTemp("", "orch-base-*")
+	if err != nil {
+		return fmt.Errorf("create base worktree directory: %w", err)
+	}
+	dir, err := paths.Canonical(tmp)
+	if err != nil {
+		return errors.Join(err, os.Remove(tmp))
+	}
+	if _, err := g.git(ctx, g.root, "worktree", "add", "--detach", dir, ref); err != nil {
+		return errors.Join(err, os.Remove(tmp))
+	}
+	defer func() {
+		// context.WithoutCancel: a canceled ctx must not leave the
+		// disposable worktree behind.
+		if _, cleanupErr := g.git(context.WithoutCancel(ctx), g.root, "worktree", "remove", "--force", dir); cleanupErr != nil {
+			err = errors.Join(err, fmt.Errorf("clean up base worktree: %w", cleanupErr))
+		}
+	}()
+	return fn(dir)
+}

--- a/internal/gitops/base_test.go
+++ b/internal/gitops/base_test.go
@@ -1,0 +1,110 @@
+package gitops
+
+import (
+	"context"
+	"errors"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx"
+)
+
+// recordingRunner answers git calls by pattern instead of exact argv,
+// because WithBaseWorktree generates its own temp path that a fixed
+// transcript cannot predict.
+type recordingRunner struct {
+	root      string
+	calls     [][]string
+	removeErr error
+}
+
+func (r *recordingRunner) Run(_ context.Context, c execx.Cmd) (execx.Result, error) {
+	r.calls = append(r.calls, c.Args)
+	switch {
+	case slices.Equal(c.Args, []string{"rev-parse", "--show-toplevel"}):
+		return execx.Result{Stdout: r.root + "\n"}, nil
+	case len(c.Args) > 1 && c.Args[0] == "worktree" && c.Args[1] == "remove":
+		if r.removeErr != nil {
+			return execx.Result{}, r.removeErr
+		}
+		// Delete the directory like real git would, so the test can
+		// assert the disposable checkout is gone (and the system temp
+		// directory stays clean).
+		return execx.Result{}, os.RemoveAll(c.Args[len(c.Args)-1])
+	default:
+		return execx.Result{}, nil
+	}
+}
+
+func openRecording(t *testing.T, removeErr error) (*Git, *recordingRunner) {
+	t.Helper()
+	r := &recordingRunner{root: tempRoot(t), removeErr: removeErr}
+	g, err := Open(context.Background(), r, r.root)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return g, r
+}
+
+func TestWithBaseWorktree(t *testing.T) {
+	g, r := openRecording(t, nil)
+	var got string
+	err := g.WithBaseWorktree(context.Background(), "origin/main", func(dir string) error {
+		got = dir
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WithBaseWorktree: %v", err)
+	}
+	if got == "" {
+		t.Fatal("fn was not called")
+	}
+	if _, err := os.Stat(got); err == nil {
+		t.Errorf("temp worktree directory %s still exists", got)
+	}
+
+	// The transcript must be: open probe, detached add of the ref at
+	// the generated dir, forced remove of that same dir.
+	if len(r.calls) != 3 {
+		t.Fatalf("got %d git calls, want 3: %v", len(r.calls), r.calls)
+	}
+	wantAdd := []string{"worktree", "add", "--detach", got, "origin/main"}
+	if !slices.Equal(r.calls[1], wantAdd) {
+		t.Errorf("add call = %v, want %v", r.calls[1], wantAdd)
+	}
+	wantRemove := []string{"worktree", "remove", "--force", got}
+	if !slices.Equal(r.calls[2], wantRemove) {
+		t.Errorf("remove call = %v, want %v", r.calls[2], wantRemove)
+	}
+}
+
+func TestWithBaseWorktreeFnErrorStillCleansUp(t *testing.T) {
+	g, r := openRecording(t, nil)
+	sentinel := errors.New("reproduction failed to build")
+	err := g.WithBaseWorktree(context.Background(), "main", func(string) error { return sentinel })
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want fn's error", err)
+	}
+	last := r.calls[len(r.calls)-1]
+	if len(last) < 3 || last[0] != "worktree" || last[1] != "remove" {
+		t.Errorf("last call = %v, want forced worktree remove", last)
+	}
+}
+
+func TestWithBaseWorktreeCleanupFailureNotSwallowed(t *testing.T) {
+	removeErr := errors.New("remove refused")
+	g, _ := openRecording(t, removeErr)
+	sentinel := errors.New("fn error")
+	err := g.WithBaseWorktree(context.Background(), "main", func(string) error { return sentinel })
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err = %v, want fn's error preserved", err)
+	}
+	if !errors.Is(err, removeErr) {
+		t.Errorf("err = %v, want cleanup error joined", err)
+	}
+	if !strings.Contains(err.Error(), "clean up base worktree") {
+		t.Errorf("err = %v, want cleanup context", err)
+	}
+}

--- a/internal/gitops/branch.go
+++ b/internal/gitops/branch.go
@@ -1,0 +1,130 @@
+package gitops
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Fetch updates refs from remote; callers use it before FastForward
+// or before reproducing a failure against a remote base ref.
+func (g *Git) Fetch(ctx context.Context, remote string, refspecs ...string) error {
+	args := append([]string{"fetch", remote}, refspecs...)
+	_, err := g.git(ctx, g.root, args...)
+	return err
+}
+
+// DeleteBranch deletes a local branch that is fully merged into the
+// current HEAD; an unmerged branch wraps ErrBranchNotMerged and is
+// preserved (PRD §15). After a squash merge the local branch is never
+// "merged" in git's ancestry terms — use ForceDeleteBranch once the
+// merge has been verified through the GitHub API.
+func (g *Git) DeleteBranch(ctx context.Context, branch string, c Confirmation) error {
+	if !c.ok {
+		return fmt.Errorf("%w: delete branch %s", ErrNotConfirmed, branch)
+	}
+	if err := g.requireBranchExists(ctx, branch); err != nil {
+		return err
+	}
+	res, err := g.run(ctx, g.root, "merge-base", "--is-ancestor", "refs/heads/"+branch, "HEAD")
+	if err != nil {
+		return err
+	}
+	switch res.ExitCode {
+	case 0:
+		// Merged; fall through to the deletion.
+	case 1:
+		return fmt.Errorf("%w: %s", ErrBranchNotMerged, branch)
+	default:
+		return fmt.Errorf("git merge-base in %s exited %d: %s", g.root, res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	_, err = g.git(ctx, g.root, "branch", "-d", branch)
+	return err
+}
+
+// ForceDeleteBranch deletes a local branch with -D. It exists solely
+// for the squash-merge default (PRD §16), where the branch never
+// becomes an ancestor of the base: the caller MUST have verified the
+// PR merged before calling. It refuses to delete a branch checked out
+// in any worktree, including the primary checkout.
+func (g *Git) ForceDeleteBranch(ctx context.Context, branch string, c Confirmation) error {
+	if !c.ok {
+		return fmt.Errorf("%w: force-delete branch %s", ErrNotConfirmed, branch)
+	}
+	if err := g.requireBranchExists(ctx, branch); err != nil {
+		return err
+	}
+	worktrees, err := g.ListWorktrees(ctx)
+	if err != nil {
+		return err
+	}
+	for _, wt := range worktrees {
+		if wt.Branch == branch {
+			return fmt.Errorf("branch %s is checked out in worktree %s; remove the worktree first", branch, wt.Path)
+		}
+	}
+	_, err = g.git(ctx, g.root, "branch", "-D", branch)
+	return err
+}
+
+// DeleteRemoteBranch deletes the merged remote branch (PRD §12 step
+// 18) with `git push <remote> --delete <branch>` — the same
+// credential path that pushed the branch in the first place.
+func (g *Git) DeleteRemoteBranch(ctx context.Context, remote, branch string, c Confirmation) error {
+	if !c.ok {
+		return fmt.Errorf("%w: delete remote branch %s/%s", ErrNotConfirmed, remote, branch)
+	}
+	_, err := g.git(ctx, g.root, "push", remote, "--delete", branch)
+	return err
+}
+
+// FastForward advances the primary checkout to remote's tip of branch
+// (PRD §12 step 20). Fail-closed gates: branch must be the branch
+// checked out in the primary checkout, and the tree must be clean.
+// Diverged history wraps ErrNotFastForward and changes nothing.
+func (g *Git) FastForward(ctx context.Context, remote, branch string) error {
+	current, err := g.CurrentBranch(ctx)
+	if err != nil {
+		return err
+	}
+	if current != branch {
+		return fmt.Errorf("primary checkout is on %s, not %s; refusing to fast-forward", current, branch)
+	}
+	if err := g.RequireClean(ctx, g.root); err != nil {
+		return err
+	}
+	if err := g.Fetch(ctx, remote, branch); err != nil {
+		return err
+	}
+	res, err := g.run(ctx, g.root, "merge-base", "--is-ancestor", "HEAD", "FETCH_HEAD")
+	if err != nil {
+		return err
+	}
+	switch res.ExitCode {
+	case 0:
+		// HEAD is an ancestor of (or equal to) the fetched tip.
+	case 1:
+		// Local commits missing from the remote tip mean either a
+		// diverged history or a locally-ahead branch; both are
+		// suspicious in Delivery, so both fail closed.
+		return fmt.Errorf("%w: local %s has commits not on %s/%s", ErrNotFastForward, branch, remote, branch)
+	default:
+		return fmt.Errorf("git merge-base in %s exited %d: %s", g.root, res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	_, err = g.git(ctx, g.root, "merge", "--ff-only", "FETCH_HEAD")
+	return err
+}
+
+// requireBranchExists fails closed when branch is not a local branch,
+// so deletion errors name the real problem instead of git's generic
+// refusal text.
+func (g *Git) requireBranchExists(ctx context.Context, branch string) error {
+	res, err := g.run(ctx, g.root, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch)
+	if err != nil {
+		return err
+	}
+	if res.ExitCode != 0 {
+		return fmt.Errorf("branch %s does not exist in %s", branch, g.root)
+	}
+	return nil
+}

--- a/internal/gitops/branch_test.go
+++ b/internal/gitops/branch_test.go
@@ -1,0 +1,187 @@
+package gitops
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+)
+
+func verifyBranchCall(branch string, exists bool) execxtest.Call {
+	exit := 1
+	if exists {
+		exit = 0
+	}
+	return execxtest.Call{
+		Name: "git", Args: []string{"rev-parse", "--verify", "--quiet", "refs/heads/" + branch}, Exit: exit,
+	}
+}
+
+func TestFetch(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "git", Args: []string{"fetch", "origin", "main"}, Dir: root,
+	})
+	if err := g.Fetch(context.Background(), "origin", "main"); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestDeleteBranchUnconfirmed(t *testing.T) {
+	g, script := openScripted(t, tempRoot(t))
+	err := g.DeleteBranch(context.Background(), "orch/issue-4", Confirmation{})
+	script.AssertExhausted() // fail closed before any git call
+	if !errors.Is(err, ErrNotConfirmed) {
+		t.Fatalf("err = %v, want ErrNotConfirmed", err)
+	}
+}
+
+func TestDeleteBranchMissing(t *testing.T) {
+	g, script := openScripted(t, tempRoot(t), verifyBranchCall("gone", false))
+	err := g.DeleteBranch(context.Background(), "gone", ExplicitConfirmation())
+	script.AssertExhausted()
+	if err == nil || !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("err = %v, want missing-branch error", err)
+	}
+}
+
+func TestDeleteBranchUnmergedPreserved(t *testing.T) {
+	g, script := openScripted(t, tempRoot(t),
+		verifyBranchCall("orch/issue-4", true),
+		execxtest.Call{Name: "git", Args: []string{"merge-base", "--is-ancestor", "refs/heads/orch/issue-4", "HEAD"}, Exit: 1},
+	)
+	err := g.DeleteBranch(context.Background(), "orch/issue-4", ExplicitConfirmation())
+	script.AssertExhausted() // no `branch -d` followed
+	if !errors.Is(err, ErrBranchNotMerged) {
+		t.Fatalf("err = %v, want ErrBranchNotMerged", err)
+	}
+}
+
+func TestDeleteBranch(t *testing.T) {
+	g, script := openScripted(t, tempRoot(t),
+		verifyBranchCall("orch/issue-4", true),
+		execxtest.Call{Name: "git", Args: []string{"merge-base", "--is-ancestor", "refs/heads/orch/issue-4", "HEAD"}},
+		execxtest.Call{Name: "git", Args: []string{"branch", "-d", "orch/issue-4"}},
+	)
+	if err := g.DeleteBranch(context.Background(), "orch/issue-4", ExplicitConfirmation()); err != nil {
+		t.Fatalf("DeleteBranch: %v", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestForceDeleteBranchCheckedOutRefused(t *testing.T) {
+	root := tempRoot(t)
+	wt := tempRoot(t)
+	g, script := openScripted(t, root,
+		verifyBranchCall("orch/issue-4", true),
+		execxtest.Call{Name: "git", Args: listArgs, Stdout: porcelain(
+			"worktree "+root, "HEAD 1111", "branch refs/heads/main", "",
+			"worktree "+wt, "HEAD 2222", "branch refs/heads/orch/issue-4",
+		)},
+	)
+	err := g.ForceDeleteBranch(context.Background(), "orch/issue-4", ExplicitConfirmation())
+	script.AssertExhausted() // no `branch -D` followed
+	if err == nil || !strings.Contains(err.Error(), "checked out") {
+		t.Fatalf("err = %v, want checked-out refusal", err)
+	}
+}
+
+func TestForceDeleteBranch(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root,
+		verifyBranchCall("orch/issue-4", true),
+		execxtest.Call{Name: "git", Args: listArgs, Stdout: porcelain(
+			"worktree "+root, "HEAD 1111", "branch refs/heads/main",
+		)},
+		execxtest.Call{Name: "git", Args: []string{"branch", "-D", "orch/issue-4"}},
+	)
+	if err := g.ForceDeleteBranch(context.Background(), "orch/issue-4", ExplicitConfirmation()); err != nil {
+		t.Fatalf("ForceDeleteBranch: %v", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestForceDeleteBranchUnconfirmed(t *testing.T) {
+	g, script := openScripted(t, tempRoot(t))
+	err := g.ForceDeleteBranch(context.Background(), "orch/issue-4", Confirmation{})
+	script.AssertExhausted()
+	if !errors.Is(err, ErrNotConfirmed) {
+		t.Fatalf("err = %v, want ErrNotConfirmed", err)
+	}
+}
+
+func TestDeleteRemoteBranch(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "git", Args: []string{"push", "origin", "--delete", "orch/issue-4"}, Dir: root,
+	})
+	if err := g.DeleteRemoteBranch(context.Background(), "origin", "orch/issue-4", ExplicitConfirmation()); err != nil {
+		t.Fatalf("DeleteRemoteBranch: %v", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestDeleteRemoteBranchUnconfirmed(t *testing.T) {
+	g, script := openScripted(t, tempRoot(t))
+	err := g.DeleteRemoteBranch(context.Background(), "origin", "orch/issue-4", Confirmation{})
+	script.AssertExhausted()
+	if !errors.Is(err, ErrNotConfirmed) {
+		t.Fatalf("err = %v, want ErrNotConfirmed", err)
+	}
+}
+
+func currentBranchCall(branch string) execxtest.Call {
+	return execxtest.Call{Name: "git", Args: []string{"symbolic-ref", "--short", "HEAD"}, Stdout: branch + "\n"}
+}
+
+func TestFastForwardWrongBranch(t *testing.T) {
+	g, script := openScripted(t, tempRoot(t), currentBranchCall("orch/issue-4"))
+	err := g.FastForward(context.Background(), "origin", "main")
+	script.AssertExhausted() // stopped before fetch
+	if err == nil || !strings.Contains(err.Error(), "refusing to fast-forward") {
+		t.Fatalf("err = %v, want wrong-branch refusal", err)
+	}
+}
+
+func TestFastForwardDirty(t *testing.T) {
+	g, script := openScripted(t, tempRoot(t),
+		currentBranchCall("main"),
+		execxtest.Call{Name: "git", Args: statusArgs, Stdout: "?? junk\n"},
+	)
+	err := g.FastForward(context.Background(), "origin", "main")
+	script.AssertExhausted()
+	if !errors.Is(err, ErrNotClean) {
+		t.Fatalf("err = %v, want ErrNotClean", err)
+	}
+}
+
+func TestFastForwardDiverged(t *testing.T) {
+	g, script := openScripted(t, tempRoot(t),
+		currentBranchCall("main"),
+		execxtest.Call{Name: "git", Args: statusArgs},
+		execxtest.Call{Name: "git", Args: []string{"fetch", "origin", "main"}},
+		execxtest.Call{Name: "git", Args: []string{"merge-base", "--is-ancestor", "HEAD", "FETCH_HEAD"}, Exit: 1},
+	)
+	err := g.FastForward(context.Background(), "origin", "main")
+	script.AssertExhausted() // no merge followed
+	if !errors.Is(err, ErrNotFastForward) {
+		t.Fatalf("err = %v, want ErrNotFastForward", err)
+	}
+}
+
+func TestFastForward(t *testing.T) {
+	g, script := openScripted(t, tempRoot(t),
+		currentBranchCall("main"),
+		execxtest.Call{Name: "git", Args: statusArgs},
+		execxtest.Call{Name: "git", Args: []string{"fetch", "origin", "main"}},
+		execxtest.Call{Name: "git", Args: []string{"merge-base", "--is-ancestor", "HEAD", "FETCH_HEAD"}},
+		execxtest.Call{Name: "git", Args: []string{"merge", "--ff-only", "FETCH_HEAD"}},
+	)
+	if err := g.FastForward(context.Background(), "origin", "main"); err != nil {
+		t.Fatalf("FastForward: %v", err)
+	}
+	script.AssertExhausted()
+}

--- a/internal/gitops/checks.go
+++ b/internal/gitops/checks.go
@@ -1,0 +1,71 @@
+package gitops
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// RequireClean returns nil only when dir's working tree has no
+// modified, staged, or untracked files (PRD §5 Delivery
+// prerequisites; §15 preservation checks). dir "" means the primary
+// checkout. The error names the offending paths so the operator knows
+// what to commit or stash.
+func (g *Git) RequireClean(ctx context.Context, dir string) error {
+	if dir == "" {
+		dir = g.root
+	}
+	out, err := g.git(ctx, dir, "status", "--porcelain=v1", "--untracked-files=all")
+	if err != nil {
+		return err
+	}
+	if out == "" {
+		return nil
+	}
+	lines := strings.Split(out, "\n")
+	shown := lines
+	const maxShown = 5
+	if len(shown) > maxShown {
+		shown = shown[:maxShown]
+	}
+	suffix := ""
+	if len(lines) > maxShown {
+		suffix = fmt.Sprintf(" (and %d more)", len(lines)-maxShown)
+	}
+	return fmt.Errorf("%w in %s: %s%s; commit or stash before continuing", ErrNotClean, dir, strings.Join(shown, ", "), suffix)
+}
+
+// CurrentBranch returns the branch checked out in the primary
+// checkout. A detached HEAD wraps ErrDetachedHead: Delivery never
+// operates detached, so callers fail closed.
+func (g *Git) CurrentBranch(ctx context.Context) (string, error) {
+	res, err := g.run(ctx, g.root, "symbolic-ref", "--short", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	if res.ExitCode != 0 {
+		return "", fmt.Errorf("%w in %s: %s", ErrDetachedHead, g.root, strings.TrimSpace(res.Stderr))
+	}
+	return strings.TrimSpace(res.Stdout), nil
+}
+
+// RequireNotOn enforces PRD §15's "the active branch must not be
+// main": the caller names the protected branches (that list is
+// policy, owned by the run engine), gitops enforces it mechanically.
+func (g *Git) RequireNotOn(ctx context.Context, protected ...string) error {
+	branch, err := g.CurrentBranch(ctx)
+	if err != nil {
+		return err
+	}
+	if slices.Contains(protected, branch) {
+		return fmt.Errorf("%w: %s", ErrProtectedBranch, branch)
+	}
+	return nil
+}
+
+// RevParse resolves ref to a full commit hash, for audit manifests
+// (PRD §13) and verification.
+func (g *Git) RevParse(ctx context.Context, ref string) (string, error) {
+	return g.git(ctx, g.root, "rev-parse", "--verify", ref+"^{commit}")
+}

--- a/internal/gitops/checks_test.go
+++ b/internal/gitops/checks_test.go
@@ -1,0 +1,109 @@
+package gitops
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+)
+
+var statusArgs = []string{"status", "--porcelain=v1", "--untracked-files=all"}
+
+func TestRequireClean(t *testing.T) {
+	cases := map[string]struct {
+		stdout  string
+		wantErr error
+		wantIn  string
+	}{
+		"clean":     {stdout: ""},
+		"modified":  {stdout: " M internal/foo.go\n", wantErr: ErrNotClean, wantIn: "internal/foo.go"},
+		"untracked": {stdout: "?? junk.txt\n", wantErr: ErrNotClean, wantIn: "junk.txt"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			root := tempRoot(t)
+			g, script := openScripted(t, root, execxtest.Call{
+				Name: "git", Args: statusArgs, Dir: root, Stdout: tc.stdout,
+			})
+			err := g.RequireClean(context.Background(), "")
+			script.AssertExhausted()
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tc.wantErr)
+			}
+			if tc.wantIn != "" && !strings.Contains(err.Error(), tc.wantIn) {
+				t.Errorf("error %q does not name %q", err, tc.wantIn)
+			}
+		})
+	}
+}
+
+func TestRequireCleanTruncatesLongLists(t *testing.T) {
+	dirty := strings.Repeat("?? junk\n", 8)
+	g, script := openScripted(t, tempRoot(t), execxtest.Call{Name: "git", Args: statusArgs, Stdout: dirty})
+	err := g.RequireClean(context.Background(), "")
+	script.AssertExhausted()
+	if err == nil || !strings.Contains(err.Error(), "and 3 more") {
+		t.Fatalf("err = %v, want truncated listing", err)
+	}
+}
+
+func TestCurrentBranch(t *testing.T) {
+	g, script := openScripted(t, tempRoot(t), execxtest.Call{
+		Name: "git", Args: []string{"symbolic-ref", "--short", "HEAD"}, Stdout: "main\n",
+	})
+	branch, err := g.CurrentBranch(context.Background())
+	script.AssertExhausted()
+	if err != nil || branch != "main" {
+		t.Fatalf("CurrentBranch = %q, %v; want main, nil", branch, err)
+	}
+}
+
+func TestCurrentBranchDetached(t *testing.T) {
+	g, script := openScripted(t, tempRoot(t), execxtest.Call{
+		Name: "git", Args: []string{"symbolic-ref", "--short", "HEAD"},
+		Stderr: "fatal: ref HEAD is not a symbolic ref", Exit: 1,
+	})
+	_, err := g.CurrentBranch(context.Background())
+	script.AssertExhausted()
+	if !errors.Is(err, ErrDetachedHead) {
+		t.Fatalf("err = %v, want ErrDetachedHead", err)
+	}
+}
+
+func TestRequireNotOn(t *testing.T) {
+	cases := map[string]struct {
+		branch    string
+		protected []string
+		wantErr   error
+	}{
+		"on protected":  {branch: "main", protected: []string{"main", "master"}, wantErr: ErrProtectedBranch},
+		"on feature":    {branch: "orch/issue-4", protected: []string{"main", "master"}},
+		"nothing named": {branch: "main", protected: nil},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			g, script := openScripted(t, tempRoot(t), execxtest.Call{
+				Name: "git", Args: []string{"symbolic-ref", "--short", "HEAD"}, Stdout: tc.branch + "\n",
+			})
+			err := g.RequireNotOn(context.Background(), tc.protected...)
+			script.AssertExhausted()
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestRevParse(t *testing.T) {
+	const hash = "0123456789abcdef0123456789abcdef01234567"
+	g, script := openScripted(t, tempRoot(t), execxtest.Call{
+		Name: "git", Args: []string{"rev-parse", "--verify", "main^{commit}"}, Stdout: hash + "\n",
+	})
+	got, err := g.RevParse(context.Background(), "main")
+	script.AssertExhausted()
+	if err != nil || got != hash {
+		t.Fatalf("RevParse = %q, %v; want %q, nil", got, err, hash)
+	}
+}

--- a/internal/gitops/errors.go
+++ b/internal/gitops/errors.go
@@ -1,0 +1,36 @@
+package gitops
+
+import "errors"
+
+// Sentinel errors callers test with errors.Is. Each marks an expected
+// fail-closed condition detected by a pre-flight plumbing check —
+// never by parsing git's human-readable stderr, whose wording varies
+// across versions.
+var (
+	// ErrNotARepo reports that the path is not inside a git work tree.
+	ErrNotARepo = errors.New("not a git repository")
+	// ErrNotClean reports modified, staged, or untracked files where
+	// a clean tree is required (PRD §5, §15).
+	ErrNotClean = errors.New("working tree is not clean")
+	// ErrDetachedHead reports a detached HEAD; Delivery never
+	// operates detached.
+	ErrDetachedHead = errors.New("HEAD is detached")
+	// ErrProtectedBranch reports that the active branch is one the
+	// caller declared protected (PRD §15: never operate on main).
+	ErrProtectedBranch = errors.New("active branch is a protected branch")
+	// ErrBranchExists reports a branch that already exists where a
+	// new one must be created (PRD §12: one fresh branch per issue).
+	ErrBranchExists = errors.New("branch already exists")
+	// ErrBranchNotMerged reports git refusing to delete an unmerged
+	// branch; the work it holds is preserved (PRD §15).
+	ErrBranchNotMerged = errors.New("branch is not fully merged")
+	// ErrUnknownWorktree reports a removal target that is not a
+	// registered worktree; gitops never deletes arbitrary paths.
+	ErrUnknownWorktree = errors.New("path is not a registered worktree")
+	// ErrNotFastForward reports diverged history where only a
+	// fast-forward is allowed (PRD §12 step 20); nothing changed.
+	ErrNotFastForward = errors.New("fast-forward is not possible")
+	// ErrNotConfirmed reports a destructive operation attempted
+	// without ExplicitConfirmation (PRD §15).
+	ErrNotConfirmed = errors.New("destructive operation requires explicit confirmation")
+)

--- a/internal/gitops/gitops.go
+++ b/internal/gitops/gitops.go
@@ -1,0 +1,105 @@
+// Package gitops executes the git mechanics of the Delivery workflow
+// (PRD §12): per-issue feature branches and worktrees, post-merge
+// cleanup, cleanliness and protected-branch preconditions (PRD §5,
+// §15), and base-branch checkouts for reproducing failures (PRD §16).
+//
+// The package is policy-free: callers supply branch names, worktree
+// paths, remotes, and protected-branch lists — naming and placement
+// policy belongs to the run engine. Every operation fails closed: any
+// git error propagates, destructive operations require an explicit
+// Confirmation (PRD §15: blocked worktrees and branches are
+// preserved), and --force never touches user work.
+//
+// Operations that pre-check and then act (for example AddWorktree)
+// are not atomic; the run engine serializes potentially conflicting
+// writes (PRD §14), so the gap is not raced in practice.
+package gitops
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/paths"
+)
+
+// gitEnv is applied to every git invocation. GIT_TERMINAL_PROMPT=0
+// makes git error instead of prompting for credentials (fail closed,
+// never hang); LC_ALL=C keeps any output the package must read stable
+// across locales.
+var gitEnv = []string{"GIT_TERMINAL_PROMPT=0", "LC_ALL=C"}
+
+// Git executes git operations against one repository through an
+// injected execx.Runner.
+type Git struct {
+	r    execx.Runner
+	root string
+}
+
+// Open binds to the repository whose primary checkout root is
+// repoRoot — the directory holding .orchestrator/. It verifies that
+// repoRoot is inside a git work tree and that git's top level equals
+// repoRoot: .orchestrator/ must live at the git root, otherwise the
+// containment guarantees of PRD §15 would not hold.
+func Open(ctx context.Context, r execx.Runner, repoRoot string) (*Git, error) {
+	root, err := paths.Canonical(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	g := &Git{r: r, root: root}
+	res, err := g.run(ctx, root, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return nil, err
+	}
+	if res.ExitCode != 0 {
+		return nil, fmt.Errorf("%w: %s (%s)", ErrNotARepo, root, strings.TrimSpace(res.Stderr))
+	}
+	top := strings.TrimSpace(res.Stdout)
+	same, err := samePath(root, top)
+	if err != nil {
+		return nil, err
+	}
+	if !same {
+		return nil, fmt.Errorf("%s is not the git top level (%s is); %s must sit at the repository root", root, top, paths.OrchestratorDir)
+	}
+	return g, nil
+}
+
+// Root returns the canonical primary-checkout root.
+func (g *Git) Root() string { return g.root }
+
+// run executes git with the fail-closed environment and returns the
+// raw result; callers that treat non-zero exit as data use this.
+func (g *Git) run(ctx context.Context, dir string, args ...string) (execx.Result, error) {
+	return g.r.Run(ctx, execx.Cmd{Name: "git", Args: args, Dir: dir, Env: gitEnv})
+}
+
+// git is run plus the common interpretation: a non-zero exit becomes
+// an error naming the subcommand, directory, and git's stderr;
+// success returns trimmed stdout.
+func (g *Git) git(ctx context.Context, dir string, args ...string) (string, error) {
+	res, err := g.run(ctx, dir, args...)
+	if err != nil {
+		return "", err
+	}
+	if res.ExitCode != 0 {
+		return "", fmt.Errorf("git %s in %s exited %d: %s", args[0], dir, res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	return strings.TrimSpace(res.Stdout), nil
+}
+
+// samePath reports whether two paths name the same canonical
+// location, reusing the segment-aware, case-folding containment
+// semantics of paths.Inside in both directions.
+func samePath(a, b string) (bool, error) {
+	ab, err := paths.Inside(a, b)
+	if err != nil {
+		return false, err
+	}
+	ba, err := paths.Inside(b, a)
+	if err != nil {
+		return false, err
+	}
+	return ab && ba, nil
+}

--- a/internal/gitops/gitops_test.go
+++ b/internal/gitops/gitops_test.go
@@ -1,0 +1,97 @@
+package gitops
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+	"github.com/kninetimmy/orch/internal/paths"
+)
+
+func canon(t *testing.T, path string) string {
+	t.Helper()
+	c, err := paths.Canonical(path)
+	if err != nil {
+		t.Fatalf("Canonical(%s): %v", path, err)
+	}
+	return c
+}
+
+func tempRoot(t *testing.T) string {
+	t.Helper()
+	return canon(t, t.TempDir())
+}
+
+// openScripted opens a Git rooted at root against a Script whose
+// first call answers Open's rev-parse probe; calls holds the
+// transcript the test itself exercises.
+func openScripted(t *testing.T, root string, calls ...execxtest.Call) (*Git, *execxtest.Script) {
+	t.Helper()
+	script := &execxtest.Script{T: t, Calls: append([]execxtest.Call{{
+		Name:   "git",
+		Args:   []string{"rev-parse", "--show-toplevel"},
+		Dir:    root,
+		Env:    []string{"GIT_TERMINAL_PROMPT=0", "LC_ALL=C"},
+		Stdout: root + "\n",
+	}}, calls...)}
+	g, err := Open(context.Background(), script, root)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return g, script
+}
+
+func TestOpen(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root)
+	script.AssertExhausted()
+	if g.Root() != root {
+		t.Errorf("Root() = %q, want %q", g.Root(), root)
+	}
+}
+
+func TestOpenNotARepo(t *testing.T) {
+	root := tempRoot(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name:   "git",
+		Args:   []string{"rev-parse", "--show-toplevel"},
+		Dir:    root,
+		Stderr: "fatal: not a git repository",
+		Exit:   128,
+	}}}
+	_, err := Open(context.Background(), script, root)
+	if !errors.Is(err, ErrNotARepo) {
+		t.Fatalf("err = %v, want ErrNotARepo", err)
+	}
+}
+
+func TestOpenTopLevelMismatch(t *testing.T) {
+	top := tempRoot(t)
+	sub := tempRoot(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name:   "git",
+		Args:   []string{"rev-parse", "--show-toplevel"},
+		Dir:    sub,
+		Stdout: top + "\n",
+	}}}
+	_, err := Open(context.Background(), script, sub)
+	if err == nil || !strings.Contains(err.Error(), "top level") {
+		t.Fatalf("err = %v, want top-level mismatch", err)
+	}
+}
+
+func TestOpenRunnerError(t *testing.T) {
+	root := tempRoot(t)
+	sentinel := errors.New("spawn failed")
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name: "git",
+		Args: []string{"rev-parse", "--show-toplevel"},
+		Err:  sentinel,
+	}}}
+	_, err := Open(context.Background(), script, root)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want wrapped runner error", err)
+	}
+}

--- a/internal/gitops/integration_test.go
+++ b/internal/gitops/integration_test.go
@@ -1,0 +1,323 @@
+package gitops
+
+// Integration tests against real git, which CI provides on all three
+// OSes; the scripted tests in the sibling files pin exact argument
+// vectors, these pin actual behavior.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx"
+)
+
+// setupGitEnv isolates every git invocation in the test process —
+// including the ones gitops itself makes — from the developer's real
+// configuration, and provides the identity commits need.
+func setupGitEnv(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("git not on PATH: %v", err)
+	}
+	cfg := filepath.Join(t.TempDir(), "gitconfig")
+	config := "[user]\n\tname = Orch Test\n\temail = orch-test@example.invalid\n"
+	if err := os.WriteFile(cfg, []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", cfg)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+}
+
+// rawGit runs git directly for test setup and assertions, failing the
+// test on any error or non-zero exit.
+func rawGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	res, err := (execx.Local{}).Run(context.Background(), execx.Cmd{
+		Name: "git", Args: args, Dir: dir, Env: gitEnv,
+	})
+	if err != nil {
+		t.Fatalf("git %v: %v", args, err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("git %v exited %d: %s", args, res.ExitCode, res.Stderr)
+	}
+	return strings.TrimSpace(res.Stdout)
+}
+
+// newRepo creates a repository on branch main with one commit and
+// returns it opened.
+func newRepo(t *testing.T) (*Git, string) {
+	t.Helper()
+	root := tempRoot(t)
+	rawGit(t, root, "init", "-b", "main")
+	commitFile(t, root, "README.md", "initial\n")
+	g, err := Open(context.Background(), execx.Local{}, root)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return g, root
+}
+
+func commitFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rawGit(t, dir, "add", "-A")
+	rawGit(t, dir, "commit", "-m", "update "+name)
+}
+
+func TestIntegrationOpen(t *testing.T) {
+	setupGitEnv(t)
+	g, root := newRepo(t)
+	if g.Root() != root {
+		t.Errorf("Root() = %q, want %q", g.Root(), root)
+	}
+
+	if _, err := Open(context.Background(), execx.Local{}, t.TempDir()); !errors.Is(err, ErrNotARepo) {
+		t.Errorf("Open(non-repo) err = %v, want ErrNotARepo", err)
+	}
+
+	sub := filepath.Join(root, "subdir")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Open(context.Background(), execx.Local{}, sub); err == nil || !strings.Contains(err.Error(), "top level") {
+		t.Errorf("Open(subdir) err = %v, want top-level mismatch", err)
+	}
+}
+
+func TestIntegrationRequireClean(t *testing.T) {
+	setupGitEnv(t)
+	g, root := newRepo(t)
+	ctx := context.Background()
+
+	if err := g.RequireClean(ctx, ""); err != nil {
+		t.Fatalf("clean repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.RequireClean(ctx, ""); !errors.Is(err, ErrNotClean) {
+		t.Errorf("modified tracked file: err = %v, want ErrNotClean", err)
+	}
+	rawGit(t, root, "checkout", "--", "README.md")
+	if err := os.WriteFile(filepath.Join(root, "untracked.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.RequireClean(ctx, ""); !errors.Is(err, ErrNotClean) {
+		t.Errorf("untracked file: err = %v, want ErrNotClean", err)
+	}
+}
+
+func TestIntegrationChecks(t *testing.T) {
+	setupGitEnv(t)
+	g, root := newRepo(t)
+	ctx := context.Background()
+
+	branch, err := g.CurrentBranch(ctx)
+	if err != nil || branch != "main" {
+		t.Fatalf("CurrentBranch = %q, %v; want main, nil", branch, err)
+	}
+	if err := g.RequireNotOn(ctx, "main"); !errors.Is(err, ErrProtectedBranch) {
+		t.Errorf("on main: err = %v, want ErrProtectedBranch", err)
+	}
+	head := rawGit(t, root, "rev-parse", "HEAD")
+	got, err := g.RevParse(ctx, "main")
+	if err != nil || got != head {
+		t.Errorf("RevParse = %q, %v; want %q, nil", got, err, head)
+	}
+	rawGit(t, root, "checkout", "--detach")
+	if _, err := g.CurrentBranch(ctx); !errors.Is(err, ErrDetachedHead) {
+		t.Errorf("detached: err = %v, want ErrDetachedHead", err)
+	}
+}
+
+func TestIntegrationWorktreeLifecycle(t *testing.T) {
+	setupGitEnv(t)
+	g, _ := newRepo(t)
+	ctx := context.Background()
+	wtPath := filepath.Join(t.TempDir(), "issue-4")
+
+	wt, err := g.AddWorktree(ctx, wtPath, "orch/issue-4", "main")
+	if err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+	if wt.Branch != "orch/issue-4" || wt.Head == "" {
+		t.Errorf("worktree = %+v, want branch orch/issue-4 with a head", wt)
+	}
+	list, err := g.ListWorktrees(ctx)
+	if err != nil || len(list) != 2 {
+		t.Fatalf("ListWorktrees = %+v, %v; want 2 entries", list, err)
+	}
+	if !list[0].Primary || list[0].Branch != "main" {
+		t.Errorf("first entry = %+v, want primary on main", list[0])
+	}
+	if list[1].Branch != "orch/issue-4" {
+		t.Errorf("second entry = %+v, want orch/issue-4", list[1])
+	}
+
+	if _, err := g.AddWorktree(ctx, filepath.Join(t.TempDir(), "again"), "orch/issue-4", "main"); !errors.Is(err, ErrBranchExists) {
+		t.Errorf("duplicate branch: err = %v, want ErrBranchExists", err)
+	}
+
+	// Preservation: unconfirmed and dirty removals both leave the
+	// worktree in place (PRD §15).
+	if err := g.RemoveWorktree(ctx, wt.Path, Confirmation{}); !errors.Is(err, ErrNotConfirmed) {
+		t.Fatalf("unconfirmed: err = %v, want ErrNotConfirmed", err)
+	}
+	if _, err := os.Stat(wt.Path); err != nil {
+		t.Fatal("worktree vanished after unconfirmed removal attempt")
+	}
+	if err := os.WriteFile(filepath.Join(wt.Path, "wip.go"), []byte("package wip\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.RemoveWorktree(ctx, wt.Path, ExplicitConfirmation()); !errors.Is(err, ErrNotClean) {
+		t.Fatalf("dirty: err = %v, want ErrNotClean", err)
+	}
+	if _, err := os.Stat(wt.Path); err != nil {
+		t.Fatal("worktree vanished after dirty removal attempt")
+	}
+
+	// Clean and confirmed: gone.
+	if err := os.Remove(filepath.Join(wt.Path, "wip.go")); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.RemoveWorktree(ctx, wt.Path, ExplicitConfirmation()); err != nil {
+		t.Fatalf("RemoveWorktree: %v", err)
+	}
+	if _, err := os.Stat(wt.Path); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("worktree still present after confirmed removal: %v", err)
+	}
+	list, err = g.ListWorktrees(ctx)
+	if err != nil || len(list) != 1 {
+		t.Errorf("ListWorktrees after removal = %+v, %v; want 1 entry", list, err)
+	}
+}
+
+func TestIntegrationBranchDeletion(t *testing.T) {
+	setupGitEnv(t)
+	g, _ := newRepo(t)
+	ctx := context.Background()
+	wtPath := filepath.Join(t.TempDir(), "issue-5")
+
+	wt, err := g.AddWorktree(ctx, wtPath, "orch/issue-5", "main")
+	if err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+	commitFile(t, wt.Path, "feature.go", "package feature\n")
+
+	// The branch is checked out: force deletion refuses.
+	if err := g.ForceDeleteBranch(ctx, "orch/issue-5", ExplicitConfirmation()); err == nil || !strings.Contains(err.Error(), "checked out") {
+		t.Fatalf("checked out: err = %v, want refusal", err)
+	}
+	if err := g.RemoveWorktree(ctx, wt.Path, ExplicitConfirmation()); err != nil {
+		t.Fatalf("RemoveWorktree: %v", err)
+	}
+
+	// Unmerged: -d preserved, -D (post-verification path) deletes.
+	if err := g.DeleteBranch(ctx, "orch/issue-5", ExplicitConfirmation()); !errors.Is(err, ErrBranchNotMerged) {
+		t.Fatalf("unmerged: err = %v, want ErrBranchNotMerged", err)
+	}
+	if err := g.ForceDeleteBranch(ctx, "orch/issue-5", ExplicitConfirmation()); err != nil {
+		t.Fatalf("ForceDeleteBranch: %v", err)
+	}
+	if err := g.DeleteBranch(ctx, "orch/issue-5", ExplicitConfirmation()); err == nil || !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("deleted branch: err = %v, want missing-branch error", err)
+	}
+}
+
+func TestIntegrationRemoteFlow(t *testing.T) {
+	setupGitEnv(t)
+	g, root := newRepo(t)
+	ctx := context.Background()
+
+	origin := filepath.Join(t.TempDir(), "origin.git")
+	rawGit(t, filepath.Dir(origin), "init", "--bare", origin)
+	rawGit(t, root, "remote", "add", "origin", origin)
+	rawGit(t, root, "push", "origin", "main")
+
+	wt, err := g.AddWorktree(ctx, filepath.Join(t.TempDir(), "issue-6"), "orch/issue-6", "main")
+	if err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+	commitFile(t, wt.Path, "feature.go", "package feature\n")
+	featureHead := rawGit(t, wt.Path, "rev-parse", "HEAD")
+	rawGit(t, wt.Path, "push", "origin", "orch/issue-6")
+
+	// Simulate the squash-merge landing on the remote: origin/main
+	// advances past the local primary checkout.
+	rawGit(t, wt.Path, "push", "origin", "orch/issue-6:main")
+
+	// PRD §12 step 18: delete the merged remote branch.
+	if err := g.DeleteRemoteBranch(ctx, "origin", "orch/issue-6", ExplicitConfirmation()); err != nil {
+		t.Fatalf("DeleteRemoteBranch: %v", err)
+	}
+	if out := rawGit(t, root, "ls-remote", "--heads", "origin", "orch/issue-6"); out != "" {
+		t.Errorf("remote branch survived deletion: %q", out)
+	}
+
+	// PRD §12 step 20: fast-forward the primary checkout.
+	if err := g.FastForward(ctx, "origin", "main"); err != nil {
+		t.Fatalf("FastForward: %v", err)
+	}
+	if head := rawGit(t, root, "rev-parse", "HEAD"); head != featureHead {
+		t.Errorf("HEAD = %s, want %s after fast-forward", head, featureHead)
+	}
+
+	// Diverge: a commit on local main plus a different commit pushed
+	// to origin main from the worktree.
+	commitFile(t, root, "local.txt", "local\n")
+	localHead := rawGit(t, root, "rev-parse", "HEAD")
+	commitFile(t, wt.Path, "remote.txt", "remote\n")
+	rawGit(t, wt.Path, "push", "origin", "orch/issue-6:main")
+
+	if err := g.FastForward(ctx, "origin", "main"); !errors.Is(err, ErrNotFastForward) {
+		t.Fatalf("diverged: err = %v, want ErrNotFastForward", err)
+	}
+	if head := rawGit(t, root, "rev-parse", "HEAD"); head != localHead {
+		t.Errorf("HEAD moved to %s on refused fast-forward, want %s", head, localHead)
+	}
+}
+
+func TestIntegrationWithBaseWorktree(t *testing.T) {
+	setupGitEnv(t)
+	g, _ := newRepo(t)
+	ctx := context.Background()
+
+	wt, err := g.AddWorktree(ctx, filepath.Join(t.TempDir(), "issue-7"), "orch/issue-7", "main")
+	if err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+	commitFile(t, wt.Path, "README.md", "feature version\n")
+
+	// fn sees the base branch's content, not the feature branch's,
+	// and may leave untracked artifacts behind (PRD §16).
+	var baseDir string
+	sentinel := errors.New("reproduced on base")
+	err = g.WithBaseWorktree(ctx, "main", func(dir string) error {
+		baseDir = dir
+		content, err := os.ReadFile(filepath.Join(dir, "README.md"))
+		if err != nil {
+			return err
+		}
+		if string(content) != "initial\n" {
+			t.Errorf("base content = %q, want the main version", content)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "build-artifact.o"), []byte("junk"), 0o644); err != nil {
+			return err
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want fn's error", err)
+	}
+	if _, err := os.Stat(baseDir); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("base worktree %s survived cleanup: %v", baseDir, err)
+	}
+}

--- a/internal/gitops/worktree.go
+++ b/internal/gitops/worktree.go
@@ -1,0 +1,181 @@
+package gitops
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+
+	"github.com/kninetimmy/orch/internal/paths"
+)
+
+// Worktree describes one entry of `git worktree list --porcelain`.
+type Worktree struct {
+	// Path is the canonical worktree directory.
+	Path string
+	// Branch is the checked-out branch, "" when detached.
+	Branch string
+	// Head is the checked-out commit hash.
+	Head string
+	// Detached reports a detached HEAD.
+	Detached bool
+	// Primary marks the main working tree, which is never removed.
+	Primary bool
+}
+
+// ListWorktrees returns every worktree registered with the
+// repository, primary checkout first (git guarantees that order).
+func (g *Git) ListWorktrees(ctx context.Context) ([]Worktree, error) {
+	out, err := g.git(ctx, g.root, "worktree", "list", "--porcelain")
+	if err != nil {
+		return nil, err
+	}
+	var list []Worktree
+	var cur *Worktree
+	flush := func() error {
+		if cur == nil {
+			return nil
+		}
+		canon, err := paths.Canonical(cur.Path)
+		if err != nil {
+			return err
+		}
+		cur.Path = canon
+		cur.Primary = len(list) == 0
+		list = append(list, *cur)
+		cur = nil
+		return nil
+	}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		switch {
+		case line == "":
+			if err := flush(); err != nil {
+				return nil, err
+			}
+		case strings.HasPrefix(line, "worktree "):
+			cur = &Worktree{Path: strings.TrimPrefix(line, "worktree ")}
+		case cur == nil:
+			return nil, fmt.Errorf("parse worktree list: unexpected line %q", line)
+		case strings.HasPrefix(line, "HEAD "):
+			cur.Head = strings.TrimPrefix(line, "HEAD ")
+		case strings.HasPrefix(line, "branch "):
+			cur.Branch = strings.TrimPrefix(strings.TrimPrefix(line, "branch "), "refs/heads/")
+		case line == "detached":
+			cur.Detached = true
+		}
+	}
+	if err := flush(); err != nil {
+		return nil, err
+	}
+	return list, nil
+}
+
+// AddWorktree creates branch at startPoint together with a new
+// worktree at path (PRD §12 step 7: one branch/worktree per issue).
+// It fails closed before touching git when path already exists (never
+// clobber), when path lies inside the primary checkout (worktrees are
+// isolated, PRD §5), or when the branch already exists
+// (ErrBranchExists). Never uses --force.
+func (g *Git) AddWorktree(ctx context.Context, path, branch, startPoint string) (*Worktree, error) {
+	canon, err := paths.Canonical(path)
+	if err != nil {
+		return nil, err
+	}
+	switch _, err := os.Lstat(canon); {
+	case err == nil:
+		return nil, fmt.Errorf("worktree path %s already exists; refusing to clobber it", canon)
+	case !errors.Is(err, fs.ErrNotExist):
+		return nil, fmt.Errorf("check worktree path %s: %w", canon, err)
+	}
+	inside, err := paths.Inside(g.root, canon)
+	if err != nil {
+		return nil, err
+	}
+	if inside {
+		return nil, fmt.Errorf("worktree path %s is inside the primary checkout %s; worktrees must be isolated", canon, g.root)
+	}
+	res, err := g.run(ctx, g.root, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch)
+	if err != nil {
+		return nil, err
+	}
+	if res.ExitCode == 0 {
+		return nil, fmt.Errorf("%w: %s", ErrBranchExists, branch)
+	}
+	if _, err := g.git(ctx, g.root, "worktree", "add", "-b", branch, canon, startPoint); err != nil {
+		return nil, err
+	}
+	head, err := g.RevParse(ctx, branch)
+	if err != nil {
+		return nil, err
+	}
+	return &Worktree{Path: canon, Branch: branch, Head: head}, nil
+}
+
+// Confirmation proves the caller obtained explicit human approval for
+// a destructive operation (PRD §15). The zero value fails closed;
+// only ExplicitConfirmation constructs a valid token. gitops never
+// prompts — collecting the approval is the CLI and run engine's job.
+type Confirmation struct{ ok bool }
+
+// ExplicitConfirmation returns the token that authorizes one
+// destructive gitops call. Call it only after a human approved the
+// specific deletion (PRD §15: cleanup or abandonment deletion
+// requires explicit confirmation).
+func ExplicitConfirmation() Confirmation { return Confirmation{ok: true} }
+
+// RemoveWorktree removes the registered worktree at path and prunes
+// stale metadata (PRD §12 step 19). Fail-closed gates, in order: the
+// Confirmation token must be valid (ErrNotConfirmed); the canonical
+// path must match a registered non-primary worktree
+// (ErrUnknownWorktree — never delete an arbitrary directory); and the
+// worktree must be clean including untracked files (ErrNotClean —
+// blocked work is preserved, PRD §15). Never uses --force.
+func (g *Git) RemoveWorktree(ctx context.Context, path string, c Confirmation) error {
+	if !c.ok {
+		return fmt.Errorf("%w: remove worktree %s", ErrNotConfirmed, path)
+	}
+	canon, err := paths.Canonical(path)
+	if err != nil {
+		return err
+	}
+	worktrees, err := g.ListWorktrees(ctx)
+	if err != nil {
+		return err
+	}
+	found := false
+	for _, wt := range worktrees {
+		same, err := samePath(wt.Path, canon)
+		if err != nil {
+			return err
+		}
+		if !same {
+			continue
+		}
+		if wt.Primary {
+			return fmt.Errorf("%s is the primary checkout; refusing to remove it", canon)
+		}
+		found = true
+		break
+	}
+	if !found {
+		return fmt.Errorf("%w: %s", ErrUnknownWorktree, canon)
+	}
+	if err := g.RequireClean(ctx, canon); err != nil {
+		return err
+	}
+	if _, err := g.git(ctx, g.root, "worktree", "remove", canon); err != nil {
+		return err
+	}
+	return g.PruneWorktrees(ctx)
+}
+
+// PruneWorktrees removes stale worktree bookkeeping whose directories
+// are already gone. It deletes no working files, so it needs no
+// Confirmation.
+func (g *Git) PruneWorktrees(ctx context.Context) error {
+	_, err := g.git(ctx, g.root, "worktree", "prune")
+	return err
+}

--- a/internal/gitops/worktree_test.go
+++ b/internal/gitops/worktree_test.go
@@ -1,0 +1,205 @@
+package gitops
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+)
+
+var listArgs = []string{"worktree", "list", "--porcelain"}
+
+// porcelain joins `worktree list --porcelain` lines; "" separates
+// stanzas.
+func porcelain(lines ...string) string {
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func TestListWorktrees(t *testing.T) {
+	primary := tempRoot(t)
+	feature := tempRoot(t)
+	detached := tempRoot(t)
+	g, script := openScripted(t, primary, execxtest.Call{
+		Name: "git", Args: listArgs,
+		Stdout: porcelain(
+			"worktree "+primary,
+			"HEAD 1111111111111111111111111111111111111111",
+			"branch refs/heads/main",
+			"",
+			"worktree "+feature,
+			"HEAD 2222222222222222222222222222222222222222",
+			"branch refs/heads/orch/issue-4",
+			"",
+			"worktree "+detached,
+			"HEAD 3333333333333333333333333333333333333333",
+			"detached",
+		),
+	})
+	got, err := g.ListWorktrees(context.Background())
+	script.AssertExhausted()
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+	want := []Worktree{
+		{Path: primary, Branch: "main", Head: "1111111111111111111111111111111111111111", Primary: true},
+		{Path: feature, Branch: "orch/issue-4", Head: "2222222222222222222222222222222222222222"},
+		{Path: detached, Head: "3333333333333333333333333333333333333333", Detached: true},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d worktrees, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("worktree %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestListWorktreesRejectsMalformedOutput(t *testing.T) {
+	g, script := openScripted(t, tempRoot(t), execxtest.Call{
+		Name: "git", Args: listArgs, Stdout: "HEAD before any worktree line\n",
+	})
+	_, err := g.ListWorktrees(context.Background())
+	script.AssertExhausted()
+	if err == nil || !strings.Contains(err.Error(), "unexpected line") {
+		t.Fatalf("err = %v, want parse failure", err)
+	}
+}
+
+func TestAddWorktree(t *testing.T) {
+	root := tempRoot(t)
+	path := canon(t, filepath.Join(t.TempDir(), "issue-4"))
+	const head = "4444444444444444444444444444444444444444"
+	g, script := openScripted(t, root,
+		execxtest.Call{Name: "git", Args: []string{"rev-parse", "--verify", "--quiet", "refs/heads/orch/issue-4"}, Dir: root, Exit: 1},
+		execxtest.Call{Name: "git", Args: []string{"worktree", "add", "-b", "orch/issue-4", path, "main"}, Dir: root},
+		execxtest.Call{Name: "git", Args: []string{"rev-parse", "--verify", "orch/issue-4^{commit}"}, Stdout: head + "\n"},
+	)
+	wt, err := g.AddWorktree(context.Background(), path, "orch/issue-4", "main")
+	script.AssertExhausted()
+	if err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+	want := Worktree{Path: path, Branch: "orch/issue-4", Head: head}
+	if *wt != want {
+		t.Errorf("worktree = %+v, want %+v", *wt, want)
+	}
+}
+
+func TestAddWorktreeBranchExists(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "issue-4")
+	g, script := openScripted(t, tempRoot(t), execxtest.Call{
+		// Exit 0: the branch is already there; no worktree add may follow.
+		Name: "git", Args: []string{"rev-parse", "--verify", "--quiet", "refs/heads/orch/issue-4"},
+	})
+	_, err := g.AddWorktree(context.Background(), path, "orch/issue-4", "main")
+	script.AssertExhausted()
+	if !errors.Is(err, ErrBranchExists) {
+		t.Fatalf("err = %v, want ErrBranchExists", err)
+	}
+}
+
+func TestAddWorktreeInsidePrimaryFailsClosed(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root)
+	_, err := g.AddWorktree(context.Background(), filepath.Join(root, "wt"), "orch/issue-4", "main")
+	script.AssertExhausted() // no git call was made
+	if err == nil || !strings.Contains(err.Error(), "inside the primary checkout") {
+		t.Fatalf("err = %v, want isolation refusal", err)
+	}
+}
+
+func TestAddWorktreeExistingPathFailsClosed(t *testing.T) {
+	g, script := openScripted(t, tempRoot(t))
+	existing := t.TempDir()
+	_, err := g.AddWorktree(context.Background(), existing, "orch/issue-4", "main")
+	script.AssertExhausted()
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("err = %v, want clobber refusal", err)
+	}
+}
+
+func TestRemoveWorktreeUnconfirmed(t *testing.T) {
+	g, script := openScripted(t, tempRoot(t))
+	err := g.RemoveWorktree(context.Background(), t.TempDir(), Confirmation{})
+	script.AssertExhausted() // fail closed before any git call
+	if !errors.Is(err, ErrNotConfirmed) {
+		t.Fatalf("err = %v, want ErrNotConfirmed", err)
+	}
+}
+
+func TestRemoveWorktreeUnknownPath(t *testing.T) {
+	root := tempRoot(t)
+	stray := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "git", Args: listArgs,
+		Stdout: porcelain("worktree "+root, "HEAD 1111", "branch refs/heads/main"),
+	})
+	err := g.RemoveWorktree(context.Background(), stray, ExplicitConfirmation())
+	script.AssertExhausted()
+	if !errors.Is(err, ErrUnknownWorktree) {
+		t.Fatalf("err = %v, want ErrUnknownWorktree", err)
+	}
+}
+
+func TestRemoveWorktreePrimaryRefused(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "git", Args: listArgs,
+		Stdout: porcelain("worktree "+root, "HEAD 1111", "branch refs/heads/main"),
+	})
+	err := g.RemoveWorktree(context.Background(), root, ExplicitConfirmation())
+	script.AssertExhausted()
+	if err == nil || !strings.Contains(err.Error(), "primary checkout") {
+		t.Fatalf("err = %v, want primary-checkout refusal", err)
+	}
+}
+
+func TestRemoveWorktreeDirtyPreserved(t *testing.T) {
+	root := tempRoot(t)
+	wt := tempRoot(t)
+	g, script := openScripted(t, root,
+		execxtest.Call{Name: "git", Args: listArgs, Stdout: porcelain(
+			"worktree "+root, "HEAD 1111", "branch refs/heads/main", "",
+			"worktree "+wt, "HEAD 2222", "branch refs/heads/orch/issue-4",
+		)},
+		execxtest.Call{Name: "git", Args: statusArgs, Dir: wt, Stdout: "?? partial-work.go\n"},
+	)
+	err := g.RemoveWorktree(context.Background(), wt, ExplicitConfirmation())
+	script.AssertExhausted() // no `worktree remove` followed
+	if !errors.Is(err, ErrNotClean) {
+		t.Fatalf("err = %v, want ErrNotClean", err)
+	}
+}
+
+func TestRemoveWorktree(t *testing.T) {
+	root := tempRoot(t)
+	wt := tempRoot(t)
+	g, script := openScripted(t, root,
+		execxtest.Call{Name: "git", Args: listArgs, Stdout: porcelain(
+			"worktree "+root, "HEAD 1111", "branch refs/heads/main", "",
+			"worktree "+wt, "HEAD 2222", "branch refs/heads/orch/issue-4",
+		)},
+		execxtest.Call{Name: "git", Args: statusArgs, Dir: wt},
+		execxtest.Call{Name: "git", Args: []string{"worktree", "remove", wt}, Dir: root},
+		execxtest.Call{Name: "git", Args: []string{"worktree", "prune"}, Dir: root},
+	)
+	if err := g.RemoveWorktree(context.Background(), wt, ExplicitConfirmation()); err != nil {
+		t.Fatalf("RemoveWorktree: %v", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestPruneWorktrees(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "git", Args: []string{"worktree", "prune"}, Dir: root,
+	})
+	if err := g.PruneWorktrees(context.Background()); err != nil {
+		t.Fatalf("PruneWorktrees: %v", err)
+	}
+	script.AssertExhausted()
+}


### PR DESCRIPTION
## What

Phase 1 roadmap item (memhub task 7): the git mechanics of the Delivery workflow, plus the exec-runner abstraction they run through.

- **`internal/execx`** — the injectable command runner (PRD §5, §12). Argument vectors only (never shell strings), explicit working directory required, env additions, captured stdout/stderr. Non-zero exit is *data* in `Result`, not an error, so reproduce-on-base (§16) can read exit codes as information. `execxtest.Script` is a transcript fake that pins exact argv in tests. **`internal/ghops` (task 8) will reuse this same runner for `gh`** — that is why it is its own package.
- **`internal/gitops`** — Delivery git operations (PRD §12 steps 7/18–20, §15, §16): per-issue branch+worktree creation with isolation/clobber/branch-exists pre-checks, worktree list/remove/prune, cleanliness + protected-branch + detached-HEAD gates, local/remote branch deletion, fast-forward of the primary checkout, and disposable detached base worktrees (`WithBaseWorktree`) for the "pre-existing only when reproduced on base" rule.
- **`orch doctor`** gains a `git repository` check (repo root must be the git top level), via a new injectable `Runner` field on `cli.Env` mirroring the `LookPath` idiom.

## Why / design decisions

- **Policy-free mechanism layer**: callers pass branch names, worktree paths, remotes, and protected-branch lists — naming/placement policy stays with the run engine (task 11), matching the `paths`/`lockfile` precedent. The PRD deliberately leaves those conventions open.
- **Fail closed everywhere** (§15): destructive operations require a typed `Confirmation` token whose zero value fails closed; blocked/dirty worktrees and unmerged branches are preserved; `--force` never touches user work (the single exception is removing the disposable detached base worktree, which contains no user work by construction, and a cleanup failure there is joined, never swallowed, per §16).
- **Sentinels from plumbing pre-checks** (`rev-parse --verify`, `status --porcelain`, `merge-base --is-ancestor`), never stderr parsing — git message text varies across versions. Every git call runs with `GIT_TERMINAL_PROMPT=0` (error instead of hanging on credential prompts) and `LC_ALL=C` (stable output). TOCTOU between pre-check and operation is documented as acceptable because the run engine serializes conflicting writes (§14).
- **Remote branch deletion stays in gitops** (`git push --delete`): same credential path as the push that created the branch; ghops stays purely GitHub-API.

## Testing

- Scripted transcript tests pin exact argv/dir/env for every operation and prove fail-closed short circuits (`AssertExhausted`: zero git calls after a denied gate).
- Integration tests run against real git in temp dirs (env-isolated via `GIT_CONFIG_NOSYSTEM`/`GIT_CONFIG_GLOBAL`), including the full step 18–20 flow against a local bare origin and divergence refusal with HEAD verified unchanged. Real git exists on all three CI OSes, so the matrix is the cross-platform proof.
- Verified locally on Windows: build, vet, full test suite, gofmt clean; `orch doctor` reports the new check ok in this repo.

Closes the runner-interface decision staged 2026-07-10 (transcript fakes in CI + t.TempDir() real repos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)