### PR TITLE
Add internal/run: Delivery run engine slice 1 (plan gate + activation)

### DIFF
--- a/cmd/orch/main.go
+++ b/cmd/orch/main.go
@@ -20,5 +20,6 @@ func main() {
 		RepoRoot: root,
 		Stdout:   os.Stdout,
 		Stderr:   os.Stderr,
+		Stdin:    os.Stdin,
 	}))
 }

--- a/internal/cli/abort_test.go
+++ b/internal/cli/abort_test.go
@@ -21,7 +21,7 @@ func TestAbortNotInitialized(t *testing.T) {
 func TestAbortDeliveryRun(t *testing.T) {
 	env, stdout, _ := testEnv(t)
 	writeConfig(t, env.RepoRoot, validTOML)
-	st, err := state.EnterDelivery(env.RepoRoot, "claude")
+	st, err := state.EnterDelivery(env.RepoRoot, "claude", testPlanRef(), testIssues())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func TestAbortDeliveryRun(t *testing.T) {
 func TestAbortIdempotent(t *testing.T) {
 	env, stdout, _ := testEnv(t)
 	writeConfig(t, env.RepoRoot, validTOML)
-	if _, err := state.EnterDelivery(env.RepoRoot, "claude"); err != nil {
+	if _, err := state.EnterDelivery(env.RepoRoot, "claude", testPlanRef(), testIssues()); err != nil {
 		t.Fatal(err)
 	}
 	if code := Run([]string{"abort"}, env); code != ExitOK {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -3,9 +3,11 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
+	"strings"
 
 	"github.com/kninetimmy/orch/internal/execx"
 )
@@ -23,6 +25,9 @@ type Env struct {
 	RepoRoot string
 	Stdout   io.Writer
 	Stderr   io.Writer
+	// Stdin is the process input; nil is treated as empty. `orch run`
+	// verbs read their JSON document from it.
+	Stdin io.Reader
 	// LookPath resolves an executable name; defaults to exec.LookPath.
 	LookPath func(string) (string, error)
 	// Runner executes external commands (git, gh); defaults to
@@ -30,30 +35,52 @@ type Env struct {
 	Runner execx.Runner
 }
 
+// usageError marks a user-facing usage mistake, as opposed to an
+// operational failure: Run maps it to ExitUsage instead of ExitError.
+type usageError string
+
+func (e usageError) Error() string { return string(e) }
+
 type command struct {
 	name    string
 	summary string
-	run     func(Env) error
+	run     func(Env, []string) error
 }
 
 // commands lists the full PRD §22 surface in documentation order, so
 // `orch help` always shows every logical command even before it works.
+// `run` is listed last and labeled plumbing (F2): it is adapter-facing
+// JSON stdin/stdout, not a command a human runs directly.
 func commands() []command {
 	return []command{
-		{"init", "Interview and bootstrap this repository (not implemented)", notImplemented("init")},
-		{"status", "Show mode and configuration summary", runStatus},
-		{"doctor", "Check environment and configuration health", runDoctor},
-		{"configure", "Change committed configuration (not implemented)", notImplemented("configure")},
-		{"configure-local", "Change machine-local overrides (not implemented)", notImplemented("configure-local")},
-		{"resume", "Resume an interrupted Delivery run (not implemented)", notImplemented("resume")},
-		{"abort", "Stop dispatch and return to Assist", runAbort},
-		{"metrics", "Show local metrics (not implemented)", notImplemented("metrics")},
+		{"init", "Interview and bootstrap this repository (not implemented)", noArgs("init", notImplemented("init"))},
+		{"status", "Show mode and configuration summary", noArgs("status", runStatus)},
+		{"doctor", "Check environment and configuration health", noArgs("doctor", runDoctor)},
+		{"configure", "Change committed configuration (not implemented)", noArgs("configure", notImplemented("configure"))},
+		{"configure-local", "Change machine-local overrides (not implemented)", noArgs("configure-local", notImplemented("configure-local"))},
+		{"resume", "Resume an interrupted Delivery run (not implemented)", noArgs("resume", notImplemented("resume"))},
+		{"abort", "Stop dispatch and return to Assist", noArgs("abort", runAbort)},
+		{"metrics", "Show local metrics (not implemented)", noArgs("metrics", notImplemented("metrics"))},
+		{"run", "Adapter plumbing: Delivery run verbs (JSON stdin/stdout; not a human command)", runRunVerb},
 	}
 }
 
 func notImplemented(name string) func(Env) error {
 	return func(Env) error {
 		return fmt.Errorf("%s is not implemented yet", name)
+	}
+}
+
+// noArgs adapts a no-trailing-argument command function to the
+// dispatcher's func(Env, []string) error shape, preserving the
+// existing trailing-argument rejection for every command that isn't
+// adapter plumbing.
+func noArgs(name string, fn func(Env) error) func(Env, []string) error {
+	return func(env Env, args []string) error {
+		if len(args) > 0 {
+			return usageError(fmt.Sprintf("orch %s: unexpected argument %q", name, args[0]))
+		}
+		return fn(env)
 	}
 }
 
@@ -65,6 +92,9 @@ func Run(args []string, env Env) int {
 	}
 	if env.Runner == nil {
 		env.Runner = execx.Local{LookPath: env.LookPath}
+	}
+	if env.Stdin == nil {
+		env.Stdin = strings.NewReader("")
 	}
 	if len(args) == 0 {
 		usage(env.Stderr)
@@ -78,15 +108,17 @@ func Run(args []string, env Env) int {
 		if c.name != args[0] {
 			continue
 		}
-		if len(args) > 1 {
-			fmt.Fprintf(env.Stderr, "orch %s: unexpected argument %q\n", c.name, args[1])
+		err := c.run(env, args[1:])
+		if err == nil {
+			return ExitOK
+		}
+		var ue usageError
+		if errors.As(err, &ue) {
+			fmt.Fprintf(env.Stderr, "%s\n", err)
 			return ExitUsage
 		}
-		if err := c.run(env); err != nil {
-			fmt.Fprintf(env.Stderr, "orch %s: %v\n", c.name, err)
-			return ExitError
-		}
-		return ExitOK
+		fmt.Fprintf(env.Stderr, "orch %s: %v\n", c.name, err)
+		return ExitError
 	}
 	fmt.Fprintf(env.Stderr, "orch: unknown command %q\n\n", args[0])
 	usage(env.Stderr)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -11,7 +11,19 @@ import (
 	"testing"
 
 	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/state"
 )
+
+// testPlanRef and testIssues supply the minimal valid
+// state.EnterDelivery arguments the delivery-mode cli tests need;
+// their content is irrelevant to what those tests assert.
+func testPlanRef() state.PlanRef {
+	return state.PlanRef{Title: "t", Digest: "sha256:test", ConfigRevision: "r1"}
+}
+
+func testIssues() []state.Issue {
+	return []state.Issue{{PlanID: "iss-a", Title: "A", Phase: state.PhasePlanned}}
+}
 
 // validTOML is a minimal valid configuration (one host, defaults).
 const validTOML = `
@@ -125,10 +137,13 @@ func TestRunHelpListsAllCommands(t *testing.T) {
 	if code := Run([]string{"help"}, env); code != ExitOK {
 		t.Errorf("exit = %d, want %d", code, ExitOK)
 	}
-	for _, name := range []string{"init", "status", "doctor", "configure", "configure-local", "resume", "abort", "metrics"} {
+	for _, name := range []string{"init", "status", "doctor", "configure", "configure-local", "resume", "abort", "metrics", "run"} {
 		if !strings.Contains(stdout.String(), name) {
 			t.Errorf("help output missing command %q", name)
 		}
+	}
+	if !strings.Contains(stdout.String(), "plumbing") {
+		t.Error("help output does not label `run` as adapter plumbing (F2)")
 	}
 }
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -126,7 +126,7 @@ func TestDoctorMissingConfig(t *testing.T) {
 func TestDoctorConsistentDeliveryPasses(t *testing.T) {
 	env, stdout, _ := testEnv(t)
 	writeConfig(t, env.RepoRoot, validTOML)
-	if _, err := state.EnterDelivery(env.RepoRoot, "claude"); err != nil {
+	if _, err := state.EnterDelivery(env.RepoRoot, "claude", testPlanRef(), testIssues()); err != nil {
 		t.Fatal(err)
 	}
 	if code := Run([]string{"doctor"}, env); code != ExitOK {
@@ -180,7 +180,7 @@ func TestDoctorNotesDeadAcquirer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	st, err := state.EnterDelivery(env.RepoRoot, "claude")
+	st, err := state.EnterDelivery(env.RepoRoot, "claude", testPlanRef(), testIssues())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/run"
+)
+
+// runRunVerb dispatches the adapter-facing plumbing verbs (PRD §22):
+// `orch run plan|activate|status --json`. Host adapters shell out to
+// it after their own native dialogs, exchanging JSON documents on
+// stdin/stdout; it is never invoked by a human directly.
+func runRunVerb(env Env, args []string) error {
+	var verb string
+	switch {
+	case len(args) == 1 && args[0] == "plan":
+		verb = "plan"
+	case len(args) == 1 && args[0] == "activate":
+		verb = "activate"
+	case len(args) == 2 && args[0] == "status" && args[1] == "--json":
+		verb = "status"
+	default:
+		return usageError("orch run: usage: orch run plan|activate|status --json")
+	}
+
+	// Only the document-taking verbs read stdin: status must not block
+	// on a console stdin that never reaches EOF.
+	var input []byte
+	if verb == "plan" || verb == "activate" {
+		stdin := env.Stdin
+		if stdin == nil {
+			stdin = strings.NewReader("")
+		}
+		var err error
+		input, err = io.ReadAll(stdin)
+		if err != nil {
+			return fmt.Errorf("read stdin: %w", err)
+		}
+	}
+
+	runEnv := run.Env{RepoRoot: env.RepoRoot, Runner: env.Runner, Now: time.Now}
+	ctx := context.Background()
+
+	var out any
+	var err error
+	switch verb {
+	case "plan":
+		out, err = run.Plan(ctx, runEnv, input)
+	case "activate":
+		out, err = run.Activate(ctx, runEnv, input)
+	case "status":
+		out, err = run.Status(ctx, runEnv)
+	}
+	if err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode %s result: %w", verb, err)
+	}
+	_, err = fmt.Fprintf(env.Stdout, "%s\n", data)
+	return err
+}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestEightCommandsRejectTrailingArgs proves noArgs still rejects a
+// trailing argument for every PRD §22 command except the adapter-
+// plumbing `run` verb, which parses its own argv.
+func TestEightCommandsRejectTrailingArgs(t *testing.T) {
+	for _, name := range []string{"init", "status", "doctor", "configure", "configure-local", "resume", "abort", "metrics"} {
+		t.Run(name, func(t *testing.T) {
+			env, _, stderr := testEnv(t)
+			if code := Run([]string{name, "extra"}, env); code != ExitUsage {
+				t.Errorf("exit = %d, want %d", code, ExitUsage)
+			}
+			if !strings.Contains(stderr.String(), "unexpected argument") {
+				t.Errorf("stderr = %q", stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunVerbUsageErrors(t *testing.T) {
+	cases := [][]string{
+		{"run"},
+		{"run", "bogus"},
+		{"run", "status"},          // missing --json
+		{"run", "plan", "extra"},   // too many args
+		{"run", "status", "--xml"}, // wrong flag
+	}
+	for _, args := range cases {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			env, _, stderr := testEnv(t)
+			if code := Run(args, env); code != ExitUsage {
+				t.Errorf("exit = %d, want %d", code, ExitUsage)
+			}
+			if !strings.Contains(stderr.String(), "orch run: usage") {
+				t.Errorf("stderr = %q", stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunPlanEndToEnd(t *testing.T) {
+	env, stdout, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	env.Stdin = bytes.NewReader([]byte(minimalPlanJSON))
+
+	if code := Run([]string{"run", "plan"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d; stderr = %s", code, ExitOK, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{`"schema_version"`, `"plan_digest"`, `"plan_title"`, `"fix-status-lock"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunPlanMalformedStdinIsExitError(t *testing.T) {
+	env, _, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	env.Stdin = bytes.NewReader([]byte("{not valid json"))
+
+	if code := Run([]string{"run", "plan"}, env); code != ExitError {
+		t.Fatalf("exit = %d, want %d", code, ExitError)
+	}
+	if stderr.String() == "" {
+		t.Error("stderr is empty, want a decode error")
+	}
+}
+
+func TestRunStatusJSONEndToEnd(t *testing.T) {
+	env, stdout, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+
+	if code := Run([]string{"run", "status", "--json"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d; stderr = %s", code, ExitOK, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"mode": "assist"`) {
+		t.Errorf("stdout = %s", stdout.String())
+	}
+}
+
+// blockingReader stands in for a console stdin that never reaches EOF:
+// any Read is a bug that would hang the process.
+type blockingReader struct{ t *testing.T }
+
+func (r blockingReader) Read([]byte) (int, error) {
+	r.t.Fatal("status read stdin; it must not (a console stdin never reaches EOF)")
+	return 0, nil
+}
+
+// TestRunStatusNeverReadsStdin pins the fix for the interactive hang:
+// `orch run status --json` invoked without piped stdin must not block
+// waiting for EOF on the console.
+func TestRunStatusNeverReadsStdin(t *testing.T) {
+	env, stdout, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	env.Stdin = blockingReader{t: t}
+
+	if code := Run([]string{"run", "status", "--json"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d; stderr = %s", code, ExitOK, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"mode": "assist"`) {
+		t.Errorf("stdout = %s", stdout.String())
+	}
+}
+
+const minimalPlanJSON = `{
+  "schema_version": 1,
+  "host": "claude",
+  "title": "Fix status lock",
+  "issues": [
+    {
+      "id": "fix-status-lock",
+      "title": "Fix the status lock race",
+      "objective": "Make status reporting race-free",
+      "acceptance_criteria": ["no data race under -race"],
+      "type": "bug",
+      "facts": {"read_only": false},
+      "wave": 1,
+      "required_tests": ["go test ./..."],
+      "usage_class": "light"
+    }
+  ]
+}`

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -57,7 +57,7 @@ func TestStatusShowsLocalOverrides(t *testing.T) {
 func TestStatusDeliveryShowsRunAndLock(t *testing.T) {
 	env, stdout, _ := testEnv(t)
 	writeConfig(t, env.RepoRoot, validTOML)
-	st, err := state.EnterDelivery(env.RepoRoot, "claude")
+	st, err := state.EnterDelivery(env.RepoRoot, "claude", testPlanRef(), testIssues())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/gitops/checks.go
+++ b/internal/gitops/checks.go
@@ -3,8 +3,11 @@ package gitops
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"slices"
 	"strings"
+
+	"github.com/kninetimmy/orch/internal/paths"
 )
 
 // RequireClean returns nil only when dir's working tree has no
@@ -68,4 +71,44 @@ func (g *Git) RequireNotOn(ctx context.Context, protected ...string) error {
 // (PRD §13) and verification.
 func (g *Git) RevParse(ctx context.Context, ref string) (string, error) {
 	return g.git(ctx, g.root, "rev-parse", "--verify", ref+"^{commit}")
+}
+
+// RequireIgnored returns nil only when path is git-ignored relative to
+// the primary checkout (F1: an inside-primary worktree relaxation is
+// only safe because an ignored path never appears in
+// `status --porcelain`, so RequireClean and isolation guarantees still
+// hold). It works for paths that do not yet exist — `git check-ignore`
+// matches by pattern, not by filesystem presence. path may be absolute
+// or relative; either way it is canonicalized and expressed relative
+// to root before the check. A path outside root is an error: this
+// check only makes sense for a candidate inside-primary location.
+//
+// The query is always sent to git with a trailing slash: path is
+// always a directory in every caller of this method (a worktree or
+// its container), and a directory-only .gitignore pattern (the common
+// case, e.g. "foo/") only matches a bare, non-existent path when git
+// is told it is a directory this way — without it, `check-ignore`
+// silently refuses to match.
+func (g *Git) RequireIgnored(ctx context.Context, path string) error {
+	canon, err := paths.Canonical(path)
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(g.root, canon)
+	if err != nil {
+		return fmt.Errorf("compute path for %s relative to %s: %w", canon, g.root, err)
+	}
+	query := filepath.ToSlash(rel) + "/"
+	res, err := g.run(ctx, g.root, "check-ignore", "-q", "--", query)
+	if err != nil {
+		return err
+	}
+	switch res.ExitCode {
+	case 0:
+		return nil
+	case 1:
+		return fmt.Errorf("%w: %s; add a line like \"%s/\" to .gitignore", ErrNotIgnored, canon, filepath.ToSlash(rel))
+	default:
+		return fmt.Errorf("git check-ignore in %s exited %d: %s", g.root, res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
 }

--- a/internal/gitops/checks_test.go
+++ b/internal/gitops/checks_test.go
@@ -3,6 +3,7 @@ package gitops
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -106,4 +107,46 @@ func TestRevParse(t *testing.T) {
 	if err != nil || got != hash {
 		t.Fatalf("RevParse = %q, %v; want %q, nil", got, err, hash)
 	}
+}
+
+func TestRequireIgnored(t *testing.T) {
+	root := tempRoot(t)
+	rel := filepath.Join(".orchestrator", "worktrees")
+	abs := filepath.Join(root, rel)
+
+	t.Run("ignored", func(t *testing.T) {
+		g, script := openScripted(t, root, execxtest.Call{
+			Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/"}, Dir: root,
+		})
+		if err := g.RequireIgnored(context.Background(), abs); err != nil {
+			t.Errorf("RequireIgnored: %v", err)
+		}
+		script.AssertExhausted()
+	})
+
+	t.Run("not ignored", func(t *testing.T) {
+		g, script := openScripted(t, root, execxtest.Call{
+			Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/"}, Dir: root, Exit: 1,
+		})
+		err := g.RequireIgnored(context.Background(), abs)
+		script.AssertExhausted()
+		if !errors.Is(err, ErrNotIgnored) {
+			t.Fatalf("err = %v, want ErrNotIgnored", err)
+		}
+		if !strings.Contains(err.Error(), ".gitignore") {
+			t.Errorf("err = %v, want .gitignore remediation", err)
+		}
+	})
+
+	t.Run("other exit code", func(t *testing.T) {
+		g, script := openScripted(t, root, execxtest.Call{
+			Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/"}, Dir: root,
+			Stderr: "fatal: bad", Exit: 128,
+		})
+		err := g.RequireIgnored(context.Background(), abs)
+		script.AssertExhausted()
+		if err == nil || errors.Is(err, ErrNotIgnored) {
+			t.Fatalf("err = %v, want a plain error, not ErrNotIgnored", err)
+		}
+	})
 }

--- a/internal/gitops/errors.go
+++ b/internal/gitops/errors.go
@@ -33,4 +33,9 @@ var (
 	// ErrNotConfirmed reports a destructive operation attempted
 	// without ExplicitConfirmation (PRD §15).
 	ErrNotConfirmed = errors.New("destructive operation requires explicit confirmation")
+	// ErrNotIgnored reports a path that RequireIgnored expected git to
+	// ignore but does not (PRD §5: an inside-primary worktree is only
+	// safe from RequireClean and isolation guarantees when git itself
+	// will never report it in `status --porcelain`).
+	ErrNotIgnored = errors.New("path is not git-ignored")
 )

--- a/internal/gitops/integration_test.go
+++ b/internal/gitops/integration_test.go
@@ -285,6 +285,40 @@ func TestIntegrationRemoteFlow(t *testing.T) {
 	}
 }
 
+func TestIntegrationAddWorktreeInsidePrimary(t *testing.T) {
+	setupGitEnv(t)
+	g, root := newRepo(t)
+	ctx := context.Background()
+
+	// Not ignored: refused, parent stays clean.
+	notIgnored := filepath.Join(root, "scratch", "issue-9")
+	if _, err := g.AddWorktree(ctx, notIgnored, "orch/issue-9", "main"); !errors.Is(err, ErrNotIgnored) {
+		t.Fatalf("not ignored: err = %v, want ErrNotIgnored", err)
+	}
+	if err := g.RequireClean(ctx, ""); err != nil {
+		t.Fatalf("primary dirtied by a refused AddWorktree: %v", err)
+	}
+
+	// Ignored: succeeds, and the ignored directory never shows up as
+	// dirty in the primary checkout's status.
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(".orchestrator/worktrees/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	commitFile(t, root, ".gitignore", ".orchestrator/worktrees/\n")
+
+	inside := filepath.Join(root, ".orchestrator", "worktrees", "issue-9")
+	wt, err := g.AddWorktree(ctx, inside, "orch/issue-9", "main")
+	if err != nil {
+		t.Fatalf("ignored inside-primary AddWorktree: %v", err)
+	}
+	if wt.Branch != "orch/issue-9" {
+		t.Errorf("worktree = %+v, want branch orch/issue-9", wt)
+	}
+	if err := g.RequireClean(ctx, ""); err != nil {
+		t.Fatalf("primary not clean with an ignored inside-primary worktree present: %v", err)
+	}
+}
+
 func TestIntegrationWithBaseWorktree(t *testing.T) {
 	setupGitEnv(t)
 	g, _ := newRepo(t)

--- a/internal/gitops/worktree.go
+++ b/internal/gitops/worktree.go
@@ -76,9 +76,12 @@ func (g *Git) ListWorktrees(ctx context.Context) ([]Worktree, error) {
 // AddWorktree creates branch at startPoint together with a new
 // worktree at path (PRD §12 step 7: one branch/worktree per issue).
 // It fails closed before touching git when path already exists (never
-// clobber), when path lies inside the primary checkout (worktrees are
-// isolated, PRD §5), or when the branch already exists
-// (ErrBranchExists). Never uses --force.
+// clobber), when the branch already exists (ErrBranchExists), or when
+// path lies inside the primary checkout and is not git-ignored (F1:
+// worktrees must be isolated from the primary checkout's tracked tree,
+// PRD §5 — an ignored inside-primary path is safe because it never
+// appears in `status --porcelain`, so RequireClean and isolation
+// guarantees still hold). Never uses --force.
 func (g *Git) AddWorktree(ctx context.Context, path, branch, startPoint string) (*Worktree, error) {
 	canon, err := paths.Canonical(path)
 	if err != nil {
@@ -95,7 +98,9 @@ func (g *Git) AddWorktree(ctx context.Context, path, branch, startPoint string) 
 		return nil, err
 	}
 	if inside {
-		return nil, fmt.Errorf("worktree path %s is inside the primary checkout %s; worktrees must be isolated", canon, g.root)
+		if err := g.RequireIgnored(ctx, canon); err != nil {
+			return nil, fmt.Errorf("worktree path %s is inside the primary checkout and not git-ignored: %w", canon, err)
+		}
 	}
 	res, err := g.run(ctx, g.root, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch)
 	if err != nil {

--- a/internal/gitops/worktree_test.go
+++ b/internal/gitops/worktree_test.go
@@ -102,13 +102,48 @@ func TestAddWorktreeBranchExists(t *testing.T) {
 	}
 }
 
-func TestAddWorktreeInsidePrimaryFailsClosed(t *testing.T) {
+func TestAddWorktreeInsidePrimaryNotIgnoredFailsClosed(t *testing.T) {
 	root := tempRoot(t)
-	g, script := openScripted(t, root)
-	_, err := g.AddWorktree(context.Background(), filepath.Join(root, "wt"), "orch/issue-4", "main")
-	script.AssertExhausted() // no git call was made
-	if err == nil || !strings.Contains(err.Error(), "inside the primary checkout") {
+	path := filepath.Join(root, "wt")
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/"}, Dir: root, Exit: 1,
+	})
+	_, err = g.AddWorktree(context.Background(), path, "orch/issue-4", "main")
+	script.AssertExhausted()
+	if !errors.Is(err, ErrNotIgnored) {
+		t.Fatalf("err = %v, want ErrNotIgnored", err)
+	}
+	if !strings.Contains(err.Error(), "inside the primary checkout and not git-ignored") {
 		t.Fatalf("err = %v, want isolation refusal", err)
+	}
+}
+
+func TestAddWorktreeInsidePrimaryIgnoredSucceeds(t *testing.T) {
+	root := tempRoot(t)
+	path := canon(t, filepath.Join(root, ".orchestrator", "worktrees", "issue-4"))
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const head = "5555555555555555555555555555555555555555"
+	g, script := openScripted(t, root,
+		execxtest.Call{Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/"}, Dir: root},
+		execxtest.Call{Name: "git", Args: []string{"rev-parse", "--verify", "--quiet", "refs/heads/orch/issue-4"}, Dir: root, Exit: 1},
+		execxtest.Call{Name: "git", Args: []string{"worktree", "add", "-b", "orch/issue-4", path, "main"}, Dir: root},
+		execxtest.Call{Name: "git", Args: []string{"rev-parse", "--verify", "orch/issue-4^{commit}"}, Stdout: head + "\n"},
+	)
+	wt, err := g.AddWorktree(context.Background(), path, "orch/issue-4", "main")
+	script.AssertExhausted()
+	if err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+	want := Worktree{Path: path, Branch: "orch/issue-4", Head: head}
+	if *wt != want {
+		t.Errorf("worktree = %+v, want %+v", *wt, want)
 	}
 }
 

--- a/internal/run/activate.go
+++ b/internal/run/activate.go
@@ -1,0 +1,314 @@
+package run
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/gitops"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/routing"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// ActivationSchemaVersion is the activation-request/result schema this
+// build accepts and emits.
+const ActivationSchemaVersion = 1
+
+// ApprovalStatement is the exact assertion an adapter's human approval
+// must carry (PRD §8): the engine cannot verify a human, so this
+// string is the recorded proof that one saw the gate and approved it,
+// tied to a specific plan digest.
+const ApprovalStatement = "approve-and-enter-delivery"
+
+// ActivationRequest is the input to Activate: the full plan plus the
+// adapter's record of the human's approval of it.
+type ActivationRequest struct {
+	SchemaVersion int      `json:"schema_version"`
+	Plan          PlanDoc  `json:"plan"`
+	Approval      Approval `json:"approval"`
+}
+
+// Approval is the adapter's assertion that a human approved plan
+// (identified by digest) for entry into Delivery.
+type Approval struct {
+	PlanDigest string    `json:"plan_digest"`
+	ApprovedBy string    `json:"approved_by"`
+	ApprovedAt time.Time `json:"approved_at"`
+	Statement  string    `json:"statement"`
+}
+
+// validate checks a against the freshly recomputed digest: the
+// statement must be the exact ApprovalStatement and the digest must
+// match. A mismatch is the "adjust the plan and resubmit" loop, not a
+// retryable condition.
+func (a Approval) validate(digest string) error {
+	if a.Statement != ApprovalStatement {
+		return fmt.Errorf("%w: approval statement %q does not equal %q", ErrBadApproval, a.Statement, ApprovalStatement)
+	}
+	if a.PlanDigest != digest {
+		return fmt.Errorf("%w: approval plan_digest %q does not match the recomputed digest %q; adjust the plan and resubmit", ErrBadApproval, a.PlanDigest, digest)
+	}
+	return nil
+}
+
+// ActivationResult is the output of a successful Activate.
+type ActivationResult struct {
+	SchemaVersion int                     `json:"schema_version"`
+	RunID         string                  `json:"run_id"`
+	Issues        []ActivationResultIssue `json:"issues"`
+}
+
+// ActivationResultIssue is one activated issue's created artifacts.
+type ActivationResultIssue struct {
+	ID       string `json:"id"`
+	Number   int    `json:"number"`
+	URL      string `json:"url"`
+	Branch   string `json:"branch"`
+	Worktree string `json:"worktree"`
+}
+
+// DecodeActivation decodes data into an ActivationRequest, rejecting
+// any field this build does not recognize at any level (including the
+// embedded plan) and any unsupported schema_version.
+func DecodeActivation(data []byte) (*ActivationRequest, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var req ActivationRequest
+	if err := dec.Decode(&req); err != nil {
+		return nil, fmt.Errorf("%w: decode activation request: %v", ErrBadApproval, err)
+	}
+	if dec.More() {
+		return nil, fmt.Errorf("%w: trailing data after activation request", ErrBadApproval)
+	}
+	if req.SchemaVersion != ActivationSchemaVersion {
+		return nil, fmt.Errorf("%w: schema_version %d is unsupported (this build supports %d)", ErrBadApproval, req.SchemaVersion, ActivationSchemaVersion)
+	}
+	return &req, nil
+}
+
+// wrapAfterEnter marks an error that occurred after state.EnterDelivery
+// succeeded: state and the Delivery lock are held, so the remediation
+// is `orch abort` (safe — it never touches branches, issues, or
+// worktrees) or a future `orch resume`, never a bare retry.
+func wrapAfterEnter(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%w (state and the delivery lock are preserved; run `orch abort` to return to assist, or a future `orch resume` to continue)", err)
+}
+
+// Activate validates a plan and its approval, runs the read-only
+// Delivery preflights, enters Delivery, and creates one GitHub issue
+// plus one branch/worktree per plan issue in wave order. See the
+// package doc and internal/run's design notes for the exact
+// phase/step ordering and abort-safety invariant; a summary:
+//
+//   - Phase 1 (pure validation): decode/validate the plan and its
+//     approval, derive routing and labels for every issue.
+//   - Phase 2 (read-only preflights): Assist+no-lock, clean primary
+//     checkout, authenticated GitHub remote, primary on the default
+//     branch (F4), the memhub gate, and the worktree container
+//     git-ignored (F1).
+//   - Phase 3 (idempotent GitHub prep): EnsureLabelTaxonomy — the only
+//     mutation before the lock is held (F6).
+//   - Phase 4: state.EnterDelivery acquires the lock and records the
+//     run.
+//   - Phase 5 (per issue, wave order): create the GitHub issue with the
+//     PRD §13 audit record, persist state, add the branch/worktree,
+//     persist state again.
+//   - Phase 6: a final state.Save, then return the result. The run
+//     stays in Delivery — dispatching issues onward is PR B.
+func Activate(ctx context.Context, env Env, reqJSON []byte) (*ActivationResult, error) {
+	// Phase 1: pure validation.
+	cfg, err := config.Load(env.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+	req, err := DecodeActivation(reqJSON)
+	if err != nil {
+		return nil, err
+	}
+	plan := &req.Plan
+	if err := plan.Validate(cfg); err != nil {
+		return nil, err
+	}
+	digest, err := plan.Digest()
+	if err != nil {
+		return nil, err
+	}
+	if err := req.Approval.validate(digest); err != nil {
+		return nil, err
+	}
+
+	profile, err := hostProfile(cfg, plan.Host)
+	if err != nil {
+		return nil, err
+	}
+	denylist := modelDenylist(cfg)
+	decisionByID := make(map[string]routing.Decision, len(plan.Issues))
+	labelsByID := make(map[string]ghops.Labels, len(plan.Issues))
+	waveByID := make(map[string]int, len(plan.Issues))
+	for _, pi := range plan.Issues {
+		d, err := decideIssue(profile, pi)
+		if err != nil {
+			return nil, err
+		}
+		l := issueLabels(pi, d)
+		if err := l.Validate(denylist...); err != nil {
+			return nil, err
+		}
+		decisionByID[pi.ID] = d
+		labelsByID[pi.ID] = l
+		waveByID[pi.ID] = pi.Wave
+	}
+
+	// Phase 2: read-only preflights.
+	if err := requireAssistNoLock(env.RepoRoot); err != nil {
+		return nil, err
+	}
+	git, err := gitops.Open(ctx, env.Runner, env.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+	if err := git.RequireClean(ctx, ""); err != nil {
+		return nil, err
+	}
+	gh, err := ghops.Open(ctx, env.Runner, env.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+	repo, err := gh.Repo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	branch, err := git.CurrentBranch(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if branch != repo.DefaultBranch {
+		return nil, fmt.Errorf("primary checkout is on %s, not the default branch %s; activation requires the primary checkout on the default branch", branch, repo.DefaultBranch)
+	}
+	if _, err := memhubGate(ctx, cfg.Memhub.Mode, execProber{runner: env.Runner, dir: env.RepoRoot}); err != nil {
+		return nil, err
+	}
+	containerAbs := filepath.Join(env.RepoRoot, filepath.FromSlash(WorktreeContainer))
+	if err := git.RequireIgnored(ctx, containerAbs); err != nil {
+		return nil, err
+	}
+
+	// Phase 3: idempotent GitHub prep (the only pre-lock mutation, F6).
+	if _, err := gh.EnsureLabelTaxonomy(ctx); err != nil {
+		return nil, err
+	}
+
+	// Phase 4: enter Delivery.
+	ordered := plan.issuesInWaveOrder()
+	stateIssues := make([]state.Issue, len(ordered))
+	for i, pi := range ordered {
+		stateIssues[i] = state.Issue{PlanID: pi.ID, Title: pi.Title, Phase: state.PhasePlanned}
+	}
+	planRef := state.PlanRef{
+		Title:          plan.Title,
+		Digest:         digest,
+		ApprovedBy:     req.Approval.ApprovedBy,
+		ApprovedAt:     req.Approval.ApprovedAt,
+		ConfigRevision: cfg.ConfigRevision,
+	}
+	st, err := state.EnterDelivery(env.RepoRoot, plan.Host, planRef, stateIssues)
+	if err != nil {
+		return nil, err
+	}
+
+	// Phase 5: per issue, wave order, state persisted after every
+	// sub-step.
+	result := &ActivationResult{SchemaVersion: ActivationSchemaVersion, RunID: st.Run.ID}
+	for j, pi := range ordered {
+		d := decisionByID[pi.ID]
+		l := labelsByID[pi.ID]
+
+		body := issueBody(pi, waveByID, digest)
+		body, err = manifest.Upsert(body, manifest.Manifest{
+			SchemaVersion:    manifest.SchemaVersion,
+			Role:             d.Role,
+			Executor:         d.Executor,
+			RoutingRationale: d.Rationale,
+			Reviewer:         d.Reviewer,
+			ConfigRevision:   cfg.ConfigRevision,
+		})
+		if err != nil {
+			return nil, wrapAfterEnter(err)
+		}
+
+		number, url, err := gh.CreateIssue(ctx, pi.Title, body, l, denylist...)
+		if err != nil {
+			return nil, wrapAfterEnter(err)
+		}
+		st.Run.Issues[j].Number = number
+		st.Run.Issues[j].URL = url
+		st.Run.Issues[j].Phase = state.PhaseIssueCreated
+		if err := state.Save(env.RepoRoot, st); err != nil {
+			return nil, wrapAfterEnter(err)
+		}
+
+		issueBranch := branchName(number, pi.Title)
+		wt, err := git.AddWorktree(ctx, worktreeAbs(env.RepoRoot, number), issueBranch, repo.DefaultBranch)
+		if err != nil {
+			return nil, wrapAfterEnter(err)
+		}
+		st.Run.Issues[j].Branch = wt.Branch
+		st.Run.Issues[j].Worktree = worktreeRel(number)
+		st.Run.Issues[j].Phase = state.PhaseWorktreeReady
+		if err := state.Save(env.RepoRoot, st); err != nil {
+			return nil, wrapAfterEnter(err)
+		}
+
+		result.Issues = append(result.Issues, ActivationResultIssue{
+			ID: pi.ID, Number: number, URL: url, Branch: wt.Branch, Worktree: worktreeRel(number),
+		})
+	}
+
+	// Phase 6: final save, then return.
+	if err := state.Save(env.RepoRoot, st); err != nil {
+		return nil, wrapAfterEnter(err)
+	}
+	return result, nil
+}
+
+// issueBody renders the human-prose portion of a created issue's body
+// (PRD §13): objective, acceptance criteria, required tests,
+// dependencies named by plan id and wave, usage class, and the plan
+// digest. manifest.Upsert appends the machine-readable audit record
+// after it.
+func issueBody(pi PlanIssue, waveByID map[string]int, digest string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "**Objective**\n\n%s\n\n", pi.Objective)
+
+	b.WriteString("**Acceptance criteria**\n\n")
+	for _, ac := range pi.AcceptanceCriteria {
+		fmt.Fprintf(&b, "- %s\n", ac)
+	}
+	b.WriteString("\n**Required tests**\n\n")
+	for _, rt := range pi.RequiredTests {
+		fmt.Fprintf(&b, "- `%s`\n", rt)
+	}
+
+	b.WriteString("\n**Dependencies**\n\n")
+	if len(pi.DependsOn) == 0 {
+		b.WriteString("_none_\n")
+	} else {
+		for _, dep := range pi.DependsOn {
+			fmt.Fprintf(&b, "- %s (wave %d)\n", dep, waveByID[dep])
+		}
+	}
+
+	fmt.Fprintf(&b, "\n**Usage class:** %s\n\n", pi.UsageClass)
+	fmt.Fprintf(&b, "**Plan digest:** `%s`\n", digest)
+	return b.String()
+}

--- a/internal/run/activate_test.go
+++ b/internal/run/activate_test.go
@@ -1,0 +1,480 @@
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/gitops"
+	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/paths"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// setupGitEnv isolates every git invocation in the test process from
+// the developer's real configuration (copied from internal/gitops's
+// integration-test idiom).
+func setupGitEnv(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("git not on PATH: %v", err)
+	}
+	cfg := filepath.Join(t.TempDir(), "gitconfig")
+	content := "[user]\n\tname = Orch Test\n\temail = orch-test@example.invalid\n"
+	if err := os.WriteFile(cfg, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", cfg)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+}
+
+func rawGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	res, err := (execx.Local{}).Run(context.Background(), execx.Cmd{
+		Name: "git", Args: args, Dir: dir, Env: []string{"GIT_TERMINAL_PROMPT=0", "LC_ALL=C"},
+	})
+	if err != nil {
+		t.Fatalf("git %v: %v", args, err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("git %v exited %d: %s", args, res.ExitCode, res.Stderr)
+	}
+	return res.Stdout
+}
+
+// newActivateRepoWithIgnore builds a real sandbox repo on branch main
+// with a committed config.toml and the given .gitignore content.
+func newActivateRepoWithIgnore(t *testing.T, gitignore string) string {
+	t.Helper()
+	setupGitEnv(t)
+	root, err := paths.Canonical(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawGit(t, root, "init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(gitignore), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".orchestrator"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".orchestrator", "config.toml"), []byte(testConfigTOML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rawGit(t, root, "add", "-A")
+	rawGit(t, root, "commit", "-m", "initial")
+	return root
+}
+
+// fullGitignore ignores the worktree container plus Orch's own
+// machine-local files (mirroring this repo's real .gitignore), so a
+// completed activation leaves the primary checkout clean.
+const fullGitignore = ".orchestrator/worktrees/\n.orchestrator/state.json\n.orchestrator/delivery.lock\n"
+
+func newActivateRepo(t *testing.T) string {
+	t.Helper()
+	return newActivateRepoWithIgnore(t, fullGitignore)
+}
+
+// muxRunner sends "git" commands to a real runner and everything else
+// (gh, memhub) to a scripted one, per the activate_test idiom: real
+// git sandboxes, scripted GitHub/memhub.
+type muxRunner struct {
+	git execx.Runner
+	gh  *execxtest.Script
+}
+
+func (m muxRunner) Run(ctx context.Context, c execx.Cmd) (execx.Result, error) {
+	if c.Name == "git" {
+		return m.git.Run(ctx, c)
+	}
+	return m.gh.Run(ctx, c)
+}
+
+func ghOpenCall() execxtest.Call {
+	return execxtest.Call{Name: "gh", Args: []string{"auth", "status"}}
+}
+
+func ghRepoViewCall(defaultBranch string) execxtest.Call {
+	return execxtest.Call{
+		Name: "gh", Args: []string{"repo", "view", "--json", "nameWithOwner,defaultBranchRef,url"},
+		Stdout: fmt.Sprintf(`{"nameWithOwner":"o/r","defaultBranchRef":{"name":%q},"url":"https://github.com/o/r"}`, defaultBranch),
+	}
+}
+
+func ghLabelListEmptyCall() execxtest.Call {
+	return execxtest.Call{Name: "gh", Args: []string{"label", "list", "--json", "name", "--limit", "1000"}, Stdout: "[]"}
+}
+
+// taxonomyLabels mirrors ghops's private label taxonomy table
+// (name, color, description) in creation order.
+var taxonomyLabels = []struct{ name, color, desc string }{
+	{"ready", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
+	{"in-progress", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
+	{"blocked", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
+	{"needs-human", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
+	{"awaiting-review", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
+	{"feature", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
+	{"bug", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
+	{"chore", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
+	{"infra", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
+	{"docs", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
+	{"research", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
+	{"implementer", "5319E7", "orch role label — exactly one per issue (PRD §13)"},
+	{"specialist", "5319E7", "orch role label — exactly one per issue (PRD §13)"},
+	{"standard", "FBCA04", "orch risk label — exactly one per issue (PRD §13)"},
+	{"critical", "B60205", "orch risk label — exactly one per issue (PRD §13)"},
+}
+
+func ghLabelCreateCalls() []execxtest.Call {
+	calls := make([]execxtest.Call, len(taxonomyLabels))
+	for i, l := range taxonomyLabels {
+		calls[i] = execxtest.Call{Name: "gh", Args: []string{"label", "create", l.name, "--color", l.color, "--description", l.desc}}
+	}
+	return calls
+}
+
+func ghIssueCreateCall(title string, labels []string, number int) execxtest.Call {
+	args := []string{"issue", "create", "--title", title, "--body-file", "-"}
+	for _, l := range labels {
+		args = append(args, "--label", l)
+	}
+	return execxtest.Call{Name: "gh", Args: args, Stdout: fmt.Sprintf("https://github.com/o/r/issues/%d\n", number)}
+}
+
+// buildActivationJSON assembles an activation request with an
+// explicit digest and statement, so tests can construct both valid
+// and deliberately-mismatched approvals.
+func buildActivationJSON(t *testing.T, planJSON, digest, statement string) []byte {
+	t.Helper()
+	req := map[string]any{
+		"schema_version": ActivationSchemaVersion,
+		"plan":           json.RawMessage(planJSON),
+		"approval": map[string]any{
+			"plan_digest": digest,
+			"approved_by": "alice",
+			"approved_at": "2026-07-11T12:00:00Z",
+			"statement":   statement,
+		},
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+// activationJSON builds a valid activation request for planJSON: the
+// correct recomputed digest and the correct approval statement.
+func activationJSON(t *testing.T, planJSON string) []byte {
+	t.Helper()
+	p, err := DecodePlan([]byte(planJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := p.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return buildActivationJSON(t, planJSON, digest, ApprovalStatement)
+}
+
+func fullTaxonomyScript() []execxtest.Call {
+	calls := []execxtest.Call{ghOpenCall(), ghRepoViewCall("main"), ghLabelListEmptyCall()}
+	return append(calls, ghLabelCreateCalls()...)
+}
+
+func assertNoDeliveryState(t *testing.T, root string) {
+	t.Helper()
+	st, err := state.Load(root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if st.Mode != state.ModeAssist {
+		t.Errorf("mode = %s, want assist", st.Mode)
+	}
+	owner, err := lockfile.Inspect(root)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if owner != nil {
+		t.Errorf("lock present: %+v, want none", owner)
+	}
+}
+
+func TestActivateHappyPathTwoIssuesTwoWaves(t *testing.T) {
+	root := newActivateRepo(t)
+	calls := fullTaxonomyScript()
+	calls = append(calls,
+		ghIssueCreateCall("Issue A", []string{"ready", "feature", "implementer", "standard"}, 1),
+		ghIssueCreateCall("Issue B", []string{"ready", "feature", "specialist", "critical"}, 2),
+	)
+	script := &execxtest.Script{T: t, Calls: calls}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	result, err := Activate(context.Background(), env, activationJSON(t, twoIssuePlanJSON()))
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	script.AssertExhausted()
+
+	if len(result.Issues) != 2 {
+		t.Fatalf("Issues = %+v, want 2", result.Issues)
+	}
+	wantA := ActivationResultIssue{ID: "a", Number: 1, URL: "https://github.com/o/r/issues/1", Branch: "orch/issue-1-issue-a", Worktree: ".orchestrator/worktrees/issue-1"}
+	wantB := ActivationResultIssue{ID: "b", Number: 2, URL: "https://github.com/o/r/issues/2", Branch: "orch/issue-2-issue-b", Worktree: ".orchestrator/worktrees/issue-2"}
+	if result.Issues[0] != wantA {
+		t.Errorf("Issues[0] = %+v, want %+v", result.Issues[0], wantA)
+	}
+	if result.Issues[1] != wantB {
+		t.Errorf("Issues[1] = %+v, want %+v", result.Issues[1], wantB)
+	}
+
+	g, err := gitops.Open(context.Background(), execx.Local{}, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := g.RequireClean(context.Background(), ""); err != nil {
+		t.Errorf("primary checkout not clean after activation: %v", err)
+	}
+	worktrees, err := g.ListWorktrees(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(worktrees) != 3 {
+		t.Errorf("ListWorktrees = %+v, want primary + 2 issue worktrees", worktrees)
+	}
+
+	st, err := state.Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Mode != state.ModeDelivery || st.Run.ID != result.RunID {
+		t.Fatalf("state = %+v, want delivery run %s", st, result.RunID)
+	}
+	if st.Run.Plan.Digest == "" || st.Run.Plan.ApprovedBy != "alice" {
+		t.Errorf("Plan = %+v", st.Run.Plan)
+	}
+	for i, want := range []state.Issue{
+		{PlanID: "a", Title: "Issue A", Phase: state.PhaseWorktreeReady, Number: 1, Branch: "orch/issue-1-issue-a", Worktree: ".orchestrator/worktrees/issue-1"},
+		{PlanID: "b", Title: "Issue B", Phase: state.PhaseWorktreeReady, Number: 2, Branch: "orch/issue-2-issue-b", Worktree: ".orchestrator/worktrees/issue-2"},
+	} {
+		got := st.Run.Issues[i]
+		if got.PlanID != want.PlanID || got.Phase != want.Phase || got.Number != want.Number || got.Branch != want.Branch || got.Worktree != want.Worktree {
+			t.Errorf("Issues[%d] = %+v, want %+v", i, got, want)
+		}
+	}
+}
+
+func TestActivateFailureAtSecondIssueCreateIsResumable(t *testing.T) {
+	root := newActivateRepo(t)
+	calls := fullTaxonomyScript()
+	calls = append(calls,
+		ghIssueCreateCall("Issue A", []string{"ready", "feature", "implementer", "standard"}, 1),
+		execxtest.Call{
+			Name: "gh", Args: []string{"issue", "create", "--title", "Issue B", "--body-file", "-", "--label", "ready", "--label", "feature", "--label", "specialist", "--label", "critical"},
+			Exit: 1, Stderr: "network error",
+		},
+	)
+	script := &execxtest.Script{T: t, Calls: calls}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	_, err := Activate(context.Background(), env, activationJSON(t, twoIssuePlanJSON()))
+	if err == nil {
+		t.Fatal("Activate succeeded, want error")
+	}
+	script.AssertExhausted()
+
+	st, err := state.Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Mode != state.ModeDelivery {
+		t.Fatalf("mode = %s, want delivery (lock held, resumable)", st.Mode)
+	}
+	if st.Run.Issues[0].Phase != state.PhaseWorktreeReady {
+		t.Errorf("issue a phase = %s, want worktree-ready", st.Run.Issues[0].Phase)
+	}
+	if st.Run.Issues[1].Phase != state.PhasePlanned {
+		t.Errorf("issue b phase = %s, want planned", st.Run.Issues[1].Phase)
+	}
+	owner, err := lockfile.Inspect(root)
+	if err != nil || owner == nil {
+		t.Fatalf("lock not held: %+v, %v", owner, err)
+	}
+
+	branchBefore := st.Run.Issues[0].Branch
+	worktreeBefore := filepath.Join(root, filepath.FromSlash(st.Run.Issues[0].Worktree))
+
+	res, err := state.Abort(root)
+	if err != nil {
+		t.Fatalf("Abort: %v", err)
+	}
+	if res.PriorRun == nil {
+		t.Error("Abort did not report a prior run")
+	}
+	if _, err := os.Stat(worktreeBefore); err != nil {
+		t.Errorf("worktree %s vanished after abort: %v", worktreeBefore, err)
+	}
+	g, err := gitops.Open(context.Background(), execx.Local{}, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := g.RevParse(context.Background(), branchBefore); err != nil {
+		t.Errorf("branch %s not preserved after abort: %v", branchBefore, err)
+	}
+
+	after, err := state.Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Mode != state.ModeAssist {
+		t.Errorf("mode after abort = %s, want assist", after.Mode)
+	}
+}
+
+func TestActivateDirtyTreeLeavesNothing(t *testing.T) {
+	root := newActivateRepo(t)
+	if err := os.WriteFile(filepath.Join(root, "untracked.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	script := &execxtest.Script{T: t}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	_, err := Activate(context.Background(), env, activationJSON(t, twoIssuePlanJSON()))
+	if !errors.Is(err, gitops.ErrNotClean) {
+		t.Fatalf("err = %v, want ErrNotClean", err)
+	}
+	script.AssertExhausted()
+	assertNoDeliveryState(t, root)
+}
+
+func TestActivateLockHeldLeavesExistingStateUntouched(t *testing.T) {
+	root := newActivateRepo(t)
+	before, err := state.EnterDelivery(root, "codex", state.PlanRef{Digest: "sha256:x"}, []state.Issue{{PlanID: "z", Phase: state.PhasePlanned}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := &execxtest.Script{T: t}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	_, err = Activate(context.Background(), env, activationJSON(t, twoIssuePlanJSON()))
+	if !errors.Is(err, ErrDeliveryActive) {
+		t.Fatalf("err = %v, want ErrDeliveryActive", err)
+	}
+	script.AssertExhausted()
+
+	after, err := state.Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Run.ID != before.Run.ID {
+		t.Errorf("existing run changed: %s -> %s", before.Run.ID, after.Run.ID)
+	}
+}
+
+func TestActivateContainerNotIgnoredLeavesNothing(t *testing.T) {
+	root := newActivateRepoWithIgnore(t, "") // worktree container not ignored
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{ghOpenCall(), ghRepoViewCall("main")}}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	_, err := Activate(context.Background(), env, activationJSON(t, twoIssuePlanJSON()))
+	if !errors.Is(err, gitops.ErrNotIgnored) {
+		t.Fatalf("err = %v, want ErrNotIgnored", err)
+	}
+	script.AssertExhausted()
+	assertNoDeliveryState(t, root)
+}
+
+func TestActivateDigestMismatchLeavesNothing(t *testing.T) {
+	root := newActivateRepo(t)
+	script := &execxtest.Script{T: t}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	req := buildActivationJSON(t, twoIssuePlanJSON(), "sha256:wrong", ApprovalStatement)
+	_, err := Activate(context.Background(), env, req)
+	if !errors.Is(err, ErrBadApproval) {
+		t.Fatalf("err = %v, want ErrBadApproval", err)
+	}
+	script.AssertExhausted()
+	assertNoDeliveryState(t, root)
+}
+
+func TestActivateWrongStatementLeavesNothing(t *testing.T) {
+	root := newActivateRepo(t)
+	script := &execxtest.Script{T: t}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	p, err := DecodePlan([]byte(twoIssuePlanJSON()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := p.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := buildActivationJSON(t, twoIssuePlanJSON(), digest, "yes-please")
+	_, err = Activate(context.Background(), env, req)
+	if !errors.Is(err, ErrBadApproval) {
+		t.Fatalf("err = %v, want ErrBadApproval", err)
+	}
+	script.AssertExhausted()
+	assertNoDeliveryState(t, root)
+}
+
+func TestActivateUnauthGHLeavesNothing(t *testing.T) {
+	root := newActivateRepo(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		{Name: "gh", Args: []string{"auth", "status"}, Exit: 1},
+	}}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	_, err := Activate(context.Background(), env, activationJSON(t, twoIssuePlanJSON()))
+	if !errors.Is(err, ghops.ErrNotAuthenticated) {
+		t.Fatalf("err = %v, want ErrNotAuthenticated", err)
+	}
+	script.AssertExhausted()
+	assertNoDeliveryState(t, root)
+}
+
+func TestActivateBranchExistsMidRun(t *testing.T) {
+	root := newActivateRepo(t)
+	// Pre-create the branch AddWorktree will try to create for issue b.
+	rawGit(t, root, "branch", "orch/issue-2-issue-b")
+
+	calls := fullTaxonomyScript()
+	calls = append(calls,
+		ghIssueCreateCall("Issue A", []string{"ready", "feature", "implementer", "standard"}, 1),
+		ghIssueCreateCall("Issue B", []string{"ready", "feature", "specialist", "critical"}, 2),
+	)
+	script := &execxtest.Script{T: t, Calls: calls}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	_, err := Activate(context.Background(), env, activationJSON(t, twoIssuePlanJSON()))
+	if !errors.Is(err, gitops.ErrBranchExists) {
+		t.Fatalf("err = %v, want ErrBranchExists", err)
+	}
+	script.AssertExhausted()
+
+	st, err := state.Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Run.Issues[0].Phase != state.PhaseWorktreeReady {
+		t.Errorf("issue a phase = %s, want worktree-ready", st.Run.Issues[0].Phase)
+	}
+	if st.Run.Issues[1].Phase != state.PhaseIssueCreated {
+		t.Errorf("issue b phase = %s, want issue-created (worktree add failed)", st.Run.Issues[1].Phase)
+	}
+}

--- a/internal/run/ci.go
+++ b/internal/run/ci.go
@@ -1,0 +1,47 @@
+package run
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CIReport is the plan gate's honest PRD §16 statement about CI. It is
+// a pre-PR heuristic only (F8): before a PR exists, required-check
+// configuration is unobservable — the real signal is
+// ghops.RequiredCI, available once a PR is open (PR B).
+type CIReport struct {
+	WorkflowsPresent bool   `json:"workflows_present"`
+	Statement        string `json:"statement"`
+}
+
+// detectCI reports whether repoRoot has any GitHub Actions workflow
+// file (*.yml or *.yaml) under .github/workflows.
+func detectCI(repoRoot string) (CIReport, error) {
+	entries, err := os.ReadDir(filepath.Join(repoRoot, ".github", "workflows"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return CIReport{Statement: ciStatement(false)}, nil
+		}
+		return CIReport{}, err
+	}
+	present := false
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := strings.ToLower(e.Name())
+		if strings.HasSuffix(name, ".yml") || strings.HasSuffix(name, ".yaml") {
+			present = true
+			break
+		}
+	}
+	return CIReport{WorkflowsPresent: present, Statement: ciStatement(present)}, nil
+}
+
+func ciStatement(present bool) string {
+	if present {
+		return ".github/workflows files are present; this is a pre-PR heuristic only — required-check configuration is unobservable until a PR exists"
+	}
+	return "no .github/workflows files found; this is a pre-PR heuristic only — required-check configuration is unobservable until a PR exists"
+}

--- a/internal/run/derive.go
+++ b/internal/run/derive.go
@@ -1,0 +1,130 @@
+package run
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/routing"
+)
+
+// hostProfile maps cfg's per-host RoleProfile set (PRD §10) to the
+// routing.Profile the pure routing package consumes. config owns the
+// model/effort vocabulary; routing never sees a config.Host directly.
+func hostProfile(cfg *config.Config, host string) (routing.Profile, error) {
+	var h *config.Host
+	switch host {
+	case "claude":
+		h = cfg.Hosts.Claude
+	case "codex":
+		h = cfg.Hosts.Codex
+	}
+	if h == nil {
+		return routing.Profile{}, fmt.Errorf("host %q is not enabled in configuration", host)
+	}
+	sel := func(rp config.RoleProfile) manifest.Selection {
+		return manifest.Selection{Model: rp.Model, Effort: rp.Effort}
+	}
+	return routing.Profile{
+		Architect:       sel(h.Roles.Architect),
+		Scout:           sel(h.Roles.Scout),
+		Implementer:     sel(h.Roles.Implementer),
+		Specialist:      sel(h.Roles.Specialist),
+		Reviewer:        sel(h.Roles.Reviewer),
+		ReviewDowngrade: sel(h.Roles.ReviewDowngrade),
+	}, nil
+}
+
+// issueTask converts a plan issue's facts into the routing.Task Decide
+// consumes.
+func issueTask(i PlanIssue) routing.Task {
+	domains := make([]routing.RiskDomain, len(i.Facts.RiskDomains))
+	for idx, d := range i.Facts.RiskDomains {
+		domains[idx] = routing.RiskDomain(d)
+	}
+	return routing.Task{
+		ReadOnly:           i.Facts.ReadOnly,
+		UnusuallyDifficult: i.Facts.UnusuallyDifficult,
+		RiskDomains:        domains,
+		Downgrade: routing.DowngradeFacts{
+			Mechanical:     i.Facts.Downgrade.Mechanical,
+			LowRisk:        i.Facts.Downgrade.LowRisk,
+			FullySpecified: i.Facts.Downgrade.FullySpecified,
+			Unsurprising:   i.Facts.Downgrade.Unsurprising,
+		},
+	}
+}
+
+// modelDenylist returns every configured model name across enabled
+// hosts (post-overlay), deduplicated and sorted. It is the
+// ghops.Labels.Validate forbidden-areas argument: PRD §13's "models
+// never become GitHub labels" as a mechanical check.
+func modelDenylist(cfg *config.Config) []string {
+	seen := map[string]bool{}
+	add := func(h *config.Host) {
+		if h == nil {
+			return
+		}
+		for _, rp := range []config.RoleProfile{
+			h.Roles.Architect, h.Roles.Scout, h.Roles.Implementer,
+			h.Roles.Specialist, h.Roles.Reviewer, h.Roles.ReviewDowngrade,
+		} {
+			if rp.Model != "" {
+				seen[rp.Model] = true
+			}
+		}
+	}
+	add(cfg.Hosts.Claude)
+	add(cfg.Hosts.Codex)
+	names := make([]string, 0, len(seen))
+	for m := range seen {
+		names = append(names, m)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// decideIssue derives the routing decision for one plan issue against
+// profile, starting from a fresh (nil) History: plan-time routing has
+// no prior attempts. ErrNoStrongerRoute propagates unwrapped — an
+// exhausted initial route is a plan-gate problem, not a validation-
+// table entry the caller should fold into ErrPlanInvalid.
+func decideIssue(profile routing.Profile, i PlanIssue) (routing.Decision, error) {
+	return routing.Decide(profile, issueTask(i), nil)
+}
+
+// deriveRisk derives PRD §11's risk classification from facts alone:
+// critical iff the issue names any risk domain, standard otherwise.
+// There is no independent "risk" field that could contradict it.
+func deriveRisk(i PlanIssue) ghops.Risk {
+	if len(i.Facts.RiskDomains) > 0 {
+		return ghops.RiskCritical
+	}
+	return ghops.RiskStandard
+}
+
+// issueLabels assembles the full PRD §13 taxonomy for one issue: ready
+// status, the plan's type, the routing decision's role, the derived
+// risk, and the plan's area labels.
+func issueLabels(i PlanIssue, d routing.Decision) ghops.Labels {
+	role := ghops.RoleImplementer
+	if d.Role == manifest.RoleSpecialist {
+		role = ghops.RoleSpecialist
+	}
+	return ghops.Labels{
+		Status: ghops.StatusReady,
+		Type:   ghops.Type(i.Type),
+		Role:   role,
+		Risk:   deriveRisk(i),
+		Areas:  i.AreaLabels,
+	}
+}
+
+// flattenLabels mirrors ghops's internal label flattening order
+// (status, type, role, risk, then areas) for the gate document's
+// labels preview, without depending on ghops's unexported flatten.
+func flattenLabels(l ghops.Labels) []string {
+	return append([]string{string(l.Status), string(l.Type), string(l.Role), string(l.Risk)}, l.Areas...)
+}

--- a/internal/run/derive_test.go
+++ b/internal/run/derive_test.go
@@ -1,0 +1,172 @@
+package run
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/routing"
+)
+
+func TestHostProfile(t *testing.T) {
+	cfg := testConfig()
+	p, err := hostProfile(cfg, "claude")
+	if err != nil {
+		t.Fatalf("hostProfile: %v", err)
+	}
+	if p.Implementer.Model != "claude-sonnet-5" || p.Implementer.Effort != "xhigh" {
+		t.Errorf("Implementer = %+v", p.Implementer)
+	}
+	if _, err := hostProfile(cfg, "codex"); err == nil {
+		t.Error("hostProfile accepted a disabled host")
+	}
+}
+
+func TestDecideIssueFacts(t *testing.T) {
+	cfg := testConfigTwoHosts()
+	profile, err := hostProfile(cfg, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := map[string]struct {
+		facts      PlanFacts
+		wantRole   manifest.Role
+		downgraded bool
+	}{
+		"plain": {
+			facts:    PlanFacts{},
+			wantRole: manifest.RoleImplementer,
+		},
+		"unusually difficult": {
+			facts:    PlanFacts{UnusuallyDifficult: true},
+			wantRole: manifest.RoleSpecialist,
+		},
+		"risky": {
+			facts:    PlanFacts{RiskDomains: []string{"concurrency"}},
+			wantRole: manifest.RoleSpecialist,
+		},
+		"downgrade eligible": {
+			facts: PlanFacts{Downgrade: PlanDowngrade{
+				Mechanical: true, LowRisk: true, FullySpecified: true, Unsurprising: true,
+			}},
+			wantRole:   manifest.RoleImplementer,
+			downgraded: true,
+		},
+		"downgrade conflicts with risk": {
+			facts: PlanFacts{
+				RiskDomains: []string{"security"},
+				Downgrade: PlanDowngrade{
+					Mechanical: true, LowRisk: true, FullySpecified: true, Unsurprising: true,
+				},
+			},
+			wantRole:   manifest.RoleSpecialist,
+			downgraded: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			i := PlanIssue{ID: "x", Facts: tc.facts}
+			d, err := decideIssue(profile, i)
+			if err != nil {
+				t.Fatalf("decideIssue: %v", err)
+			}
+			if d.Role != tc.wantRole {
+				t.Errorf("Role = %s, want %s", d.Role, tc.wantRole)
+			}
+			if d.ReviewerDowngraded != tc.downgraded {
+				t.Errorf("ReviewerDowngraded = %v, want %v", d.ReviewerDowngraded, tc.downgraded)
+			}
+			if d.Rationale == "" {
+				t.Error("Rationale is empty")
+			}
+		})
+	}
+}
+
+func TestDecideIssueBadDomainPropagates(t *testing.T) {
+	cfg := testConfig()
+	profile, err := hostProfile(cfg, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = decideIssue(profile, PlanIssue{ID: "x", Facts: PlanFacts{RiskDomains: []string{"bogus"}}})
+	if !errors.Is(err, routing.ErrBadTask) {
+		t.Fatalf("err = %v, want routing.ErrBadTask", err)
+	}
+}
+
+func TestModelDenylist(t *testing.T) {
+	one := modelDenylist(testConfig())
+	if len(one) != 2 { // claude-opus-4-8, claude-sonnet-5
+		t.Fatalf("one-host denylist = %v, want 2 models", one)
+	}
+	for _, want := range []string{"claude-opus-4-8", "claude-sonnet-5"} {
+		found := false
+		for _, m := range one {
+			if m == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("denylist %v missing %q", one, want)
+		}
+	}
+
+	two := modelDenylist(testConfigTwoHosts())
+	if len(two) != 4 { // + gpt-5.6-sol, gpt-5.6-terra
+		t.Fatalf("two-host denylist = %v, want 4 models", two)
+	}
+
+	// Overlay: an override changing a model name still surfaces in the
+	// denylist since modelDenylist reads the passed *Config directly.
+	overlaid := testConfig()
+	overlaid.Hosts.Claude.Roles.Implementer.Model = "claude-sonnet-6"
+	d := modelDenylist(overlaid)
+	found := false
+	for _, m := range d {
+		if m == "claude-sonnet-6" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("denylist %v missing overlaid model claude-sonnet-6", d)
+	}
+}
+
+func TestDeriveRisk(t *testing.T) {
+	if got := deriveRisk(PlanIssue{}); got != ghops.RiskStandard {
+		t.Errorf("no risk domains = %s, want standard", got)
+	}
+	if got := deriveRisk(PlanIssue{Facts: PlanFacts{RiskDomains: []string{"secrets"}}}); got != ghops.RiskCritical {
+		t.Errorf("with risk domains = %s, want critical", got)
+	}
+}
+
+func TestIssueLabelsRolePerDecision(t *testing.T) {
+	i := PlanIssue{Type: "bug", AreaLabels: []string{"core"}}
+
+	implLabels := issueLabels(i, routing.Decision{Role: manifest.RoleImplementer})
+	if implLabels.Role != ghops.RoleImplementer {
+		t.Errorf("Role = %s, want implementer", implLabels.Role)
+	}
+	if implLabels.Status != ghops.StatusReady || implLabels.Type != ghops.TypeBug {
+		t.Errorf("labels = %+v", implLabels)
+	}
+
+	specLabels := issueLabels(i, routing.Decision{Role: manifest.RoleSpecialist})
+	if specLabels.Role != ghops.RoleSpecialist {
+		t.Errorf("Role = %s, want specialist", specLabels.Role)
+	}
+}
+
+func TestFlattenLabels(t *testing.T) {
+	l := ghops.Labels{Status: ghops.StatusReady, Type: ghops.TypeBug, Role: ghops.RoleImplementer, Risk: ghops.RiskStandard, Areas: []string{"core", "cli"}}
+	got := flattenLabels(l)
+	want := []string{"ready", "bug", "implementer", "standard", "core", "cli"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("flattenLabels = %v, want %v", got, want)
+	}
+}

--- a/internal/run/errors.go
+++ b/internal/run/errors.go
@@ -1,0 +1,30 @@
+package run
+
+import "errors"
+
+// Sentinel errors callers test with errors.Is. Specifics wrap these
+// with %w and detail (state.go / manifest.go house style) rather than
+// replace them.
+var (
+	// ErrPlanInvalid reports a plan document that fails validation:
+	// unsupported schema, a host not enabled, malformed or duplicate
+	// issue ids, unresolved/self-referencing/non-acyclic dependencies,
+	// invalid risk domains, read-only work (rejected — F3), labels that
+	// fail the PRD §13 taxonomy or the model denylist, an unrecognized
+	// usage class, or any empty required text field.
+	ErrPlanInvalid = errors.New("plan document is invalid")
+	// ErrBadApproval reports a malformed activation request envelope or
+	// an approval assertion that does not match the plan it approves:
+	// unsupported schema, unparsable/unknown-field JSON, a statement
+	// other than ApprovalStatement, or a plan_digest that does not
+	// equal the recomputed digest (the "adjust = resubmit" loop).
+	ErrBadApproval = errors.New("activation approval is invalid")
+	// ErrMemhubRequired reports that config.Memhub.Mode is "required"
+	// and the memhub probe failed or could not run (PRD §20: fail
+	// closed rather than proceed without memory).
+	ErrMemhubRequired = errors.New("memhub is required but unavailable")
+	// ErrDeliveryActive reports that a Delivery run is already active
+	// (or the state/lock pair is inconsistent) when a verb requires
+	// Assist with no lock held.
+	ErrDeliveryActive = errors.New("a delivery run is already active")
+)

--- a/internal/run/gate.go
+++ b/internal/run/gate.go
@@ -1,0 +1,158 @@
+package run
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// GateSchemaVersion is the gate-document schema this build emits.
+const GateSchemaVersion = 1
+
+// GateDoc is the human decision gate for a plan (PRD §8, covering
+// every §8 bullet): the adapter renders it natively and owns the four
+// §8 choices (approve and enter Delivery, adjust agent routing, revise
+// scope, or cancel and remain read-only).
+type GateDoc struct {
+	SchemaVersion   int          `json:"schema_version"`
+	PlanDigest      string       `json:"plan_digest"`
+	PlanTitle       string       `json:"plan_title"`
+	Host            string       `json:"host"`
+	ConfigRevision  string       `json:"config_revision"`
+	ConfigOverrides []string     `json:"config_overrides,omitempty"`
+	MergeStrategy   string       `json:"merge_strategy"`
+	Memhub          MemhubReport `json:"memhub"`
+	CI              CIReport     `json:"ci"`
+	Issues          []GateIssue  `json:"issues"`
+}
+
+// GateIssue is one plan issue's gate view: what it will do plus the
+// routing the engine derived for it. Executor and Reviewer reuse
+// manifest.Selection — the same exact model/effort pairing the audit
+// record carries.
+type GateIssue struct {
+	ID                 string             `json:"id"`
+	Title              string             `json:"title"`
+	Objective          string             `json:"objective"`
+	AcceptanceCriteria []string           `json:"acceptance_criteria"`
+	Role               manifest.Role      `json:"role"`
+	Executor           manifest.Selection `json:"executor"`
+	Reviewer           manifest.Selection `json:"reviewer"`
+	ReviewerDowngraded bool               `json:"reviewer_downgraded"`
+	RoutingRationale   string             `json:"routing_rationale"`
+	DependsOn          []string           `json:"depends_on,omitempty"`
+	Wave               int                `json:"wave"`
+	RequiredTests      []string           `json:"required_tests"`
+	Risk               string             `json:"risk"`
+	UsageClass         string             `json:"usage_class"`
+	Labels             []string           `json:"labels"`
+}
+
+// Plan validates a plan document and reports the human decision gate
+// for it. Every step is read-only except the memhub probe (PRD §20).
+func Plan(ctx context.Context, env Env, planJSON []byte) (*GateDoc, error) {
+	cfg, err := config.Load(env.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireAssistNoLock(env.RepoRoot); err != nil {
+		return nil, err
+	}
+
+	plan, err := DecodePlan(planJSON)
+	if err != nil {
+		return nil, err
+	}
+	if err := plan.Validate(cfg); err != nil {
+		return nil, err
+	}
+	digest, err := plan.Digest()
+	if err != nil {
+		return nil, err
+	}
+
+	profile, err := hostProfile(cfg, plan.Host)
+	if err != nil {
+		return nil, err
+	}
+	denylist := modelDenylist(cfg)
+
+	ci, err := detectCI(env.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	mh, err := memhubGate(ctx, cfg.Memhub.Mode, execProber{runner: env.Runner, dir: env.RepoRoot})
+	if err != nil {
+		return nil, err
+	}
+
+	issues := make([]GateIssue, len(plan.Issues))
+	for idx, i := range plan.Issues {
+		d, err := decideIssue(profile, i)
+		if err != nil {
+			return nil, err
+		}
+		labels := issueLabels(i, d)
+		if err := labels.Validate(denylist...); err != nil {
+			return nil, err
+		}
+		issues[idx] = GateIssue{
+			ID:                 i.ID,
+			Title:              i.Title,
+			Objective:          i.Objective,
+			AcceptanceCriteria: i.AcceptanceCriteria,
+			Role:               d.Role,
+			Executor:           d.Executor,
+			Reviewer:           d.Reviewer,
+			ReviewerDowngraded: d.ReviewerDowngraded,
+			RoutingRationale:   d.Rationale,
+			DependsOn:          i.DependsOn,
+			Wave:               i.Wave,
+			RequiredTests:      i.RequiredTests,
+			Risk:               string(deriveRisk(i)),
+			UsageClass:         i.UsageClass,
+			Labels:             flattenLabels(labels),
+		}
+	}
+
+	return &GateDoc{
+		SchemaVersion:   GateSchemaVersion,
+		PlanDigest:      digest,
+		PlanTitle:       plan.Title,
+		Host:            plan.Host,
+		ConfigRevision:  cfg.ConfigRevision,
+		ConfigOverrides: cfg.Overrides,
+		MergeStrategy:   cfg.Merge.Strategy,
+		Memhub:          mh,
+		CI:              ci,
+		Issues:          issues,
+	}, nil
+}
+
+// requireAssistNoLock enforces the precondition Plan and Activate
+// share: the repository must be in Assist with no Delivery lock held.
+// An existing run must be resolved (`orch abort`, or a future
+// `orch resume`) before a new plan is gated or activated.
+func requireAssistNoLock(repoRoot string) error {
+	st, err := state.Load(repoRoot)
+	if err != nil {
+		return err
+	}
+	owner, err := lockfile.Inspect(repoRoot)
+	if err != nil {
+		return err
+	}
+	if err := state.CheckConsistent(st, owner); err != nil {
+		return err
+	}
+	if st.Mode != state.ModeAssist {
+		return fmt.Errorf("%w: run %s is active (host %s, started %s); run `orch abort` first", ErrDeliveryActive, st.Run.ID, st.Run.Host, st.Run.StartedAt.Format(time.RFC3339))
+	}
+	return nil
+}

--- a/internal/run/gate_test.go
+++ b/internal/run/gate_test.go
@@ -1,0 +1,191 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// testConfigTOML is the on-disk committed configuration matching
+// testConfig(): one host (claude), memhub off.
+const testConfigTOML = `
+schema_version  = 1
+config_revision = "r1"
+
+[memhub]
+mode = "off"
+
+[hosts.claude.roles.architect]
+model  = "claude-opus-4-8"
+effort = "xhigh"
+
+[hosts.claude.roles.scout]
+model  = "claude-sonnet-5"
+effort = "low"
+
+[hosts.claude.roles.implementer]
+model  = "claude-sonnet-5"
+effort = "xhigh"
+
+[hosts.claude.roles.specialist]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.reviewer]
+model  = "claude-opus-4-8"
+effort = "high"
+
+[hosts.claude.roles.review_downgrade]
+model  = "claude-sonnet-5"
+effort = "high"
+`
+
+// setupRepo returns a temp repo root with .orchestrator/config.toml
+// written from tomlContent. No state.json is written, so Load reports
+// Assist.
+func setupRepo(t *testing.T, tomlContent string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".orchestrator"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".orchestrator", "config.toml"), []byte(tomlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func fixedNow() time.Time { return time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC) }
+
+func TestPlanGoldenTwoIssue(t *testing.T) {
+	root := setupRepo(t, testConfigTOML)
+	env := Env{RepoRoot: root, Now: fixedNow}
+
+	doc, err := Plan(context.Background(), env, []byte(twoIssuePlanJSON()))
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+
+	if doc.SchemaVersion != GateSchemaVersion {
+		t.Errorf("SchemaVersion = %d, want %d", doc.SchemaVersion, GateSchemaVersion)
+	}
+	if doc.PlanTitle != "Two issue plan" || doc.Host != "claude" {
+		t.Errorf("PlanTitle/Host = %q/%q", doc.PlanTitle, doc.Host)
+	}
+	if doc.ConfigRevision != "r1" || doc.MergeStrategy != "squash" {
+		t.Errorf("ConfigRevision/MergeStrategy = %q/%q", doc.ConfigRevision, doc.MergeStrategy)
+	}
+	if len(doc.ConfigOverrides) != 0 {
+		t.Errorf("ConfigOverrides = %v, want none", doc.ConfigOverrides)
+	}
+	if doc.Memhub.Mode != "off" || doc.Memhub.Probe != "skipped" {
+		t.Errorf("Memhub = %+v, want off/skipped", doc.Memhub)
+	}
+	if doc.CI.WorkflowsPresent {
+		t.Error("CI.WorkflowsPresent = true, want false (no workflow fixture)")
+	}
+	if !strings.Contains(doc.CI.Statement, "no .github/workflows files found") {
+		t.Errorf("CI.Statement = %q", doc.CI.Statement)
+	}
+
+	p, err := DecodePlan([]byte(twoIssuePlanJSON()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantDigest, err := p.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doc.PlanDigest != wantDigest {
+		t.Errorf("PlanDigest = %q, want %q", doc.PlanDigest, wantDigest)
+	}
+
+	if len(doc.Issues) != 2 {
+		t.Fatalf("Issues = %+v, want 2", doc.Issues)
+	}
+	a, b := doc.Issues[0], doc.Issues[1]
+
+	if a.ID != "a" || a.Role != "implementer" || a.ReviewerDowngraded {
+		t.Errorf("issue a = %+v", a)
+	}
+	if a.Executor.Model != "claude-sonnet-5" || a.Executor.Effort != "xhigh" {
+		t.Errorf("issue a executor = %+v", a.Executor)
+	}
+	if a.Reviewer.Model != "claude-opus-4-8" || a.Reviewer.Effort != "high" {
+		t.Errorf("issue a reviewer = %+v", a.Reviewer)
+	}
+	wantRationaleA := "Routed to an implementer with a strong reviewer with no reviewer downgrade requested."
+	if a.RoutingRationale != wantRationaleA {
+		t.Errorf("issue a rationale = %q, want %q", a.RoutingRationale, wantRationaleA)
+	}
+	if a.Risk != "standard" {
+		t.Errorf("issue a risk = %q, want standard", a.Risk)
+	}
+	wantLabelsA := []string{"ready", "feature", "implementer", "standard"}
+	if strings.Join(a.Labels, ",") != strings.Join(wantLabelsA, ",") {
+		t.Errorf("issue a labels = %v, want %v", a.Labels, wantLabelsA)
+	}
+
+	if b.ID != "b" || b.Role != "specialist" || b.ReviewerDowngraded {
+		t.Errorf("issue b = %+v", b)
+	}
+	if b.Executor.Model != "claude-opus-4-8" || b.Executor.Effort != "high" {
+		t.Errorf("issue b executor = %+v", b.Executor)
+	}
+	wantRationaleB := "Routed to a specialist with a strong reviewer because risk domains (concurrency)."
+	if b.RoutingRationale != wantRationaleB {
+		t.Errorf("issue b rationale = %q, want %q", b.RoutingRationale, wantRationaleB)
+	}
+	if b.Risk != "critical" {
+		t.Errorf("issue b risk = %q, want critical", b.Risk)
+	}
+	wantLabelsB := []string{"ready", "feature", "specialist", "critical"}
+	if strings.Join(b.Labels, ",") != strings.Join(wantLabelsB, ",") {
+		t.Errorf("issue b labels = %v, want %v", b.Labels, wantLabelsB)
+	}
+	if len(b.DependsOn) != 1 || b.DependsOn[0] != "a" || b.Wave != 2 {
+		t.Errorf("issue b deps/wave = %v/%d", b.DependsOn, b.Wave)
+	}
+}
+
+func TestPlanCIStatementWithWorkflowFixture(t *testing.T) {
+	root := setupRepo(t, testConfigTOML)
+	wfDir := filepath.Join(root, ".github", "workflows")
+	if err := os.MkdirAll(wfDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wfDir, "ci.yml"), []byte("name: ci\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	env := Env{RepoRoot: root, Now: fixedNow}
+
+	doc, err := Plan(context.Background(), env, []byte(validPlanJSON()))
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if !doc.CI.WorkflowsPresent {
+		t.Error("CI.WorkflowsPresent = false, want true")
+	}
+	if !strings.Contains(doc.CI.Statement, "are present") {
+		t.Errorf("CI.Statement = %q", doc.CI.Statement)
+	}
+}
+
+func TestPlanErrDeliveryActive(t *testing.T) {
+	root := setupRepo(t, testConfigTOML)
+	if _, err := state.EnterDelivery(root, "claude", state.PlanRef{Digest: "sha256:x"}, []state.Issue{{PlanID: "a", Phase: state.PhasePlanned}}); err != nil {
+		t.Fatal(err)
+	}
+	env := Env{RepoRoot: root, Now: fixedNow}
+
+	_, err := Plan(context.Background(), env, []byte(validPlanJSON()))
+	if !errors.Is(err, ErrDeliveryActive) {
+		t.Fatalf("err = %v, want ErrDeliveryActive", err)
+	}
+}

--- a/internal/run/lifecycle.go
+++ b/internal/run/lifecycle.go
@@ -1,0 +1,47 @@
+// This file sketches PR B's per-issue lifecycle verbs as doc comments
+// only — nothing here is implemented in PR A. Every field these verbs
+// will need already exists in state schema v2 (Issue's PR B fields;
+// Phase's PR B values), so PR B needs no v3 migration.
+//
+// orch run dispatch
+//
+//	Phase → dispatched, SetStatus in-progress, emits the worktree and
+//	branch plus the routing selection for the adapter to spawn the
+//	executor into.
+//
+// orch run pr-open
+//
+//	CreatePR with the manifest (Verifications recorded), persists
+//	PRNumber/PRURL, moves to awaiting-review.
+//
+// orch run review
+//
+//	ReviewCycles++, one consolidated review cycle per PRD §12.11;
+//	escalations feed the persisted Attempts (↔ routing.History) into
+//	routing.Escalate.
+//
+// orch run ci
+//
+//	Folds ghops.RequiredCI's tri-state into the manifest.
+//
+// orch run merge-report
+//
+//	Pins PR.HeadRefOid → ApprovedHeadOID, moves to awaiting-merge.
+//
+// orch run merge
+//
+//	The per-PR human approval assertion plus the pinned head OID drive
+//	ghops.MergePR(strategy, headOID, ExplicitConfirmation()), then
+//	confirm issue closure.
+//
+// orch run cleanup
+//
+//	Explicit confirmation: DeleteRemoteBranch, RemoveWorktree,
+//	ForceDeleteBranch.
+//
+// orch run complete
+//
+//	Once every issue is merged/abandoned and cleaned: FastForward the
+//	primary checkout, run the memhub wrap-up hook, and return state to
+//	Assist with the lock released (auto-return, PRD §7).
+package run

--- a/internal/run/memhub.go
+++ b/internal/run/memhub.go
@@ -1,0 +1,61 @@
+package run
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kninetimmy/orch/internal/execx"
+)
+
+// Prober checks memhub reachability. execProber is the production
+// implementation; tests inject a fake so they never spawn a real
+// memhub process. The interface is shaped so a future internal/memhub
+// package can absorb it without changing this package's call sites.
+type Prober interface {
+	Probe(ctx context.Context) error
+}
+
+// execProber runs `memhub status` via the injected Runner with the
+// primary checkout as its explicit working directory (PRD §20).
+type execProber struct {
+	runner execx.Runner
+	dir    string
+}
+
+func (p execProber) Probe(ctx context.Context) error {
+	res, err := p.runner.Run(ctx, execx.Cmd{Name: "memhub", Args: []string{"status"}, Dir: p.dir})
+	if err != nil {
+		return err
+	}
+	if res.ExitCode != 0 {
+		return fmt.Errorf("memhub status exited %d: %s", res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	return nil
+}
+
+// MemhubReport records a plan/gate document's memhub probe outcome.
+type MemhubReport struct {
+	Mode   string `json:"mode"`
+	Probe  string `json:"probe"` // "healthy" | "unhealthy" | "skipped"
+	Detail string `json:"detail,omitempty"`
+}
+
+// memhubGate applies config.Memhub.Mode's policy to a probe (PRD §20):
+// "off" never calls the prober; "required" fails closed with
+// ErrMemhubRequired on any probe failure (exit non-zero or a spawn
+// error, both mean the same thing here — memhub cannot be reached);
+// "best-effort" records the failure without stopping the caller.
+func memhubGate(ctx context.Context, mode string, p Prober) (MemhubReport, error) {
+	if mode == "off" {
+		return MemhubReport{Mode: mode, Probe: "skipped"}, nil
+	}
+	err := p.Probe(ctx)
+	if err == nil {
+		return MemhubReport{Mode: mode, Probe: "healthy"}, nil
+	}
+	if mode == "required" {
+		return MemhubReport{}, fmt.Errorf("%w: %v", ErrMemhubRequired, err)
+	}
+	return MemhubReport{Mode: mode, Probe: "unhealthy", Detail: err.Error()}, nil
+}

--- a/internal/run/memhub_test.go
+++ b/internal/run/memhub_test.go
@@ -1,0 +1,105 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+)
+
+func TestExecProberProbe(t *testing.T) {
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name: "memhub", Args: []string{"status"}, Dir: "/repo",
+	}}}
+	p := execProber{runner: script, dir: "/repo"}
+	if err := p.Probe(context.Background()); err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestExecProberNonZeroExit(t *testing.T) {
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name: "memhub", Args: []string{"status"}, Dir: "/repo", Exit: 1, Stderr: "unreachable",
+	}}}
+	p := execProber{runner: script, dir: "/repo"}
+	if err := p.Probe(context.Background()); err == nil {
+		t.Fatal("Probe succeeded, want error")
+	}
+	script.AssertExhausted()
+}
+
+func TestMemhubGateRequiredHealthy(t *testing.T) {
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{Name: "memhub", Args: []string{"status"}, Dir: "/repo"}}}
+	rep, err := memhubGate(context.Background(), "required", execProber{runner: script, dir: "/repo"})
+	if err != nil {
+		t.Fatalf("memhubGate: %v", err)
+	}
+	if rep.Probe != "healthy" || rep.Mode != "required" {
+		t.Errorf("report = %+v", rep)
+	}
+	script.AssertExhausted()
+}
+
+func TestMemhubGateRequiredExitOneFailsClosed(t *testing.T) {
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name: "memhub", Args: []string{"status"}, Dir: "/repo", Exit: 1,
+	}}}
+	_, err := memhubGate(context.Background(), "required", execProber{runner: script, dir: "/repo"})
+	if !errors.Is(err, ErrMemhubRequired) {
+		t.Fatalf("err = %v, want ErrMemhubRequired", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestMemhubGateRequiredSpawnErrorFailsClosed(t *testing.T) {
+	sentinel := errors.New("exec: \"memhub\": executable file not found in $PATH")
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name: "memhub", Args: []string{"status"}, Dir: "/repo", Err: sentinel,
+	}}}
+	_, err := memhubGate(context.Background(), "required", execProber{runner: script, dir: "/repo"})
+	if !errors.Is(err, ErrMemhubRequired) {
+		t.Fatalf("err = %v, want ErrMemhubRequired", err)
+	}
+	if !strings.Contains(err.Error(), sentinel.Error()) {
+		t.Errorf("err = %v, want to mention the spawn error", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestMemhubGateBestEffortRecordsNotFatal(t *testing.T) {
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name: "memhub", Args: []string{"status"}, Dir: "/repo", Exit: 1, Stderr: "down",
+	}}}
+	rep, err := memhubGate(context.Background(), "best-effort", execProber{runner: script, dir: "/repo"})
+	if err != nil {
+		t.Fatalf("memhubGate: %v", err)
+	}
+	if rep.Probe != "unhealthy" || rep.Detail == "" {
+		t.Errorf("report = %+v, want unhealthy with detail", rep)
+	}
+	script.AssertExhausted()
+}
+
+func TestMemhubGateOffSkipsProbe(t *testing.T) {
+	script := &execxtest.Script{T: t} // no calls scripted
+	rep, err := memhubGate(context.Background(), "off", execProber{runner: script, dir: "/repo"})
+	if err != nil {
+		t.Fatalf("memhubGate: %v", err)
+	}
+	if rep.Probe != "skipped" {
+		t.Errorf("report = %+v, want skipped", rep)
+	}
+	script.AssertExhausted() // proves no call was made
+}
+
+// fakeProber lets memhubGate tests avoid execx entirely where useful.
+type fakeProber struct{ err error }
+
+func (f fakeProber) Probe(context.Context) error { return f.err }
+
+var _ Prober = fakeProber{}
+var _ execx.Runner = (*execxtest.Script)(nil)

--- a/internal/run/names.go
+++ b/internal/run/names.go
@@ -1,0 +1,48 @@
+package run
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// WorktreeContainer is the repo-relative directory activation creates
+// per-issue worktrees under. It must be listed in .gitignore (F1):
+// gitops.RequireIgnored enforces that before activation touches git.
+const WorktreeContainer = ".orchestrator/worktrees"
+
+var slugNonAlnum = regexp.MustCompile(`[^a-z0-9]+`)
+
+// slugify lowercases s, collapses every run of non-[a-z0-9] characters
+// to a single "-", trims leading/trailing "-", and caps the result at
+// 40 characters (trimming any trailing "-" the cut leaves). An empty
+// result becomes "issue".
+func slugify(s string) string {
+	slug := slugNonAlnum.ReplaceAllString(strings.ToLower(s), "-")
+	slug = strings.Trim(slug, "-")
+	if len(slug) > 40 {
+		slug = strings.TrimRight(slug[:40], "-")
+	}
+	if slug == "" {
+		slug = "issue"
+	}
+	return slug
+}
+
+// branchName is the per-issue feature branch name (PRD §12).
+func branchName(number int, title string) string {
+	return fmt.Sprintf("orch/issue-%d-%s", number, slugify(title))
+}
+
+// worktreeRel is the repo-relative, slash-separated worktree path for
+// issue number, the form state.Issue.Worktree persists.
+func worktreeRel(number int) string {
+	return WorktreeContainer + "/" + fmt.Sprintf("issue-%d", number)
+}
+
+// worktreeAbs is the canonical filesystem path for issue number's
+// worktree under repoRoot, the form gitops.AddWorktree takes.
+func worktreeAbs(repoRoot string, number int) string {
+	return filepath.Join(repoRoot, filepath.FromSlash(worktreeRel(number)))
+}

--- a/internal/run/plandoc.go
+++ b/internal/run/plandoc.go
@@ -1,0 +1,238 @@
+package run
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/routing"
+)
+
+// PlanSchemaVersion is the plan-document schema this build accepts.
+const PlanSchemaVersion = 1
+
+// PlanDoc is the adapter-submitted plan: a set of issues, grouped into
+// dependency-respecting waves, that `orch run plan` gates and
+// `orch run activate` turns into a Delivery run.
+type PlanDoc struct {
+	SchemaVersion int         `json:"schema_version"`
+	Host          string      `json:"host"`
+	Title         string      `json:"title"`
+	Summary       string      `json:"summary,omitempty"`
+	Issues        []PlanIssue `json:"issues"`
+}
+
+// PlanIssue is one unit of work in the plan.
+type PlanIssue struct {
+	ID                 string    `json:"id"`
+	Title              string    `json:"title"`
+	Objective          string    `json:"objective"`
+	AcceptanceCriteria []string  `json:"acceptance_criteria"`
+	Type               string    `json:"type"` // ghops.Type
+	AreaLabels         []string  `json:"area_labels,omitempty"`
+	Facts              PlanFacts `json:"facts"`
+	DependsOn          []string  `json:"depends_on,omitempty"`
+	Wave               int       `json:"wave"`
+	RequiredTests      []string  `json:"required_tests"`
+	UsageClass         string    `json:"usage_class"` // light|medium|heavy
+}
+
+// PlanFacts carries the routing-relevant facts about one issue (PRD
+// §9–§11). Routing is derived from these, never independently
+// declared: "adjust routing" means revise facts and resubmit.
+type PlanFacts struct {
+	ReadOnly           bool          `json:"read_only"`
+	UnusuallyDifficult bool          `json:"unusually_difficult"`
+	RiskDomains        []string      `json:"risk_domains,omitempty"`
+	Downgrade          PlanDowngrade `json:"downgrade"`
+}
+
+// PlanDowngrade mirrors routing.DowngradeFacts on the wire.
+type PlanDowngrade struct {
+	Mechanical     bool `json:"mechanical"`
+	LowRisk        bool `json:"low_risk"`
+	FullySpecified bool `json:"fully_specified"`
+	Unsurprising   bool `json:"unsurprising"`
+}
+
+// idPattern is the closed issue-id shape: lowercase, starting with a
+// letter or digit, otherwise letters, digits, and hyphens.
+var idPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+
+// usageClasses is the closed usage_class set.
+var usageClasses = map[string]bool{"light": true, "medium": true, "heavy": true}
+
+// DecodePlan decodes data into a PlanDoc, rejecting any field this
+// build does not recognize at any level (schema-versioned documents
+// fail closed on drift rather than silently ignore it).
+func DecodePlan(data []byte) (*PlanDoc, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var p PlanDoc
+	if err := dec.Decode(&p); err != nil {
+		return nil, fmt.Errorf("%w: decode plan document: %v", ErrPlanInvalid, err)
+	}
+	if dec.More() {
+		return nil, fmt.Errorf("%w: trailing data after plan document", ErrPlanInvalid)
+	}
+	return &p, nil
+}
+
+// Digest returns the plan's stable content hash: "sha256:" followed by
+// the hex SHA-256 of the re-marshaled struct. Marshaling the decoded
+// struct (rather than hashing the raw input bytes) makes the digest
+// agree regardless of the adapter's original whitespace or key order,
+// so plan and activate compute the same value for the same content.
+func (p *PlanDoc) Digest() (string, error) {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return "", fmt.Errorf("encode plan for digest: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+// issuesInWaveOrder returns a copy of p.Issues stably sorted by
+// ascending Wave; issues within the same wave keep their original
+// relative order.
+func (p *PlanDoc) issuesInWaveOrder() []PlanIssue {
+	out := make([]PlanIssue, len(p.Issues))
+	copy(out, p.Issues)
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Wave < out[j].Wave })
+	return out
+}
+
+// Validate checks the plan against cfg, collecting every violation
+// into one error wrapping ErrPlanInvalid rather than stopping at the
+// first problem (config-package house style). It never mutates p.
+//
+// Strictly increasing waves across a dependency edge (dep.wave <
+// issue.wave) prove the dependency graph acyclic without a separate
+// topological sort. Risk is not independently checked here beyond
+// domain membership: it is derived from facts.risk_domains (see
+// deriveRisk), never declared, so it cannot contradict them.
+func (p *PlanDoc) Validate(cfg *config.Config) error {
+	var problems []string
+	fail := func(format string, args ...any) {
+		problems = append(problems, fmt.Sprintf(format, args...))
+	}
+
+	if p.SchemaVersion != PlanSchemaVersion {
+		fail("schema_version: unsupported version %d (this build supports %d)", p.SchemaVersion, PlanSchemaVersion)
+	}
+	hostEnabled := false
+	for _, h := range cfg.EnabledHosts() {
+		if h == p.Host {
+			hostEnabled = true
+			break
+		}
+	}
+	if !hostEnabled {
+		fail("host: %q is not enabled in configuration", p.Host)
+	}
+	if p.Title == "" {
+		fail("title: must not be empty")
+	}
+	if len(p.Issues) == 0 {
+		fail("issues: must have at least one entry")
+	}
+
+	denylist := modelDenylist(cfg)
+	waveByID := map[string]int{}
+	for _, iss := range p.Issues {
+		waveByID[strings.ToLower(iss.ID)] = iss.Wave
+	}
+
+	seenIDs := map[string]bool{}
+	for i, iss := range p.Issues {
+		prefix := fmt.Sprintf("issues[%d] (%s)", i, iss.ID)
+		folded := strings.ToLower(iss.ID)
+
+		if !idPattern.MatchString(iss.ID) {
+			fail("%s: id must match %s", prefix, idPattern.String())
+		}
+		if seenIDs[folded] {
+			fail("%s: duplicate id", prefix)
+		}
+		seenIDs[folded] = true
+
+		if iss.Title == "" {
+			fail("%s: title must not be empty", prefix)
+		}
+		if iss.Objective == "" {
+			fail("%s: objective must not be empty", prefix)
+		}
+		if len(iss.AcceptanceCriteria) == 0 {
+			fail("%s: acceptance_criteria must have at least one entry", prefix)
+		}
+		for j, ac := range iss.AcceptanceCriteria {
+			if ac == "" {
+				fail("%s: acceptance_criteria[%d] must not be empty", prefix, j)
+			}
+		}
+		if len(iss.RequiredTests) == 0 {
+			fail("%s: required_tests must have at least one entry", prefix)
+		}
+		for j, rt := range iss.RequiredTests {
+			if rt == "" {
+				fail("%s: required_tests[%d] must not be empty", prefix, j)
+			}
+		}
+		if !usageClasses[iss.UsageClass] {
+			fail("%s: usage_class %q is not one of light, medium, heavy", prefix, iss.UsageClass)
+		}
+		if iss.Wave < 1 {
+			fail("%s: wave must be >= 1, got %d", prefix, iss.Wave)
+		}
+		if iss.Facts.ReadOnly {
+			fail("%s: facts.read_only must be false (read-only work stays in Assist)", prefix)
+		}
+		for _, d := range iss.Facts.RiskDomains {
+			if !routing.RiskDomain(d).Valid() {
+				fail("%s: facts.risk_domains: unknown domain %q", prefix, d)
+			}
+		}
+		for _, dep := range iss.DependsOn {
+			depFolded := strings.ToLower(dep)
+			if depFolded == folded {
+				fail("%s: depends_on: self-reference to %q", prefix, dep)
+				continue
+			}
+			depWave, ok := waveByID[depFolded]
+			if !ok {
+				fail("%s: depends_on: %q does not resolve to a plan issue", prefix, dep)
+				continue
+			}
+			if !(depWave < iss.Wave) {
+				fail("%s: depends_on: %q is in wave %d, which is not strictly before this issue's wave %d", prefix, dep, depWave, iss.Wave)
+			}
+		}
+
+		// Label-shape validation: the plan type and area labels are
+		// checked here through the taxonomy itself (status and role are
+		// placeholders — routing has not run yet — but they are always
+		// valid, so only type and areas can fail this call).
+		labels := ghops.Labels{
+			Status: ghops.StatusReady,
+			Type:   ghops.Type(iss.Type),
+			Role:   ghops.RoleImplementer,
+			Risk:   deriveRisk(iss),
+			Areas:  iss.AreaLabels,
+		}
+		if err := labels.Validate(denylist...); err != nil {
+			fail("%s: %v", prefix, err)
+		}
+	}
+
+	if len(problems) > 0 {
+		return fmt.Errorf("%w:\n  - %s", ErrPlanInvalid, strings.Join(problems, "\n  - "))
+	}
+	return nil
+}

--- a/internal/run/plandoc.go
+++ b/internal/run/plandoc.go
@@ -210,7 +210,7 @@ func (p *PlanDoc) Validate(cfg *config.Config) error {
 				fail("%s: depends_on: %q does not resolve to a plan issue", prefix, dep)
 				continue
 			}
-			if !(depWave < iss.Wave) {
+			if depWave >= iss.Wave {
 				fail("%s: depends_on: %q is in wave %d, which is not strictly before this issue's wave %d", prefix, dep, depWave, iss.Wave)
 			}
 		}

--- a/internal/run/plandoc_test.go
+++ b/internal/run/plandoc_test.go
@@ -1,0 +1,244 @@
+package run
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func mustDecodePlan(t *testing.T, js string) *PlanDoc {
+	t.Helper()
+	p, err := DecodePlan([]byte(js))
+	if err != nil {
+		t.Fatalf("DecodePlan: %v", err)
+	}
+	return p
+}
+
+func TestDecodePlanValid(t *testing.T) {
+	p := mustDecodePlan(t, validPlanJSON())
+	if p.SchemaVersion != 1 || p.Host != "claude" || len(p.Issues) != 1 {
+		t.Fatalf("decoded plan = %+v", p)
+	}
+	if err := p.Validate(testConfig()); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestDecodePlanRejectsUnknownFields(t *testing.T) {
+	cases := map[string]string{
+		"top level": `{"schema_version":1,"host":"claude","title":"t","issues":[],"bogus":true}`,
+		"issue level": `{"schema_version":1,"host":"claude","title":"t","issues":[
+			{"id":"a","title":"t","objective":"o","acceptance_criteria":["x"],"type":"bug",
+			 "facts":{"read_only":false},"wave":1,"required_tests":["t"],"usage_class":"light","bogus":true}]}`,
+		"facts level": `{"schema_version":1,"host":"claude","title":"t","issues":[
+			{"id":"a","title":"t","objective":"o","acceptance_criteria":["x"],"type":"bug",
+			 "facts":{"read_only":false,"bogus":true},"wave":1,"required_tests":["t"],"usage_class":"light"}]}`,
+		"downgrade level": `{"schema_version":1,"host":"claude","title":"t","issues":[
+			{"id":"a","title":"t","objective":"o","acceptance_criteria":["x"],"type":"bug",
+			 "facts":{"read_only":false,"downgrade":{"mechanical":true,"bogus":true}},
+			 "wave":1,"required_tests":["t"],"usage_class":"light"}]}`,
+	}
+	for name, js := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := DecodePlan([]byte(js))
+			if !errors.Is(err, ErrPlanInvalid) {
+				t.Fatalf("err = %v, want ErrPlanInvalid", err)
+			}
+			if !strings.Contains(err.Error(), "unknown field") {
+				t.Errorf("err = %v, want mention of the unknown field", err)
+			}
+		})
+	}
+}
+
+func TestDecodePlanRejectsTrailingData(t *testing.T) {
+	_, err := DecodePlan([]byte(validPlanJSON() + `{}`))
+	if !errors.Is(err, ErrPlanInvalid) {
+		t.Fatalf("err = %v, want ErrPlanInvalid", err)
+	}
+}
+
+func TestPlanDocValidate(t *testing.T) {
+	cases := map[string]struct {
+		mutate func(p *PlanDoc)
+		wantIn string
+	}{
+		"wrong version": {
+			mutate: func(p *PlanDoc) { p.SchemaVersion = 2 },
+			wantIn: "schema_version: unsupported version 2",
+		},
+		"disabled host": {
+			mutate: func(p *PlanDoc) { p.Host = "codex" },
+			wantIn: `host: "codex" is not enabled`,
+		},
+		"empty title": {
+			mutate: func(p *PlanDoc) { p.Title = "" },
+			wantIn: "title: must not be empty",
+		},
+		"no issues": {
+			mutate: func(p *PlanDoc) { p.Issues = nil },
+			wantIn: "issues: must have at least one entry",
+		},
+		"bad id pattern": {
+			mutate: func(p *PlanDoc) { p.Issues[0].ID = "Not_Valid" },
+			wantIn: "id must match",
+		},
+		"empty objective": {
+			mutate: func(p *PlanDoc) { p.Issues[0].Objective = "" },
+			wantIn: "objective must not be empty",
+		},
+		"empty acceptance criteria": {
+			mutate: func(p *PlanDoc) { p.Issues[0].AcceptanceCriteria = nil },
+			wantIn: "acceptance_criteria must have at least one entry",
+		},
+		"empty required tests": {
+			mutate: func(p *PlanDoc) { p.Issues[0].RequiredTests = nil },
+			wantIn: "required_tests must have at least one entry",
+		},
+		"bad usage class": {
+			mutate: func(p *PlanDoc) { p.Issues[0].UsageClass = "extreme" },
+			wantIn: `usage_class "extreme" is not one of`,
+		},
+		"bad wave": {
+			mutate: func(p *PlanDoc) { p.Issues[0].Wave = 0 },
+			wantIn: "wave must be >= 1",
+		},
+		"read only rejected": {
+			mutate: func(p *PlanDoc) { p.Issues[0].Facts.ReadOnly = true },
+			wantIn: "facts.read_only must be false",
+		},
+		"invalid risk domain": {
+			mutate: func(p *PlanDoc) { p.Issues[0].Facts.RiskDomains = []string{"bogus-domain"} },
+			wantIn: `unknown domain "bogus-domain"`,
+		},
+		"bad type": {
+			mutate: func(p *PlanDoc) { p.Issues[0].Type = "not-a-type" },
+			wantIn: `type "not-a-type" is not one of`,
+		},
+		"area label hits model denylist": {
+			mutate: func(p *PlanDoc) { p.Issues[0].AreaLabels = []string{"claude-opus-4-8"} },
+			wantIn: "forbidden",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := mustDecodePlan(t, validPlanJSON())
+			tc.mutate(p)
+			err := p.Validate(testConfig())
+			if err == nil {
+				t.Fatal("Validate succeeded, want error")
+			}
+			if !errors.Is(err, ErrPlanInvalid) {
+				t.Errorf("err = %v, want ErrPlanInvalid", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantIn) {
+				t.Errorf("err = %v, want to contain %q", err, tc.wantIn)
+			}
+		})
+	}
+}
+
+func TestPlanDocValidateDependencyGraph(t *testing.T) {
+	cases := map[string]struct {
+		mutate func(p *PlanDoc)
+		wantIn string
+	}{
+		"duplicate id": {
+			mutate: func(p *PlanDoc) { p.Issues[1].ID = "a" },
+			wantIn: "duplicate id",
+		},
+		"dangling dependency": {
+			mutate: func(p *PlanDoc) { p.Issues[1].DependsOn = []string{"missing"} },
+			wantIn: `"missing" does not resolve to a plan issue`,
+		},
+		"self reference": {
+			mutate: func(p *PlanDoc) { p.Issues[1].DependsOn = []string{"b"} },
+			wantIn: "self-reference",
+		},
+		"wave not strictly increasing": {
+			mutate: func(p *PlanDoc) { p.Issues[1].Wave = 1 }, // same wave as its dependency
+			wantIn: "not strictly before",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := mustDecodePlan(t, twoIssuePlanJSON())
+			tc.mutate(p)
+			err := p.Validate(testConfig())
+			if err == nil {
+				t.Fatal("Validate succeeded, want error")
+			}
+			if !errors.Is(err, ErrPlanInvalid) {
+				t.Errorf("err = %v, want ErrPlanInvalid", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantIn) {
+				t.Errorf("err = %v, want to contain %q", err, tc.wantIn)
+			}
+		})
+	}
+}
+
+func TestPlanDocValidateTwoIssuePlanOK(t *testing.T) {
+	p := mustDecodePlan(t, twoIssuePlanJSON())
+	if err := p.Validate(testConfig()); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestDigestStableAcrossWhitespaceAndKeyOrder(t *testing.T) {
+	a := mustDecodePlan(t, validPlanJSON())
+
+	reordered := `{
+  "issues": [
+    {
+      "wave": 1,
+      "usage_class": "light",
+      "required_tests": ["go test ./..."],
+      "facts": {"read_only": false},
+      "type": "bug",
+      "acceptance_criteria": ["no data race under -race"],
+      "objective": "Make status reporting race-free",
+      "title": "Fix the status lock race",
+      "id": "fix-status-lock"
+    }
+  ],
+  "title": "Fix status lock",
+  "host": "claude",
+  "schema_version": 1
+}`
+	b := mustDecodePlan(t, reordered)
+
+	// Sanity: the two documents really do decode to the same struct.
+	aj, _ := json.Marshal(a)
+	bj, _ := json.Marshal(b)
+	if string(aj) != string(bj) {
+		t.Fatalf("decoded structs differ:\n%s\n%s", aj, bj)
+	}
+
+	da, err := a.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := b.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if da != db {
+		t.Errorf("Digest = %q, %q; want equal", da, db)
+	}
+	if !strings.HasPrefix(da, "sha256:") {
+		t.Errorf("Digest = %q, want sha256: prefix", da)
+	}
+}
+
+func TestIssuesInWaveOrder(t *testing.T) {
+	p := mustDecodePlan(t, twoIssuePlanJSON())
+	// Reverse the input order; wave order must still be a, then b.
+	p.Issues[0], p.Issues[1] = p.Issues[1], p.Issues[0]
+	ordered := p.issuesInWaveOrder()
+	if len(ordered) != 2 || ordered[0].ID != "a" || ordered[1].ID != "b" {
+		t.Fatalf("issuesInWaveOrder = %+v, want [a b]", ordered)
+	}
+}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -1,0 +1,47 @@
+// Package run is the Delivery run engine: the policy home that
+// composes internal/paths, internal/execx, internal/gitops,
+// internal/ghops, internal/manifest, internal/routing, and
+// internal/state+internal/lockfile (all policy-free) into the
+// adapter-facing plumbing surface PRD §22 calls for. There is no
+// manual delivery command — host adapters shell out to `orch run
+// <verb>` after their own native dialogs, exchanging JSON documents on
+// stdin/stdout:
+//
+//	orch run plan            # plan JSON on stdin → gate document JSON on stdout
+//	orch run activate        # activation request JSON on stdin → activation result JSON on stdout
+//	orch run status --json   # run-state JSON on stdout
+//
+// Concurrency invariant: plan and status are read-only. activate is
+// the only PR A mutator, and it acquires the cross-host Delivery lock
+// via state.EnterDelivery before any mutation except the idempotent
+// label-taxonomy ensure (PRD §14 F6). Every future mutating verb (PR
+// B) must verify state.Load + lockfile.Inspect + state.CheckConsistent
+// and st.Run.ID == owner.RunID before touching anything. Within one
+// invocation writes are sequential, so PRD §14's serialization
+// requirement holds trivially.
+//
+// All documents this package accepts are schema-versioned
+// (exact-match, fail closed) and decoded with DisallowUnknownFields:
+// an adapter sending a field this build does not recognize is a bug to
+// surface immediately, not silently drop.
+package run
+
+import (
+	"time"
+
+	"github.com/kninetimmy/orch/internal/execx"
+)
+
+// Env carries the invocation context for every run verb, mirroring
+// cli.Env's shape but scoped to what this package needs.
+type Env struct {
+	// RepoRoot is the directory containing .orchestrator/.
+	RepoRoot string
+	// Runner executes external commands (git, gh, memhub).
+	Runner execx.Runner
+	// Now returns the current time; nil defaults to time.Now. Declared
+	// for every verb's determinism (tests inject a fixed clock); no PR
+	// A document currently carries a timestamp field, so no verb reads
+	// it yet — PR B's lifecycle verbs will.
+	Now func() time.Time
+}

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -1,0 +1,100 @@
+package run
+
+import (
+	"github.com/kninetimmy/orch/internal/config"
+)
+
+// testConfig returns a minimal valid configuration with one host
+// (claude) enabled, matching the PRD §10 default model profiles.
+func testConfig() *config.Config {
+	return &config.Config{
+		SchemaVersion:  1,
+		ConfigRevision: "r1",
+		Concurrency:    config.Concurrency{MaxSubagents: 3},
+		Merge:          config.Merge{Strategy: "squash"},
+		Memhub:         config.Memhub{Mode: "off"},
+		Hosts: config.Hosts{
+			Claude: &config.Host{Roles: config.Roles{
+				Architect:       config.RoleProfile{Model: "claude-opus-4-8", Effort: "xhigh"},
+				Scout:           config.RoleProfile{Model: "claude-sonnet-5", Effort: "low"},
+				Implementer:     config.RoleProfile{Model: "claude-sonnet-5", Effort: "xhigh"},
+				Specialist:      config.RoleProfile{Model: "claude-opus-4-8", Effort: "high"},
+				Reviewer:        config.RoleProfile{Model: "claude-opus-4-8", Effort: "high"},
+				ReviewDowngrade: config.RoleProfile{Model: "claude-sonnet-5", Effort: "high"},
+			}},
+		},
+	}
+}
+
+// testConfigTwoHosts adds an enabled codex host to testConfig, for
+// denylist/host-selection tests that need more than one host.
+func testConfigTwoHosts() *config.Config {
+	cfg := testConfig()
+	cfg.Hosts.Codex = &config.Host{Roles: config.Roles{
+		Architect:       config.RoleProfile{Model: "gpt-5.6-sol", Effort: "high"},
+		Scout:           config.RoleProfile{Model: "gpt-5.6-terra", Effort: "low"},
+		Implementer:     config.RoleProfile{Model: "gpt-5.6-terra", Effort: "high"},
+		Specialist:      config.RoleProfile{Model: "gpt-5.6-sol", Effort: "medium"},
+		Reviewer:        config.RoleProfile{Model: "gpt-5.6-sol", Effort: "medium"},
+		ReviewDowngrade: config.RoleProfile{Model: "gpt-5.6-terra", Effort: "high"},
+	}}
+	return cfg
+}
+
+// validPlanJSON is a minimal single-issue plan that passes Validate
+// against testConfig().
+func validPlanJSON() string {
+	return `{
+  "schema_version": 1,
+  "host": "claude",
+  "title": "Fix status lock",
+  "issues": [
+    {
+      "id": "fix-status-lock",
+      "title": "Fix the status lock race",
+      "objective": "Make status reporting race-free",
+      "acceptance_criteria": ["no data race under -race"],
+      "type": "bug",
+      "facts": {"read_only": false},
+      "wave": 1,
+      "required_tests": ["go test ./..."],
+      "usage_class": "light"
+    }
+  ]
+}`
+}
+
+// twoIssuePlanJSON is a two-issue, two-wave plan where "b" depends on
+// "a", passing Validate against testConfig().
+func twoIssuePlanJSON() string {
+	return `{
+  "schema_version": 1,
+  "host": "claude",
+  "title": "Two issue plan",
+  "issues": [
+    {
+      "id": "a",
+      "title": "Issue A",
+      "objective": "Do A",
+      "acceptance_criteria": ["A works"],
+      "type": "feature",
+      "facts": {"read_only": false},
+      "wave": 1,
+      "required_tests": ["go test ./..."],
+      "usage_class": "light"
+    },
+    {
+      "id": "b",
+      "title": "Issue B",
+      "objective": "Do B",
+      "acceptance_criteria": ["B works"],
+      "type": "feature",
+      "facts": {"read_only": false, "risk_domains": ["concurrency"]},
+      "depends_on": ["a"],
+      "wave": 2,
+      "required_tests": ["go test ./..."],
+      "usage_class": "medium"
+    }
+  ]
+}`
+}

--- a/internal/run/status.go
+++ b/internal/run/status.go
@@ -1,0 +1,68 @@
+package run
+
+import (
+	"context"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// StatusSchemaVersion is the status-document schema this build emits.
+const StatusSchemaVersion = 1
+
+// StatusDoc is the run-state document `orch run status --json`
+// reports. It never loads config, and it never fails on an
+// inconsistent state/lock pair — a second host must be able to see
+// broken state to report it (PRD §14), so any CheckConsistent problem
+// goes into Warning, never the returned error.
+type StatusDoc struct {
+	SchemaVersion int             `json:"schema_version"`
+	Mode          state.Mode      `json:"mode"`
+	Consistent    bool            `json:"consistent"`
+	Warning       string          `json:"warning,omitempty"`
+	Lock          *lockfile.Owner `json:"lock,omitempty"`
+	Run           *RunView        `json:"run,omitempty"`
+}
+
+// RunView is the active Delivery run's status view.
+type RunView struct {
+	ID        string        `json:"id"`
+	Host      string        `json:"host"`
+	StartedAt time.Time     `json:"started_at"`
+	Plan      state.PlanRef `json:"plan"`
+	Issues    []state.Issue `json:"issues"`
+}
+
+// Status reports the run-state document.
+func Status(ctx context.Context, env Env) (*StatusDoc, error) {
+	st, err := state.Load(env.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+	owner, err := lockfile.Inspect(env.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	doc := &StatusDoc{
+		SchemaVersion: StatusSchemaVersion,
+		Mode:          st.Mode,
+		Consistent:    true,
+		Lock:          owner,
+	}
+	if err := state.CheckConsistent(st, owner); err != nil {
+		doc.Consistent = false
+		doc.Warning = err.Error()
+	}
+	if st.Run != nil {
+		doc.Run = &RunView{
+			ID:        st.Run.ID,
+			Host:      st.Run.Host,
+			StartedAt: st.Run.StartedAt,
+			Plan:      st.Run.Plan,
+			Issues:    st.Run.Issues,
+		}
+	}
+	return doc, nil
+}

--- a/internal/run/status_test.go
+++ b/internal/run/status_test.go
@@ -1,0 +1,83 @@
+package run
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+func TestStatusAssist(t *testing.T) {
+	root := setupRepo(t, testConfigTOML)
+	doc, err := Status(context.Background(), Env{RepoRoot: root})
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if doc.Mode != state.ModeAssist || !doc.Consistent || doc.Warning != "" {
+		t.Errorf("doc = %+v, want clean assist", doc)
+	}
+	if doc.Lock != nil || doc.Run != nil {
+		t.Errorf("doc = %+v, want no lock and no run", doc)
+	}
+}
+
+func TestStatusDelivery(t *testing.T) {
+	root := setupRepo(t, testConfigTOML)
+	planRef := state.PlanRef{Title: "t", Digest: "sha256:x", ConfigRevision: "r1"}
+	issues := []state.Issue{{PlanID: "a", Title: "A", Phase: state.PhasePlanned}}
+	st, err := state.EnterDelivery(root, "claude", planRef, issues)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doc, err := Status(context.Background(), Env{RepoRoot: root})
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if doc.Mode != state.ModeDelivery || !doc.Consistent || doc.Warning != "" {
+		t.Errorf("doc = %+v, want consistent delivery", doc)
+	}
+	if doc.Lock == nil || doc.Lock.RunID != st.Run.ID {
+		t.Fatalf("Lock = %+v, want run %s", doc.Lock, st.Run.ID)
+	}
+	if doc.Run == nil || doc.Run.ID != st.Run.ID || doc.Run.Plan.Digest != "sha256:x" {
+		t.Fatalf("Run = %+v", doc.Run)
+	}
+	if len(doc.Run.Issues) != 1 || doc.Run.Issues[0].PlanID != "a" {
+		t.Errorf("Run.Issues = %+v", doc.Run.Issues)
+	}
+}
+
+func TestStatusInconsistentOrphanedLockWarnsNotFails(t *testing.T) {
+	root := setupRepo(t, testConfigTOML)
+	err := lockfile.Acquire(root, lockfile.Owner{RunID: "run-orphan", Host: "codex", Hostname: "h", PID: 1, AcquiredAt: time.Now().UTC()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doc, err := Status(context.Background(), Env{RepoRoot: root})
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if doc.Consistent {
+		t.Error("Consistent = true, want false for an orphaned lock")
+	}
+	if !strings.Contains(doc.Warning, "orch abort") {
+		t.Errorf("Warning = %q, want abort remediation", doc.Warning)
+	}
+	if doc.Mode != state.ModeAssist {
+		t.Errorf("Mode = %s, want assist (state file still says assist)", doc.Mode)
+	}
+}
+
+func TestStatusDoesNotLoadConfig(t *testing.T) {
+	// No .orchestrator/config.toml is written at all: Status must still
+	// succeed because it never loads config.
+	root := t.TempDir()
+	if _, err := Status(context.Background(), Env{RepoRoot: root}); err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -12,13 +12,17 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/kninetimmy/orch/internal/manifest"
 )
 
 // Path is the repo-relative location of the state file.
 const Path = ".orchestrator/state.json"
 
 // SchemaVersion is the state-file schema this build reads and writes.
-const SchemaVersion = 1
+// v1 never ran a real Delivery (Task 11 is the first slice that
+// activates one), so a v1 file on disk can only be a test artifact.
+const SchemaVersion = 2
 
 // Mode is the operating mode (PRD §7).
 type Mode string
@@ -28,11 +32,98 @@ const (
 	ModeDelivery Mode = "delivery"
 )
 
+// PlanRef records the approved plan an active Delivery run was entered
+// from (PRD §8). The engine cannot verify a human; this is the
+// adapter's assertion, kept for the audit trail.
+type PlanRef struct {
+	Title          string    `json:"title"`
+	Digest         string    `json:"digest"`
+	ApprovedBy     string    `json:"approved_by"`
+	ApprovedAt     time.Time `json:"approved_at"`
+	ConfigRevision string    `json:"config_revision"`
+}
+
+// Phase is one issue's position in the Delivery lifecycle (PRD §12).
+// The set is closed. PR A (this slice) only ever writes Planned,
+// IssueCreated, and WorktreeReady; the remaining values belong to PR B
+// and are declared now so the schema needs no v3 migration when PR B
+// lands.
+type Phase string
+
+const (
+	// PhasePlanned is an issue's state immediately after EnterDelivery,
+	// before its GitHub issue exists.
+	PhasePlanned Phase = "planned"
+	// PhaseIssueCreated marks a created GitHub issue, before its
+	// branch/worktree exist.
+	PhaseIssueCreated Phase = "issue-created"
+	// PhaseWorktreeReady marks a created branch and worktree, ready for
+	// dispatch.
+	PhaseWorktreeReady Phase = "worktree-ready"
+
+	// PR B values, declared now:
+	PhaseDispatched    Phase = "dispatched"
+	PhasePROpen        Phase = "pr-open"
+	PhaseInReview      Phase = "in-review"
+	PhaseAwaitingMerge Phase = "awaiting-merge"
+	PhaseMerged        Phase = "merged"
+	PhaseCleaned       Phase = "cleaned"
+	PhaseAbandoned     Phase = "abandoned"
+	PhaseBlocked       Phase = "blocked"
+)
+
+// Valid reports whether p is a member of the closed Phase set.
+func (p Phase) Valid() bool {
+	switch p {
+	case PhasePlanned, PhaseIssueCreated, PhaseWorktreeReady,
+		PhaseDispatched, PhasePROpen, PhaseInReview, PhaseAwaitingMerge,
+		PhaseMerged, PhaseCleaned, PhaseAbandoned, PhaseBlocked:
+		return true
+	default:
+		return false
+	}
+}
+
+// Attempt mirrors routing.Attempt in persistable form, so an issue's
+// escalation history (routing.History) survives an orch restart (PR B;
+// this package imports manifest, not routing, to stay off the routing
+// policy dependency edge).
+type Attempt struct {
+	Role      manifest.Role      `json:"role"`
+	Selection manifest.Selection `json:"selection"`
+	Failed    bool               `json:"failed"`
+	Reason    string             `json:"reason,omitempty"`
+}
+
+// Issue is one plan issue's persisted Delivery state.
+type Issue struct {
+	PlanID string `json:"plan_id"`
+	Title  string `json:"title"`
+	Phase  Phase  `json:"phase"`
+	Number int    `json:"number,omitempty"`
+	URL    string `json:"url,omitempty"`
+	// Branch is the feature branch name. Worktree is the worktree
+	// directory as a repo-relative slash path.
+	Branch   string `json:"branch,omitempty"`
+	Worktree string `json:"worktree,omitempty"`
+
+	// PR B fields, declared now to avoid a v3 (see lifecycle.go in
+	// internal/run for the verb sketch that will populate them).
+	PRNumber        int       `json:"pr_number,omitempty"`
+	PRURL           string    `json:"pr_url,omitempty"`
+	ApprovedHeadOID string    `json:"approved_head_oid,omitempty"`
+	ReviewCycles    int       `json:"review_cycles,omitempty"`
+	BlockedReason   string    `json:"blocked_reason,omitempty"`
+	Attempts        []Attempt `json:"attempts,omitempty"`
+}
+
 // Run describes the active Delivery run.
 type Run struct {
 	ID        string    `json:"id"`
 	Host      string    `json:"host"` // "claude" or "codex"
 	StartedAt time.Time `json:"started_at"`
+	Plan      PlanRef   `json:"plan"`
+	Issues    []Issue   `json:"issues"`
 }
 
 // State is the persisted operating state.
@@ -63,22 +154,70 @@ func Load(repoRoot string) (*State, error) {
 	if err := json.Unmarshal(data, &st); err != nil {
 		return nil, fmt.Errorf("parse %s: %v (run `orch abort` to reset to assist)", Path, err)
 	}
+	if err := st.validate(); err != nil {
+		return nil, err
+	}
+	return &st, nil
+}
+
+// validate reports the first schema/consistency violation in st. Load
+// applies it to a freshly-decoded file; Save applies it to a value the
+// run engine is about to persist, so a bug there fails closed instead
+// of writing state that Load would later refuse to read back.
+func (st *State) validate() error {
 	if st.SchemaVersion != SchemaVersion {
-		return nil, fmt.Errorf("%s: unsupported schema_version %d (this build understands %d)", Path, st.SchemaVersion, SchemaVersion)
+		return fmt.Errorf("%s: unsupported schema_version %d (this build understands %d; run `orch abort` to reset to assist)", Path, st.SchemaVersion, SchemaVersion)
 	}
 	switch st.Mode {
 	case ModeAssist:
 		if st.Run != nil {
-			return nil, fmt.Errorf("%s: assist mode with a recorded run (run `orch abort` to reset)", Path)
+			return fmt.Errorf("%s: assist mode with a recorded run (run `orch abort` to reset)", Path)
 		}
 	case ModeDelivery:
 		if st.Run == nil {
-			return nil, fmt.Errorf("%s: delivery mode without a recorded run (run `orch abort` to reset)", Path)
+			return fmt.Errorf("%s: delivery mode without a recorded run (run `orch abort` to reset)", Path)
+		}
+		if err := st.Run.validateIssues(); err != nil {
+			return fmt.Errorf("%s: %v (run `orch abort` to reset)", Path, err)
 		}
 	default:
-		return nil, fmt.Errorf("%s: unknown mode %q (run `orch abort` to reset)", Path, st.Mode)
+		return fmt.Errorf("%s: unknown mode %q (run `orch abort` to reset)", Path, st.Mode)
 	}
-	return &st, nil
+	return nil
+}
+
+// validateIssues checks every issue's phase is a member of the closed
+// set and that Number/Branch/Worktree were populated once the
+// lifecycle reached the phase that requires them: Number from
+// issue-created onward, Branch/Worktree from worktree-ready onward.
+func (r *Run) validateIssues() error {
+	for i, iss := range r.Issues {
+		if !iss.Phase.Valid() {
+			return fmt.Errorf("issue %d (%s): invalid phase %q", i, iss.PlanID, iss.Phase)
+		}
+		if iss.Phase != PhasePlanned && iss.Number <= 0 {
+			return fmt.Errorf("issue %d (%s): phase %s requires a positive issue number", i, iss.PlanID, iss.Phase)
+		}
+		if iss.Phase != PhasePlanned && iss.Phase != PhaseIssueCreated {
+			if iss.Branch == "" || iss.Worktree == "" {
+				return fmt.Errorf("issue %d (%s): phase %s requires branch and worktree", i, iss.PlanID, iss.Phase)
+			}
+		}
+	}
+	return nil
+}
+
+// Save persists st under repoRoot: it stamps UpdatedAt, validates (the
+// same check Load applies on read), then writes atomically. It is the
+// incremental-persistence primitive the run engine calls after every
+// Delivery sub-step (PRD §23), so a crash leaves the state file
+// matching the last completed step.
+func Save(repoRoot string, st *State) error {
+	st.UpdatedAt = time.Now().UTC()
+	if err := st.validate(); err != nil {
+		return err
+	}
+	return write(repoRoot, st)
 }
 
 // write atomically replaces the state file: temp file in the same

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -28,6 +28,16 @@ func writeState(t *testing.T, root, content string) {
 	}
 }
 
+// testPlanRef and testIssues supply minimal valid EnterDelivery
+// arguments; their content is irrelevant to what most tests assert.
+func testPlanRef() PlanRef {
+	return PlanRef{Title: "t", Digest: "sha256:test", ConfigRevision: "r1"}
+}
+
+func testIssues() []Issue {
+	return []Issue{{PlanID: "iss-a", Title: "A", Phase: PhasePlanned}}
+}
+
 func TestLoadMissingFileIsAssist(t *testing.T) {
 	st, err := Load(stateDir(t))
 	if err != nil {
@@ -45,9 +55,22 @@ func TestLoadRejectsBadState(t *testing.T) {
 	}{
 		"corrupt json":    {"{broken", "parse"},
 		"wrong schema":    {`{"schema_version": 99, "mode": "assist"}`, "schema_version 99"},
-		"unknown mode":    {`{"schema_version": 1, "mode": "turbo"}`, `unknown mode "turbo"`},
-		"delivery no run": {`{"schema_version": 1, "mode": "delivery"}`, "without a recorded run"},
-		"assist with run": {`{"schema_version": 1, "mode": "assist", "run": {"id": "r", "host": "claude", "started_at": "2026-07-10T12:00:00Z"}}`, "assist mode with a recorded run"},
+		"v1 rejected":     {`{"schema_version": 1, "mode": "assist"}`, "schema_version 1"},
+		"unknown mode":    {`{"schema_version": 2, "mode": "turbo"}`, `unknown mode "turbo"`},
+		"delivery no run": {`{"schema_version": 2, "mode": "delivery"}`, "without a recorded run"},
+		"assist with run": {`{"schema_version": 2, "mode": "assist", "run": {"id": "r", "host": "claude", "started_at": "2026-07-10T12:00:00Z", "plan": {}, "issues": null}}`, "assist mode with a recorded run"},
+		"invalid phase": {
+			`{"schema_version": 2, "mode": "delivery", "run": {"id": "r", "host": "claude", "started_at": "2026-07-10T12:00:00Z", "plan": {"digest": "sha256:x"}, "issues": [{"plan_id": "a", "phase": "bogus"}]}}`,
+			`invalid phase "bogus"`,
+		},
+		"issue-created without number": {
+			`{"schema_version": 2, "mode": "delivery", "run": {"id": "r", "host": "claude", "started_at": "2026-07-10T12:00:00Z", "plan": {"digest": "sha256:x"}, "issues": [{"plan_id": "a", "phase": "issue-created"}]}}`,
+			"requires a positive issue number",
+		},
+		"worktree-ready without branch": {
+			`{"schema_version": 2, "mode": "delivery", "run": {"id": "r", "host": "claude", "started_at": "2026-07-10T12:00:00Z", "plan": {"digest": "sha256:x"}, "issues": [{"plan_id": "a", "phase": "worktree-ready", "number": 4}]}}`,
+			"requires branch and worktree",
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -64,6 +87,27 @@ func TestLoadRejectsBadState(t *testing.T) {
 	}
 }
 
+func TestLoadAcceptsV2RoundTrip(t *testing.T) {
+	root := stateDir(t)
+	st, err := EnterDelivery(root, "claude", testPlanRef(), testIssues())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Mode != ModeDelivery || got.Run.ID != st.Run.ID {
+		t.Errorf("Load = %+v, want delivery run %s", got, st.Run.ID)
+	}
+	if got.Run.Plan.Digest != testPlanRef().Digest {
+		t.Errorf("Plan.Digest = %q, want %q", got.Run.Plan.Digest, testPlanRef().Digest)
+	}
+	if len(got.Run.Issues) != 1 || got.Run.Issues[0].PlanID != "iss-a" {
+		t.Errorf("Issues = %+v, want one planned issue", got.Run.Issues)
+	}
+}
+
 func TestWriteReplacesExistingState(t *testing.T) {
 	root := stateDir(t)
 	first := &State{SchemaVersion: SchemaVersion, Mode: ModeAssist, UpdatedAt: time.Now().UTC()}
@@ -73,8 +117,11 @@ func TestWriteReplacesExistingState(t *testing.T) {
 	second := &State{
 		SchemaVersion: SchemaVersion,
 		Mode:          ModeDelivery,
-		Run:           &Run{ID: "run-x", Host: "claude", StartedAt: time.Now().UTC()},
-		UpdatedAt:     time.Now().UTC(),
+		Run: &Run{
+			ID: "run-x", Host: "claude", StartedAt: time.Now().UTC(),
+			Plan: testPlanRef(), Issues: testIssues(),
+		},
+		UpdatedAt: time.Now().UTC(),
 	}
 	// Rename over an existing file must work on Windows too.
 	if err := write(root, second); err != nil {
@@ -96,9 +143,55 @@ func TestWriteReplacesExistingState(t *testing.T) {
 	}
 }
 
+func TestSaveValidatesAndStampsUpdatedAt(t *testing.T) {
+	root := stateDir(t)
+	st, err := EnterDelivery(root, "claude", testPlanRef(), testIssues())
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := st.UpdatedAt
+	st.Run.Issues[0].Number = 7
+	st.Run.Issues[0].URL = "https://example.invalid/issues/7"
+	st.Run.Issues[0].Phase = PhaseIssueCreated
+	time.Sleep(time.Millisecond)
+	if err := Save(root, st); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if !st.UpdatedAt.After(before) {
+		t.Errorf("UpdatedAt not advanced: before %v, after %v", before, st.UpdatedAt)
+	}
+	got, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Run.Issues[0].Phase != PhaseIssueCreated || got.Run.Issues[0].Number != 7 {
+		t.Errorf("Load after Save = %+v", got.Run.Issues[0])
+	}
+}
+
+func TestSaveRejectsInvalidState(t *testing.T) {
+	root := stateDir(t)
+	st, err := EnterDelivery(root, "claude", testPlanRef(), testIssues())
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Run.Issues[0].Phase = "not-a-real-phase"
+	if err := Save(root, st); err == nil {
+		t.Fatal("Save accepted an invalid phase")
+	}
+	// The on-disk file must be untouched by the rejected write.
+	got, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Run.Issues[0].Phase != PhasePlanned {
+		t.Errorf("on-disk phase = %q, want unchanged %q", got.Run.Issues[0].Phase, PhasePlanned)
+	}
+}
+
 func TestEnterDelivery(t *testing.T) {
 	root := stateDir(t)
-	st, err := EnterDelivery(root, "claude")
+	st, err := EnterDelivery(root, "claude", testPlanRef(), testIssues())
 	if err != nil {
 		t.Fatalf("EnterDelivery: %v", err)
 	}
@@ -118,21 +211,42 @@ func TestEnterDelivery(t *testing.T) {
 }
 
 func TestEnterDeliveryRejectsUnknownHost(t *testing.T) {
-	if _, err := EnterDelivery(stateDir(t), "emacs"); err == nil {
+	if _, err := EnterDelivery(stateDir(t), "emacs", testPlanRef(), testIssues()); err == nil {
 		t.Error("EnterDelivery accepted unknown host")
+	}
+}
+
+func TestEnterDeliveryRejectsEmptyDigest(t *testing.T) {
+	ref := testPlanRef()
+	ref.Digest = ""
+	if _, err := EnterDelivery(stateDir(t), "claude", ref, testIssues()); err == nil {
+		t.Error("EnterDelivery accepted an empty plan digest")
+	}
+}
+
+func TestEnterDeliveryRejectsNoIssues(t *testing.T) {
+	if _, err := EnterDelivery(stateDir(t), "claude", testPlanRef(), nil); err == nil {
+		t.Error("EnterDelivery accepted zero issues")
+	}
+}
+
+func TestEnterDeliveryRejectsNonPlannedIssue(t *testing.T) {
+	issues := []Issue{{PlanID: "a", Phase: PhaseIssueCreated, Number: 1}}
+	if _, err := EnterDelivery(stateDir(t), "claude", testPlanRef(), issues); err == nil {
+		t.Error("EnterDelivery accepted a non-planned issue")
 	}
 }
 
 func TestEnterDeliveryContentionLeavesStateUntouched(t *testing.T) {
 	root := stateDir(t)
-	if _, err := EnterDelivery(root, "claude"); err != nil {
+	if _, err := EnterDelivery(root, "claude", testPlanRef(), testIssues()); err != nil {
 		t.Fatal(err)
 	}
 	before, err := Load(root)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = EnterDelivery(root, "codex")
+	_, err = EnterDelivery(root, "codex", testPlanRef(), testIssues())
 	if !errors.Is(err, lockfile.ErrHeld) {
 		t.Fatalf("second EnterDelivery = %v, want ErrHeld", err)
 	}
@@ -147,7 +261,7 @@ func TestEnterDeliveryContentionLeavesStateUntouched(t *testing.T) {
 
 func TestAbortFromDelivery(t *testing.T) {
 	root := stateDir(t)
-	st, err := EnterDelivery(root, "claude")
+	st, err := EnterDelivery(root, "claude", testPlanRef(), testIssues())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,6 +328,25 @@ func TestAbortResetsCorruptState(t *testing.T) {
 	}
 	if !res.StateReset {
 		t.Errorf("StateReset = false: %+v", res)
+	}
+	after, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load after abort: %v", err)
+	}
+	if after.Mode != ModeAssist {
+		t.Errorf("mode = %s, want assist", after.Mode)
+	}
+}
+
+func TestAbortResetsV1State(t *testing.T) {
+	root := stateDir(t)
+	writeState(t, root, `{"schema_version": 1, "mode": "assist"}`)
+	res, err := Abort(root)
+	if err != nil {
+		t.Fatalf("Abort: %v", err)
+	}
+	if !res.StateReset {
+		t.Errorf("StateReset = false for a v1 file: %+v", res)
 	}
 	after, err := Load(root)
 	if err != nil {

--- a/internal/state/transition.go
+++ b/internal/state/transition.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -10,17 +11,30 @@ import (
 )
 
 // EnterDelivery acquires the cross-host Delivery lock and records a new
-// delivery run. Ordering matters for crash safety: lock first, state
-// second — a crash between the two leaves an orphaned lock, which
-// denies every new run (fail closed) until `orch abort` clears it. The
-// reverse order could leave delivery state without a lock, letting a
-// second host acquire.
+// delivery run over plan and issues. Ordering matters for crash
+// safety: lock first, state second — a crash between the two leaves an
+// orphaned lock, which denies every new run (fail closed) until
+// `orch abort` clears it. The reverse order could leave delivery state
+// without a lock, letting a second host acquire.
 //
-// In this slice only tests call EnterDelivery; the plan gate that will
-// invoke it is future work (PRD §22: no manual delivery command).
-func EnterDelivery(repoRoot, host string) (*State, error) {
+// issues must all be at PhasePlanned and in the order the run engine
+// wants them processed (wave order); plan.Digest must be non-empty
+// (EnterDelivery does not recompute it — the caller has already
+// validated the plan and its approval).
+func EnterDelivery(repoRoot, host string, plan PlanRef, issues []Issue) (*State, error) {
 	if host != "claude" && host != "codex" {
 		return nil, fmt.Errorf("unknown host %q (want claude or codex)", host)
+	}
+	if plan.Digest == "" {
+		return nil, errors.New("EnterDelivery: plan digest must not be empty")
+	}
+	if len(issues) == 0 {
+		return nil, errors.New("EnterDelivery: at least one issue is required")
+	}
+	for i, iss := range issues {
+		if iss.Phase != PhasePlanned {
+			return nil, fmt.Errorf("EnterDelivery: issue %d (%s) has phase %q, want %q", i, iss.PlanID, iss.Phase, PhasePlanned)
+		}
 	}
 	now := time.Now().UTC()
 	runID, err := newRunID(now)
@@ -43,7 +57,7 @@ func EnterDelivery(repoRoot, host string) (*State, error) {
 	st := &State{
 		SchemaVersion: SchemaVersion,
 		Mode:          ModeDelivery,
-		Run:           &Run{ID: runID, Host: host, StartedAt: now},
+		Run:           &Run{ID: runID, Host: host, StartedAt: now, Plan: plan, Issues: issues},
 		UpdatedAt:     now,
 	}
 	if err := write(repoRoot, st); err != nil {


### PR DESCRIPTION
## What

The first slice of the Delivery run engine (roadmap task 11, PR A of 2): a new `internal/run` package — the policy home composing every Phase 1 mechanic — exposed through adapter-facing plumbing verbs `orch run plan | activate | status --json` (JSON on stdin/stdout).

- **Plan document** (schema v1): per-issue objective, acceptance criteria, type, routing facts, dependencies/waves, required tests, usage class. Fail-closed validation collects every problem into one error; strictly increasing waves across dependency edges prove the graph acyclic; **risk is derived** from `facts.risk_domains` (critical iff non-empty), never independently declared. Canonical `sha256:` digest over the re-marshaled struct so plan and activate agree regardless of adapter formatting.
- **Gate document** (PRD §8, every bullet): executor/reviewer derived per issue via `routing.Decide` from facts alone — "adjust routing" means revise facts and resubmit — with the rationale verbatim, config revision + applied overrides, merge strategy, a memhub probe report (`memhub status` via execx; `required` fails closed per PRD §20), and an honest pre-PR CI statement (workflow-file heuristic, stated as such; the real signal is `ghops.RequiredCI` once a PR exists).
- **Activation** (PRD §12 steps 6–7): takes the plan plus a recorded human-approval assertion pinned to the plan digest (digest mismatch = the resubmit loop). Read-only preflights (assist + no lock, clean primary on the default branch, gh auth/repo, memhub gate, worktree container git-ignored), idempotent label-taxonomy ensure, then `state.EnterDelivery` (lock first), then per issue in wave order: GitHub issue carrying the §13 manifest audit record, branch `orch/issue-<n>-<slug>` + worktree under `.orchestrator/worktrees/`, with state persisted after every sub-step so a crash leaves a resumable/abortable record. `orch abort` stays safe everywhere — it never deletes issues, branches, or worktrees.
- **state schema v2**: `Run` carries the approved-plan reference and per-issue lifecycle entries (closed `Phase` set; PR B fields declared now so no v3 later); new `Save` primitive validates before the atomic write.
- **gitops**: `AddWorktree` now permits an inside-primary path iff git-ignored — new `RequireIgnored` via `git check-ignore` with a trailing-slash query so directory-only patterns match not-yet-existing paths. Ignored paths never appear in `status --porcelain`, so `RequireClean` and isolation guarantees hold.
- **cli**: dispatcher extended to subcommand argv with usage-error mapping (all eight §22 commands still reject trailing args); `Env.Stdin`; `run` listed in help, labeled adapter plumbing. Only document-taking verbs read stdin — `status` cannot hang on a console (caught by the end-to-end smoke test, pinned by a regression test).

## Why

PRD §22 defines no manual Delivery command: plan approval *is* activation. Host adapters (Phase 3) present the native plan gate and shell out to these verbs, so the engine ships as machine-readable contracts now, independently testable before any adapter exists. Facts-only routing keeps `internal/routing` the single policy source, and deriving risk from the same facts removes a redundant field that could contradict them.

PR B completes task 11: per-issue lifecycle from dispatch through review cycles, CI wait, merge gate, cleanup, and auto-return to Assist (verbs sketched in `lifecycle.go`; state schema already carries their fields).

## Testing

All 11 packages pass on Windows locally (270+ subtests): validation/digest tables, execxtest transcripts for gh/memhub, real git-sandbox integration tests for activation (happy path across two waves, mid-run failure leaving a resumable state, every preflight leaving nothing behind), plus an end-to-end smoke of `orch run plan` / `status --json` against a live sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)