### PR TITLE
Add internal/ghops: GitHub operations via authenticated gh CLI

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -57,25 +58,46 @@ func testEnv(t *testing.T) (Env, *bytes.Buffer, *bytes.Buffer) {
 		Stdout:   &stdout,
 		Stderr:   &stderr,
 		LookPath: func(name string) (string, error) { return "/fake/" + name, nil },
-		Runner:   fakeGitRunner{toplevel: root},
+		Runner:   fakeRunner{toplevel: root},
 	}
 	return env, &stdout, &stderr
 }
 
-// fakeGitRunner answers `git rev-parse --show-toplevel` (the doctor
-// repository probe) with a fixed top level; exit carries a scripted
-// failure.
-type fakeGitRunner struct {
-	toplevel string
-	exit     int
-	stderr   string
+// fakeRunner answers the doctor probes: `git rev-parse
+// --show-toplevel` with a fixed top level, `gh auth status` and
+// `gh repo view` with scripted exits (zero values report healthy).
+type fakeRunner struct {
+	toplevel  string
+	gitExit   int
+	gitStderr string
+	authExit  int
+	repoExit  int
+	repoJSON  string
 }
 
-func (f fakeGitRunner) Run(context.Context, execx.Cmd) (execx.Result, error) {
-	if f.exit != 0 {
-		return execx.Result{Stderr: f.stderr, ExitCode: f.exit}, nil
+func (f fakeRunner) Run(_ context.Context, c execx.Cmd) (execx.Result, error) {
+	switch c.Name {
+	case "git":
+		if f.gitExit != 0 {
+			return execx.Result{Stderr: f.gitStderr, ExitCode: f.gitExit}, nil
+		}
+		return execx.Result{Stdout: f.toplevel + "\n"}, nil
+	case "gh":
+		switch c.Args[0] {
+		case "auth":
+			return execx.Result{ExitCode: f.authExit}, nil
+		case "repo":
+			if f.repoExit != 0 {
+				return execx.Result{Stderr: "none of the git remotes point to a known GitHub host", ExitCode: f.repoExit}, nil
+			}
+			j := f.repoJSON
+			if j == "" {
+				j = `{"nameWithOwner":"o/r","defaultBranchRef":{"name":"main"},"url":"https://github.com/o/r"}`
+			}
+			return execx.Result{Stdout: j}, nil
+		}
 	}
-	return execx.Result{Stdout: f.toplevel + "\n"}, nil
+	return execx.Result{}, fmt.Errorf("fakeRunner: unexpected command %s %v", c.Name, c.Args)
 }
 
 func writeConfig(t *testing.T, root, content string) {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/gitops"
 	"github.com/kninetimmy/orch/internal/lockfile"
 	"github.com/kninetimmy/orch/internal/state"
@@ -35,6 +36,24 @@ func runDoctor(env Env) error {
 
 	_, ghErr := env.LookPath("gh")
 	check("gh on PATH", ghErr)
+
+	if ghErr == nil {
+		gh, authErr := ghops.Open(context.Background(), env.Runner, env.RepoRoot)
+		check("gh authentication", authErr)
+		if authErr == nil {
+			repo, repoErr := gh.Repo(context.Background())
+			switch {
+			case errors.Is(repoErr, ghops.ErrNoGitHubRepo):
+				// Assist works without a remote (PRD §5); Delivery
+				// preflight fails closed on this same probe.
+				fmt.Fprintf(env.Stdout, "note  no GitHub repository resolved; Assist works without one, Delivery will fail closed (%v)\n", repoErr)
+			case repoErr != nil:
+				check("gh repository", repoErr)
+			default:
+				fmt.Fprintf(env.Stdout, "ok    gh repository: %s\n", repo.NameWithOwner)
+			}
+		}
+	}
 
 	_, cfgErr := config.Load(env.RepoRoot)
 	check("configuration", cfgErr)

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -19,17 +19,45 @@ func TestDoctorAllChecksPass(t *testing.T) {
 		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
 	}
 	out := stdout.String()
-	for _, want := range []string{"ok    git on PATH", "ok    git repository", "ok    gh on PATH", "ok    configuration"} {
+	for _, want := range []string{"ok    git on PATH", "ok    git repository", "ok    gh on PATH", "ok    gh authentication", "ok    gh repository: o/r", "ok    configuration"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q:\n%s", want, out)
 		}
 	}
 }
 
+func TestDoctorUnauthenticatedGh(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	env.Runner = fakeRunner{toplevel: env.RepoRoot, authExit: 1}
+	if code := Run([]string{"doctor"}, env); code != ExitError {
+		t.Errorf("exit = %d, want %d", code, ExitError)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "FAIL  gh authentication") {
+		t.Errorf("stdout missing auth failure:\n%s", out)
+	}
+	if strings.Contains(out, "gh repository") {
+		t.Errorf("repository probe ran without authentication:\n%s", out)
+	}
+}
+
+func TestDoctorNoGitHubRepoIsNote(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	env.Runner = fakeRunner{toplevel: env.RepoRoot, repoExit: 1}
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (Assist works without a remote)\n%s", code, ExitOK, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "note  no GitHub repository resolved") {
+		t.Errorf("stdout missing no-repo note:\n%s", stdout.String())
+	}
+}
+
 func TestDoctorNotAGitRepo(t *testing.T) {
 	env, stdout, _ := testEnv(t)
 	writeConfig(t, env.RepoRoot, validTOML)
-	env.Runner = fakeGitRunner{exit: 128, stderr: "fatal: not a git repository"}
+	env.Runner = fakeRunner{gitExit: 128, gitStderr: "fatal: not a git repository"}
 	if code := Run([]string{"doctor"}, env); code != ExitError {
 		t.Errorf("exit = %d, want %d", code, ExitError)
 	}
@@ -73,6 +101,9 @@ func TestDoctorMissingTool(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "FAIL  gh on PATH") {
 		t.Errorf("stdout missing gh failure:\n%s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "gh authentication") {
+		t.Errorf("authentication check ran without gh on PATH:\n%s", stdout.String())
 	}
 	if !strings.Contains(stdout.String(), "ok    git on PATH") {
 		t.Errorf("doctor stopped at first failure instead of running all checks:\n%s", stdout.String())

--- a/internal/execx/execxtest/script.go
+++ b/internal/execx/execxtest/script.go
@@ -6,6 +6,7 @@ package execxtest
 
 import (
 	"context"
+	"io"
 	"slices"
 	"testing"
 
@@ -23,6 +24,9 @@ type Call struct {
 	Dir string
 	// Env, when non-nil, is the expected exact Cmd.Env.
 	Env []string
+	// Stdin, when non-empty, is the expected full standard input;
+	// empty skips the check, matching the Dir convention.
+	Stdin string
 
 	// Stdout, Stderr, and Exit form the scripted Result.
 	Stdout string
@@ -62,6 +66,18 @@ func (s *Script) Run(_ context.Context, c execx.Cmd) (execx.Result, error) {
 	}
 	if want.Env != nil && !slices.Equal(c.Env, want.Env) {
 		s.T.Fatalf("call %d: %s env\ngot  %q\nwant %q", s.next, c.Name, c.Env, want.Env)
+	}
+	if want.Stdin != "" {
+		if c.Stdin == nil {
+			s.T.Fatalf("call %d: %s stdin\ngot  no stdin\nwant %q", s.next, c.Name, want.Stdin)
+		}
+		got, err := io.ReadAll(c.Stdin)
+		if err != nil {
+			s.T.Fatalf("call %d: %s stdin read: %v", s.next, c.Name, err)
+		}
+		if string(got) != want.Stdin {
+			s.T.Fatalf("call %d: %s stdin\ngot  %q\nwant %q", s.next, c.Name, got, want.Stdin)
+		}
 	}
 	if want.Err != nil {
 		return execx.Result{}, want.Err

--- a/internal/ghops/checks.go
+++ b/internal/ghops/checks.go
@@ -1,0 +1,111 @@
+package ghops
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// CIState is the PRD §16 merge-gate signal over a PR's required
+// checks.
+type CIState string
+
+// The four CI states. CINoChecks is distinct from CIPassing because
+// "if no CI exists, the plan gate states that explicitly" (PRD §16) —
+// green and absent must never be conflated.
+const (
+	CINoChecks CIState = "no-checks"
+	CIPending  CIState = "pending"
+	CIFailing  CIState = "failing"
+	CIPassing  CIState = "passing"
+)
+
+// Check is one required check on a PR.
+type Check struct {
+	Name string
+	// State is the check's own state string as reported by gh.
+	State string
+	// Bucket is gh's classification: pass, fail, pending, skipping,
+	// or cancel.
+	Bucket string
+	// Link points at the check's detail page, for the ready-to-merge
+	// report.
+	Link string
+}
+
+// CISummary reports the required-CI state of one PR: the derived
+// gate signal, the required checks as evidence (PRD §15: CI state is
+// reported honestly), and the total check count so the engine can
+// phrase "CI exists but none of it is required" explicitly.
+type CISummary struct {
+	State    CIState
+	Required []Check
+	Total    int
+}
+
+// RequiredCI reports the state of the PR's required checks. Two
+// probes: `pr view --json statusCheckRollup` distinguishes
+// no-CI-at-all (empty rollup — PRD §16's explicit no-CI statement)
+// before `pr checks --required` reads the required subset, whose
+// exit codes 0 (passing), 1 (something failed), and 8 (pending,
+// documented by gh) are all data, not errors.
+func (g *GH) RequiredCI(ctx context.Context, number int) (CISummary, error) {
+	var rollup struct {
+		StatusCheckRollup []json.RawMessage `json:"statusCheckRollup"`
+	}
+	if err := g.ghJSON(ctx, &rollup, "pr", "view", strconv.Itoa(number), "--json", "statusCheckRollup"); err != nil {
+		return CISummary{}, err
+	}
+	total := len(rollup.StatusCheckRollup)
+	if total == 0 {
+		return CISummary{State: CINoChecks}, nil
+	}
+
+	res, err := g.run(ctx, nil, "pr", "checks", strconv.Itoa(number), "--required", "--json", "name,state,bucket,link")
+	if err != nil {
+		return CISummary{}, err
+	}
+	switch res.ExitCode {
+	case 0, 1, 8:
+		// Data: 0 all passing, 1 something failed, 8 checks pending.
+	default:
+		return CISummary{}, fmt.Errorf("gh pr checks in %s exited %d: %s", g.root, res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	var decoded []struct {
+		Name   string `json:"name"`
+		State  string `json:"state"`
+		Bucket string `json:"bucket"`
+		Link   string `json:"link"`
+	}
+	if err := json.Unmarshal([]byte(res.Stdout), &decoded); err != nil {
+		return CISummary{}, fmt.Errorf("gh pr checks in %s returned unparsable JSON: %w", g.root, err)
+	}
+	required := make([]Check, len(decoded))
+	for i, c := range decoded {
+		required[i] = Check{Name: c.Name, State: c.State, Bucket: c.Bucket, Link: c.Link}
+	}
+	return CISummary{State: deriveCIState(required), Required: required, Total: total}, nil
+}
+
+// deriveCIState folds check buckets into the gate signal: any
+// fail/cancel is failing, else any pending is pending, else passing.
+// No required checks while other checks exist is no-checks — nothing
+// gates the merge, and the engine must say so rather than claim
+// green (PRD §16).
+func deriveCIState(required []Check) CIState {
+	if len(required) == 0 {
+		return CINoChecks
+	}
+	state := CIPassing
+	for _, c := range required {
+		switch c.Bucket {
+		case "fail", "cancel":
+			return CIFailing
+		case "pending":
+			state = CIPending
+		}
+	}
+	return state
+}

--- a/internal/ghops/checks_test.go
+++ b/internal/ghops/checks_test.go
@@ -1,0 +1,152 @@
+package ghops
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+)
+
+func rollupCall(root, stdout string) execxtest.Call {
+	return execxtest.Call{
+		Name:   "gh",
+		Args:   []string{"pr", "view", "43", "--json", "statusCheckRollup"},
+		Dir:    root,
+		Env:    ghTestEnv,
+		Stdout: stdout,
+	}
+}
+
+func checksCall(root, stdout string, exit int) execxtest.Call {
+	return execxtest.Call{
+		Name:   "gh",
+		Args:   []string{"pr", "checks", "43", "--required", "--json", "name,state,bucket,link"},
+		Dir:    root,
+		Env:    ghTestEnv,
+		Stdout: stdout,
+		Exit:   exit,
+	}
+}
+
+func TestRequiredCINoChecks(t *testing.T) {
+	root := tempRoot(t)
+	// Empty rollup: exactly one call — pr checks is never invoked.
+	g, script := openScripted(t, root, rollupCall(root, `{"statusCheckRollup":[]}`))
+	sum, err := g.RequiredCI(context.Background(), 43)
+	if err != nil {
+		t.Fatalf("RequiredCI: %v", err)
+	}
+	script.AssertExhausted()
+	if sum.State != CINoChecks || sum.Total != 0 || len(sum.Required) != 0 {
+		t.Errorf("sum = %+v, want no-checks", sum)
+	}
+}
+
+func TestRequiredCIPassing(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root,
+		rollupCall(root, `{"statusCheckRollup":[{},{},{}]}`),
+		checksCall(root, `[{"name":"build","state":"SUCCESS","bucket":"pass","link":"https://ci/1"},{"name":"lint","state":"SUCCESS","bucket":"pass","link":"https://ci/2"}]`, 0),
+	)
+	sum, err := g.RequiredCI(context.Background(), 43)
+	if err != nil {
+		t.Fatalf("RequiredCI: %v", err)
+	}
+	script.AssertExhausted()
+	if sum.State != CIPassing || sum.Total != 3 || len(sum.Required) != 2 {
+		t.Errorf("sum = %+v, want passing with 2 required of 3", sum)
+	}
+	if sum.Required[0].Name != "build" || sum.Required[0].Link != "https://ci/1" {
+		t.Errorf("Required[0] = %+v", sum.Required[0])
+	}
+}
+
+func TestRequiredCIPendingExit8(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root,
+		rollupCall(root, `{"statusCheckRollup":[{},{}]}`),
+		checksCall(root, `[{"name":"build","state":"IN_PROGRESS","bucket":"pending","link":""},{"name":"lint","state":"SUCCESS","bucket":"pass","link":""}]`, 8),
+	)
+	sum, err := g.RequiredCI(context.Background(), 43)
+	if err != nil {
+		t.Fatalf("RequiredCI: %v", err)
+	}
+	script.AssertExhausted()
+	if sum.State != CIPending {
+		t.Errorf("State = %q, want pending", sum.State)
+	}
+}
+
+func TestRequiredCIFailingExit1(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root,
+		rollupCall(root, `{"statusCheckRollup":[{},{}]}`),
+		checksCall(root, `[{"name":"build","state":"FAILURE","bucket":"fail","link":""},{"name":"lint","state":"IN_PROGRESS","bucket":"pending","link":""}]`, 1),
+	)
+	sum, err := g.RequiredCI(context.Background(), 43)
+	if err != nil {
+		t.Fatalf("RequiredCI: %v", err)
+	}
+	script.AssertExhausted()
+	if sum.State != CIFailing {
+		t.Errorf("State = %q, want failing (fail wins over pending)", sum.State)
+	}
+}
+
+func TestRequiredCINoneRequired(t *testing.T) {
+	root := tempRoot(t)
+	// Checks exist but none is required: no-checks with Total > 0 so
+	// the engine can say "CI exists but none of it is required".
+	g, script := openScripted(t, root,
+		rollupCall(root, `{"statusCheckRollup":[{},{}]}`),
+		checksCall(root, `[]`, 0),
+	)
+	sum, err := g.RequiredCI(context.Background(), 43)
+	if err != nil {
+		t.Fatalf("RequiredCI: %v", err)
+	}
+	script.AssertExhausted()
+	if sum.State != CINoChecks || sum.Total != 2 {
+		t.Errorf("sum = %+v, want no-checks with Total 2", sum)
+	}
+}
+
+func TestRequiredCIUnexpectedExit(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root,
+		rollupCall(root, `{"statusCheckRollup":[{}]}`),
+		checksCall(root, "", 4),
+	)
+	_, err := g.RequiredCI(context.Background(), 43)
+	script.AssertExhausted()
+	if err == nil || !strings.Contains(err.Error(), "exited 4") {
+		t.Fatalf("err = %v, want unexpected exit error", err)
+	}
+}
+
+func TestDeriveCIState(t *testing.T) {
+	tests := map[string]struct {
+		buckets []string
+		want    CIState
+	}{
+		"none":               {nil, CINoChecks},
+		"all pass":           {[]string{"pass", "pass"}, CIPassing},
+		"skipping is pass":   {[]string{"pass", "skipping"}, CIPassing},
+		"pending":            {[]string{"pass", "pending"}, CIPending},
+		"fail":               {[]string{"pass", "fail"}, CIFailing},
+		"cancel":             {[]string{"cancel"}, CIFailing},
+		"fail beats pending": {[]string{"pending", "fail"}, CIFailing},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			checks := make([]Check, len(tt.buckets))
+			for i, b := range tt.buckets {
+				checks[i] = Check{Bucket: b}
+			}
+			if got := deriveCIState(checks); got != tt.want {
+				t.Errorf("deriveCIState(%v) = %q, want %q", tt.buckets, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ghops/errors.go
+++ b/internal/ghops/errors.go
@@ -1,0 +1,24 @@
+package ghops
+
+import "errors"
+
+// Sentinel errors callers test with errors.Is. Each marks an expected
+// fail-closed condition detected by a structured check (exit codes,
+// closed enums, the Confirmation token) — never by parsing gh's
+// human-readable output, whose wording varies across versions.
+var (
+	// ErrNotAuthenticated reports that gh has no usable credentials
+	// (PRD §5: Delivery fails closed unless authentication passes).
+	ErrNotAuthenticated = errors.New("gh is not authenticated")
+	// ErrNoGitHubRepo reports that gh could not resolve a GitHub
+	// repository from this directory (PRD §5: Assist may operate
+	// without a remote; Delivery fails closed).
+	ErrNoGitHubRepo = errors.New("no GitHub repository resolved from this directory")
+	// ErrBadLabels reports labels violating the PRD §13 taxonomy:
+	// exactly one value per group, no reserved or forbidden area
+	// names (models never become GitHub labels).
+	ErrBadLabels = errors.New("labels do not satisfy the label taxonomy")
+	// ErrNotConfirmed reports a destructive operation attempted
+	// without ExplicitConfirmation (PRD §15).
+	ErrNotConfirmed = errors.New("destructive operation requires explicit confirmation")
+)

--- a/internal/ghops/ghops.go
+++ b/internal/ghops/ghops.go
@@ -1,0 +1,128 @@
+// Package ghops executes the GitHub mechanics of the Delivery
+// workflow (PRD §12 steps 6, 9, 13-17) through the authenticated gh
+// CLI (PRD §5), via an injected execx.Runner: repository resolution,
+// the PRD §13 label taxonomy, issue lifecycle, and PR open, status,
+// required-CI state, and merge.
+//
+// The package is policy-free like gitops: callers supply issue
+// titles, bodies, branch names, and label values — naming policy
+// belongs to the run engine, and issue and PR bodies (the PRD §13
+// audit record) are opaque strings here. Every operation fails
+// closed: any gh error propagates, destructive operations require an
+// explicit Confirmation (PRD §15), and merging is only ever invoked
+// after the human merge gate (PRD §8) — ghops itself never decides to
+// merge.
+//
+// Operations that pre-check and then act (for example
+// EnsureLabelTaxonomy) are not atomic; the run engine serializes
+// potentially conflicting writes (PRD §14), so the gap is not raced
+// in practice.
+package ghops
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/paths"
+)
+
+// ghEnv is applied to every gh invocation. GH_PROMPT_DISABLED makes
+// gh error instead of prompting (fail closed, never hang); the update
+// notifier and spinner are silenced so captured output holds only
+// command results; NO_COLOR and CLICOLOR keep parsed output free of
+// ANSI escapes.
+var ghEnv = []string{
+	"GH_PROMPT_DISABLED=1",
+	"GH_NO_UPDATE_NOTIFIER=1",
+	"GH_SPINNER_DISABLED=1",
+	"NO_COLOR=1",
+	"CLICOLOR=0",
+}
+
+// GH executes GitHub operations against one repository through an
+// injected execx.Runner.
+type GH struct {
+	r    execx.Runner
+	root string
+}
+
+// Open binds to the repository whose primary checkout root is
+// repoRoot and verifies gh authentication with a `gh auth status`
+// probe: a non-zero exit means no usable credentials and Open fails
+// closed with ErrNotAuthenticated (PRD §5). The exit code is the
+// structured signal — gh's human-readable status text is never
+// parsed. Repository association is checked separately by Repo,
+// because Assist may operate without a GitHub remote (PRD §5); the
+// Delivery preflight composes Open and Repo.
+func Open(ctx context.Context, r execx.Runner, repoRoot string) (*GH, error) {
+	root, err := paths.Canonical(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	g := &GH{r: r, root: root}
+	res, err := g.run(ctx, nil, "auth", "status")
+	if err != nil {
+		return nil, err
+	}
+	if res.ExitCode != 0 {
+		return nil, fmt.Errorf("%w (gh auth status exited %d)", ErrNotAuthenticated, res.ExitCode)
+	}
+	return g, nil
+}
+
+// Root returns the canonical primary-checkout root.
+func (g *GH) Root() string { return g.root }
+
+// run executes gh with the fail-closed environment and returns the
+// raw result; callers that treat non-zero exit as data use this.
+func (g *GH) run(ctx context.Context, stdin io.Reader, args ...string) (execx.Result, error) {
+	return g.r.Run(ctx, execx.Cmd{Name: "gh", Args: args, Dir: g.root, Env: ghEnv, Stdin: stdin})
+}
+
+// gh is run plus the common interpretation: a non-zero exit becomes
+// an error naming the subcommand, directory, and gh's stderr; success
+// returns trimmed stdout.
+func (g *GH) gh(ctx context.Context, args ...string) (string, error) {
+	return g.ghStdin(ctx, nil, args...)
+}
+
+// ghStdin is gh with standard input attached; issue and PR bodies
+// travel this way (--body-file -) because they can exceed
+// command-line length limits and must never be shell-quoted.
+func (g *GH) ghStdin(ctx context.Context, stdin io.Reader, args ...string) (string, error) {
+	res, err := g.run(ctx, stdin, args...)
+	if err != nil {
+		return "", err
+	}
+	if res.ExitCode != 0 {
+		return "", fmt.Errorf("gh %s in %s exited %d: %s", args[0], g.root, res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	return strings.TrimSpace(res.Stdout), nil
+}
+
+// ghJSON runs gh and unmarshals its stdout into out; the explicit
+// --json field list in args is what pins the response shape.
+func (g *GH) ghJSON(ctx context.Context, out any, args ...string) error {
+	stdout, err := g.gh(ctx, args...)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal([]byte(stdout), out); err != nil {
+		return fmt.Errorf("gh %s in %s returned unparsable JSON: %w", args[0], g.root, err)
+	}
+	return nil
+}
+
+// Confirmation is a typed approval token for destructive operations.
+// The zero value fails closed; only ExplicitConfirmation produces a
+// confirming token. ghops never prompts — collecting the human's
+// approval is the caller's job (PRD §8, §15).
+type Confirmation struct{ ok bool }
+
+// ExplicitConfirmation returns a token stating the caller obtained
+// explicit approval for a destructive operation.
+func ExplicitConfirmation() Confirmation { return Confirmation{ok: true} }

--- a/internal/ghops/ghops_test.go
+++ b/internal/ghops/ghops_test.go
@@ -1,0 +1,91 @@
+package ghops
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+	"github.com/kninetimmy/orch/internal/paths"
+)
+
+// ghTestEnv mirrors ghEnv so transcripts pin the exact fail-closed
+// environment every invocation must carry.
+var ghTestEnv = []string{
+	"GH_PROMPT_DISABLED=1",
+	"GH_NO_UPDATE_NOTIFIER=1",
+	"GH_SPINNER_DISABLED=1",
+	"NO_COLOR=1",
+	"CLICOLOR=0",
+}
+
+func canon(t *testing.T, path string) string {
+	t.Helper()
+	c, err := paths.Canonical(path)
+	if err != nil {
+		t.Fatalf("Canonical(%s): %v", path, err)
+	}
+	return c
+}
+
+func tempRoot(t *testing.T) string {
+	t.Helper()
+	return canon(t, t.TempDir())
+}
+
+// openScripted opens a GH rooted at root against a Script whose first
+// call answers Open's auth-status probe; calls holds the transcript
+// the test itself exercises.
+func openScripted(t *testing.T, root string, calls ...execxtest.Call) (*GH, *execxtest.Script) {
+	t.Helper()
+	script := &execxtest.Script{T: t, Calls: append([]execxtest.Call{{
+		Name: "gh",
+		Args: []string{"auth", "status"},
+		Dir:  root,
+		Env:  ghTestEnv,
+	}}, calls...)}
+	g, err := Open(context.Background(), script, root)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return g, script
+}
+
+func TestOpen(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root)
+	script.AssertExhausted()
+	if g.Root() != root {
+		t.Errorf("Root() = %q, want %q", g.Root(), root)
+	}
+}
+
+func TestOpenNotAuthenticated(t *testing.T) {
+	root := tempRoot(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name:   "gh",
+		Args:   []string{"auth", "status"},
+		Dir:    root,
+		Env:    ghTestEnv,
+		Stderr: "You are not logged into any GitHub hosts.",
+		Exit:   1,
+	}}}
+	_, err := Open(context.Background(), script, root)
+	if !errors.Is(err, ErrNotAuthenticated) {
+		t.Fatalf("err = %v, want ErrNotAuthenticated", err)
+	}
+}
+
+func TestOpenRunnerError(t *testing.T) {
+	root := tempRoot(t)
+	sentinel := errors.New("spawn failed")
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name: "gh",
+		Args: []string{"auth", "status"},
+		Err:  sentinel,
+	}}}
+	_, err := Open(context.Background(), script, root)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want wrapped runner error", err)
+	}
+}

--- a/internal/ghops/integration_test.go
+++ b/internal/ghops/integration_test.go
@@ -1,0 +1,67 @@
+package ghops
+
+// Live tests against a real gh binary. Everything here is
+// non-mutating: it reads auth state and repository resolution only.
+// The mutating end-to-end pass (label taxonomy, issue lifecycle, PR
+// open through merge) is a MANUAL procedure against the throwaway
+// sandbox repository, per the staged test-harness decision:
+//
+//  1. Create a scratch repo on GitHub and clone it.
+//  2. From its root: EnsureLabelTaxonomy, then CreateIssue with a
+//     full Labels set, SetStatus through each transition, CreatePR
+//     from a pushed branch, RequiredCI, MergePR with the viewed
+//     HeadRefOid, CloseIssue — confirming each result on github.com.
+//  3. Delete the scratch repo.
+//
+// CI never runs that pass; it requires authenticated gh and leaves
+// remote state behind on failure.
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx"
+)
+
+// requireGH skips unless gh is on PATH and authenticated, so the
+// live tests are inert on CI and unauthenticated machines.
+func requireGH(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("gh"); err != nil {
+		t.Skipf("gh not on PATH: %v", err)
+	}
+	res, err := (execx.Local{}).Run(context.Background(), execx.Cmd{
+		Name: "gh", Args: []string{"auth", "status"}, Dir: t.TempDir(), Env: ghEnv,
+	})
+	if err != nil || res.ExitCode != 0 {
+		t.Skip("gh is not authenticated")
+	}
+}
+
+func TestLiveOpen(t *testing.T) {
+	requireGH(t)
+	root := tempRoot(t)
+	g, err := Open(context.Background(), execx.Local{}, root)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if g.Root() != root {
+		t.Errorf("Root() = %q, want %q", g.Root(), root)
+	}
+}
+
+func TestLiveRepoNoRemote(t *testing.T) {
+	requireGH(t)
+	// A bare temp dir has no git remotes, so repository resolution
+	// must fail closed with the sentinel.
+	root := tempRoot(t)
+	g, err := Open(context.Background(), execx.Local{}, root)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if _, err := g.Repo(context.Background()); !errors.Is(err, ErrNoGitHubRepo) {
+		t.Fatalf("Repo err = %v, want ErrNoGitHubRepo", err)
+	}
+}

--- a/internal/ghops/issue.go
+++ b/internal/ghops/issue.go
@@ -1,0 +1,125 @@
+package ghops
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Issue is the read-back view of a GitHub issue.
+type Issue struct {
+	Number int
+	// State is GitHub's issue state, "OPEN" or "CLOSED".
+	State  string
+	Title  string
+	URL    string
+	Labels []string
+}
+
+// CreateIssue creates an issue carrying the full PRD §13 taxonomy.
+// The body (the audit record) is opaque to ghops and travels over
+// stdin, never the command line. Labels are validated before any gh
+// call; forbiddenAreas is the caller's model-name denylist (PRD §13:
+// models do not become GitHub labels).
+func (g *GH) CreateIssue(ctx context.Context, title, body string, labels Labels, forbiddenAreas ...string) (number int, url string, err error) {
+	flat, err := labels.flatten(forbiddenAreas...)
+	if err != nil {
+		return 0, "", err
+	}
+	args := []string{"issue", "create", "--title", title, "--body-file", "-"}
+	for _, l := range flat {
+		// One --label flag per value: gh splits the comma form on
+		// commas, which would corrupt area labels containing one.
+		args = append(args, "--label", l)
+	}
+	// With a non-TTY stdout gh prints exactly the created issue URL.
+	out, err := g.ghStdin(ctx, strings.NewReader(body), args...)
+	if err != nil {
+		return 0, "", err
+	}
+	number, err = parseNumberFromURL(out, "issues")
+	if err != nil {
+		return 0, "", err
+	}
+	return number, out, nil
+}
+
+// Issue reads one issue; the run engine uses it to confirm closure
+// (PRD §12 step 17).
+func (g *GH) Issue(ctx context.Context, number int) (Issue, error) {
+	var decoded struct {
+		Number int    `json:"number"`
+		State  string `json:"state"`
+		Title  string `json:"title"`
+		URL    string `json:"url"`
+		Labels []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+	}
+	if err := g.ghJSON(ctx, &decoded, "issue", "view", strconv.Itoa(number), "--json", "number,state,title,url,labels"); err != nil {
+		return Issue{}, err
+	}
+	if decoded.Number != number {
+		return Issue{}, fmt.Errorf("gh issue view %d in %s returned issue %d", number, g.root, decoded.Number)
+	}
+	names := make([]string, len(decoded.Labels))
+	for i, l := range decoded.Labels {
+		names[i] = l.Name
+	}
+	return Issue{Number: decoded.Number, State: decoded.State, Title: decoded.Title, URL: decoded.URL, Labels: names}, nil
+}
+
+// SetIssueBody replaces the issue body (the PRD §13 audit record is
+// updated as routing decisions and verification results accumulate).
+func (g *GH) SetIssueBody(ctx context.Context, number int, body string) error {
+	_, err := g.ghStdin(ctx, strings.NewReader(body), "issue", "edit", strconv.Itoa(number), "--body-file", "-")
+	return err
+}
+
+// SetStatus moves the issue to status to, removing every other
+// status label in one edit so the exactly-one-status invariant of
+// PRD §13 is restored even if it was violated out-of-band. Removing
+// an absent label is a no-op for gh.
+func (g *GH) SetStatus(ctx context.Context, number int, to Status) error {
+	if !memberOf(string(to), statusNames()) {
+		return fmt.Errorf("%w: status %q is not one of %s", ErrBadLabels, to, strings.Join(statusNames(), ", "))
+	}
+	args := []string{"issue", "edit", strconv.Itoa(number)}
+	for _, s := range statuses {
+		if s != to {
+			args = append(args, "--remove-label", string(s))
+		}
+	}
+	args = append(args, "--add-label", string(to))
+	_, err := g.gh(ctx, args...)
+	return err
+}
+
+// CloseIssue closes the issue. Closing is destructive bookkeeping
+// (PRD §12 step 17 confirms closure only after the merge result is
+// recorded), so it requires ExplicitConfirmation.
+func (g *GH) CloseIssue(ctx context.Context, number int, c Confirmation) error {
+	if !c.ok {
+		return fmt.Errorf("%w: close issue #%d", ErrNotConfirmed, number)
+	}
+	_, err := g.gh(ctx, "issue", "close", strconv.Itoa(number))
+	return err
+}
+
+// parseNumberFromURL extracts the trailing number from a GitHub
+// issue or PR URL, requiring the penultimate path segment to be kind
+// ("issues" or "pull"); anything unexpected fails closed rather than
+// guessing.
+func parseNumberFromURL(url, kind string) (int, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(url), "/")
+	segments := strings.Split(trimmed, "/")
+	if len(segments) < 2 || segments[len(segments)-2] != kind {
+		return 0, fmt.Errorf("cannot parse %s number from gh output %q", kind, url)
+	}
+	n, err := strconv.Atoi(segments[len(segments)-1])
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("cannot parse %s number from gh output %q", kind, url)
+	}
+	return n, nil
+}

--- a/internal/ghops/issue_test.go
+++ b/internal/ghops/issue_test.go
@@ -1,0 +1,223 @@
+package ghops
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+)
+
+func TestCreateIssue(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "gh",
+		Args: []string{
+			"issue", "create", "--title", "Add widget", "--body-file", "-",
+			"--label", "ready", "--label", "feature", "--label", "implementer", "--label", "standard",
+			"--label", "core",
+		},
+		Dir:    root,
+		Env:    ghTestEnv,
+		Stdin:  "audit record body",
+		Stdout: "https://github.com/octo/orch/issues/42\n",
+	})
+	labels := validLabels()
+	labels.Areas = []string{"core"}
+	number, url, err := g.CreateIssue(context.Background(), "Add widget", "audit record body", labels)
+	if err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+	script.AssertExhausted()
+	if number != 42 {
+		t.Errorf("number = %d, want 42", number)
+	}
+	if url != "https://github.com/octo/orch/issues/42" {
+		t.Errorf("url = %q", url)
+	}
+}
+
+func TestCreateIssueBadLabels(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root) // empty transcript: no gh call may happen
+	_, _, err := g.CreateIssue(context.Background(), "t", "b", Labels{})
+	if !errors.Is(err, ErrBadLabels) {
+		t.Fatalf("err = %v, want ErrBadLabels", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestCreateIssueForbiddenArea(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root)
+	labels := validLabels()
+	labels.Areas = []string{"opus-4-8"}
+	_, _, err := g.CreateIssue(context.Background(), "t", "b", labels, "opus-4-8")
+	if !errors.Is(err, ErrBadLabels) {
+		t.Fatalf("err = %v, want ErrBadLabels", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestCreateIssueUnparsableURL(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "gh",
+		Args: []string{
+			"issue", "create", "--title", "t", "--body-file", "-",
+			"--label", "ready", "--label", "feature", "--label", "implementer", "--label", "standard",
+		},
+		Dir:    root,
+		Env:    ghTestEnv,
+		Stdin:  "b",
+		Stdout: "something unexpected",
+	})
+	_, _, err := g.CreateIssue(context.Background(), "t", "b", validLabels())
+	script.AssertExhausted()
+	if err == nil || !strings.Contains(err.Error(), "cannot parse issues number") {
+		t.Fatalf("err = %v, want parse failure", err)
+	}
+}
+
+func TestParseNumberFromURL(t *testing.T) {
+	tests := map[string]struct {
+		url, kind string
+		want      int // 0 = expect error
+	}{
+		"issue url":            {"https://github.com/o/r/issues/7", "issues", 7},
+		"pr url":               {"https://github.com/o/r/pull/123", "pull", 123},
+		"trailing newline":     {"https://github.com/o/r/issues/7\n", "issues", 7},
+		"trailing slash":       {"https://github.com/o/r/issues/7/", "issues", 7},
+		"wrong kind":           {"https://github.com/o/r/issues/7", "pull", 0},
+		"no number":            {"https://github.com/o/r/issues/abc", "issues", 0},
+		"negative":             {"https://github.com/o/r/issues/-1", "issues", 0},
+		"zero":                 {"https://github.com/o/r/issues/0", "issues", 0},
+		"empty":                {"", "issues", 0},
+		"not a url":            {"created!", "issues", 0},
+		"kind not penultimate": {"https://github.com/o/r/issues/7/comments", "issues", 0},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := parseNumberFromURL(tt.url, tt.kind)
+			if tt.want == 0 {
+				if err == nil {
+					t.Fatalf("parseNumberFromURL(%q) = %d, want error", tt.url, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseNumberFromURL(%q): %v", tt.url, err)
+			}
+			if got != tt.want {
+				t.Errorf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIssueView(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name:   "gh",
+		Args:   []string{"issue", "view", "42", "--json", "number,state,title,url,labels"},
+		Dir:    root,
+		Env:    ghTestEnv,
+		Stdout: `{"number":42,"state":"CLOSED","title":"Add widget","url":"https://github.com/o/r/issues/42","labels":[{"name":"ready"},{"name":"feature"}]}`,
+	})
+	issue, err := g.Issue(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	script.AssertExhausted()
+	if issue.Number != 42 || issue.State != "CLOSED" || issue.Title != "Add widget" {
+		t.Errorf("issue = %+v", issue)
+	}
+	if len(issue.Labels) != 2 || issue.Labels[0] != "ready" || issue.Labels[1] != "feature" {
+		t.Errorf("labels = %v", issue.Labels)
+	}
+}
+
+func TestIssueViewNumberMismatch(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name:   "gh",
+		Args:   []string{"issue", "view", "42", "--json", "number,state,title,url,labels"},
+		Dir:    root,
+		Env:    ghTestEnv,
+		Stdout: `{"number":7,"state":"OPEN","title":"","url":"","labels":[]}`,
+	})
+	_, err := g.Issue(context.Background(), 42)
+	script.AssertExhausted()
+	if err == nil || !strings.Contains(err.Error(), "returned issue 7") {
+		t.Fatalf("err = %v, want number mismatch", err)
+	}
+}
+
+func TestSetIssueBody(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name:  "gh",
+		Args:  []string{"issue", "edit", "42", "--body-file", "-"},
+		Dir:   root,
+		Env:   ghTestEnv,
+		Stdin: "updated audit record",
+	})
+	if err := g.SetIssueBody(context.Background(), 42, "updated audit record"); err != nil {
+		t.Fatalf("SetIssueBody: %v", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestSetStatus(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "gh",
+		Args: []string{
+			"issue", "edit", "42",
+			"--remove-label", "ready", "--remove-label", "in-progress",
+			"--remove-label", "needs-human", "--remove-label", "awaiting-review",
+			"--add-label", "blocked",
+		},
+		Dir: root,
+		Env: ghTestEnv,
+	})
+	if err := g.SetStatus(context.Background(), 42, StatusBlocked); err != nil {
+		t.Fatalf("SetStatus: %v", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestSetStatusBadValue(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root) // no gh call may happen
+	err := g.SetStatus(context.Background(), 42, Status("done"))
+	if !errors.Is(err, ErrBadLabels) {
+		t.Fatalf("err = %v, want ErrBadLabels", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestCloseIssue(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "gh",
+		Args: []string{"issue", "close", "42"},
+		Dir:  root,
+		Env:  ghTestEnv,
+	})
+	if err := g.CloseIssue(context.Background(), 42, ExplicitConfirmation()); err != nil {
+		t.Fatalf("CloseIssue: %v", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestCloseIssueNotConfirmed(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root) // empty transcript proves the short circuit
+	err := g.CloseIssue(context.Background(), 42, Confirmation{})
+	if !errors.Is(err, ErrNotConfirmed) {
+		t.Fatalf("err = %v, want ErrNotConfirmed", err)
+	}
+	script.AssertExhausted()
+}

--- a/internal/ghops/labels.go
+++ b/internal/ghops/labels.go
@@ -1,0 +1,222 @@
+package ghops
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// The PRD §13 label taxonomy: every issue carries exactly one label
+// from each of the four groups, plus optional repository-defined area
+// labels. The groups are closed Go types so nothing outside these
+// values — in particular no model name (PRD §13: models do not become
+// GitHub labels) — can ever occupy a taxonomy slot.
+
+// Status is the exactly-one workflow-status label (PRD §13).
+type Status string
+
+// The five status labels.
+const (
+	StatusReady          Status = "ready"
+	StatusInProgress     Status = "in-progress"
+	StatusBlocked        Status = "blocked"
+	StatusNeedsHuman     Status = "needs-human"
+	StatusAwaitingReview Status = "awaiting-review"
+)
+
+// Type is the exactly-one change-type label (PRD §13).
+type Type string
+
+// The six type labels.
+const (
+	TypeFeature  Type = "feature"
+	TypeBug      Type = "bug"
+	TypeChore    Type = "chore"
+	TypeInfra    Type = "infra"
+	TypeDocs     Type = "docs"
+	TypeResearch Type = "research"
+)
+
+// Role is the exactly-one executor-role label (PRD §13).
+type Role string
+
+// The two role labels.
+const (
+	RoleImplementer Role = "implementer"
+	RoleSpecialist  Role = "specialist"
+)
+
+// Risk is the exactly-one risk-class label (PRD §13); risk domains
+// route to critical (PRD §11).
+type Risk string
+
+// The two risk labels.
+const (
+	RiskStandard Risk = "standard"
+	RiskCritical Risk = "critical"
+)
+
+// statuses lists all status labels in canonical order; SetStatus and
+// the taxonomy table depend on this order being stable.
+var statuses = []Status{StatusReady, StatusInProgress, StatusBlocked, StatusNeedsHuman, StatusAwaitingReview}
+
+// labelDef pins a taxonomy label's repository definition so
+// EnsureLabelTaxonomy is deterministic and transcripts are stable.
+type labelDef struct {
+	name        string
+	color       string // 6-digit hex, no leading #
+	description string
+}
+
+// taxonomy is every label EnsureLabelTaxonomy guarantees, in creation
+// order: statuses, types, roles, risks. Colors group by kind so the
+// GitHub issue list reads at a glance.
+var taxonomy = []labelDef{
+	{"ready", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
+	{"in-progress", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
+	{"blocked", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
+	{"needs-human", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
+	{"awaiting-review", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
+	{"feature", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
+	{"bug", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
+	{"chore", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
+	{"infra", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
+	{"docs", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
+	{"research", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
+	{"implementer", "5319E7", "orch role label — exactly one per issue (PRD §13)"},
+	{"specialist", "5319E7", "orch role label — exactly one per issue (PRD §13)"},
+	{"standard", "FBCA04", "orch risk label — exactly one per issue (PRD §13)"},
+	{"critical", "B60205", "orch risk label — exactly one per issue (PRD §13)"},
+}
+
+// Labels is the complete PRD §13 taxonomy for one issue: exactly one
+// value per group plus optional repository-defined area labels.
+type Labels struct {
+	Status Status
+	Type   Type
+	Role   Role
+	Risk   Risk
+	Areas  []string
+}
+
+// Validate enforces the taxonomy mechanically: each group value must
+// be a member of its closed set (a zero value fails — exactly one
+// per group), and every area label must be non-empty, unique, not a
+// reserved taxonomy name, and not equal to any caller-supplied
+// forbidden string (all case-insensitive). The run engine passes the
+// configured model names as forbidden, making PRD §13's "models do
+// not become GitHub labels" a mechanical check rather than a
+// convention. All failures wrap ErrBadLabels.
+func (l Labels) Validate(forbiddenAreas ...string) error {
+	var problems []string
+	if !memberOf(string(l.Status), statusNames()) {
+		problems = append(problems, fmt.Sprintf("status %q is not one of %s", l.Status, strings.Join(statusNames(), ", ")))
+	}
+	types := []string{string(TypeFeature), string(TypeBug), string(TypeChore), string(TypeInfra), string(TypeDocs), string(TypeResearch)}
+	if !memberOf(string(l.Type), types) {
+		problems = append(problems, fmt.Sprintf("type %q is not one of %s", l.Type, strings.Join(types, ", ")))
+	}
+	roles := []string{string(RoleImplementer), string(RoleSpecialist)}
+	if !memberOf(string(l.Role), roles) {
+		problems = append(problems, fmt.Sprintf("role %q is not one of %s", l.Role, strings.Join(roles, ", ")))
+	}
+	risks := []string{string(RiskStandard), string(RiskCritical)}
+	if !memberOf(string(l.Risk), risks) {
+		problems = append(problems, fmt.Sprintf("risk %q is not one of %s", l.Risk, strings.Join(risks, ", ")))
+	}
+	seen := map[string]bool{}
+	for _, area := range l.Areas {
+		folded := strings.ToLower(area)
+		switch {
+		case area == "":
+			problems = append(problems, "area label is empty")
+		case seen[folded]:
+			problems = append(problems, fmt.Sprintf("area %q is duplicated", area))
+		case reservedName(folded):
+			problems = append(problems, fmt.Sprintf("area %q is a reserved taxonomy label", area))
+		case matchesAny(folded, forbiddenAreas):
+			problems = append(problems, fmt.Sprintf("area %q is forbidden (models never become labels)", area))
+		}
+		seen[folded] = true
+	}
+	if len(problems) > 0 {
+		return fmt.Errorf("%w: %s", ErrBadLabels, strings.Join(problems, "; "))
+	}
+	return nil
+}
+
+// flatten validates and returns the labels in deterministic order:
+// status, type, role, risk, then areas as given.
+func (l Labels) flatten(forbiddenAreas ...string) ([]string, error) {
+	if err := l.Validate(forbiddenAreas...); err != nil {
+		return nil, err
+	}
+	out := []string{string(l.Status), string(l.Type), string(l.Role), string(l.Risk)}
+	return append(out, l.Areas...), nil
+}
+
+func statusNames() []string {
+	names := make([]string, len(statuses))
+	for i, s := range statuses {
+		names[i] = string(s)
+	}
+	return names
+}
+
+func memberOf(v string, set []string) bool {
+	for _, s := range set {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func reservedName(folded string) bool {
+	for _, def := range taxonomy {
+		if folded == def.name {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesAny(folded string, forbidden []string) bool {
+	for _, f := range forbidden {
+		if folded == strings.ToLower(f) {
+			return true
+		}
+	}
+	return false
+}
+
+// EnsureLabelTaxonomy lists the repository's labels and creates any
+// missing taxonomy label with its pinned color and description;
+// existing labels are never modified (no --force: repository
+// customizations survive). Idempotent; returns the names it created,
+// in taxonomy order, for the audit trail. The list-then-create gap is
+// not atomic; the run engine serializes conflicting writes (PRD §14).
+func (g *GH) EnsureLabelTaxonomy(ctx context.Context) ([]string, error) {
+	var existing []struct {
+		Name string `json:"name"`
+	}
+	// gh's default list limit is 30; --limit must be explicit.
+	if err := g.ghJSON(ctx, &existing, "label", "list", "--json", "name", "--limit", "1000"); err != nil {
+		return nil, err
+	}
+	present := map[string]bool{}
+	for _, l := range existing {
+		present[strings.ToLower(l.Name)] = true
+	}
+	var created []string
+	for _, def := range taxonomy {
+		if present[def.name] {
+			continue
+		}
+		if _, err := g.gh(ctx, "label", "create", def.name, "--color", def.color, "--description", def.description); err != nil {
+			return created, err
+		}
+		created = append(created, def.name)
+	}
+	return created, nil
+}

--- a/internal/ghops/labels_test.go
+++ b/internal/ghops/labels_test.go
@@ -1,0 +1,185 @@
+package ghops
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+)
+
+func validLabels() Labels {
+	return Labels{Status: StatusReady, Type: TypeFeature, Role: RoleImplementer, Risk: RiskStandard}
+}
+
+func TestLabelsValidate(t *testing.T) {
+	tests := map[string]struct {
+		labels    Labels
+		forbidden []string
+		wantErr   string // substring of the ErrBadLabels detail; empty = valid
+	}{
+		"valid minimal": {
+			labels: validLabels(),
+		},
+		"valid with areas": {
+			labels: Labels{Status: StatusAwaitingReview, Type: TypeBug, Role: RoleSpecialist, Risk: RiskCritical, Areas: []string{"core", "cli"}},
+		},
+		"missing status": {
+			labels:  Labels{Type: TypeFeature, Role: RoleImplementer, Risk: RiskStandard},
+			wantErr: `status ""`,
+		},
+		"bad status value": {
+			labels:  Labels{Status: "done", Type: TypeFeature, Role: RoleImplementer, Risk: RiskStandard},
+			wantErr: `status "done"`,
+		},
+		"bad type value": {
+			labels:  Labels{Status: StatusReady, Type: "enhancement", Role: RoleImplementer, Risk: RiskStandard},
+			wantErr: `type "enhancement"`,
+		},
+		"bad role value": {
+			labels:  Labels{Status: StatusReady, Type: TypeFeature, Role: "reviewer", Risk: RiskStandard},
+			wantErr: `role "reviewer"`,
+		},
+		"bad risk value": {
+			labels:  Labels{Status: StatusReady, Type: TypeFeature, Role: RoleImplementer, Risk: "high"},
+			wantErr: `risk "high"`,
+		},
+		"empty area": {
+			labels:  Labels{Status: StatusReady, Type: TypeFeature, Role: RoleImplementer, Risk: RiskStandard, Areas: []string{""}},
+			wantErr: "area label is empty",
+		},
+		"duplicate area case-insensitive": {
+			labels:  Labels{Status: StatusReady, Type: TypeFeature, Role: RoleImplementer, Risk: RiskStandard, Areas: []string{"Core", "core"}},
+			wantErr: "duplicated",
+		},
+		"reserved area": {
+			labels:  Labels{Status: StatusReady, Type: TypeFeature, Role: RoleImplementer, Risk: RiskStandard, Areas: []string{"Blocked"}},
+			wantErr: "reserved taxonomy label",
+		},
+		"forbidden area model name": {
+			labels:    Labels{Status: StatusReady, Type: TypeFeature, Role: RoleImplementer, Risk: RiskStandard, Areas: []string{"Opus-4-8"}},
+			forbidden: []string{"opus-4-8"},
+			wantErr:   "models never become labels",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := tt.labels.Validate(tt.forbidden...)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate: %v, want nil", err)
+				}
+				return
+			}
+			if !errors.Is(err, ErrBadLabels) {
+				t.Fatalf("err = %v, want ErrBadLabels", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("err = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+var labelListCall = execxtest.Call{
+	Name: "gh",
+	Args: []string{"label", "list", "--json", "name", "--limit", "1000"},
+}
+
+func labelJSON(names ...string) string {
+	quoted := make([]string, len(names))
+	for i, n := range names {
+		quoted[i] = `{"name":"` + n + `"}`
+	}
+	return "[" + strings.Join(quoted, ",") + "]"
+}
+
+func allTaxonomyNames() []string {
+	names := make([]string, len(taxonomy))
+	for i, def := range taxonomy {
+		names[i] = def.name
+	}
+	return names
+}
+
+func TestEnsureLabelTaxonomyAllPresent(t *testing.T) {
+	root := tempRoot(t)
+	list := labelListCall
+	list.Dir = root
+	list.Env = ghTestEnv
+	list.Stdout = labelJSON(allTaxonomyNames()...)
+	g, script := openScripted(t, root, list)
+	created, err := g.EnsureLabelTaxonomy(context.Background())
+	if err != nil {
+		t.Fatalf("EnsureLabelTaxonomy: %v", err)
+	}
+	script.AssertExhausted()
+	if len(created) != 0 {
+		t.Errorf("created = %v, want none", created)
+	}
+}
+
+func TestEnsureLabelTaxonomyCreatesMissing(t *testing.T) {
+	root := tempRoot(t)
+	// Everything present except needs-human and critical; existing
+	// names match case-insensitively (GitHub labels are).
+	var have []string
+	for _, def := range taxonomy {
+		if def.name == "needs-human" || def.name == "critical" {
+			continue
+		}
+		have = append(have, strings.ToUpper(def.name[:1])+def.name[1:])
+	}
+	list := labelListCall
+	list.Dir = root
+	list.Env = ghTestEnv
+	list.Stdout = labelJSON(have...)
+	g, script := openScripted(t, root, list,
+		execxtest.Call{
+			Name: "gh",
+			Args: []string{"label", "create", "needs-human", "--color", "1D76DB", "--description", "orch status label — exactly one per issue (PRD §13)"},
+			Dir:  root,
+			Env:  ghTestEnv,
+		},
+		execxtest.Call{
+			Name: "gh",
+			Args: []string{"label", "create", "critical", "--color", "B60205", "--description", "orch risk label — exactly one per issue (PRD §13)"},
+			Dir:  root,
+			Env:  ghTestEnv,
+		},
+	)
+	created, err := g.EnsureLabelTaxonomy(context.Background())
+	if err != nil {
+		t.Fatalf("EnsureLabelTaxonomy: %v", err)
+	}
+	script.AssertExhausted()
+	want := []string{"needs-human", "critical"}
+	if len(created) != len(want) || created[0] != want[0] || created[1] != want[1] {
+		t.Errorf("created = %v, want %v", created, want)
+	}
+}
+
+func TestEnsureLabelTaxonomyCreateFails(t *testing.T) {
+	root := tempRoot(t)
+	list := labelListCall
+	list.Dir = root
+	list.Env = ghTestEnv
+	list.Stdout = labelJSON(allTaxonomyNames()[1:]...) // "ready" missing
+	g, script := openScripted(t, root, list, execxtest.Call{
+		Name:   "gh",
+		Args:   []string{"label", "create", "ready", "--color", "1D76DB", "--description", "orch status label — exactly one per issue (PRD §13)"},
+		Dir:    root,
+		Env:    ghTestEnv,
+		Stderr: "HTTP 403: forbidden",
+		Exit:   1,
+	})
+	created, err := g.EnsureLabelTaxonomy(context.Background())
+	script.AssertExhausted()
+	if err == nil || !strings.Contains(err.Error(), "exited 1") {
+		t.Fatalf("err = %v, want create failure", err)
+	}
+	if len(created) != 0 {
+		t.Errorf("created = %v, want none", created)
+	}
+}

--- a/internal/ghops/pr.go
+++ b/internal/ghops/pr.go
@@ -1,0 +1,133 @@
+package ghops
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// PRSpec describes a PR to open. The body (the PRD §13 audit record)
+// is opaque to ghops.
+type PRSpec struct {
+	// Head is the feature branch, Base the merge target.
+	Head, Base string
+	Title      string
+	Body       string
+}
+
+// PR is the read-back view of a pull request.
+type PR struct {
+	Number int
+	// State is "OPEN", "CLOSED", or "MERGED".
+	State string
+	Title string
+	URL   string
+	// HeadRefName and BaseRefName are the branch names.
+	HeadRefName, BaseRefName string
+	// HeadRefOid is the head commit SHA the human's merge approval
+	// refers to; MergePR pins it (PRD §8).
+	HeadRefOid string
+	// MergeStateStatus is GitHub's merge-state summary, for example
+	// "CLEAN", "BLOCKED", or "DIRTY".
+	MergeStateStatus string
+	// MergedAt is the RFC3339 merge time, empty while unmerged.
+	MergedAt string
+}
+
+// mergeFlags maps the config-validated merge strategies
+// (internal/config: squash|rebase|merge-commit) to gh's merge flags.
+// ghops re-validates rather than trusting its caller.
+var mergeFlags = map[string]string{
+	"squash":       "--squash",
+	"rebase":       "--rebase",
+	"merge-commit": "--merge",
+}
+
+// CreatePR opens one PR for the issue's feature branch (PRD §12
+// step 9). The body travels over stdin, never the command line.
+func (g *GH) CreatePR(ctx context.Context, spec PRSpec) (number int, url string, err error) {
+	if spec.Head == "" || spec.Base == "" {
+		return 0, "", fmt.Errorf("pr create requires head and base branches (head %q, base %q)", spec.Head, spec.Base)
+	}
+	// With a non-TTY stdout gh prints exactly the created PR URL.
+	out, err := g.ghStdin(ctx, strings.NewReader(spec.Body),
+		"pr", "create", "--head", spec.Head, "--base", spec.Base, "--title", spec.Title, "--body-file", "-")
+	if err != nil {
+		return 0, "", err
+	}
+	number, err = parseNumberFromURL(out, "pull")
+	if err != nil {
+		return 0, "", err
+	}
+	return number, out, nil
+}
+
+// PR reads one pull request; the run engine uses it for the
+// ready-to-merge report (PRD §12 step 14) and to obtain the
+// HeadRefOid a merge approval pins.
+func (g *GH) PR(ctx context.Context, number int) (PR, error) {
+	var decoded struct {
+		Number           int    `json:"number"`
+		State            string `json:"state"`
+		Title            string `json:"title"`
+		URL              string `json:"url"`
+		HeadRefName      string `json:"headRefName"`
+		BaseRefName      string `json:"baseRefName"`
+		HeadRefOid       string `json:"headRefOid"`
+		MergeStateStatus string `json:"mergeStateStatus"`
+		MergedAt         string `json:"mergedAt"`
+	}
+	if err := g.ghJSON(ctx, &decoded, "pr", "view", strconv.Itoa(number),
+		"--json", "number,state,title,url,headRefName,baseRefName,headRefOid,mergeStateStatus,mergedAt"); err != nil {
+		return PR{}, err
+	}
+	if decoded.Number != number {
+		return PR{}, fmt.Errorf("gh pr view %d in %s returned PR %d", number, g.root, decoded.Number)
+	}
+	return PR{
+		Number:           decoded.Number,
+		State:            decoded.State,
+		Title:            decoded.Title,
+		URL:              decoded.URL,
+		HeadRefName:      decoded.HeadRefName,
+		BaseRefName:      decoded.BaseRefName,
+		HeadRefOid:       decoded.HeadRefOid,
+		MergeStateStatus: decoded.MergeStateStatus,
+		MergedAt:         decoded.MergedAt,
+	}, nil
+}
+
+// MergePR merges an approved PR with the configured strategy. It is
+// only ever invoked after the human merge gate (PRD §8) and requires
+// ExplicitConfirmation. headOID pins the commit the human approved
+// (--match-head-commit): if the PR moved after approval, gh refuses
+// and the merge fails mechanically instead of merging unreviewed
+// commits. Remote branch deletion is deliberately separate
+// (gitops.DeleteRemoteBranch, PRD §12 step 18): --delete-branch
+// would also delete the local branch and touch the invoking
+// checkout, and each destructive act carries its own confirmation.
+func (g *GH) MergePR(ctx context.Context, number int, strategy, headOID string, c Confirmation) error {
+	if !c.ok {
+		return fmt.Errorf("%w: merge PR #%d", ErrNotConfirmed, number)
+	}
+	flag, ok := mergeFlags[strategy]
+	if !ok {
+		return fmt.Errorf("unknown merge strategy %q (want squash, rebase, or merge-commit)", strategy)
+	}
+	if headOID == "" {
+		return fmt.Errorf("merge PR #%d requires the approved head commit SHA (PRD §8: approval pins one PR state)", number)
+	}
+	_, err := g.gh(ctx, "pr", "merge", strconv.Itoa(number), flag, "--match-head-commit", headOID)
+	return err
+}
+
+// ClosePR closes a PR without merging; abandoning tracked work is
+// destructive bookkeeping and requires ExplicitConfirmation.
+func (g *GH) ClosePR(ctx context.Context, number int, c Confirmation) error {
+	if !c.ok {
+		return fmt.Errorf("%w: close PR #%d", ErrNotConfirmed, number)
+	}
+	_, err := g.gh(ctx, "pr", "close", strconv.Itoa(number))
+	return err
+}

--- a/internal/ghops/pr_test.go
+++ b/internal/ghops/pr_test.go
@@ -1,0 +1,165 @@
+package ghops
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+)
+
+func TestCreatePR(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name:   "gh",
+		Args:   []string{"pr", "create", "--head", "orch/7-add-widget", "--base", "main", "--title", "Add widget", "--body-file", "-"},
+		Dir:    root,
+		Env:    ghTestEnv,
+		Stdin:  "manifest body",
+		Stdout: "https://github.com/octo/orch/pull/43\n",
+	})
+	number, url, err := g.CreatePR(context.Background(), PRSpec{
+		Head: "orch/7-add-widget", Base: "main", Title: "Add widget", Body: "manifest body",
+	})
+	if err != nil {
+		t.Fatalf("CreatePR: %v", err)
+	}
+	script.AssertExhausted()
+	if number != 43 {
+		t.Errorf("number = %d, want 43", number)
+	}
+	if url != "https://github.com/octo/orch/pull/43" {
+		t.Errorf("url = %q", url)
+	}
+}
+
+func TestCreatePRMissingBranches(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root) // no gh call may happen
+	_, _, err := g.CreatePR(context.Background(), PRSpec{Title: "t", Body: "b"})
+	script.AssertExhausted()
+	if err == nil || !strings.Contains(err.Error(), "requires head and base") {
+		t.Fatalf("err = %v, want head/base validation error", err)
+	}
+}
+
+func TestPRView(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "gh",
+		Args: []string{"pr", "view", "43", "--json", "number,state,title,url,headRefName,baseRefName,headRefOid,mergeStateStatus,mergedAt"},
+		Dir:  root,
+		Env:  ghTestEnv,
+		Stdout: `{"number":43,"state":"OPEN","title":"Add widget","url":"https://github.com/o/r/pull/43",` +
+			`"headRefName":"orch/7-add-widget","baseRefName":"main","headRefOid":"abc123",` +
+			`"mergeStateStatus":"CLEAN","mergedAt":null}`,
+	})
+	pr, err := g.PR(context.Background(), 43)
+	if err != nil {
+		t.Fatalf("PR: %v", err)
+	}
+	script.AssertExhausted()
+	if pr.Number != 43 || pr.State != "OPEN" || pr.HeadRefOid != "abc123" || pr.MergeStateStatus != "CLEAN" {
+		t.Errorf("pr = %+v", pr)
+	}
+	if pr.MergedAt != "" {
+		t.Errorf("MergedAt = %q, want empty while unmerged", pr.MergedAt)
+	}
+}
+
+func TestPRViewNumberMismatch(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name:   "gh",
+		Args:   []string{"pr", "view", "43", "--json", "number,state,title,url,headRefName,baseRefName,headRefOid,mergeStateStatus,mergedAt"},
+		Dir:    root,
+		Env:    ghTestEnv,
+		Stdout: `{"number":9,"state":"OPEN"}`,
+	})
+	_, err := g.PR(context.Background(), 43)
+	script.AssertExhausted()
+	if err == nil || !strings.Contains(err.Error(), "returned PR 9") {
+		t.Fatalf("err = %v, want number mismatch", err)
+	}
+}
+
+func TestMergePR(t *testing.T) {
+	tests := map[string]struct {
+		strategy string
+		flag     string
+	}{
+		"squash":       {"squash", "--squash"},
+		"rebase":       {"rebase", "--rebase"},
+		"merge-commit": {"merge-commit", "--merge"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			root := tempRoot(t)
+			g, script := openScripted(t, root, execxtest.Call{
+				Name: "gh",
+				Args: []string{"pr", "merge", "43", tt.flag, "--match-head-commit", "abc123"},
+				Dir:  root,
+				Env:  ghTestEnv,
+			})
+			if err := g.MergePR(context.Background(), 43, tt.strategy, "abc123", ExplicitConfirmation()); err != nil {
+				t.Fatalf("MergePR: %v", err)
+			}
+			script.AssertExhausted()
+		})
+	}
+}
+
+func TestMergePRNotConfirmed(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root) // empty transcript proves the short circuit
+	err := g.MergePR(context.Background(), 43, "squash", "abc123", Confirmation{})
+	if !errors.Is(err, ErrNotConfirmed) {
+		t.Fatalf("err = %v, want ErrNotConfirmed", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestMergePRUnknownStrategy(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root)
+	err := g.MergePR(context.Background(), 43, "octopus", "abc123", ExplicitConfirmation())
+	script.AssertExhausted()
+	if err == nil || !strings.Contains(err.Error(), `unknown merge strategy "octopus"`) {
+		t.Fatalf("err = %v, want unknown strategy error", err)
+	}
+}
+
+func TestMergePRRequiresHeadOID(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root)
+	err := g.MergePR(context.Background(), 43, "squash", "", ExplicitConfirmation())
+	script.AssertExhausted()
+	if err == nil || !strings.Contains(err.Error(), "head commit SHA") {
+		t.Fatalf("err = %v, want missing head SHA error", err)
+	}
+}
+
+func TestClosePR(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "gh",
+		Args: []string{"pr", "close", "43"},
+		Dir:  root,
+		Env:  ghTestEnv,
+	})
+	if err := g.ClosePR(context.Background(), 43, ExplicitConfirmation()); err != nil {
+		t.Fatalf("ClosePR: %v", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestClosePRNotConfirmed(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root)
+	err := g.ClosePR(context.Background(), 43, Confirmation{})
+	if !errors.Is(err, ErrNotConfirmed) {
+		t.Fatalf("err = %v, want ErrNotConfirmed", err)
+	}
+	script.AssertExhausted()
+}

--- a/internal/ghops/repo.go
+++ b/internal/ghops/repo.go
@@ -1,0 +1,52 @@
+package ghops
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Repo identifies the GitHub repository gh resolves from the primary
+// checkout's remotes.
+type Repo struct {
+	// NameWithOwner is the owner/name slug, for example "octo/orch".
+	NameWithOwner string
+	// DefaultBranch is the repository's default branch name.
+	DefaultBranch string
+	// URL is the repository's web URL.
+	URL string
+}
+
+// Repo resolves the GitHub repository from the checkout's remotes.
+// Any non-zero gh exit maps to ErrNoGitHubRepo — gh does not
+// distinguish "no remotes" from network failure by exit code, and
+// both fail Delivery closed (PRD §5); the wrapped stderr names the
+// actual cause for humans.
+func (g *GH) Repo(ctx context.Context) (Repo, error) {
+	var decoded struct {
+		NameWithOwner    string `json:"nameWithOwner"`
+		DefaultBranchRef struct {
+			Name string `json:"name"`
+		} `json:"defaultBranchRef"`
+		URL string `json:"url"`
+	}
+	res, err := g.run(ctx, nil, "repo", "view", "--json", "nameWithOwner,defaultBranchRef,url")
+	if err != nil {
+		return Repo{}, err
+	}
+	if res.ExitCode != 0 {
+		return Repo{}, fmt.Errorf("%w: %s", ErrNoGitHubRepo, strings.TrimSpace(res.Stderr))
+	}
+	if err := json.Unmarshal([]byte(res.Stdout), &decoded); err != nil {
+		return Repo{}, fmt.Errorf("gh repo view in %s returned unparsable JSON: %w", g.root, err)
+	}
+	if decoded.NameWithOwner == "" {
+		return Repo{}, fmt.Errorf("gh repo view in %s returned no nameWithOwner", g.root)
+	}
+	return Repo{
+		NameWithOwner: decoded.NameWithOwner,
+		DefaultBranch: decoded.DefaultBranchRef.Name,
+		URL:           decoded.URL,
+	}, nil
+}

--- a/internal/ghops/repo_test.go
+++ b/internal/ghops/repo_test.go
@@ -1,0 +1,84 @@
+package ghops
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+)
+
+var repoViewArgs = []string{"repo", "view", "--json", "nameWithOwner,defaultBranchRef,url"}
+
+func TestRepo(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name:   "gh",
+		Args:   repoViewArgs,
+		Dir:    root,
+		Env:    ghTestEnv,
+		Stdout: `{"nameWithOwner":"octo/orch","defaultBranchRef":{"name":"main"},"url":"https://github.com/octo/orch"}` + "\n",
+	})
+	repo, err := g.Repo(context.Background())
+	if err != nil {
+		t.Fatalf("Repo: %v", err)
+	}
+	script.AssertExhausted()
+	want := Repo{NameWithOwner: "octo/orch", DefaultBranch: "main", URL: "https://github.com/octo/orch"}
+	if repo != want {
+		t.Errorf("Repo = %+v, want %+v", repo, want)
+	}
+}
+
+func TestRepoNoRemote(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name:   "gh",
+		Args:   repoViewArgs,
+		Dir:    root,
+		Env:    ghTestEnv,
+		Stderr: "none of the git remotes configured for this repository point to a known GitHub host",
+		Exit:   1,
+	})
+	_, err := g.Repo(context.Background())
+	script.AssertExhausted()
+	if !errors.Is(err, ErrNoGitHubRepo) {
+		t.Fatalf("err = %v, want ErrNoGitHubRepo", err)
+	}
+	if !strings.Contains(err.Error(), "known GitHub host") {
+		t.Errorf("err = %v, want gh's stderr preserved", err)
+	}
+}
+
+func TestRepoBadJSON(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name:   "gh",
+		Args:   repoViewArgs,
+		Dir:    root,
+		Env:    ghTestEnv,
+		Stdout: "not json",
+	})
+	_, err := g.Repo(context.Background())
+	script.AssertExhausted()
+	if err == nil || !strings.Contains(err.Error(), "unparsable JSON") {
+		t.Fatalf("err = %v, want unparsable JSON error", err)
+	}
+}
+
+func TestRepoMissingNameWithOwner(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name:   "gh",
+		Args:   repoViewArgs,
+		Dir:    root,
+		Env:    ghTestEnv,
+		Stdout: `{"nameWithOwner":"","defaultBranchRef":{"name":"main"},"url":""}`,
+	})
+	_, err := g.Repo(context.Background())
+	script.AssertExhausted()
+	if err == nil || !strings.Contains(err.Error(), "nameWithOwner") {
+		t.Fatalf("err = %v, want missing nameWithOwner error", err)
+	}
+}


### PR DESCRIPTION
## What

Roadmap task 8 (Phase 1): `internal/ghops`, the GitHub half of the Delivery mechanics, plus a small `execxtest` extension and two new `orch doctor` checks.

- **Preflight (PRD §5):** `Open` probes `gh auth status` (exit code only — no output parsing); `Repo` resolves the GitHub repository via `gh repo view --json`. Assist works without a remote by construction; the Delivery preflight composes Open+Repo and fails closed (`ErrNotAuthenticated`, `ErrNoGitHubRepo`).
- **Label taxonomy (PRD §13):** the four exclusive groups as closed Go types (`Status`/`Type`/`Role`/`Risk`), `Labels.Validate` with a caller-supplied forbidden list so "models never become GitHub labels" is a mechanical check; `EnsureLabelTaxonomy` is idempotent and never modifies existing labels (no `--force`).
- **Issues:** create (labels validated before any gh call; body over stdin via `--body-file -`), view, body update, `SetStatus` (removes the other four status labels in one edit — self-healing exactly-one-status), Confirmation-gated close.
- **PRs (PRD §8, §12, §16):** create, view, Confirmation-gated merge with the config-validated strategy and `--match-head-commit` pinning the approved head SHA (a PR that moved after human approval fails mechanically), Confirmation-gated close. Deliberately no `--delete-branch` — remote branch deletion stays with `gitops.DeleteRemoteBranch` so each destructive act keeps its own confirmation and the worktree checkout is never touched.
- **Required CI (PRD §16):** tri-state-plus-one `CISummary` — `no-checks` is explicit and never conflated with green; `pr checks --required --json` exit codes 0/1/8 are data.
- **Doctor:** `gh authentication` (FAIL when logged out) and `gh repository` (note when unresolved — Assist-legitimate).

## Why

The run engine (task 11) needs GitHub issue/PR/CI mechanics behind the same injectable-runner, fail-closed contract gitops established in #5. Landing ghops now unblocks manifests (task 9) and routing (task 10) while keeping policy — naming, bodies, gate sequencing — out of the package.

## Testing

- Transcript tests via `execxtest.Script` pin exact argv, env, and stdin for every operation; fail-closed short-circuits proven with empty transcripts (`AssertExhausted`).
- `execxtest.Call` gained a `Stdin` assertion (bodies travel over stdin; empty skips, matching the `Dir` convention).
- Live non-mutating integration tests (`requireGH` skips unless gh is present and authenticated); verified locally against gh 2.87.3, including `orch doctor` end-to-end. Mutating e2e stays manual against the sandbox repo per the staged test-harness decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
