### PR TITLE
Add internal/routing: role routing and escalation decision logic

### DIFF
--- a/internal/routing/decide.go
+++ b/internal/routing/decide.go
@@ -1,0 +1,106 @@
+package routing
+
+import (
+	"fmt"
+
+	"github.com/kninetimmy/orch/internal/manifest"
+)
+
+// Decision is the routing chosen for a task: the role and the exact
+// executor and reviewer selections, plus whether the reviewer was
+// downgraded and a human-readable rationale (PRD §13). The rationale is
+// always non-empty and feeds manifest.RoutingRationale verbatim.
+type Decision struct {
+	Role               manifest.Role
+	Executor           manifest.Selection
+	Reviewer           manifest.Selection
+	ReviewerDowngraded bool
+	Rationale          string
+}
+
+// Decide chooses the role, executor selection, and reviewer for a task
+// against a profile and the history of prior attempts (PRD §9–§11). It
+// applies the first-match-wins policy table, resolving conflicts toward
+// the stronger route (PRD §11: uncertainty favors the stronger route)
+// and recording any refused downgrade in the rationale rather than
+// erroring. A nil history is a fresh task.
+//
+// It fails closed: an incomplete profile is ErrBadProfile and an
+// unknown risk domain is ErrBadTask. When the only stronger executor a
+// row calls for has already failed, initial routing is exhausted and it
+// returns ErrNoStrongerRoute (a plan-gate problem, distinct from an
+// escalation returning to the Architect).
+func Decide(p Profile, t Task, h History) (Decision, error) {
+	if err := p.validate(); err != nil {
+		return Decision{}, err
+	}
+	for _, d := range t.RiskDomains {
+		if !d.Valid() {
+			return Decision{}, fmt.Errorf("%w: unknown risk domain %q", ErrBadTask, d)
+		}
+	}
+
+	risk := len(t.RiskDomains) > 0
+	difficult := t.UnusuallyDifficult
+
+	switch {
+	// Row 1: read-only work that is risky, difficult, or whose scout
+	// model already failed runs on the specialist model in read-only
+	// mode (role stays scout).
+	case t.ReadOnly && (risk || difficult || h.FailedModel(p.Scout.Model)):
+		if h.FailedModel(p.Specialist.Model) {
+			return Decision{}, fmt.Errorf("%w: read-only work needs the specialist model but it has already failed", ErrNoStrongerRoute)
+		}
+		return Decision{
+			Role:      manifest.RoleScout,
+			Executor:  p.Specialist,
+			Reviewer:  p.Reviewer,
+			Rationale: rationaleScoutEscalated(t, h, p),
+		}, nil
+
+	// Row 2: plain read-only work goes to a scout.
+	case t.ReadOnly:
+		return Decision{
+			Role:      manifest.RoleScout,
+			Executor:  p.Scout,
+			Reviewer:  p.Reviewer,
+			Rationale: rationaleScoutPlain(),
+		}, nil
+
+	// Row 3: risky, difficult, or implementer-model-failed work goes to a
+	// specialist with a strong reviewer. Review is never downgraded here,
+	// even if all four downgrade facts hold — the refusal is recorded in
+	// the rationale.
+	case risk || difficult || h.FailedModel(p.Implementer.Model):
+		if h.FailedModel(p.Specialist.Model) {
+			return Decision{}, fmt.Errorf("%w: work needs the specialist model but it has already failed", ErrNoStrongerRoute)
+		}
+		return Decision{
+			Role:      manifest.RoleSpecialist,
+			Executor:  p.Specialist,
+			Reviewer:  p.Reviewer,
+			Rationale: rationaleSpecialist(t, h, p),
+		}, nil
+
+	// Row 4: a change that is affirmatively mechanical, low-risk, fully
+	// specified, and unsurprising earns a downgraded reviewer.
+	case t.Downgrade.Eligible():
+		return Decision{
+			Role:               manifest.RoleImplementer,
+			Executor:           p.Implementer,
+			Reviewer:           p.ReviewDowngrade,
+			ReviewerDowngraded: true,
+			Rationale:          rationaleDowngrade(),
+		}, nil
+
+	// Row 5: default — a normal change goes to an implementer with a
+	// strong reviewer.
+	default:
+		return Decision{
+			Role:      manifest.RoleImplementer,
+			Executor:  p.Implementer,
+			Reviewer:  p.Reviewer,
+			Rationale: rationaleImplementer(t),
+		}, nil
+	}
+}

--- a/internal/routing/decide_test.go
+++ b/internal/routing/decide_test.go
@@ -1,0 +1,307 @@
+package routing
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/manifest"
+)
+
+// testProfile is a complete profile with a distinct model string per
+// role, so failed-set logic is unambiguous in tests.
+func testProfile() Profile {
+	return Profile{
+		Architect:       manifest.Selection{Model: "architect-m", Effort: "xhigh"},
+		Scout:           manifest.Selection{Model: "scout-m", Effort: "low"},
+		Implementer:     manifest.Selection{Model: "impl-m", Effort: "high"},
+		Specialist:      manifest.Selection{Model: "spec-m", Effort: "high"},
+		Reviewer:        manifest.Selection{Model: "rev-m", Effort: "high"},
+		ReviewDowngrade: manifest.Selection{Model: "revdown-m", Effort: "medium"},
+	}
+}
+
+func TestDecideBaseline(t *testing.T) {
+	p := testProfile()
+	d, err := Decide(p, Task{}, nil)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if d.Role != manifest.RoleImplementer {
+		t.Errorf("role = %q, want implementer", d.Role)
+	}
+	if d.Executor != p.Implementer {
+		t.Errorf("executor = %+v, want %+v", d.Executor, p.Implementer)
+	}
+	if d.Reviewer != p.Reviewer {
+		t.Errorf("reviewer = %+v, want %+v", d.Reviewer, p.Reviewer)
+	}
+	if d.ReviewerDowngraded {
+		t.Error("baseline task must not downgrade the reviewer")
+	}
+	if d.Rationale == "" {
+		t.Error("rationale must be non-empty")
+	}
+}
+
+func TestDecideRiskDomainsRouteToSpecialist(t *testing.T) {
+	p := testProfile()
+	for _, dom := range Domains() {
+		t.Run(string(dom), func(t *testing.T) {
+			d, err := Decide(p, Task{RiskDomains: []RiskDomain{dom}}, nil)
+			if err != nil {
+				t.Fatalf("Decide: %v", err)
+			}
+			if d.Role != manifest.RoleSpecialist {
+				t.Errorf("role = %q, want specialist", d.Role)
+			}
+			if d.Executor != p.Specialist {
+				t.Errorf("executor = %+v, want specialist", d.Executor)
+			}
+			if d.Reviewer != p.Reviewer {
+				t.Errorf("reviewer = %+v, want strong reviewer", d.Reviewer)
+			}
+			if d.ReviewerDowngraded {
+				t.Error("risk work must never downgrade the reviewer")
+			}
+		})
+	}
+}
+
+// TestDecideDowngradeMatrix exhaustively covers 16 downgrade-fact combos
+// × {risk, no-risk} × {difficult, not} = 64 cases and asserts the
+// downgrade is granted in exactly one (all four facts, no risk, not
+// difficult).
+func TestDecideDowngradeMatrix(t *testing.T) {
+	p := testProfile()
+	grants := 0
+	for combo := 0; combo < 16; combo++ {
+		facts := DowngradeFacts{
+			Mechanical:     combo&1 != 0,
+			LowRisk:        combo&2 != 0,
+			FullySpecified: combo&4 != 0,
+			Unsurprising:   combo&8 != 0,
+		}
+		for _, risk := range []bool{false, true} {
+			for _, difficult := range []bool{false, true} {
+				task := Task{UnusuallyDifficult: difficult, Downgrade: facts}
+				if risk {
+					task.RiskDomains = []RiskDomain{RiskSecurity}
+				}
+				d, err := Decide(p, task, nil)
+				if err != nil {
+					t.Fatalf("combo=%d risk=%v difficult=%v: %v", combo, risk, difficult, err)
+				}
+				wantGrant := facts.Eligible() && !risk && !difficult
+				if d.ReviewerDowngraded != wantGrant {
+					t.Errorf("combo=%d risk=%v difficult=%v: downgraded=%v, want %v", combo, risk, difficult, d.ReviewerDowngraded, wantGrant)
+				}
+				switch {
+				case wantGrant:
+					grants++
+					if d.Role != manifest.RoleImplementer || d.Reviewer != p.ReviewDowngrade {
+						t.Errorf("granted downgrade: role=%q reviewer=%+v, want implementer + downgrade reviewer", d.Role, d.Reviewer)
+					}
+				case risk || difficult:
+					if d.Role != manifest.RoleSpecialist || d.Reviewer != p.Reviewer {
+						t.Errorf("combo=%d risk=%v difficult=%v: role=%q reviewer=%+v, want specialist + strong reviewer", combo, risk, difficult, d.Role, d.Reviewer)
+					}
+				default:
+					if d.Role != manifest.RoleImplementer || d.Reviewer != p.Reviewer {
+						t.Errorf("combo=%d: role=%q reviewer=%+v, want implementer + strong reviewer", combo, d.Role, d.Reviewer)
+					}
+				}
+			}
+		}
+	}
+	if grants != 1 {
+		t.Errorf("downgrade granted in %d cases, want exactly 1", grants)
+	}
+}
+
+func TestDecideReadOnly(t *testing.T) {
+	p := testProfile()
+	tests := map[string]struct {
+		task         Task
+		history      History
+		wantExecutor manifest.Selection
+	}{
+		"plain read-only goes to scout": {
+			Task{ReadOnly: true},
+			nil,
+			p.Scout,
+		},
+		"risky read-only goes to specialist model": {
+			Task{ReadOnly: true, RiskDomains: []RiskDomain{RiskSecrets}},
+			nil,
+			p.Specialist,
+		},
+		"difficult read-only goes to specialist model": {
+			Task{ReadOnly: true, UnusuallyDifficult: true},
+			nil,
+			p.Specialist,
+		},
+		"read-only with failed scout goes to specialist model": {
+			Task{ReadOnly: true},
+			History{{Role: manifest.RoleScout, Selection: p.Scout, Failed: true}},
+			p.Specialist,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			d, err := Decide(p, tt.task, tt.history)
+			if err != nil {
+				t.Fatalf("Decide: %v", err)
+			}
+			if d.Role != manifest.RoleScout {
+				t.Errorf("role = %q, want scout (read-only)", d.Role)
+			}
+			if d.Executor != tt.wantExecutor {
+				t.Errorf("executor = %+v, want %+v", d.Executor, tt.wantExecutor)
+			}
+			if d.ReviewerDowngraded {
+				t.Error("read-only work must not downgrade the reviewer")
+			}
+		})
+	}
+}
+
+func TestDecideConflictPrefersStrongerRoute(t *testing.T) {
+	p := testProfile()
+	// All four downgrade facts assert, but the task is unusually
+	// difficult: the stronger route wins and the refusal is recorded.
+	d, err := Decide(p, Task{
+		UnusuallyDifficult: true,
+		Downgrade:          DowngradeFacts{Mechanical: true, LowRisk: true, FullySpecified: true, Unsurprising: true},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if d.Role != manifest.RoleSpecialist {
+		t.Errorf("role = %q, want specialist", d.Role)
+	}
+	if d.ReviewerDowngraded {
+		t.Error("conflict must not downgrade the reviewer")
+	}
+	if want := "overriding the reviewer downgrade"; !strings.Contains(d.Rationale, want) {
+		t.Errorf("rationale %q does not record the refusal (%q)", d.Rationale, want)
+	}
+}
+
+func TestDecideHistoryAware(t *testing.T) {
+	p := testProfile()
+
+	t.Run("failed implementer escalates to specialist", func(t *testing.T) {
+		h := History{{Role: manifest.RoleImplementer, Selection: p.Implementer, Failed: true}}
+		d, err := Decide(p, Task{}, h)
+		if err != nil {
+			t.Fatalf("Decide: %v", err)
+		}
+		if d.Role != manifest.RoleSpecialist || d.Executor != p.Specialist {
+			t.Errorf("role=%q executor=%+v, want specialist", d.Role, d.Executor)
+		}
+	})
+
+	t.Run("both implementer and specialist failed exhaust the route", func(t *testing.T) {
+		h := History{
+			{Role: manifest.RoleImplementer, Selection: p.Implementer, Failed: true},
+			{Role: manifest.RoleSpecialist, Selection: p.Specialist, Failed: true},
+		}
+		_, err := Decide(p, Task{}, h)
+		if !errors.Is(err, ErrNoStrongerRoute) {
+			t.Errorf("err = %v, want ErrNoStrongerRoute", err)
+		}
+	})
+
+	t.Run("read-only exhausts when specialist failed", func(t *testing.T) {
+		h := History{{Role: manifest.RoleSpecialist, Selection: p.Specialist, Failed: true}}
+		_, err := Decide(p, Task{ReadOnly: true, RiskDomains: []RiskDomain{RiskSecurity}}, h)
+		if !errors.Is(err, ErrNoStrongerRoute) {
+			t.Errorf("err = %v, want ErrNoStrongerRoute", err)
+		}
+	})
+}
+
+// TestDecideBadProfile generates the 12 incompleteness cases: 6
+// selections × {model, effort} empty.
+func TestDecideBadProfile(t *testing.T) {
+	fields := []struct {
+		name string
+		set  func(*Profile, manifest.Selection)
+	}{
+		{"architect", func(p *Profile, s manifest.Selection) { p.Architect = s }},
+		{"scout", func(p *Profile, s manifest.Selection) { p.Scout = s }},
+		{"implementer", func(p *Profile, s manifest.Selection) { p.Implementer = s }},
+		{"specialist", func(p *Profile, s manifest.Selection) { p.Specialist = s }},
+		{"reviewer", func(p *Profile, s manifest.Selection) { p.Reviewer = s }},
+		{"review_downgrade", func(p *Profile, s manifest.Selection) { p.ReviewDowngrade = s }},
+	}
+	missings := map[string]manifest.Selection{
+		"empty model":  {Model: "", Effort: "high"},
+		"empty effort": {Model: "m", Effort: ""},
+	}
+	for _, f := range fields {
+		for miss, sel := range missings {
+			t.Run(f.name+" "+miss, func(t *testing.T) {
+				p := testProfile()
+				f.set(&p, sel)
+				_, err := Decide(p, Task{}, nil)
+				if !errors.Is(err, ErrBadProfile) {
+					t.Errorf("err = %v, want ErrBadProfile", err)
+				}
+			})
+		}
+	}
+}
+
+func TestDecideUnknownRiskDomain(t *testing.T) {
+	p := testProfile()
+	_, err := Decide(p, Task{RiskDomains: []RiskDomain{"performance"}}, nil)
+	if !errors.Is(err, ErrBadTask) {
+		t.Errorf("err = %v, want ErrBadTask", err)
+	}
+}
+
+func TestDecideRationaleGolden(t *testing.T) {
+	p := testProfile()
+	tests := map[string]struct {
+		task Task
+		want string
+	}{
+		"plain implementer": {
+			Task{},
+			"Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
+		},
+		"granted downgrade": {
+			Task{Downgrade: DowngradeFacts{Mechanical: true, LowRisk: true, FullySpecified: true, Unsurprising: true}},
+			"Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
+		},
+		"partial downgrade refused names the gap": {
+			Task{Downgrade: DowngradeFacts{Mechanical: true, FullySpecified: true}},
+			"Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively low-risk.",
+		},
+		"specialist for a single risk domain": {
+			Task{RiskDomains: []RiskDomain{RiskSecurity}},
+			"Routed to a specialist with a strong reviewer because risk domains (security).",
+		},
+		"specialist renders domains in canonical order": {
+			Task{RiskDomains: []RiskDomain{RiskConcurrency, RiskSecurity}},
+			"Routed to a specialist with a strong reviewer because risk domains (security, concurrency).",
+		},
+		"plain read-only scout": {
+			Task{ReadOnly: true},
+			"Routed read-only work to a scout with no elevated risk or difficulty.",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			d, err := Decide(p, tt.task, nil)
+			if err != nil {
+				t.Fatalf("Decide: %v", err)
+			}
+			if d.Rationale != tt.want {
+				t.Errorf("rationale =\n  %q\nwant\n  %q", d.Rationale, tt.want)
+			}
+		})
+	}
+}

--- a/internal/routing/escalate.go
+++ b/internal/routing/escalate.go
@@ -1,0 +1,232 @@
+package routing
+
+import (
+	"fmt"
+
+	"github.com/kninetimmy/orch/internal/manifest"
+)
+
+// Trigger names a PRD §11 escalation event a running attempt can raise.
+// The set is closed; any other value is ErrBadTrigger.
+type Trigger string
+
+const (
+	// TriggerScoutUncertainty: a scout reports it cannot resolve the work
+	// read-only; escalate to the specialist model in read-only mode.
+	TriggerScoutUncertainty Trigger = "scout-uncertainty"
+	// TriggerImplementerHardExecution: an implementer finds execution
+	// unusually hard; transfer the worktree to a specialist.
+	TriggerImplementerHardExecution Trigger = "implementer-hard-execution"
+	// TriggerWeakModelFailure: one meaningful failure of an underpowered
+	// model; climb one tier rather than retry.
+	TriggerWeakModelFailure Trigger = "weak-model-failure"
+	// TriggerReviewerUncertainty: a downgraded reviewer reports doubt;
+	// escalate to a complete strong-model review. A strong reviewer's
+	// doubt is architectural-ambiguity, not this.
+	TriggerReviewerUncertainty Trigger = "reviewer-uncertainty"
+	// TriggerArchitecturalAmbiguity: unresolved design ambiguity from any
+	// role; return to the Architect.
+	TriggerArchitecturalAmbiguity Trigger = "architectural-ambiguity"
+)
+
+// OutcomeKind distinguishes the two shapes an Escalate result takes.
+type OutcomeKind string
+
+const (
+	// OutcomeReroute is a new executor and/or reviewer selection to run.
+	OutcomeReroute OutcomeKind = "reroute"
+	// OutcomeReturnToArchitect hands the task back to the Architect: the
+	// escalation ladder is exhausted or the trouble is architectural.
+	// Decision is the zero value — there is no executor route to run.
+	OutcomeReturnToArchitect OutcomeKind = "return-to-architect"
+)
+
+// Outcome is the result of an escalation. On a reroute Decision holds
+// the new routing and Escalations records the change(s) for the audit
+// manifest; on a return-to-architect Decision is zero and Escalations
+// is empty. History is always the input history with any retired
+// attempt appended (the correct input to a follow-up Escalate), and
+// Reason is a non-empty human-readable summary.
+type Outcome struct {
+	Kind        OutcomeKind
+	Decision    Decision
+	Escalations []manifest.Escalation
+	History     History
+	Reason      string
+}
+
+// Escalate applies a PRD §11 escalation to a decision. It appends a
+// failed Attempt for every model it retires (one meaningful failure
+// retires a model permanently) and emits a manifest.Escalation for each
+// selection change with At left empty for the run engine to stamp. A
+// trigger that does not fit the decision is ErrTriggerMismatch and an
+// unknown trigger is ErrBadTrigger; a return to the Architect is a
+// first-class Outcome, never an error.
+//
+// Cross-cutting rule: any executor reroute on a downgraded-reviewer
+// decision also restores the strong reviewer and emits a second
+// escalation record — a task that needed escalation was, by evidence,
+// not "unsurprising".
+func Escalate(p Profile, d Decision, h History, tr Trigger, detail string) (Outcome, error) {
+	if err := p.validate(); err != nil {
+		return Outcome{}, err
+	}
+
+	switch tr {
+	case TriggerScoutUncertainty:
+		if d.Role != manifest.RoleScout {
+			return Outcome{}, fmt.Errorf("%w: scout-uncertainty requires a scout decision, got role %q", ErrTriggerMismatch, d.Role)
+		}
+		return climbExecutor(p, d, h, tr, detail, manifest.RoleScout, p.Specialist), nil
+
+	case TriggerImplementerHardExecution:
+		if d.Role != manifest.RoleImplementer {
+			return Outcome{}, fmt.Errorf("%w: implementer-hard-execution requires an implementer decision, got role %q", ErrTriggerMismatch, d.Role)
+		}
+		return climbExecutor(p, d, h, tr, detail, manifest.RoleSpecialist, p.Specialist), nil
+
+	case TriggerWeakModelFailure:
+		switch d.Role {
+		case manifest.RoleScout:
+			return climbExecutor(p, d, h, tr, detail, manifest.RoleScout, p.Specialist), nil
+		case manifest.RoleImplementer:
+			return climbExecutor(p, d, h, tr, detail, manifest.RoleSpecialist, p.Specialist), nil
+		case manifest.RoleSpecialist:
+			// Nowhere stronger to climb: retire the specialist and return
+			// to the Architect.
+			return Outcome{
+				Kind:    OutcomeReturnToArchitect,
+				History: appendAttempt(h, retiredExecutor(d, detail)),
+				Reason:  reasonSpecialistExhausted(detail),
+			}, nil
+		default:
+			return Outcome{}, fmt.Errorf("%w: weak-model-failure requires an executor role, got %q", ErrTriggerMismatch, d.Role)
+		}
+
+	case TriggerReviewerUncertainty:
+		if !d.ReviewerDowngraded {
+			return Outcome{}, fmt.Errorf("%w: reviewer-uncertainty requires a downgraded reviewer (a strong reviewer's doubt is architectural-ambiguity)", ErrTriggerMismatch)
+		}
+		return escalateReviewer(p, d, h, detail), nil
+
+	case TriggerArchitecturalAmbiguity:
+		return Outcome{
+			Kind:    OutcomeReturnToArchitect,
+			History: h,
+			Reason:  reasonArchitecturalAmbiguity(detail),
+		}, nil
+
+	default:
+		return Outcome{}, fmt.Errorf("%w: unknown trigger %q", ErrBadTrigger, tr)
+	}
+}
+
+// climbExecutor retires the current executor and reroutes to target
+// under newRole, or returns to the Architect when target is already
+// exhausted (its model has failed — including the just-retired one, so a
+// degenerate profile whose stronger tier reuses a failed model closes
+// here). On a downgraded-reviewer decision a successful reroute also
+// restores the strong reviewer with a second escalation record.
+func climbExecutor(p Profile, d Decision, h History, tr Trigger, detail string, newRole manifest.Role, target manifest.Selection) Outcome {
+	newHistory := appendAttempt(h, retiredExecutor(d, detail))
+	if newHistory.FailedModel(target.Model) {
+		return Outcome{
+			Kind:    OutcomeReturnToArchitect,
+			History: newHistory,
+			Reason:  reasonExecutorExhausted(d.Role, detail),
+		}
+	}
+
+	newDecision := Decision{
+		Role:               newRole,
+		Executor:           target,
+		Reviewer:           d.Reviewer,
+		ReviewerDowngraded: d.ReviewerDowngraded,
+		Rationale:          rationaleReroute(newRole, tr),
+	}
+	escalations := []manifest.Escalation{{
+		Kind:   "escalation",
+		Role:   newRole,
+		From:   d.Executor,
+		To:     target,
+		Reason: reasonExecutorReroute(d.Role, tr, detail),
+	}}
+
+	if d.ReviewerDowngraded {
+		newDecision.Reviewer = p.Reviewer
+		newDecision.ReviewerDowngraded = false
+		escalations = append(escalations, manifest.Escalation{
+			Kind:   "escalation",
+			Role:   manifest.RoleReviewer,
+			From:   d.Reviewer,
+			To:     p.Reviewer,
+			Reason: reasonReviewerRestored(detail),
+		})
+	}
+
+	return Outcome{
+		Kind:        OutcomeReroute,
+		Decision:    newDecision,
+		Escalations: escalations,
+		History:     newHistory,
+		Reason:      escalations[0].Reason,
+	}
+}
+
+// escalateReviewer retires the downgraded reviewer and reroutes to the
+// strong reviewer, leaving the executor untouched. A degenerate profile
+// whose strong reviewer shares the downgrade's model has no stronger
+// review to offer and returns to the Architect.
+func escalateReviewer(p Profile, d Decision, h History, detail string) Outcome {
+	newHistory := appendAttempt(h, Attempt{
+		Role:      manifest.RoleReviewer,
+		Selection: d.Reviewer,
+		Failed:    true,
+		Reason:    detail,
+	})
+	if newHistory.FailedModel(p.Reviewer.Model) {
+		return Outcome{
+			Kind:    OutcomeReturnToArchitect,
+			History: newHistory,
+			Reason:  reasonReviewerDegenerate(detail),
+		}
+	}
+
+	newDecision := d
+	newDecision.Reviewer = p.Reviewer
+	newDecision.ReviewerDowngraded = false
+	newDecision.Rationale = rationaleReviewerEscalated()
+
+	return Outcome{
+		Kind:     OutcomeReroute,
+		Decision: newDecision,
+		Escalations: []manifest.Escalation{{
+			Kind:   "escalation",
+			Role:   manifest.RoleReviewer,
+			From:   d.Reviewer,
+			To:     p.Reviewer,
+			Reason: reasonReviewerUncertainty(detail),
+		}},
+		History: newHistory,
+		Reason:  reasonReviewerUncertainty(detail),
+	}
+}
+
+// retiredExecutor is the failed Attempt for a decision's executor.
+func retiredExecutor(d Decision, detail string) Attempt {
+	return Attempt{
+		Role:      d.Role,
+		Selection: d.Executor,
+		Failed:    true,
+		Reason:    detail,
+	}
+}
+
+// appendAttempt returns h with a appended, never aliasing the caller's
+// backing array, so a caller that round-trips History keeps its own copy
+// intact.
+func appendAttempt(h History, a Attempt) History {
+	out := make(History, len(h), len(h)+1)
+	copy(out, h)
+	return append(out, a)
+}

--- a/internal/routing/escalate_test.go
+++ b/internal/routing/escalate_test.go
@@ -1,0 +1,371 @@
+package routing
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/manifest"
+)
+
+// scoutDecision, implementerDecision, specialistDecision, and
+// downgradedDecision build the canonical Decide outputs the escalation
+// triggers act on.
+func scoutDecision(t *testing.T, p Profile) Decision {
+	t.Helper()
+	d, err := Decide(p, Task{ReadOnly: true}, nil)
+	if err != nil {
+		t.Fatalf("scout decision: %v", err)
+	}
+	return d
+}
+
+func implementerDecision(t *testing.T, p Profile) Decision {
+	t.Helper()
+	d, err := Decide(p, Task{}, nil)
+	if err != nil {
+		t.Fatalf("implementer decision: %v", err)
+	}
+	return d
+}
+
+func specialistDecision(t *testing.T, p Profile) Decision {
+	t.Helper()
+	d, err := Decide(p, Task{UnusuallyDifficult: true}, nil)
+	if err != nil {
+		t.Fatalf("specialist decision: %v", err)
+	}
+	return d
+}
+
+func downgradedDecision(t *testing.T, p Profile) Decision {
+	t.Helper()
+	d, err := Decide(p, Task{Downgrade: DowngradeFacts{Mechanical: true, LowRisk: true, FullySpecified: true, Unsurprising: true}}, nil)
+	if err != nil {
+		t.Fatalf("downgraded decision: %v", err)
+	}
+	if !d.ReviewerDowngraded {
+		t.Fatalf("expected a downgraded reviewer decision, got %+v", d)
+	}
+	return d
+}
+
+func TestEscalateScoutUncertainty(t *testing.T) {
+	p := testProfile()
+	d := scoutDecision(t, p)
+	out, err := Escalate(p, d, nil, TriggerScoutUncertainty, "cannot resolve read-only")
+	if err != nil {
+		t.Fatalf("Escalate: %v", err)
+	}
+	if out.Kind != OutcomeReroute {
+		t.Fatalf("kind = %q, want reroute", out.Kind)
+	}
+	if out.Decision.Role != manifest.RoleScout || out.Decision.Executor != p.Specialist {
+		t.Errorf("decision role=%q executor=%+v, want scout on specialist model", out.Decision.Role, out.Decision.Executor)
+	}
+	if len(out.Escalations) != 1 {
+		t.Fatalf("escalations = %d, want 1", len(out.Escalations))
+	}
+	if out.Escalations[0].From != p.Scout || out.Escalations[0].To != p.Specialist {
+		t.Errorf("escalation %+v, want scout->specialist", out.Escalations[0])
+	}
+	if !out.History.FailedModel(p.Scout.Model) {
+		t.Error("returned history must retire the scout model")
+	}
+}
+
+func TestEscalateImplementerHardExecution(t *testing.T) {
+	p := testProfile()
+	d := implementerDecision(t, p)
+	out, err := Escalate(p, d, nil, TriggerImplementerHardExecution, "")
+	if err != nil {
+		t.Fatalf("Escalate: %v", err)
+	}
+	if out.Kind != OutcomeReroute {
+		t.Fatalf("kind = %q, want reroute", out.Kind)
+	}
+	if out.Decision.Role != manifest.RoleSpecialist || out.Decision.Executor != p.Specialist {
+		t.Errorf("decision role=%q executor=%+v, want specialist", out.Decision.Role, out.Decision.Executor)
+	}
+	if len(out.Escalations) != 1 {
+		t.Fatalf("escalations = %d, want 1", len(out.Escalations))
+	}
+	if !out.History.FailedModel(p.Implementer.Model) {
+		t.Error("returned history must retire the implementer model")
+	}
+}
+
+func TestEscalateImplementerHardWithDowngradedReviewer(t *testing.T) {
+	p := testProfile()
+	d := downgradedDecision(t, p)
+	out, err := Escalate(p, d, nil, TriggerImplementerHardExecution, "hidden invariant")
+	if err != nil {
+		t.Fatalf("Escalate: %v", err)
+	}
+	if out.Kind != OutcomeReroute {
+		t.Fatalf("kind = %q, want reroute", out.Kind)
+	}
+	if out.Decision.ReviewerDowngraded {
+		t.Error("reviewer must be restored to strong on escalation")
+	}
+	if out.Decision.Reviewer != p.Reviewer {
+		t.Errorf("reviewer = %+v, want strong reviewer", out.Decision.Reviewer)
+	}
+	if len(out.Escalations) != 2 {
+		t.Fatalf("escalations = %d, want 2 (executor + reviewer restore)", len(out.Escalations))
+	}
+	if out.Escalations[0].Role != manifest.RoleSpecialist {
+		t.Errorf("first escalation role = %q, want specialist", out.Escalations[0].Role)
+	}
+	if out.Escalations[1].Role != manifest.RoleReviewer || out.Escalations[1].From != p.ReviewDowngrade || out.Escalations[1].To != p.Reviewer {
+		t.Errorf("second escalation %+v, want downgrade->strong reviewer", out.Escalations[1])
+	}
+}
+
+func TestEscalateWeakModelFailure(t *testing.T) {
+	p := testProfile()
+	tests := map[string]struct {
+		decision func(*testing.T, Profile) Decision
+		wantKind OutcomeKind
+		wantRole manifest.Role
+	}{
+		"scout climbs to specialist model": {
+			scoutDecision, OutcomeReroute, manifest.RoleScout,
+		},
+		"implementer climbs to specialist": {
+			implementerDecision, OutcomeReroute, manifest.RoleSpecialist,
+		},
+		"specialist returns to architect": {
+			specialistDecision, OutcomeReturnToArchitect, "",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			d := tt.decision(t, p)
+			out, err := Escalate(p, d, nil, TriggerWeakModelFailure, "weak model")
+			if err != nil {
+				t.Fatalf("Escalate: %v", err)
+			}
+			if out.Kind != tt.wantKind {
+				t.Fatalf("kind = %q, want %q", out.Kind, tt.wantKind)
+			}
+			if out.Reason == "" {
+				t.Error("reason must be non-empty")
+			}
+			if tt.wantKind == OutcomeReroute {
+				if out.Decision.Role != tt.wantRole || out.Decision.Executor != p.Specialist {
+					t.Errorf("decision role=%q executor=%+v, want %q on specialist", out.Decision.Role, out.Decision.Executor, tt.wantRole)
+				}
+			} else {
+				if len(out.Escalations) != 0 {
+					t.Errorf("return-to-architect must emit no escalations, got %d", len(out.Escalations))
+				}
+				if !out.History.FailedModel(p.Specialist.Model) {
+					t.Error("returned history must retire the specialist model")
+				}
+			}
+		})
+	}
+}
+
+func TestEscalateReviewerUncertainty(t *testing.T) {
+	p := testProfile()
+	d := downgradedDecision(t, p)
+	out, err := Escalate(p, d, nil, TriggerReviewerUncertainty, "unsure about acceptance")
+	if err != nil {
+		t.Fatalf("Escalate: %v", err)
+	}
+	if out.Kind != OutcomeReroute {
+		t.Fatalf("kind = %q, want reroute", out.Kind)
+	}
+	if out.Decision.Reviewer != p.Reviewer || out.Decision.ReviewerDowngraded {
+		t.Errorf("reviewer=%+v downgraded=%v, want strong reviewer, not downgraded", out.Decision.Reviewer, out.Decision.ReviewerDowngraded)
+	}
+	if out.Decision.Executor != p.Implementer {
+		t.Errorf("executor = %+v, want unchanged implementer", out.Decision.Executor)
+	}
+	if len(out.Escalations) != 1 || out.Escalations[0].Role != manifest.RoleReviewer {
+		t.Errorf("escalations = %+v, want one reviewer escalation", out.Escalations)
+	}
+}
+
+func TestEscalateArchitecturalAmbiguityFromEveryRole(t *testing.T) {
+	p := testProfile()
+	decisions := map[string]Decision{
+		"scout":       scoutDecision(t, p),
+		"implementer": implementerDecision(t, p),
+		"specialist":  specialistDecision(t, p),
+		"downgraded":  downgradedDecision(t, p),
+	}
+	for name, d := range decisions {
+		t.Run(name, func(t *testing.T) {
+			out, err := Escalate(p, d, nil, TriggerArchitecturalAmbiguity, "contract is ambiguous")
+			if err != nil {
+				t.Fatalf("Escalate: %v", err)
+			}
+			if out.Kind != OutcomeReturnToArchitect {
+				t.Errorf("kind = %q, want return-to-architect", out.Kind)
+			}
+			if len(out.Escalations) != 0 {
+				t.Errorf("escalations = %d, want 0", len(out.Escalations))
+			}
+			if out.Reason == "" {
+				t.Error("reason must be non-empty")
+			}
+		})
+	}
+}
+
+func TestEscalateTriggerMismatch(t *testing.T) {
+	p := testProfile()
+	tests := map[string]struct {
+		decision Decision
+		trigger  Trigger
+	}{
+		"scout-uncertainty on implementer": {
+			implementerDecision(t, p), TriggerScoutUncertainty,
+		},
+		"implementer-hard on scout": {
+			scoutDecision(t, p), TriggerImplementerHardExecution,
+		},
+		"reviewer-uncertainty on non-downgraded decision": {
+			implementerDecision(t, p), TriggerReviewerUncertainty,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := Escalate(p, tt.decision, nil, tt.trigger, "")
+			if !errors.Is(err, ErrTriggerMismatch) {
+				t.Errorf("err = %v, want ErrTriggerMismatch", err)
+			}
+		})
+	}
+}
+
+func TestEscalateUnknownTrigger(t *testing.T) {
+	p := testProfile()
+	_, err := Escalate(p, implementerDecision(t, p), nil, Trigger("meltdown"), "")
+	if !errors.Is(err, ErrBadTrigger) {
+		t.Errorf("err = %v, want ErrBadTrigger", err)
+	}
+}
+
+func TestEscalateBadProfile(t *testing.T) {
+	p := testProfile()
+	d := implementerDecision(t, p)
+	p.Specialist = manifest.Selection{} // corrupt after building the decision
+	_, err := Escalate(p, d, nil, TriggerImplementerHardExecution, "")
+	if !errors.Is(err, ErrBadProfile) {
+		t.Errorf("err = %v, want ErrBadProfile", err)
+	}
+}
+
+// TestEscalateDoubleClosesToArchitect round-trips the History from a
+// first escalation into a second and confirms the ladder closes at the
+// Architect.
+func TestEscalateDoubleClosesToArchitect(t *testing.T) {
+	p := testProfile()
+
+	t.Run("scout uncertainty twice", func(t *testing.T) {
+		d := scoutDecision(t, p)
+		first, err := Escalate(p, d, nil, TriggerScoutUncertainty, "still unsure")
+		if err != nil {
+			t.Fatalf("first Escalate: %v", err)
+		}
+		if first.Kind != OutcomeReroute {
+			t.Fatalf("first kind = %q, want reroute", first.Kind)
+		}
+		second, err := Escalate(p, first.Decision, first.History, TriggerScoutUncertainty, "specialist also unsure")
+		if err != nil {
+			t.Fatalf("second Escalate: %v", err)
+		}
+		if second.Kind != OutcomeReturnToArchitect {
+			t.Errorf("second kind = %q, want return-to-architect", second.Kind)
+		}
+		if len(second.Escalations) != 0 {
+			t.Errorf("closing outcome must emit no escalations, got %d", len(second.Escalations))
+		}
+	})
+
+	t.Run("weak model failure implementer then specialist", func(t *testing.T) {
+		d := implementerDecision(t, p)
+		first, err := Escalate(p, d, nil, TriggerWeakModelFailure, "impl too weak")
+		if err != nil {
+			t.Fatalf("first Escalate: %v", err)
+		}
+		second, err := Escalate(p, first.Decision, first.History, TriggerWeakModelFailure, "spec too weak")
+		if err != nil {
+			t.Fatalf("second Escalate: %v", err)
+		}
+		if second.Kind != OutcomeReturnToArchitect {
+			t.Errorf("second kind = %q, want return-to-architect", second.Kind)
+		}
+	})
+}
+
+func TestEscalateDegenerateProfiles(t *testing.T) {
+	t.Run("specialist model equals implementer returns to architect", func(t *testing.T) {
+		p := testProfile()
+		p.Specialist = p.Implementer
+		d := implementerDecision(t, p)
+		out, err := Escalate(p, d, nil, TriggerImplementerHardExecution, "hard")
+		if err != nil {
+			t.Fatalf("Escalate: %v", err)
+		}
+		if out.Kind != OutcomeReturnToArchitect {
+			t.Errorf("kind = %q, want return-to-architect (no stronger model)", out.Kind)
+		}
+	})
+
+	t.Run("reviewer equals downgrade returns to architect", func(t *testing.T) {
+		p := testProfile()
+		p.ReviewDowngrade = p.Reviewer
+		d := downgradedDecision(t, p)
+		out, err := Escalate(p, d, nil, TriggerReviewerUncertainty, "unsure")
+		if err != nil {
+			t.Fatalf("Escalate: %v", err)
+		}
+		if out.Kind != OutcomeReturnToArchitect {
+			t.Errorf("kind = %q, want return-to-architect (no stronger reviewer)", out.Kind)
+		}
+	})
+}
+
+// TestEscalateManifestRoundTrip is the end-to-end proof: every emitted
+// escalation, embedded in a manifest.Manifest built from the rerouted
+// Decision, passes manifest.Render.
+func TestEscalateManifestRoundTrip(t *testing.T) {
+	p := testProfile()
+	reroutes := map[string]struct {
+		decision Decision
+		trigger  Trigger
+	}{
+		"scout uncertainty":          {scoutDecision(t, p), TriggerScoutUncertainty},
+		"implementer hard":           {implementerDecision(t, p), TriggerImplementerHardExecution},
+		"weak model implementer":     {implementerDecision(t, p), TriggerWeakModelFailure},
+		"implementer hard downgrade": {downgradedDecision(t, p), TriggerImplementerHardExecution},
+		"reviewer uncertainty":       {downgradedDecision(t, p), TriggerReviewerUncertainty},
+	}
+	for name, tt := range reroutes {
+		t.Run(name, func(t *testing.T) {
+			out, err := Escalate(p, tt.decision, nil, tt.trigger, "detail for the record")
+			if err != nil {
+				t.Fatalf("Escalate: %v", err)
+			}
+			if out.Kind != OutcomeReroute {
+				t.Fatalf("kind = %q, want reroute", out.Kind)
+			}
+			m := manifest.Manifest{
+				SchemaVersion:    manifest.SchemaVersion,
+				Role:             out.Decision.Role,
+				Executor:         out.Decision.Executor,
+				RoutingRationale: out.Decision.Rationale,
+				Reviewer:         out.Decision.Reviewer,
+				Escalations:      out.Escalations,
+				ConfigRevision:   "cfg-2026-07-11",
+			}
+			if _, err := manifest.Render(m); err != nil {
+				t.Fatalf("manifest.Render on escalated decision: %v", err)
+			}
+		})
+	}
+}

--- a/internal/routing/history.go
+++ b/internal/routing/history.go
@@ -1,0 +1,34 @@
+package routing
+
+import "github.com/kninetimmy/orch/internal/manifest"
+
+// Attempt records one prior routing attempt and its fate. Failed marks
+// a meaningful failure that permanently retires the attempt's model
+// (PRD §11: Orch does not repeatedly retry an underpowered model);
+// Reason is the caller-supplied detail behind that failure.
+type Attempt struct {
+	Role      manifest.Role
+	Selection manifest.Selection
+	Failed    bool
+	Reason    string
+}
+
+// History is the ordered list of prior attempts for a task. A nil
+// History is a fresh task with nothing retired. Both entry points take
+// it as a required positional argument, and Escalate returns the
+// updated History with the retired attempt appended — so the correct
+// input to a second call is the first call's output.
+type History []Attempt
+
+// FailedModel reports whether any recorded attempt on model failed. The
+// match is on the model string only: an effort bump on a model that has
+// already failed is still a retry of that model, never a fresh route,
+// so routing never offers it again (PRD §11).
+func (h History) FailedModel(model string) bool {
+	for _, a := range h {
+		if a.Failed && a.Selection.Model == model {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/routing/history_test.go
+++ b/internal/routing/history_test.go
@@ -1,0 +1,84 @@
+package routing
+
+import (
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/manifest"
+)
+
+func TestFailedModel(t *testing.T) {
+	tests := map[string]struct {
+		history History
+		query   string
+		want    bool
+	}{
+		"nil history": {nil, "impl-m", false},
+		"empty history": {
+			History{},
+			"impl-m",
+			false,
+		},
+		"failed model matches": {
+			History{{Role: manifest.RoleImplementer, Selection: manifest.Selection{Model: "impl-m", Effort: "high"}, Failed: true}},
+			"impl-m",
+			true,
+		},
+		"other model does not match": {
+			History{{Role: manifest.RoleImplementer, Selection: manifest.Selection{Model: "impl-m", Effort: "high"}, Failed: true}},
+			"spec-m",
+			false,
+		},
+		"non-failed attempt does not match": {
+			History{{Role: manifest.RoleImplementer, Selection: manifest.Selection{Model: "impl-m", Effort: "high"}, Failed: false}},
+			"impl-m",
+			false,
+		},
+		"effort bump on failed model still matches on model string": {
+			History{{Role: manifest.RoleImplementer, Selection: manifest.Selection{Model: "impl-m", Effort: "low"}, Failed: true}},
+			"impl-m",
+			true,
+		},
+		"matches among several attempts": {
+			History{
+				{Role: manifest.RoleScout, Selection: manifest.Selection{Model: "scout-m", Effort: "low"}, Failed: false},
+				{Role: manifest.RoleImplementer, Selection: manifest.Selection{Model: "impl-m", Effort: "high"}, Failed: true},
+			},
+			"impl-m",
+			true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := tt.history.FailedModel(tt.query); got != tt.want {
+				t.Errorf("FailedModel(%q) = %v, want %v", tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDowngradeFactsEligible(t *testing.T) {
+	all := DowngradeFacts{Mechanical: true, LowRisk: true, FullySpecified: true, Unsurprising: true}
+	if !all.Eligible() {
+		t.Error("all four facts should be Eligible")
+	}
+	if (DowngradeFacts{}).Eligible() {
+		t.Error("zero value must not be Eligible (absence is never permission)")
+	}
+	// Every single-fact-missing combination is ineligible.
+	for i := 0; i < 4; i++ {
+		f := all
+		switch i {
+		case 0:
+			f.Mechanical = false
+		case 1:
+			f.LowRisk = false
+		case 2:
+			f.FullySpecified = false
+		case 3:
+			f.Unsurprising = false
+		}
+		if f.Eligible() {
+			t.Errorf("facts with field %d cleared should not be Eligible", i)
+		}
+	}
+}

--- a/internal/routing/rationale.go
+++ b/internal/routing/rationale.go
@@ -1,0 +1,179 @@
+package routing
+
+import (
+	"strings"
+
+	"github.com/kninetimmy/orch/internal/manifest"
+)
+
+// This file holds the deterministic, single-sentence rationale and
+// reason builders. Every result is non-empty so it satisfies manifest's
+// non-empty RoutingRationale / Escalation.Reason / Outcome.Reason
+// validation. Risk domains are always rendered in Domains() order and
+// downgrade refusals name the specific gap, so the audit record reads
+// the same for the same inputs.
+
+// renderDomains lists the present risk domains in canonical Domains()
+// order, de-duplicated, comma-separated.
+func renderDomains(ds []RiskDomain) string {
+	present := make(map[RiskDomain]bool, len(ds))
+	for _, d := range ds {
+		present[d] = true
+	}
+	var names []string
+	for _, d := range Domains() {
+		if present[d] {
+			names = append(names, string(d))
+		}
+	}
+	return strings.Join(names, ", ")
+}
+
+// joinClauses joins reason clauses into one grammatical list.
+func joinClauses(parts []string) string {
+	switch len(parts) {
+	case 0:
+		return ""
+	case 1:
+		return parts[0]
+	case 2:
+		return parts[0] + " and " + parts[1]
+	default:
+		return strings.Join(parts[:len(parts)-1], ", ") + ", and " + parts[len(parts)-1]
+	}
+}
+
+// escalationReasons collects the reasons a task escaped the plain route:
+// risk domains (in canonical order), difficulty, and a failed model of
+// the named role.
+func escalationReasons(t Task, h History, failedRole string, failedModel string) []string {
+	var reasons []string
+	if len(t.RiskDomains) > 0 {
+		reasons = append(reasons, "risk domains ("+renderDomains(t.RiskDomains)+")")
+	}
+	if t.UnusuallyDifficult {
+		reasons = append(reasons, "the task is unusually difficult")
+	}
+	if h.FailedModel(failedModel) {
+		reasons = append(reasons, "the "+failedRole+" model previously failed")
+	}
+	return reasons
+}
+
+func rationaleScoutPlain() string {
+	return "Routed read-only work to a scout with no elevated risk or difficulty."
+}
+
+func rationaleScoutEscalated(t Task, h History, p Profile) string {
+	reasons := escalationReasons(t, h, "scout", p.Scout.Model)
+	return "Routed read-only work to a scout on the specialist model in read-only mode because " + joinClauses(reasons) + "."
+}
+
+func rationaleSpecialist(t Task, h History, p Profile) string {
+	reasons := escalationReasons(t, h, "implementer", p.Implementer.Model)
+	base := "Routed to a specialist with a strong reviewer because " + joinClauses(reasons)
+	if t.Downgrade.Eligible() {
+		base += ", overriding the reviewer downgrade the change would otherwise qualify for"
+	}
+	return base + "."
+}
+
+func rationaleDowngrade() string {
+	return "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising."
+}
+
+func rationaleImplementer(t Task) string {
+	if t.Downgrade.requested() {
+		return "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is " + firstMissingFact(t.Downgrade) + "."
+	}
+	return "Routed to an implementer with a strong reviewer with no reviewer downgrade requested."
+}
+
+// firstMissingFact names the first affirmative downgrade fact the caller
+// did not assert, in the canonical mechanical/low-risk/specified/
+// unsurprising order, so a refusal always names one concrete gap.
+func firstMissingFact(f DowngradeFacts) string {
+	switch {
+	case !f.Mechanical:
+		return "not affirmatively mechanical"
+	case !f.LowRisk:
+		return "not affirmatively low-risk"
+	case !f.FullySpecified:
+		return "not affirmatively fully specified"
+	case !f.Unsurprising:
+		return "not affirmatively unsurprising"
+	default:
+		return "affirmatively downgrade-eligible"
+	}
+}
+
+// rationaleReroute describes the executor selection after an escalation,
+// for the rerouted Decision's RoutingRationale.
+func rationaleReroute(newRole manifest.Role, tr Trigger) string {
+	switch tr {
+	case TriggerScoutUncertainty:
+		return "Re-routed read-only work to a scout on the specialist model in read-only mode after scout uncertainty."
+	case TriggerImplementerHardExecution:
+		return "Re-routed to a specialist after the implementer hit unusually hard execution."
+	case TriggerWeakModelFailure:
+		if newRole == manifest.RoleScout {
+			return "Re-routed read-only work to a scout on the specialist model in read-only mode after a weak-model failure."
+		}
+		return "Re-routed to a specialist after a weak-model failure on the implementer."
+	default:
+		return "Re-routed to a stronger executor after escalation."
+	}
+}
+
+func rationaleReviewerEscalated() string {
+	return "Escalated to a full strong-model review after the downgraded reviewer reported uncertainty."
+}
+
+// withDetail terminates a reason sentence, appending the caller's detail
+// in parentheses when present. The base is always non-empty, so the
+// result is too.
+func withDetail(base, detail string) string {
+	if detail == "" {
+		return base + "."
+	}
+	return base + " (" + detail + ")."
+}
+
+func reasonExecutorReroute(fromRole manifest.Role, tr Trigger, detail string) string {
+	var base string
+	switch tr {
+	case TriggerScoutUncertainty:
+		base = "Scout reported uncertainty; escalated to the specialist model in read-only mode"
+	case TriggerImplementerHardExecution:
+		base = "Implementer hit unusually hard execution; transferred the worktree to a specialist"
+	case TriggerWeakModelFailure:
+		base = "Weak-model failure on the " + string(fromRole) + "; escalated to the next model tier"
+	default:
+		base = "Escalated to a stronger executor model"
+	}
+	return withDetail(base, detail)
+}
+
+func reasonReviewerRestored(detail string) string {
+	return withDetail("Restored the strong reviewer because a task requiring escalation is, by evidence, no longer unsurprising", detail)
+}
+
+func reasonReviewerUncertainty(detail string) string {
+	return withDetail("Downgraded reviewer reported uncertainty; escalated to a full strong-model review", detail)
+}
+
+func reasonExecutorExhausted(role manifest.Role, detail string) string {
+	return withDetail("No stronger executor model remains after the "+string(role)+" failed; returning to the Architect", detail)
+}
+
+func reasonSpecialistExhausted(detail string) string {
+	return withDetail("Specialist execution failed and no stronger executor model remains; returning to the Architect", detail)
+}
+
+func reasonReviewerDegenerate(detail string) string {
+	return withDetail("Strong review is unavailable because the reviewer and downgrade profiles share a model; returning to the Architect", detail)
+}
+
+func reasonArchitecturalAmbiguity(detail string) string {
+	return withDetail("Unresolved architectural ambiguity; returning to the Architect", detail)
+}

--- a/internal/routing/risk.go
+++ b/internal/routing/risk.go
@@ -1,0 +1,47 @@
+package routing
+
+// RiskDomain is one of the sensitive domains PRD §11 routes directly to
+// a Specialist executor plus a strong Reviewer. The set is closed: any
+// other value is an unknown domain and rejected as ErrBadTask.
+type RiskDomain string
+
+const (
+	RiskSecurity              RiskDomain = "security"
+	RiskAuthentication        RiskDomain = "authentication"
+	RiskAuthorization         RiskDomain = "authorization"
+	RiskSecrets               RiskDomain = "secrets"
+	RiskCryptography          RiskDomain = "cryptography"
+	RiskMigrations            RiskDomain = "migrations"
+	RiskConcurrency           RiskDomain = "concurrency"
+	RiskDataIntegrity         RiskDomain = "data-integrity"
+	RiskDestructiveOperations RiskDomain = "destructive-operations"
+)
+
+// Domains returns the nine risk domains in canonical order. Rationale
+// strings render present domains in this order, so the audit record is
+// deterministic regardless of the caller's Task ordering.
+func Domains() []RiskDomain {
+	return []RiskDomain{
+		RiskSecurity,
+		RiskAuthentication,
+		RiskAuthorization,
+		RiskSecrets,
+		RiskCryptography,
+		RiskMigrations,
+		RiskConcurrency,
+		RiskDataIntegrity,
+		RiskDestructiveOperations,
+	}
+}
+
+// Valid reports whether d is a member of the closed risk-domain set.
+func (d RiskDomain) Valid() bool {
+	switch d {
+	case RiskSecurity, RiskAuthentication, RiskAuthorization, RiskSecrets,
+		RiskCryptography, RiskMigrations, RiskConcurrency, RiskDataIntegrity,
+		RiskDestructiveOperations:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/routing/risk_test.go
+++ b/internal/routing/risk_test.go
@@ -1,0 +1,57 @@
+package routing
+
+import "testing"
+
+func TestRiskDomainValid(t *testing.T) {
+	tests := map[string]struct {
+		domain RiskDomain
+		want   bool
+	}{
+		"security":               {RiskSecurity, true},
+		"authentication":         {RiskAuthentication, true},
+		"authorization":          {RiskAuthorization, true},
+		"secrets":                {RiskSecrets, true},
+		"cryptography":           {RiskCryptography, true},
+		"migrations":             {RiskMigrations, true},
+		"concurrency":            {RiskConcurrency, true},
+		"data-integrity":         {RiskDataIntegrity, true},
+		"destructive-operations": {RiskDestructiveOperations, true},
+		"empty rejected":         {"", false},
+		"titlecase rejected":     {"Security", false},
+		"unknown rejected":       {"performance", false},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := tt.domain.Valid(); got != tt.want {
+				t.Errorf("RiskDomain(%q).Valid() = %v, want %v", tt.domain, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDomainsOrderStable(t *testing.T) {
+	want := []RiskDomain{
+		RiskSecurity, RiskAuthentication, RiskAuthorization, RiskSecrets,
+		RiskCryptography, RiskMigrations, RiskConcurrency, RiskDataIntegrity,
+		RiskDestructiveOperations,
+	}
+	for call := 0; call < 2; call++ {
+		got := Domains()
+		if len(got) != len(want) {
+			t.Fatalf("Domains() returned %d domains, want %d", len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("Domains()[%d] = %q, want %q", i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func TestDomainsAllValid(t *testing.T) {
+	for _, d := range Domains() {
+		if !d.Valid() {
+			t.Errorf("Domains() member %q is not Valid()", d)
+		}
+	}
+}

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -1,0 +1,90 @@
+// Package routing is Orch's pure role-routing and escalation policy
+// core (PRD §9 roles, §10 default profiles, §11 routing and
+// escalation). Given a host Profile, a Task's read-only/risk/difficulty
+// facts, and the History of prior attempts, Decide picks the role,
+// executor, and reviewer for a fresh routing, and Escalate applies the
+// PRD §11 escalation rules when a running attempt reports trouble.
+//
+// The package is deliberately narrow and fail-closed. It performs no
+// I/O, reads no clock, and imports only internal/manifest, whose
+// Role/Selection/Escalation types it emits verbatim so the run engine
+// can record a decision in a PRD §13 audit manifest without a
+// translation layer. It never ranks model strength: model identifiers
+// are opaque strings and it trusts the profile's role semantics (config
+// owns the model vocabulary). Degenerate profiles — where a stronger
+// role's model equals one that has already failed — are caught by
+// string equality on the failed set and resolved by returning to the
+// Architect, never by guessing at a strength order.
+package routing
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/kninetimmy/orch/internal/manifest"
+)
+
+// Profile is the per-host model/effort assignment routing consumes. Its
+// six selections mirror config.Roles (PRD §10) one-for-one, but routing
+// does not import config: the run engine maps each config.RoleProfile
+// to a manifest.Selection and hands the result here, keeping this
+// package off the TOML chain.
+type Profile struct {
+	Architect       manifest.Selection
+	Scout           manifest.Selection
+	Implementer     manifest.Selection
+	Specialist      manifest.Selection
+	Reviewer        manifest.Selection
+	ReviewDowngrade manifest.Selection
+}
+
+// Sentinel errors callers test with errors.Is. Specifics wrap these
+// with %w and a remediation hint (state.go / manifest.go house style)
+// rather than replace them.
+var (
+	// ErrBadProfile reports a Profile with an incomplete selection: some
+	// role is missing its model or effort. Routing cannot emit a valid
+	// audit record from it, so it refuses rather than guess a default.
+	ErrBadProfile = errors.New("routing profile is incomplete")
+	// ErrBadTask reports a Task carrying an unknown risk domain — a value
+	// outside the closed PRD §11 set (see Domains).
+	ErrBadTask = errors.New("routing task is invalid")
+	// ErrBadTrigger reports an Escalate call with a trigger outside the
+	// closed set (see the Trigger constants).
+	ErrBadTrigger = errors.New("escalation trigger is unknown")
+	// ErrTriggerMismatch reports an escalation trigger applied to a
+	// decision it does not fit — e.g. scout-uncertainty on a non-scout
+	// decision, or reviewer-uncertainty on a decision whose reviewer was
+	// never downgraded.
+	ErrTriggerMismatch = errors.New("escalation trigger does not match the decision")
+	// ErrNoStrongerRoute reports that initial routing needs a stronger
+	// executor than the profile can supply because the only candidate has
+	// already failed. Unlike an escalation exhaustion (which returns to
+	// the Architect), this is a plan-gate problem surfaced at Decide time.
+	ErrNoStrongerRoute = errors.New("no stronger executor route remains")
+)
+
+// validate reports the first Profile completeness violation, wrapping
+// ErrBadProfile with the offending field. Both entry points reject an
+// invalid profile before making any decision (fail closed).
+func (p Profile) validate() error {
+	for _, f := range []struct {
+		name string
+		sel  manifest.Selection
+	}{
+		{"architect", p.Architect},
+		{"scout", p.Scout},
+		{"implementer", p.Implementer},
+		{"specialist", p.Specialist},
+		{"reviewer", p.Reviewer},
+		{"review_downgrade", p.ReviewDowngrade},
+	} {
+		if f.sel.Model == "" {
+			return fmt.Errorf("%w: %s.model is empty", ErrBadProfile, f.name)
+		}
+		if f.sel.Effort == "" {
+			return fmt.Errorf("%w: %s.effort is empty", ErrBadProfile, f.name)
+		}
+	}
+	return nil
+}

--- a/internal/routing/task.go
+++ b/internal/routing/task.go
@@ -1,0 +1,46 @@
+package routing
+
+// Task carries the routing-relevant facts about one unit of work. All
+// fields default to the safe answer: a zero Task is a read/write,
+// low-difficulty change with no risk domains and no downgrade
+// permission, which Decide routes to a plain implementer with a strong
+// reviewer.
+type Task struct {
+	// ReadOnly marks work that only reads the repository (PRD §9 Scout).
+	ReadOnly bool
+	// UnusuallyDifficult marks work whose implementation is itself hard
+	// (PRD §9 Specialist), forcing a specialist regardless of risk.
+	UnusuallyDifficult bool
+	// RiskDomains lists the sensitive domains the change touches; any
+	// non-empty set forces a specialist plus a strong reviewer (PRD §11).
+	RiskDomains []RiskDomain
+	// Downgrade holds the caller's affirmative claims about the change.
+	// It only ever weakens the reviewer, and only when Eligible.
+	Downgrade DowngradeFacts
+}
+
+// DowngradeFacts are the four conditions PRD §11 requires before a
+// reviewer may be downgraded: the change must be affirmatively
+// mechanical, low-risk, fully specified, and unsurprising.
+type DowngradeFacts struct {
+	Mechanical     bool
+	LowRisk        bool
+	FullySpecified bool
+	Unsurprising   bool
+}
+
+// Eligible reports whether all four downgrade facts are affirmatively
+// true. The zero value is not eligible: absence of information is never
+// permission to downgrade review (PRD §11: uncertainty favors the
+// stronger route).
+func (f DowngradeFacts) Eligible() bool {
+	return f.Mechanical && f.LowRisk && f.FullySpecified && f.Unsurprising
+}
+
+// requested reports whether the caller asserted any downgrade fact. It
+// distinguishes a partial, refused downgrade request (some facts true)
+// from a task that never asked for one (the zero value), which the
+// rationale narrates differently.
+func (f DowngradeFacts) requested() bool {
+	return f.Mechanical || f.LowRisk || f.FullySpecified || f.Unsurprising
+}


### PR DESCRIPTION
## What

New pure package `internal/routing` — the PRD §9–§11 policy core (roadmap task 10). Two entry points:

- **`Decide(Profile, Task, History)`** — initial routing via a first-match-wins table: read-only work goes to a Scout (on the Specialist model when risk/difficulty/history demands, per §11 "Specialist model in read-only mode"); risk domains (closed 9-domain enum) or affirmed difficulty route directly to Specialist + strong Reviewer; reviewer downgrade is granted only when a change is affirmatively mechanical, low-risk, fully specified, AND unsurprising — the zero value forbids it, and conflicts resolve silently to the stronger route with the refusal named in the rationale.
- **`Escalate(Profile, Decision, History, Trigger, detail)`** — the §11 escalation ladder: scout uncertainty → Specialist model read-only; implementer hardness → fresh Specialist; one meaningful weak-model failure climbs a tier (never retries — `History.FailedModel` matches on model string only, so an effort bump is still a retry); downgraded-reviewer uncertainty → full strong review; architectural ambiguity → return to the Architect. Exhaustion and degenerate profiles (a stronger tier sharing a failed model) close to a first-class `OutcomeReturnToArchitect`, never an error and never a guess at model strength.

Decisions emit `manifest.Selection` / `manifest.Escalation` directly (routing imports internal/manifest only — no config, no clock, no I/O), so the run engine records audit manifests with zero translation. Any executor reroute on a downgraded-reviewer decision also restores the strong reviewer with a second escalation record: a task that needed escalation was, by evidence, not "unsurprising".

## Why

First policy package — everything landed so far (paths, gitops, ghops, manifest) is mechanics. Routing is the piece the plan gate and run engine consume: it makes §11's conservative-escalation rules mechanical and auditable instead of prompt-enforced. History is a required positional argument and `Escalate` returns the updated History, so "has this model already failed" is impossible to ignore by construction.

## Tests

Table-driven throughout: a generated 64-case downgrade matrix (grant in exactly one cell), per-trigger escalation tables, double-escalation closing to the Architect via round-tripped History, degenerate-profile cases, 12 generated bad-profile cases, golden rationale strings, and a manifest round-trip proving every emitted record passes `manifest.Render`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)