### PR TITLE
Add internal/manifest: issue/PR audit manifests

### DIFF
--- a/internal/ghops/issue.go
+++ b/internal/ghops/issue.go
@@ -15,6 +15,9 @@ type Issue struct {
 	Title  string
 	URL    string
 	Labels []string
+	// Body is the raw issue body (the PRD §13 audit record), which
+	// resume/recovery parses back into run state (PRD §23).
+	Body string
 }
 
 // CreateIssue creates an issue carrying the full PRD §13 taxonomy.
@@ -56,8 +59,9 @@ func (g *GH) Issue(ctx context.Context, number int) (Issue, error) {
 		Labels []struct {
 			Name string `json:"name"`
 		} `json:"labels"`
+		Body string `json:"body"`
 	}
-	if err := g.ghJSON(ctx, &decoded, "issue", "view", strconv.Itoa(number), "--json", "number,state,title,url,labels"); err != nil {
+	if err := g.ghJSON(ctx, &decoded, "issue", "view", strconv.Itoa(number), "--json", "number,state,title,url,labels,body"); err != nil {
 		return Issue{}, err
 	}
 	if decoded.Number != number {
@@ -67,7 +71,7 @@ func (g *GH) Issue(ctx context.Context, number int) (Issue, error) {
 	for i, l := range decoded.Labels {
 		names[i] = l.Name
 	}
-	return Issue{Number: decoded.Number, State: decoded.State, Title: decoded.Title, URL: decoded.URL, Labels: names}, nil
+	return Issue{Number: decoded.Number, State: decoded.State, Title: decoded.Title, URL: decoded.URL, Labels: names, Body: decoded.Body}, nil
 }
 
 // SetIssueBody replaces the issue body (the PRD §13 audit record is

--- a/internal/ghops/issue_test.go
+++ b/internal/ghops/issue_test.go
@@ -120,10 +120,10 @@ func TestIssueView(t *testing.T) {
 	root := tempRoot(t)
 	g, script := openScripted(t, root, execxtest.Call{
 		Name:   "gh",
-		Args:   []string{"issue", "view", "42", "--json", "number,state,title,url,labels"},
+		Args:   []string{"issue", "view", "42", "--json", "number,state,title,url,labels,body"},
 		Dir:    root,
 		Env:    ghTestEnv,
-		Stdout: `{"number":42,"state":"CLOSED","title":"Add widget","url":"https://github.com/o/r/issues/42","labels":[{"name":"ready"},{"name":"feature"}]}`,
+		Stdout: `{"number":42,"state":"CLOSED","title":"Add widget","url":"https://github.com/o/r/issues/42","labels":[{"name":"ready"},{"name":"feature"}],"body":"audit record body"}`,
 	})
 	issue, err := g.Issue(context.Background(), 42)
 	if err != nil {
@@ -136,16 +136,19 @@ func TestIssueView(t *testing.T) {
 	if len(issue.Labels) != 2 || issue.Labels[0] != "ready" || issue.Labels[1] != "feature" {
 		t.Errorf("labels = %v", issue.Labels)
 	}
+	if issue.Body != "audit record body" {
+		t.Errorf("Body = %q, want the round-tripped audit record", issue.Body)
+	}
 }
 
 func TestIssueViewNumberMismatch(t *testing.T) {
 	root := tempRoot(t)
 	g, script := openScripted(t, root, execxtest.Call{
 		Name:   "gh",
-		Args:   []string{"issue", "view", "42", "--json", "number,state,title,url,labels"},
+		Args:   []string{"issue", "view", "42", "--json", "number,state,title,url,labels,body"},
 		Dir:    root,
 		Env:    ghTestEnv,
-		Stdout: `{"number":7,"state":"OPEN","title":"","url":"","labels":[]}`,
+		Stdout: `{"number":7,"state":"OPEN","title":"","url":"","labels":[],"body":""}`,
 	})
 	_, err := g.Issue(context.Background(), 42)
 	script.AssertExhausted()

--- a/internal/ghops/pr.go
+++ b/internal/ghops/pr.go
@@ -33,6 +33,9 @@ type PR struct {
 	MergeStateStatus string
 	// MergedAt is the RFC3339 merge time, empty while unmerged.
 	MergedAt string
+	// Body is the raw PR body (the PRD §13 audit record), which
+	// resume/recovery parses back into run state (PRD §23).
+	Body string
 }
 
 // mergeFlags maps the config-validated merge strategies
@@ -77,9 +80,10 @@ func (g *GH) PR(ctx context.Context, number int) (PR, error) {
 		HeadRefOid       string `json:"headRefOid"`
 		MergeStateStatus string `json:"mergeStateStatus"`
 		MergedAt         string `json:"mergedAt"`
+		Body             string `json:"body"`
 	}
 	if err := g.ghJSON(ctx, &decoded, "pr", "view", strconv.Itoa(number),
-		"--json", "number,state,title,url,headRefName,baseRefName,headRefOid,mergeStateStatus,mergedAt"); err != nil {
+		"--json", "number,state,title,url,headRefName,baseRefName,headRefOid,mergeStateStatus,mergedAt,body"); err != nil {
 		return PR{}, err
 	}
 	if decoded.Number != number {
@@ -95,6 +99,7 @@ func (g *GH) PR(ctx context.Context, number int) (PR, error) {
 		HeadRefOid:       decoded.HeadRefOid,
 		MergeStateStatus: decoded.MergeStateStatus,
 		MergedAt:         decoded.MergedAt,
+		Body:             decoded.Body,
 	}, nil
 }
 

--- a/internal/ghops/pr_test.go
+++ b/internal/ghops/pr_test.go
@@ -48,12 +48,12 @@ func TestPRView(t *testing.T) {
 	root := tempRoot(t)
 	g, script := openScripted(t, root, execxtest.Call{
 		Name: "gh",
-		Args: []string{"pr", "view", "43", "--json", "number,state,title,url,headRefName,baseRefName,headRefOid,mergeStateStatus,mergedAt"},
+		Args: []string{"pr", "view", "43", "--json", "number,state,title,url,headRefName,baseRefName,headRefOid,mergeStateStatus,mergedAt,body"},
 		Dir:  root,
 		Env:  ghTestEnv,
 		Stdout: `{"number":43,"state":"OPEN","title":"Add widget","url":"https://github.com/o/r/pull/43",` +
 			`"headRefName":"orch/7-add-widget","baseRefName":"main","headRefOid":"abc123",` +
-			`"mergeStateStatus":"CLEAN","mergedAt":null}`,
+			`"mergeStateStatus":"CLEAN","mergedAt":null,"body":"manifest body"}`,
 	})
 	pr, err := g.PR(context.Background(), 43)
 	if err != nil {
@@ -66,13 +66,16 @@ func TestPRView(t *testing.T) {
 	if pr.MergedAt != "" {
 		t.Errorf("MergedAt = %q, want empty while unmerged", pr.MergedAt)
 	}
+	if pr.Body != "manifest body" {
+		t.Errorf("Body = %q, want the round-tripped audit record", pr.Body)
+	}
 }
 
 func TestPRViewNumberMismatch(t *testing.T) {
 	root := tempRoot(t)
 	g, script := openScripted(t, root, execxtest.Call{
 		Name:   "gh",
-		Args:   []string{"pr", "view", "43", "--json", "number,state,title,url,headRefName,baseRefName,headRefOid,mergeStateStatus,mergedAt"},
+		Args:   []string{"pr", "view", "43", "--json", "number,state,title,url,headRefName,baseRefName,headRefOid,mergeStateStatus,mergedAt,body"},
 		Dir:    root,
 		Env:    ghTestEnv,
 		Stdout: `{"number":9,"state":"OPEN"}`,

--- a/internal/manifest/errors.go
+++ b/internal/manifest/errors.go
@@ -1,0 +1,23 @@
+package manifest
+
+import "errors"
+
+// Sentinel errors callers test with errors.Is. Each marks a distinct
+// fail-closed condition Parse detects structurally; specifics wrap these
+// with %w and a remediation hint (state.go style) rather than replace
+// them.
+var (
+	// ErrNoManifest reports that the body carries no manifest region:
+	// neither marker is present. Upsert treats this as "append", Parse
+	// as "nothing to read".
+	ErrNoManifest = errors.New("no manifest region in body")
+	// ErrBadManifest reports a region that is present but unusable:
+	// mispaired markers, a missing/unterminated/duplicated data comment,
+	// unparsable JSON, an unsupported schema_version, or a decoded record
+	// that fails validation.
+	ErrBadManifest = errors.New("manifest region is malformed")
+	// ErrDrift reports that the region does not match the canonical
+	// render of its own JSON record — the managed region was hand-edited
+	// inconsistently and cannot be trusted (PRD §15: fail closed).
+	ErrDrift = errors.New("manifest region does not match its canonical record")
+)

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -1,0 +1,200 @@
+// Package manifest renders and parses the PRD §13 audit record that
+// every Orch issue and PR body carries: the selected role, the exact
+// executor/reviewer model+effort, the routing rationale, escalations
+// and substitutions, the config revision, and named verification
+// commands and results. Resume/recovery (PRD §23: interrupted runs
+// resume) rebuilds run state from these posted bodies, so the record
+// must render into a managed markdown region AND parse back out
+// losslessly.
+//
+// Like gitops and ghops the package is policy-free: it owns the schema,
+// the managed region, and drift detection, while the run engine decides
+// content. It imports no config — model and effort vocabulary is
+// config's job, not this package's.
+//
+// The managed region wraps two views of one canonical record: rendered
+// human-readable markdown (PRD §23 requires the model and effort be
+// visible in bodies) and, inside an HTML comment, the canonical JSON
+// that Parse reads. Bytes outside the region are human-owned and
+// preserved verbatim by Upsert. Parse fails closed on any drift: it
+// re-renders the decoded record and byte-compares it against the found
+// region, so a hand edit to either view that is not mirrored in the
+// other is rejected. A hand edit that rewrites the JSON and the
+// markdown consistently is undetectable in v1 (no signature); the check
+// guarantees the region's internal consistency, not its provenance.
+package manifest
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// SchemaVersion is the manifest schema this build renders and parses.
+// It lives only in the JSON record (see Manifest.SchemaVersion); the
+// markers are locators, never a second source of truth.
+const SchemaVersion = 1
+
+// BeginMarker and EndMarker delimit the managed region. A line is a
+// marker only if, after stripping at most one trailing "\r", it equals
+// the marker exactly — mid-line mentions in prose are ordinary content.
+const (
+	BeginMarker = "<!-- orch:manifest:begin -->"
+	EndMarker   = "<!-- orch:manifest:end -->"
+)
+
+// dataOpen introduces the canonical-JSON comment inside the region and
+// dataClose terminates it. The JSON occupies the lines between a line
+// equal to dataOpen and the first following line equal to dataClose;
+// because dataOpen begins an HTML comment the JSON is invisible on
+// GitHub.
+const (
+	dataOpen  = "<!-- orch:manifest:data"
+	dataClose = "-->"
+)
+
+// Role is the routed agent role recorded in the audit record. The five
+// values mirror config's role set; membership is validated here, but
+// the model and effort chosen for a role are config's vocabulary.
+type Role string
+
+const (
+	RoleArchitect   Role = "architect"
+	RoleScout       Role = "scout"
+	RoleImplementer Role = "implementer"
+	RoleSpecialist  Role = "specialist"
+	RoleReviewer    Role = "reviewer"
+)
+
+// Selection is an exact model and effort pairing (PRD §13).
+type Selection struct {
+	Model  string `json:"model"`
+	Effort string `json:"effort"`
+}
+
+// Escalation records a routing change: an escalation to a stronger
+// selection or a substitution of an equivalent one. From and To are the
+// selections before and after; At is a caller-supplied RFC3339 UTC
+// timestamp (a plain string so Render never touches the clock).
+type Escalation struct {
+	Kind   string    `json:"kind"` // "escalation" | "substitution"
+	Role   Role      `json:"role,omitempty"`
+	From   Selection `json:"from"`
+	To     Selection `json:"to"`
+	Reason string    `json:"reason"`
+	At     string    `json:"at,omitempty"`
+}
+
+// Verification records one named check and its outcome. Command is
+// empty for CI-state entries that report a status without a local
+// command; Result is a free string ("pass", "CLEAN", ...).
+type Verification struct {
+	Name    string `json:"name"`
+	Command string `json:"command,omitempty"`
+	Result  string `json:"result"`
+	Detail  string `json:"detail,omitempty"`
+	At      string `json:"at,omitempty"`
+}
+
+// Manifest is the canonical audit record. SchemaVersion is first and
+// mandatory, exactly like internal/state: Render refuses to write and
+// Parse refuses to accept any other version rather than guess.
+type Manifest struct {
+	SchemaVersion    int            `json:"schema_version"`
+	Role             Role           `json:"role"`
+	Executor         Selection      `json:"executor"`
+	RoutingRationale string         `json:"routing_rationale"`
+	Reviewer         Selection      `json:"reviewer"`
+	Escalations      []Escalation   `json:"escalations,omitempty"`
+	ConfigRevision   string         `json:"config_revision"`
+	Verifications    []Verification `json:"verifications,omitempty"`
+}
+
+// validate reports the first schema-completeness violation in m. Render
+// treats a violation as a caller bug and returns it plainly; Parse
+// re-wraps a decoded record's violation as ErrBadManifest.
+func (m Manifest) validate() error {
+	if m.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("schema_version %d is unsupported (this build renders %d; regenerate the record)", m.SchemaVersion, SchemaVersion)
+	}
+	if !validRole(m.Role) {
+		return fmt.Errorf("role %q is not one of %s", m.Role, strings.Join(roleNames(), ", "))
+	}
+	if err := validateSelection("executor", m.Executor); err != nil {
+		return err
+	}
+	if err := validateSelection("reviewer", m.Reviewer); err != nil {
+		return err
+	}
+	if m.RoutingRationale == "" {
+		return errors.New("routing_rationale is empty")
+	}
+	if m.ConfigRevision == "" {
+		return errors.New("config_revision is empty")
+	}
+	for i, e := range m.Escalations {
+		if err := validateEscalation(e); err != nil {
+			return fmt.Errorf("escalations[%d]: %w", i, err)
+		}
+	}
+	for i, v := range m.Verifications {
+		if err := validateVerification(v); err != nil {
+			return fmt.Errorf("verifications[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func validateSelection(field string, s Selection) error {
+	if s.Model == "" {
+		return fmt.Errorf("%s.model is empty", field)
+	}
+	if s.Effort == "" {
+		return fmt.Errorf("%s.effort is empty", field)
+	}
+	return nil
+}
+
+func validateEscalation(e Escalation) error {
+	switch e.Kind {
+	case "escalation", "substitution":
+	default:
+		return fmt.Errorf("kind %q is not one of escalation, substitution", e.Kind)
+	}
+	if err := validateSelection("from", e.From); err != nil {
+		return err
+	}
+	if err := validateSelection("to", e.To); err != nil {
+		return err
+	}
+	if e.Reason == "" {
+		return errors.New("reason is empty")
+	}
+	return nil
+}
+
+func validateVerification(v Verification) error {
+	if v.Name == "" {
+		return errors.New("name is empty")
+	}
+	if v.Result == "" {
+		return errors.New("result is empty")
+	}
+	return nil
+}
+
+func validRole(r Role) bool {
+	switch r {
+	case RoleArchitect, RoleScout, RoleImplementer, RoleSpecialist, RoleReviewer:
+		return true
+	default:
+		return false
+	}
+}
+
+func roleNames() []string {
+	return []string{
+		string(RoleArchitect), string(RoleScout), string(RoleImplementer),
+		string(RoleSpecialist), string(RoleReviewer),
+	}
+}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1,0 +1,137 @@
+package manifest
+
+import (
+	"strings"
+	"testing"
+)
+
+// minimalManifest is a valid record with no escalations or
+// verifications — the smallest thing Render accepts.
+func minimalManifest() Manifest {
+	return Manifest{
+		SchemaVersion:    SchemaVersion,
+		Role:             RoleImplementer,
+		Executor:         Selection{Model: "opus-4-8", Effort: "high"},
+		RoutingRationale: "Selected implementer for a bounded single-file change.",
+		Reviewer:         Selection{Model: "gpt-5.6-sol", Effort: "medium"},
+		ConfigRevision:   "cfg-2026-07-10",
+	}
+}
+
+// fullManifest exercises every optional field: two escalations (an
+// escalation with a role and At, a substitution without) and three
+// verifications, the last a CI-state entry with no command.
+func fullManifest() Manifest {
+	m := minimalManifest()
+	m.Escalations = []Escalation{
+		{
+			Kind:   "escalation",
+			Role:   RoleImplementer,
+			From:   Selection{Model: "sonnet-4-8", Effort: "medium"},
+			To:     Selection{Model: "opus-4-8", Effort: "high"},
+			Reason: "Repeated test failures on the concurrency path.",
+			At:     "2026-07-10T14:03:00Z",
+		},
+		{
+			Kind:   "substitution",
+			From:   Selection{Model: "opus-4-8", Effort: "high"},
+			To:     Selection{Model: "opus-4-8", Effort: "medium"},
+			Reason: "Downgraded effort after the fix landed.",
+		},
+	}
+	m.Verifications = []Verification{
+		{Name: "targeted-tests", Command: "go test ./internal/manifest/...", Result: "pass", At: "2026-07-10T14:20:00Z"},
+		{Name: "vet", Command: "go vet ./...", Result: "pass", Detail: "no findings"},
+		{Name: "ci", Result: "CLEAN", Detail: "required checks green", At: "2026-07-10T14:45:00Z"},
+	}
+	return m
+}
+
+// hostileManifest packs marker-forging and markdown-breaking content
+// into every free-text field: a rationale containing "-->", a line
+// equal to EndMarker, a CRLF pair, and a <script> tag; a command with
+// backticks, pipes, and an ampersand; a model with a pipe; a config
+// revision with all three entity characters; an escalation whose reason
+// is a data-close and whose At smuggles a begin-marker line; and a
+// verification whose name, result, and At each smuggle a marker or
+// data-comment line. Render must escape all of it so the region still
+// contains exactly one of each structural line and parses back.
+func hostileManifest() Manifest {
+	return Manifest{
+		SchemaVersion: SchemaVersion,
+		Role:          RoleReviewer,
+		Executor:      Selection{Model: "weird|model", Effort: "high"},
+		RoutingRationale: "Rationale with a marker attempt -->\r\n" +
+			EndMarker + "\n" +
+			"and a <script>alert(1)</script> tag.",
+		Reviewer:       Selection{Model: "opus-4-8", Effort: "low"},
+		ConfigRevision: "rev&<>",
+		Escalations: []Escalation{
+			{
+				Kind:   "escalation",
+				From:   Selection{Model: "sonnet-4-8", Effort: "low"},
+				To:     Selection{Model: "opus-4-8", Effort: "high"},
+				Reason: "reason ending in " + dataClose,
+				At:     "2026-07-10T00:00:00Z\n" + BeginMarker,
+			},
+		},
+		Verifications: []Verification{
+			{
+				Name:    "targeted-tests\n" + EndMarker,
+				Command: "go test -run 'A|B' ./... `backtick` && echo done",
+				Result:  "pass\n" + dataOpen,
+				At:      "2026-07-10T14:20:00Z\n" + dataClose,
+			},
+		},
+	}
+}
+
+func TestValidateRejects(t *testing.T) {
+	tests := map[string]struct {
+		mutate func(*Manifest)
+		want   string
+	}{
+		"bad schema version":        {func(m *Manifest) { m.SchemaVersion = 2 }, "schema_version 2 is unsupported"},
+		"absent schema version":     {func(m *Manifest) { m.SchemaVersion = 0 }, "schema_version 0 is unsupported"},
+		"unknown role":              {func(m *Manifest) { m.Role = "wizard" }, `role "wizard" is not one of`},
+		"empty executor model":      {func(m *Manifest) { m.Executor.Model = "" }, "executor.model is empty"},
+		"empty executor effort":     {func(m *Manifest) { m.Executor.Effort = "" }, "executor.effort is empty"},
+		"empty reviewer model":      {func(m *Manifest) { m.Reviewer.Model = "" }, "reviewer.model is empty"},
+		"empty reviewer effort":     {func(m *Manifest) { m.Reviewer.Effort = "" }, "reviewer.effort is empty"},
+		"empty rationale":           {func(m *Manifest) { m.RoutingRationale = "" }, "routing_rationale is empty"},
+		"empty config revision":     {func(m *Manifest) { m.ConfigRevision = "" }, "config_revision is empty"},
+		"bad escalation kind":       {func(m *Manifest) { m.Escalations[0].Kind = "demotion" }, `escalations[0]: kind "demotion" is not one of`},
+		"escalation empty from":     {func(m *Manifest) { m.Escalations[0].From.Model = "" }, "escalations[0]: from.model is empty"},
+		"escalation empty to":       {func(m *Manifest) { m.Escalations[1].To.Effort = "" }, "escalations[1]: to.effort is empty"},
+		"escalation empty reason":   {func(m *Manifest) { m.Escalations[0].Reason = "" }, "escalations[0]: reason is empty"},
+		"verification empty name":   {func(m *Manifest) { m.Verifications[2].Name = "" }, "verifications[2]: name is empty"},
+		"verification empty result": {func(m *Manifest) { m.Verifications[0].Result = "" }, "verifications[0]: result is empty"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			m := fullManifest()
+			tt.mutate(&m)
+			_, err := Render(m)
+			if err == nil {
+				t.Fatalf("Render succeeded, want validation error mentioning %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("error %q does not mention %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateAcceptsFixtures(t *testing.T) {
+	for name, m := range map[string]Manifest{
+		"minimal": minimalManifest(),
+		"full":    fullManifest(),
+		"hostile": hostileManifest(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := m.validate(); err != nil {
+				t.Fatalf("validate: %v", err)
+			}
+		})
+	}
+}

--- a/internal/manifest/parse.go
+++ b/internal/manifest/parse.go
@@ -1,0 +1,142 @@
+package manifest
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Parse locates the managed region in body, decodes its canonical JSON,
+// and fails closed on any drift. It returns ErrNoManifest when no region
+// is present, ErrBadManifest when the region is present but unusable
+// (mispaired markers, a broken data comment, unparsable JSON, an
+// unsupported schema_version, or a record that fails validation), and
+// ErrDrift when the region does not byte-match the canonical render of
+// its own decoded record.
+//
+// Only the extracted region is CRLF-normalized ("\r\n"→"\n") before the
+// decode and drift compare; bytes outside the region are never touched.
+// A lone "\r" inside the region survives normalization and fails the
+// compare, which is the intended fail-closed behavior.
+func Parse(body string) (Manifest, error) {
+	lines := splitLines(body)
+	loc, err := locate(lines)
+	if err != nil {
+		return Manifest{}, err
+	}
+
+	region := regionText(body, lines, loc)
+	jsonText, err := extractData(region)
+	if err != nil {
+		return Manifest{}, err
+	}
+
+	var m Manifest
+	if err := json.Unmarshal([]byte(jsonText), &m); err != nil {
+		return Manifest{}, fmt.Errorf("%w: decode JSON: %v", ErrBadManifest, err)
+	}
+	if err := m.validate(); err != nil {
+		return Manifest{}, fmt.Errorf("%w: %v", ErrBadManifest, err)
+	}
+
+	rendered, err := Render(m)
+	if err != nil {
+		// Unreachable: validate already passed. Fail closed regardless.
+		return Manifest{}, fmt.Errorf("%w: %v", ErrBadManifest, err)
+	}
+	if region != rendered {
+		return Manifest{}, fmt.Errorf("%w (the managed region was hand-edited; regenerate it from the run record)", ErrDrift)
+	}
+	return m, nil
+}
+
+// line is one physical line of the body: its start byte offset, its text
+// up to but excluding the terminating "\n" (a trailing "\r" is kept so
+// marker matching can strip it), and the offset just past the "\n" (or
+// the end of body for a final line without a newline).
+type line struct {
+	start   int
+	text    string
+	fullEnd int
+}
+
+// splitLines splits body on "\n". A final "\n" does not yield a trailing
+// empty line; an empty body yields no lines.
+func splitLines(body string) []line {
+	var lines []line
+	start := 0
+	for i := 0; i < len(body); i++ {
+		if body[i] == '\n' {
+			lines = append(lines, line{start: start, text: body[start:i], fullEnd: i + 1})
+			start = i + 1
+		}
+	}
+	if start < len(body) {
+		lines = append(lines, line{start: start, text: body[start:], fullEnd: len(body)})
+	}
+	return lines
+}
+
+// location is the line indices of the begin and end markers bounding the
+// single valid region.
+type location struct{ begin, end int }
+
+// locate finds the one begin marker preceding the one end marker.
+// Zero markers is ErrNoManifest; any other count or ordering is
+// ErrBadManifest.
+func locate(lines []line) (location, error) {
+	var begins, ends []int
+	for i, l := range lines {
+		switch strings.TrimSuffix(l.text, "\r") {
+		case BeginMarker:
+			begins = append(begins, i)
+		case EndMarker:
+			ends = append(ends, i)
+		}
+	}
+	if len(begins) == 0 && len(ends) == 0 {
+		return location{}, ErrNoManifest
+	}
+	if len(begins) == 1 && len(ends) == 1 && begins[0] < ends[0] {
+		return location{begin: begins[0], end: ends[0]}, nil
+	}
+	return location{}, fmt.Errorf("%w: found %d begin and %d end markers (want exactly one begin marker before one end marker)", ErrBadManifest, len(begins), len(ends))
+}
+
+// regionText returns the region — from the begin marker's first byte
+// through the end marker's last byte, excluding the end marker's line
+// terminator — with its interior CRLF pairs normalized to LF. The result
+// is directly comparable to Render output, which carries no trailing
+// newline.
+func regionText(body string, lines []line, loc location) string {
+	start := lines[loc.begin].start
+	end := lines[loc.end].start + len(EndMarker)
+	return strings.ReplaceAll(body[start:end], "\r\n", "\n")
+}
+
+// extractData returns the canonical JSON text from a normalized region:
+// the lines between the single dataOpen line and the first following
+// dataClose line. Missing, unterminated, or duplicated data comments are
+// ErrBadManifest.
+func extractData(region string) (string, error) {
+	rlines := strings.Split(region, "\n")
+	openCount, openIdx := 0, -1
+	for i, l := range rlines {
+		if l == dataOpen {
+			openCount++
+			openIdx = i
+		}
+	}
+	if openCount == 0 {
+		return "", fmt.Errorf("%w: missing %q data comment", ErrBadManifest, dataOpen)
+	}
+	if openCount > 1 {
+		return "", fmt.Errorf("%w: %d %q data comments (want exactly one)", ErrBadManifest, openCount, dataOpen)
+	}
+	for i := openIdx + 1; i < len(rlines); i++ {
+		if rlines[i] == dataClose {
+			return strings.Join(rlines[openIdx+1:i], "\n"), nil
+		}
+	}
+	return "", fmt.Errorf("%w: unterminated data comment (no %q line after %q)", ErrBadManifest, dataClose, dataOpen)
+}

--- a/internal/manifest/parse_test.go
+++ b/internal/manifest/parse_test.go
@@ -1,0 +1,215 @@
+package manifest
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// mustRender renders m or fails the test.
+func mustRender(t *testing.T, m Manifest) string {
+	t.Helper()
+	s, err := Render(m)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	return s
+}
+
+// equalManifest compares two manifests treating nil and empty slices as
+// equal, since omitempty makes Parse(Render(m)) return nil where the
+// input held empty non-nil slices.
+func equalManifest(a, b Manifest) bool {
+	na := a
+	nb := b
+	if len(na.Escalations) == 0 {
+		na.Escalations = nil
+	}
+	if len(nb.Escalations) == 0 {
+		nb.Escalations = nil
+	}
+	if len(na.Verifications) == 0 {
+		na.Verifications = nil
+	}
+	if len(nb.Verifications) == 0 {
+		nb.Verifications = nil
+	}
+	return reflect.DeepEqual(na, nb)
+}
+
+func TestParseRoundTrip(t *testing.T) {
+	for name, m := range map[string]Manifest{
+		"minimal": minimalManifest(),
+		"full":    fullManifest(),
+		"hostile": hostileManifest(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := Parse(mustRender(t, m))
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			if !equalManifest(got, m) {
+				t.Errorf("round trip mismatch\n got %+v\nwant %+v", got, m)
+			}
+		})
+	}
+}
+
+func TestParseEmptySlicesBecomeNil(t *testing.T) {
+	m := minimalManifest()
+	m.Escalations = []Escalation{}
+	m.Verifications = []Verification{}
+	got, err := Parse(mustRender(t, m))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got.Escalations != nil {
+		t.Errorf("Escalations = %v, want nil", got.Escalations)
+	}
+	if got.Verifications != nil {
+		t.Errorf("Verifications = %v, want nil", got.Verifications)
+	}
+}
+
+func TestParseRegionPosition(t *testing.T) {
+	region := mustRender(t, fullManifest())
+	cases := map[string]string{
+		"whole body": region,
+		"at start":   region + "\n\ntrailing human notes\n",
+		"at end":     "leading human notes\n\n" + region,
+		"mid body":   "leading\n\n" + region + "\n\ntrailing\n",
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := Parse(body)
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			if !equalManifest(got, fullManifest()) {
+				t.Errorf("mismatch: %+v", got)
+			}
+		})
+	}
+}
+
+func TestParseNoManifest(t *testing.T) {
+	cases := map[string]string{
+		"empty":           "",
+		"plain text":      "Just some issue body with no audit record.\n",
+		"mid-line begin":  "See <!-- orch:manifest:begin --> mentioned inline.\n",
+		"mid-line end":    "prefix " + EndMarker + " suffix\n",
+		"marker in words": "The manifest:begin marker is documented elsewhere.\n",
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := Parse(body)
+			if !errors.Is(err, ErrNoManifest) {
+				t.Fatalf("err = %v, want ErrNoManifest", err)
+			}
+		})
+	}
+}
+
+func TestParseBadManifest(t *testing.T) {
+	valid := mustRender(t, minimalManifest())
+	cases := map[string]string{
+		"unpaired begin":       BeginMarker + "\n### body\n",
+		"unpaired end":         "### body\n" + EndMarker + "\n",
+		"duplicated begin":     BeginMarker + "\n" + valid + "\n",
+		"reversed markers":     EndMarker + "\nbody\n" + BeginMarker + "\n",
+		"missing data comment": BeginMarker + "\n### Orch audit record\n" + EndMarker,
+		"unterminated data":    BeginMarker + "\n" + dataOpen + "\n{}\n" + EndMarker,
+		"double data comment":  BeginMarker + "\n" + dataOpen + "\n{}\n" + dataClose + "\n" + dataOpen + "\n{}\n" + dataClose + "\n" + EndMarker,
+		"bad json":             BeginMarker + "\n" + dataOpen + "\nthis is not json\n" + dataClose + "\n" + EndMarker,
+		"schema version zero":  tamperJSON(valid, `"schema_version": 1`, `"schema_version": 0`),
+		"schema version two":   tamperJSON(valid, `"schema_version": 1`, `"schema_version": 2`),
+		"schema absent":        BeginMarker + "\n" + dataOpen + "\n{\"role\":\"implementer\"}\n" + dataClose + "\n" + EndMarker,
+		"invalid record":       tamperJSON(valid, `"role": "implementer"`, `"role": "wizard"`),
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := Parse(body)
+			if !errors.Is(err, ErrBadManifest) {
+				t.Fatalf("err = %v, want ErrBadManifest", err)
+			}
+		})
+	}
+}
+
+func TestParseDrift(t *testing.T) {
+	base := mustRender(t, fullManifest())
+	cases := map[string]string{
+		"markdown char changed": strings.Replace(base, "| Role |", "| role |", 1),
+		"blank line inserted":   strings.Replace(base, "### Orch audit record\n", "### Orch audit record\n\n", 1),
+		"sentence inserted":     strings.Replace(base, "**Verification:**", "An extra human sentence.\n\n**Verification:**", 1),
+		"json keys reordered": strings.Replace(base,
+			"{\n  \"schema_version\": 1,\n  \"role\": \"implementer\",",
+			"{\n  \"role\": \"implementer\",\n  \"schema_version\": 1,", 1),
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			if body == base {
+				t.Fatal("test setup did not change the body")
+			}
+			_, err := Parse(body)
+			if !errors.Is(err, ErrDrift) {
+				t.Fatalf("err = %v, want ErrDrift", err)
+			}
+		})
+	}
+}
+
+func TestParseCRLF(t *testing.T) {
+	base := mustRender(t, fullManifest())
+	lead, trail := "intro line\n\n", "\n\ntrailing line\n"
+	crlf := func(s string) string { return strings.ReplaceAll(s, "\n", "\r\n") }
+
+	// Split the region into its human markdown and its data comment so
+	// one case can carry CRLF only in the human content.
+	idx := strings.Index(base, "\n"+dataOpen)
+	if idx < 0 {
+		t.Fatal("could not locate data comment in region")
+	}
+	human, data := base[:idx], base[idx:]
+
+	pass := map[string]string{
+		"whole body crlf":    crlf(lead + base + trail),
+		"region only crlf":   lead + crlf(base) + trail,
+		"human content crlf": lead + crlf(human) + data + trail,
+	}
+	for name, body := range pass {
+		t.Run(name, func(t *testing.T) {
+			got, err := Parse(body)
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			if !equalManifest(got, fullManifest()) {
+				t.Errorf("mismatch: %+v", got)
+			}
+		})
+	}
+
+	t.Run("lone carriage return fails", func(t *testing.T) {
+		// A bare CR inside a human line survives normalization (it is not
+		// part of a CRLF pair) and fails the drift compare.
+		body := strings.Replace(base, "bounded single-file", "bounded\rsingle-file", 1)
+		if body == base {
+			t.Fatal("test setup did not insert a carriage return")
+		}
+		_, err := Parse(body)
+		if !errors.Is(err, ErrDrift) {
+			t.Fatalf("err = %v, want ErrDrift", err)
+		}
+	})
+}
+
+// tamperJSON replaces old with new in body, requiring the swap to change
+// something so a test cannot silently pass on an unchanged body.
+func tamperJSON(body, old, new string) string {
+	out := strings.Replace(body, old, new, 1)
+	if out == body {
+		panic("tamperJSON: substring not found: " + old)
+	}
+	return out
+}

--- a/internal/manifest/render.go
+++ b/internal/manifest/render.go
@@ -1,0 +1,197 @@
+package manifest
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Render returns the full managed region for m as a single LF-terminated
+// block with no trailing newline. It is a pure function of m — it never
+// reads the clock — which is what makes Parse's drift check sound: the
+// same m always yields the same bytes. It validates m first (an invalid
+// manifest is a caller bug, reported plainly) and emits, in order, the
+// begin marker, the human-readable markdown, the canonical-JSON data
+// comment, and the end marker.
+func Render(m Manifest) (string, error) {
+	if err := m.validate(); err != nil {
+		return "", fmt.Errorf("render manifest: %w", err)
+	}
+	// json.MarshalIndent keeps its default HTML escaping ON: "<", ">",
+	// and "&" encode as \u003c, \u003e, \u0026, so no string field can
+	// emit a literal "-->" or forge a marker inside the data comment.
+	// Never swap this for a json.Encoder with SetEscapeHTML(false).
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("render manifest: encode JSON: %w", err)
+	}
+
+	var b strings.Builder
+	b.WriteString(BeginMarker)
+	b.WriteByte('\n')
+	writeHuman(&b, m)
+	b.WriteByte('\n')
+	b.WriteString(dataOpen)
+	b.WriteByte('\n')
+	b.Write(data)
+	b.WriteByte('\n')
+	b.WriteString(dataClose)
+	b.WriteByte('\n')
+	b.WriteString(EndMarker)
+	return b.String(), nil
+}
+
+// writeHuman renders the human-readable markdown between the begin
+// marker and the data comment. Its shape is fixed: a heading, a summary
+// table, the routing rationale as a paragraph (never a table cell), then
+// the escalations and verifications sections, each always present so the
+// layout is deterministic.
+func writeHuman(b *strings.Builder, m Manifest) {
+	b.WriteString("### Orch audit record\n\n")
+	b.WriteString("| Field | Value |\n")
+	b.WriteString("| --- | --- |\n")
+	fmt.Fprintf(b, "| Role | %s |\n", mdCodeCell(string(m.Role)))
+	fmt.Fprintf(b, "| Executor | %s — effort %s |\n", mdCodeCell(m.Executor.Model), mdCodeCell(m.Executor.Effort))
+	fmt.Fprintf(b, "| Reviewer | %s — effort %s |\n", mdCodeCell(m.Reviewer.Model), mdCodeCell(m.Reviewer.Effort))
+	fmt.Fprintf(b, "| Config revision | %s |\n", mdCodeCell(m.ConfigRevision))
+	b.WriteByte('\n')
+	fmt.Fprintf(b, "**Routing rationale:** %s\n", mdText(m.RoutingRationale))
+	b.WriteByte('\n')
+	writeEscalations(b, m.Escalations)
+	b.WriteByte('\n')
+	writeVerifications(b, m.Verifications)
+}
+
+func writeEscalations(b *strings.Builder, es []Escalation) {
+	if len(es) == 0 {
+		b.WriteString("**Escalations:** _none_\n")
+		return
+	}
+	b.WriteString("**Escalations:**\n")
+	for _, e := range es {
+		b.WriteString(escalationBullet(e))
+		b.WriteByte('\n')
+	}
+}
+
+// escalationBullet renders one escalation as a single list line:
+//
+//   - <At> — <kind> (<role>): `from` (effort `e`) → `to` (effort `e`) — <reason>
+//
+// The "<At> — " prefix and the "(<role>)" segment are omitted when their
+// fields are empty.
+func escalationBullet(e Escalation) string {
+	var b strings.Builder
+	b.WriteString("- ")
+	if e.At != "" {
+		b.WriteString(mdText(e.At))
+		b.WriteString(" — ")
+	}
+	b.WriteString(e.Kind)
+	if e.Role != "" {
+		fmt.Fprintf(&b, " (%s)", e.Role)
+	}
+	fmt.Fprintf(&b, ": %s (effort %s) → %s (effort %s) — %s",
+		mdCode(e.From.Model), mdCode(e.From.Effort),
+		mdCode(e.To.Model), mdCode(e.To.Effort),
+		mdText(e.Reason))
+	return b.String()
+}
+
+func writeVerifications(b *strings.Builder, vs []Verification) {
+	if len(vs) == 0 {
+		b.WriteString("**Verification:** _none_\n")
+		return
+	}
+	b.WriteString("**Verification:**\n")
+	for _, v := range vs {
+		b.WriteString(verificationBullet(v))
+		b.WriteByte('\n')
+	}
+}
+
+// verificationBullet renders one verification as a single list line:
+//
+//   - **<name>** — <result> — `<command>` — <detail> (<at>)
+//
+// The command, detail, and timestamp segments are omitted when their
+// fields are empty.
+func verificationBullet(v Verification) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "- **%s** — %s", mdText(v.Name), mdText(v.Result))
+	if v.Command != "" {
+		fmt.Fprintf(&b, " — %s", mdCode(v.Command))
+	}
+	if v.Detail != "" {
+		fmt.Fprintf(&b, " — %s", mdText(v.Detail))
+	}
+	if v.At != "" {
+		fmt.Fprintf(&b, " (%s)", mdText(v.At))
+	}
+	return b.String()
+}
+
+// mdText escapes every free-text value bound for the human section
+// (rationale, reason, detail, verification names and results, At
+// timestamps) so no rendered line can equal a marker: "&", "<", ">"
+// become entities (ampersand first, so the entity ampersands are not
+// re-escaped), and raw carriage returns are dropped so Render output
+// stays LF-only even when a field value carries CRLF (the JSON record
+// still preserves the original value). A "-->" becomes "--&gt;" and
+// "<!-- ... -->" loses its opening angle bracket, so injected text can
+// neither forge a data-close nor a begin/end marker.
+func mdText(s string) string {
+	s = strings.ReplaceAll(s, "\r", "")
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	return s
+}
+
+// mdCode renders an identifier (model, effort, command) as an inline
+// code span safe outside a table cell.
+func mdCode(s string) string {
+	return codeSpan(s, false)
+}
+
+// mdCodeCell renders an identifier as an inline code span safe inside a
+// GFM table cell: pipes are backslash-escaped so the row is not split.
+func mdCodeCell(s string) string {
+	return codeSpan(s, true)
+}
+
+// codeSpan wraps s in a CommonMark inline code span. Newlines collapse
+// to spaces (a code span is single-line); the backtick fence is one
+// longer than the longest backtick run in s so any interior backticks
+// are literal; and the content is space-padded when it starts or ends
+// with a backtick so the fence is unambiguous. In a table cell pipes are
+// escaped to "\|", which GFM unescapes to a literal pipe inside the span.
+func codeSpan(s string, inTable bool) string {
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	if inTable {
+		s = strings.ReplaceAll(s, "|", `\|`)
+	}
+	fence := strings.Repeat("`", longestBacktickRun(s)+1)
+	pad := ""
+	if strings.HasPrefix(s, "`") || strings.HasSuffix(s, "`") {
+		pad = " "
+	}
+	return fence + pad + s + pad + fence
+}
+
+func longestBacktickRun(s string) int {
+	longest, cur := 0, 0
+	for _, r := range s {
+		if r == '`' {
+			cur++
+			if cur > longest {
+				longest = cur
+			}
+		} else {
+			cur = 0
+		}
+	}
+	return longest
+}

--- a/internal/manifest/render_test.go
+++ b/internal/manifest/render_test.go
@@ -1,0 +1,90 @@
+package manifest
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// update regenerates the golden files instead of comparing against them.
+// The goldens are written with LF only; .gitattributes pins *.md to
+// eol=lf so they check out identically on every OS and the byte compare
+// below holds.
+var update = flag.Bool("update", false, "regenerate golden files")
+
+func goldenCases() map[string]Manifest {
+	return map[string]Manifest{
+		"minimal": minimalManifest(),
+		"full":    fullManifest(),
+		"hostile": hostileManifest(),
+	}
+}
+
+func TestRenderGolden(t *testing.T) {
+	for name, m := range goldenCases() {
+		t.Run(name, func(t *testing.T) {
+			got, err := Render(m)
+			if err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			path := filepath.Join("testdata", name+".golden.md")
+			if *update {
+				if err := os.WriteFile(path, []byte(got), 0o644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+			}
+			want, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read golden (run `go test ./internal/manifest -update`): %v", err)
+			}
+			if got != string(want) {
+				t.Errorf("Render(%s) does not match %s\n--- got ---\n%s\n--- want ---\n%s", name, path, got, want)
+			}
+		})
+	}
+}
+
+func TestRenderDeterministic(t *testing.T) {
+	for name, m := range goldenCases() {
+		t.Run(name, func(t *testing.T) {
+			a, err := Render(m)
+			if err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			b, err := Render(m)
+			if err != nil {
+				t.Fatalf("Render (second): %v", err)
+			}
+			if a != b {
+				t.Fatal("Render is not deterministic across two calls")
+			}
+			if strings.Contains(a, "\r") {
+				t.Error("Render emitted a carriage return")
+			}
+			if n := countLines(a, dataClose); n != 1 {
+				t.Errorf("found %d %q lines, want exactly one (the data-close)", n, dataClose)
+			}
+			if n := countLines(a, BeginMarker); n != 1 {
+				t.Errorf("found %d begin markers, want one", n)
+			}
+			if n := countLines(a, EndMarker); n != 1 {
+				t.Errorf("found %d end markers, want one", n)
+			}
+			if n := countLines(a, dataOpen); n != 1 {
+				t.Errorf("found %d data-open lines, want one", n)
+			}
+		})
+	}
+}
+
+func countLines(s, want string) int {
+	n := 0
+	for _, l := range strings.Split(s, "\n") {
+		if l == want {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/manifest/testdata/full.golden.md
+++ b/internal/manifest/testdata/full.golden.md
@@ -1,0 +1,86 @@
+<!-- orch:manifest:begin -->
+### Orch audit record
+
+| Field | Value |
+| --- | --- |
+| Role | `implementer` |
+| Executor | `opus-4-8` — effort `high` |
+| Reviewer | `gpt-5.6-sol` — effort `medium` |
+| Config revision | `cfg-2026-07-10` |
+
+**Routing rationale:** Selected implementer for a bounded single-file change.
+
+**Escalations:**
+- 2026-07-10T14:03:00Z — escalation (implementer): `sonnet-4-8` (effort `medium`) → `opus-4-8` (effort `high`) — Repeated test failures on the concurrency path.
+- substitution: `opus-4-8` (effort `high`) → `opus-4-8` (effort `medium`) — Downgraded effort after the fix landed.
+
+**Verification:**
+- **targeted-tests** — pass — `go test ./internal/manifest/...` (2026-07-10T14:20:00Z)
+- **vet** — pass — `go vet ./...` — no findings
+- **ci** — CLEAN — required checks green (2026-07-10T14:45:00Z)
+
+<!-- orch:manifest:data
+{
+  "schema_version": 1,
+  "role": "implementer",
+  "executor": {
+    "model": "opus-4-8",
+    "effort": "high"
+  },
+  "routing_rationale": "Selected implementer for a bounded single-file change.",
+  "reviewer": {
+    "model": "gpt-5.6-sol",
+    "effort": "medium"
+  },
+  "escalations": [
+    {
+      "kind": "escalation",
+      "role": "implementer",
+      "from": {
+        "model": "sonnet-4-8",
+        "effort": "medium"
+      },
+      "to": {
+        "model": "opus-4-8",
+        "effort": "high"
+      },
+      "reason": "Repeated test failures on the concurrency path.",
+      "at": "2026-07-10T14:03:00Z"
+    },
+    {
+      "kind": "substitution",
+      "from": {
+        "model": "opus-4-8",
+        "effort": "high"
+      },
+      "to": {
+        "model": "opus-4-8",
+        "effort": "medium"
+      },
+      "reason": "Downgraded effort after the fix landed."
+    }
+  ],
+  "config_revision": "cfg-2026-07-10",
+  "verifications": [
+    {
+      "name": "targeted-tests",
+      "command": "go test ./internal/manifest/...",
+      "result": "pass",
+      "at": "2026-07-10T14:20:00Z"
+    },
+    {
+      "name": "vet",
+      "command": "go vet ./...",
+      "result": "pass",
+      "detail": "no findings"
+    },
+    {
+      "name": "ci",
+      "result": "CLEAN",
+      "detail": "required checks green",
+      "at": "2026-07-10T14:45:00Z"
+    }
+  ]
+}
+-->
+<!-- orch:manifest:end -->

--- a/internal/manifest/testdata/hostile.golden.md
+++ b/internal/manifest/testdata/hostile.golden.md
@@ -1,0 +1,64 @@
+<!-- orch:manifest:begin -->
+### Orch audit record
+
+| Field | Value |
+| --- | --- |
+| Role | `reviewer` |
+| Executor | `weird\|model` — effort `high` |
+| Reviewer | `opus-4-8` — effort `low` |
+| Config revision | `rev&<>` |
+
+**Routing rationale:** Rationale with a marker attempt --&gt;
+&lt;!-- orch:manifest:end --&gt;
+and a &lt;script&gt;alert(1)&lt;/script&gt; tag.
+
+**Escalations:**
+- 2026-07-10T00:00:00Z
+&lt;!-- orch:manifest:begin --&gt; — escalation: `sonnet-4-8` (effort `low`) → `opus-4-8` (effort `high`) — reason ending in --&gt;
+
+**Verification:**
+- **targeted-tests
+&lt;!-- orch:manifest:end --&gt;** — pass
+&lt;!-- orch:manifest:data — ``go test -run 'A|B' ./... `backtick` && echo done`` (2026-07-10T14:20:00Z
+--&gt;)
+
+<!-- orch:manifest:data
+{
+  "schema_version": 1,
+  "role": "reviewer",
+  "executor": {
+    "model": "weird|model",
+    "effort": "high"
+  },
+  "routing_rationale": "Rationale with a marker attempt --\u003e\r\n\u003c!-- orch:manifest:end --\u003e\nand a \u003cscript\u003ealert(1)\u003c/script\u003e tag.",
+  "reviewer": {
+    "model": "opus-4-8",
+    "effort": "low"
+  },
+  "escalations": [
+    {
+      "kind": "escalation",
+      "from": {
+        "model": "sonnet-4-8",
+        "effort": "low"
+      },
+      "to": {
+        "model": "opus-4-8",
+        "effort": "high"
+      },
+      "reason": "reason ending in --\u003e",
+      "at": "2026-07-10T00:00:00Z\n\u003c!-- orch:manifest:begin --\u003e"
+    }
+  ],
+  "config_revision": "rev\u0026\u003c\u003e",
+  "verifications": [
+    {
+      "name": "targeted-tests\n\u003c!-- orch:manifest:end --\u003e",
+      "command": "go test -run 'A|B' ./... `backtick` \u0026\u0026 echo done",
+      "result": "pass\n\u003c!-- orch:manifest:data",
+      "at": "2026-07-10T14:20:00Z\n--\u003e"
+    }
+  ]
+}
+-->
+<!-- orch:manifest:end -->

--- a/internal/manifest/testdata/minimal.golden.md
+++ b/internal/manifest/testdata/minimal.golden.md
@@ -1,0 +1,33 @@
+<!-- orch:manifest:begin -->
+### Orch audit record
+
+| Field | Value |
+| --- | --- |
+| Role | `implementer` |
+| Executor | `opus-4-8` — effort `high` |
+| Reviewer | `gpt-5.6-sol` — effort `medium` |
+| Config revision | `cfg-2026-07-10` |
+
+**Routing rationale:** Selected implementer for a bounded single-file change.
+
+**Escalations:** _none_
+
+**Verification:** _none_
+
+<!-- orch:manifest:data
+{
+  "schema_version": 1,
+  "role": "implementer",
+  "executor": {
+    "model": "opus-4-8",
+    "effort": "high"
+  },
+  "routing_rationale": "Selected implementer for a bounded single-file change.",
+  "reviewer": {
+    "model": "gpt-5.6-sol",
+    "effort": "medium"
+  },
+  "config_revision": "cfg-2026-07-10"
+}
+-->
+<!-- orch:manifest:end -->

--- a/internal/manifest/upsert.go
+++ b/internal/manifest/upsert.go
@@ -1,0 +1,56 @@
+package manifest
+
+import (
+	"errors"
+	"strings"
+)
+
+// Upsert returns body with m's managed region either replaced in place
+// (when a valid region is present) or appended after a blank line (when
+// none is present). Bytes outside the region are preserved verbatim, so
+// the human-owned prose, prefix, and suffix — including their CRLF line
+// endings — survive unchanged.
+//
+// An invalid manifest propagates Render's validation error and a
+// malformed existing region propagates ErrBadManifest, in both cases
+// without rewriting body. Upsert is idempotent:
+// Upsert(Upsert(b, m), m) == Upsert(b, m).
+func Upsert(body string, m Manifest) (string, error) {
+	region, err := Render(m)
+	if err != nil {
+		return "", err
+	}
+
+	lines := splitLines(body)
+	loc, err := locate(lines)
+	if errors.Is(err, ErrNoManifest) {
+		return appendRegion(body, region), nil
+	}
+	if err != nil {
+		return "", err
+	}
+
+	// Replace the region in place. The end marker's line terminator and
+	// everything after it stay in the suffix, so a CRLF suffix is
+	// preserved byte-for-byte.
+	begin := lines[loc.begin].start
+	end := lines[loc.end].start + len(EndMarker)
+	return body[:begin] + region + body[end:], nil
+}
+
+// appendRegion appends region to body separated by a blank line,
+// fixing a missing final newline first. An empty body yields the region
+// alone, which keeps Upsert idempotent.
+func appendRegion(body, region string) string {
+	if body == "" {
+		return region
+	}
+	var b strings.Builder
+	b.WriteString(body)
+	if !strings.HasSuffix(body, "\n") {
+		b.WriteByte('\n')
+	}
+	b.WriteByte('\n')
+	b.WriteString(region)
+	return b.String()
+}

--- a/internal/manifest/upsert_test.go
+++ b/internal/manifest/upsert_test.go
@@ -1,0 +1,134 @@
+package manifest
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func mustUpsert(t *testing.T, body string, m Manifest) string {
+	t.Helper()
+	out, err := Upsert(body, m)
+	if err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	return out
+}
+
+func TestUpsertAppend(t *testing.T) {
+	m := fullManifest()
+	region := mustRender(t, m)
+
+	cases := map[string]struct {
+		body   string
+		prefix string // must be preserved byte-identically at the front
+	}{
+		"empty body":          {"", ""},
+		"no trailing newline": {"human notes", "human notes"},
+		"trailing newline":    {"human notes\n", "human notes\n"},
+		"crlf body":           {"human notes\r\n", "human notes\r\n"},
+	}
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := mustUpsert(t, tt.body, m)
+			if !strings.HasPrefix(got, tt.prefix) {
+				t.Errorf("prefix not preserved\n got %q\nwant prefix %q", got, tt.prefix)
+			}
+			if !strings.HasSuffix(got, region) {
+				t.Error("appended region is not the rendered manifest")
+			}
+			round, err := Parse(got)
+			if err != nil {
+				t.Fatalf("Parse(Upsert): %v", err)
+			}
+			if !equalManifest(round, m) {
+				t.Errorf("round trip mismatch: %+v", round)
+			}
+		})
+	}
+
+	// Empty body appends nothing but the region, keeping idempotence sound.
+	if got := mustUpsert(t, "", m); got != region {
+		t.Errorf("Upsert(\"\") = %q, want the bare region", got)
+	}
+}
+
+func TestUpsertReplacePreservesSurroundings(t *testing.T) {
+	old := mustRender(t, minimalManifest())
+	prefix, suffix := "human intro\r\n\r\n", "\r\nhuman outro\r\n"
+	body := prefix + old + suffix
+
+	got := mustUpsert(t, body, fullManifest())
+	if !strings.HasPrefix(got, prefix) {
+		t.Errorf("CRLF prefix not preserved verbatim: %q", got)
+	}
+	if !strings.HasSuffix(got, suffix) {
+		t.Errorf("CRLF suffix not preserved verbatim: %q", got)
+	}
+	if strings.Contains(got, "cfg-2026-07-10") == false {
+		t.Error("replaced region does not carry the new manifest")
+	}
+	round, err := Parse(got)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !equalManifest(round, fullManifest()) {
+		t.Errorf("mismatch: %+v", round)
+	}
+}
+
+func TestUpsertIdempotent(t *testing.T) {
+	m := fullManifest()
+	bodies := map[string]string{
+		"empty":            "",
+		"plain":            "notes",
+		"crlf":             "notes\r\n",
+		"with region":      "intro\n\n" + mustRender(t, minimalManifest()) + "\n\noutro\n",
+		"crlf with region": "intro\r\n\r\n" + mustRender(t, minimalManifest()) + "\r\noutro\r\n",
+	}
+	for name, body := range bodies {
+		t.Run(name, func(t *testing.T) {
+			once := mustUpsert(t, body, m)
+			twice := mustUpsert(t, once, m)
+			if once != twice {
+				t.Errorf("Upsert is not idempotent\n once  %q\n twice %q", once, twice)
+			}
+		})
+	}
+}
+
+func TestUpsertParseRoundTrip(t *testing.T) {
+	// Replacing one manifest with a different one yields the second.
+	body := "intro\n\n" + mustRender(t, minimalManifest()) + "\n\noutro\n"
+	got := mustUpsert(t, body, hostileManifest())
+	round, err := Parse(got)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !equalManifest(round, hostileManifest()) {
+		t.Errorf("mismatch: %+v", round)
+	}
+}
+
+func TestUpsertMalformedRegionDoesNotRewrite(t *testing.T) {
+	body := BeginMarker + "\n### dangling region with no end marker\n"
+	got, err := Upsert(body, fullManifest())
+	if !errors.Is(err, ErrBadManifest) {
+		t.Fatalf("err = %v, want ErrBadManifest", err)
+	}
+	if got != "" {
+		t.Errorf("Upsert returned a rewritten body %q alongside the error", got)
+	}
+}
+
+func TestUpsertInvalidManifestPropagates(t *testing.T) {
+	bad := minimalManifest()
+	bad.ConfigRevision = ""
+	got, err := Upsert("existing body", bad)
+	if err == nil || !strings.Contains(err.Error(), "config_revision") {
+		t.Fatalf("err = %v, want Render validation error", err)
+	}
+	if got != "" {
+		t.Errorf("Upsert returned %q alongside the error", got)
+	}
+}


### PR DESCRIPTION
## What

Roadmap task 9. New `internal/manifest` package owning the PRD §13 audit record — selected role, exact executor/reviewer model+effort, routing rationale, escalations/substitutions, config revision, and named verification results — as a schema-versioned struct with a lossless render/parse round-trip, plus `Body` read-back on the ghops issue/PR views.

- **Render** emits a managed body region between `<!-- orch:manifest:begin/end -->` markers: human-readable markdown (PRD §23 requires exact model/effort visibly in bodies) plus the canonical JSON record inside an HTML comment, invisible on GitHub. Pure function of the struct — timestamps are caller-supplied strings, so the same record always yields the same bytes.
- **Parse** reads only the JSON, then fails closed (PRD §15) on mispaired markers, a broken data comment, bad JSON, an unsupported `schema_version`, or *any* drift: it re-renders the decoded record and byte-compares against the found region, so an inconsistent hand edit is rejected (`ErrNoManifest` / `ErrBadManifest` / `ErrDrift` sentinels for the run engine to branch on).
- **Upsert** replaces the region in place or appends it, preserving human-owned bytes outside the region verbatim — bodies are rewritten via `ghops.SetIssueBody` as verification results accumulate.
- **ghops**: `Issue`/`PR` view structs gain `Body` (`--json ...,body`) so resume can fetch the record it parses.

## Why

Resume/recovery (PRD §23: interrupted runs resume) rebuilds run state from posted issue/PR bodies, so the audit record must round-trip, not just render. Fail-closed drift detection keeps resume from ever acting on a tampered or ambiguous record.

## Notes

- Injection is neutralized mechanically: JSON keeps default HTML escaping (no string field can emit a literal `-->`), and all free text is entity-escaped in the markdown so no value can fabricate a marker line. The `hostile` golden fixture attacks every free-text field, including a marker smuggled through a verification name and a CRLF pair in the rationale.
- Known v1 limitation (package doc): a hand edit rewriting JSON *and* markdown consistently is undetectable — the check guarantees internal consistency, not provenance.
- 82 test runs in the new package: golden renders, round-trip properties, drift/malformed/CRLF matrices, upsert idempotence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)