### PR TITLE
Fix PIDAlive reporting exited processes as alive on Windows

### DIFF
--- a/internal/lockfile/pid_windows.go
+++ b/internal/lockfile/pid_windows.go
@@ -4,13 +4,16 @@ package lockfile
 
 import (
 	"errors"
-	"os"
 	"syscall"
 )
 
 // PIDAlive reports whether a process with the given PID currently
-// exists. On Windows os.FindProcess opens a real handle, so it fails
-// when no such process exists; access-denied counts as alive (the
+// exists and has not exited. Merely opening the PID is not enough: a
+// Windows process object outlives its exit while any handle to it
+// remains open (Go itself keeps one after exec.Cmd.Wait), so an
+// exited process can still be opened. A zero-timeout wait on the
+// handle distinguishes the two: WAIT_TIMEOUT means still running,
+// signaled means exited. Access-denied on open counts as alive (the
 // process exists but is not openable). Advisory only — PIDs are
 // reused, and the acquiring orch process is expected to exit during a
 // healthy Delivery run.
@@ -18,10 +21,11 @@ func PIDAlive(pid int) bool {
 	if pid <= 0 {
 		return false
 	}
-	p, err := os.FindProcess(pid)
+	h, err := syscall.OpenProcess(syscall.SYNCHRONIZE, false, uint32(pid))
 	if err != nil {
 		return errors.Is(err, syscall.ERROR_ACCESS_DENIED)
 	}
-	_ = p.Release()
-	return true
+	defer syscall.CloseHandle(h)
+	ev, err := syscall.WaitForSingleObject(h, 0)
+	return err == nil && ev == uint32(syscall.WAIT_TIMEOUT)
 }


### PR DESCRIPTION
## What

`lockfile.PIDAlive` on Windows answered "can this PID be opened," but a Windows process object outlives its exit while any handle to it remains open — and Go itself keeps one after `exec.Cmd.Wait`. A just-exited process therefore probed as alive. The fix opens the PID with `SYNCHRONIZE` and does a zero-timeout `WaitForSingleObject`: `WAIT_TIMEOUT` means still running, signaled means exited. Access-denied on open still counts as alive, and the check remains advisory (PID reuse is documented).

## Why

`TestPIDAlive` fails deterministically on windows-latest with Go 1.26.5 (it blocked PR #6's CI twice, and reproduces locally with `-count=1`; earlier green runs were an older Go patch level plus test caching). Beyond the test, the broken probe meant `orch doctor`'s dead-acquirer note — "the lock's acquiring process is no longer running, consider `orch abort`" — could never fire on Windows. The lock's fail-closed semantics were never affected: PIDAlive is advisory audit only, and recovery is always explicit `orch abort`.

## Testing

`go test -run TestPIDAlive -count=10 ./internal/lockfile/` now passes on Windows locally (failed every run before the fix); full `lockfile` and `cli` suites pass with `-count=1`. The 3-OS CI matrix on this PR is the cross-platform verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
