### PR TITLE
Add internal/run: Delivery run engine slice 2 (per-issue lifecycle)

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -11,55 +11,82 @@ import (
 	"github.com/kninetimmy/orch/internal/run"
 )
 
-// runRunVerb dispatches the adapter-facing plumbing verbs (PRD §22):
-// `orch run plan|activate|status --json`. Host adapters shell out to
-// it after their own native dialogs, exchanging JSON documents on
-// stdin/stdout; it is never invoked by a human directly.
-func runRunVerb(env Env, args []string) error {
-	var verb string
-	switch {
-	case len(args) == 1 && args[0] == "plan":
-		verb = "plan"
-	case len(args) == 1 && args[0] == "activate":
-		verb = "activate"
-	case len(args) == 2 && args[0] == "status" && args[1] == "--json":
-		verb = "status"
-	default:
-		return usageError("orch run: usage: orch run plan|activate|status --json")
-	}
+// runUsage is the one-line usage for the adapter plumbing surface.
+const runUsage = "orch run: usage: orch run plan|activate|dispatch|pr-open|review|escalate|ci|merge-report|merge|block|abandon|cleanup|complete (JSON document on stdin) | orch run status --json"
 
-	// Only the document-taking verbs read stdin: status must not block
-	// on a console stdin that never reaches EOF.
-	var input []byte
-	if verb == "plan" || verb == "activate" {
-		stdin := env.Stdin
-		if stdin == nil {
-			stdin = strings.NewReader("")
-		}
-		var err error
-		input, err = io.ReadAll(stdin)
+// runVerbs maps each document-taking verb to its run-engine entry point.
+// Every one reads a JSON request on stdin and writes a JSON result on
+// stdout; status is handled separately because it must never read stdin.
+var runVerbs = map[string]func(context.Context, run.Env, []byte) (any, error){
+	"plan":         adaptRunVerb(run.Plan),
+	"activate":     adaptRunVerb(run.Activate),
+	"dispatch":     adaptRunVerb(run.Dispatch),
+	"pr-open":      adaptRunVerb(run.PROpen),
+	"review":       adaptRunVerb(run.Review),
+	"escalate":     adaptRunVerb(run.Escalate),
+	"ci":           adaptRunVerb(run.CI),
+	"merge-report": adaptRunVerb(run.MergeReport),
+	"merge":        adaptRunVerb(run.Merge),
+	"block":        adaptRunVerb(run.Block),
+	"abandon":      adaptRunVerb(run.Abandon),
+	"cleanup":      adaptRunVerb(run.Cleanup),
+	"complete":     adaptRunVerb(run.Complete),
+}
+
+// adaptRunVerb erases a verb's concrete result type so every document
+// verb shares one dispatch shape; a nil result on error keeps the JSON
+// encoder off a typed-nil pointer.
+func adaptRunVerb[T any](fn func(context.Context, run.Env, []byte) (T, error)) func(context.Context, run.Env, []byte) (any, error) {
+	return func(ctx context.Context, env run.Env, input []byte) (any, error) {
+		out, err := fn(ctx, env, input)
 		if err != nil {
-			return fmt.Errorf("read stdin: %w", err)
+			return nil, err
 		}
+		return out, nil
+	}
+}
+
+// runRunVerb dispatches the adapter-facing plumbing verbs (PRD §22):
+// `orch run <verb>` (JSON stdin/stdout) plus `orch run status --json`.
+// Host adapters shell out to it after their own native dialogs; it is
+// never invoked by a human directly.
+func runRunVerb(env Env, args []string) error {
+	// status is the one verb that must not block on a console stdin that
+	// never reaches EOF, so it is matched first and never reads input.
+	if len(args) == 2 && args[0] == "status" && args[1] == "--json" {
+		return emitRunResult(env, "status", func(ctx context.Context, runEnv run.Env) (any, error) {
+			return run.Status(ctx, runEnv)
+		})
+	}
+	if len(args) != 1 {
+		return usageError(runUsage)
+	}
+	handler, ok := runVerbs[args[0]]
+	if !ok {
+		return usageError(runUsage)
 	}
 
+	stdin := env.Stdin
+	if stdin == nil {
+		stdin = strings.NewReader("")
+	}
+	input, err := io.ReadAll(stdin)
+	if err != nil {
+		return fmt.Errorf("read stdin: %w", err)
+	}
+
+	return emitRunResult(env, args[0], func(ctx context.Context, runEnv run.Env) (any, error) {
+		return handler(ctx, runEnv, input)
+	})
+}
+
+// emitRunResult runs one verb and writes its JSON result to stdout.
+func emitRunResult(env Env, verb string, fn func(context.Context, run.Env) (any, error)) error {
 	runEnv := run.Env{RepoRoot: env.RepoRoot, Runner: env.Runner, Now: time.Now}
-	ctx := context.Background()
-
-	var out any
-	var err error
-	switch verb {
-	case "plan":
-		out, err = run.Plan(ctx, runEnv, input)
-	case "activate":
-		out, err = run.Activate(ctx, runEnv, input)
-	case "status":
-		out, err = run.Status(ctx, runEnv)
-	}
+	out, err := fn(context.Background(), runEnv)
 	if err != nil {
 		return err
 	}
-
 	data, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encode %s result: %w", verb, err)

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -110,6 +110,39 @@ func TestRunStatusNeverReadsStdin(t *testing.T) {
 	}
 }
 
+// TestRunLifecycleVerbsAreRouted proves each new verb is recognized by
+// the dispatcher (not a usage error) and reaches the run engine, which
+// fails closed because the repo is in Assist. A recognized verb with a
+// valid document yields ExitError, never ExitUsage.
+func TestRunLifecycleVerbsAreRouted(t *testing.T) {
+	verbs := map[string]string{
+		"dispatch":     `{"schema_version":1,"issue_number":1}`,
+		"pr-open":      `{"schema_version":1,"issue_number":1,"verifications":[{"name":"t","result":"pass"}]}`,
+		"review":       `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"h","verdict":"approve","summary":"s","reviewer":{"model":"m","effort":"e"}}`,
+		"escalate":     `{"schema_version":1,"issue_number":1,"trigger":"architectural-ambiguity","detail":"x"}`,
+		"ci":           `{"schema_version":1,"issue_number":1}`,
+		"merge-report": `{"schema_version":1,"issue_number":1}`,
+		"merge":        `{"schema_version":1,"issue_number":1,"approval":{"pr_number":1,"head_oid":"h","approved_by":"a","approved_at":"2026-07-11T12:00:00Z","statement":"approve-merge"}}`,
+		"block":        `{"schema_version":1,"issue_number":1,"class":"other","detail":"x"}`,
+		"abandon":      `{"schema_version":1,"issue_number":1,"reason":"x","statement":"abandon-issue"}`,
+		"cleanup":      `{"schema_version":1,"issue_number":1,"statement":"cleanup-issue"}`,
+		"complete":     `{"schema_version":1}`,
+	}
+	for verb, doc := range verbs {
+		t.Run(verb, func(t *testing.T) {
+			env, _, stderr := testEnv(t)
+			writeConfig(t, env.RepoRoot, validTOML)
+			env.Stdin = bytes.NewReader([]byte(doc))
+			if code := Run([]string{"run", verb}, env); code != ExitError {
+				t.Fatalf("exit = %d, want %d (recognized verb, no delivery run); stderr = %s", code, ExitError, stderr.String())
+			}
+			if !strings.Contains(stderr.String(), "no delivery run is active") {
+				t.Errorf("stderr = %q, want the no-delivery-run remediation", stderr.String())
+			}
+		})
+	}
+}
+
 const minimalPlanJSON = `{
   "schema_version": 1,
   "host": "claude",

--- a/internal/ghops/issue.go
+++ b/internal/ghops/issue.go
@@ -100,6 +100,25 @@ func (g *GH) SetStatus(ctx context.Context, number int, to Status) error {
 	return err
 }
 
+// SetRole moves the issue to role to, removing every other role label
+// in one edit so the exactly-one-role invariant of PRD §13 survives an
+// escalation that changes the executor role. Removing an absent label is
+// a no-op for gh.
+func (g *GH) SetRole(ctx context.Context, number int, to Role) error {
+	if !memberOf(string(to), roleNames()) {
+		return fmt.Errorf("%w: role %q is not one of %s", ErrBadLabels, to, strings.Join(roleNames(), ", "))
+	}
+	args := []string{"issue", "edit", strconv.Itoa(number)}
+	for _, r := range roleLabels {
+		if r != to {
+			args = append(args, "--remove-label", string(r))
+		}
+	}
+	args = append(args, "--add-label", string(to))
+	_, err := g.gh(ctx, args...)
+	return err
+}
+
 // CloseIssue closes the issue. Closing is destructive bookkeeping
 // (PRD §12 step 17 confirms closure only after the merge result is
 // recorded), so it requires ExplicitConfirmation.

--- a/internal/ghops/issue_test.go
+++ b/internal/ghops/issue_test.go
@@ -201,6 +201,34 @@ func TestSetStatusBadValue(t *testing.T) {
 	script.AssertExhausted()
 }
 
+func TestSetRole(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "gh",
+		Args: []string{
+			"issue", "edit", "42",
+			"--remove-label", "implementer",
+			"--add-label", "specialist",
+		},
+		Dir: root,
+		Env: ghTestEnv,
+	})
+	if err := g.SetRole(context.Background(), 42, RoleSpecialist); err != nil {
+		t.Fatalf("SetRole: %v", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestSetRoleBadValue(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root) // no gh call may happen
+	err := g.SetRole(context.Background(), 42, Role("architect"))
+	if !errors.Is(err, ErrBadLabels) {
+		t.Fatalf("err = %v, want ErrBadLabels", err)
+	}
+	script.AssertExhausted()
+}
+
 func TestCloseIssue(t *testing.T) {
 	root := tempRoot(t)
 	g, script := openScripted(t, root, execxtest.Call{

--- a/internal/ghops/labels.go
+++ b/internal/ghops/labels.go
@@ -60,6 +60,10 @@ const (
 // the taxonomy table depend on this order being stable.
 var statuses = []Status{StatusReady, StatusInProgress, StatusBlocked, StatusNeedsHuman, StatusAwaitingReview}
 
+// roleLabels lists all role labels in canonical order; SetRole depends
+// on this order being stable.
+var roleLabels = []Role{RoleImplementer, RoleSpecialist}
+
 // labelDef pins a taxonomy label's repository definition so
 // EnsureLabelTaxonomy is deterministic and transcripts are stable.
 type labelDef struct {
@@ -159,6 +163,14 @@ func statusNames() []string {
 	names := make([]string, len(statuses))
 	for i, s := range statuses {
 		names[i] = string(s)
+	}
+	return names
+}
+
+func roleNames() []string {
+	names := make([]string, len(roleLabels))
+	for i, r := range roleLabels {
+		names[i] = string(r)
 	}
 	return names
 }

--- a/internal/ghops/pr.go
+++ b/internal/ghops/pr.go
@@ -66,41 +66,79 @@ func (g *GH) CreatePR(ctx context.Context, spec PRSpec) (number int, url string,
 	return number, out, nil
 }
 
+// prFields is the JSON field list every PR read pins, shared by PR and
+// PRForBranch so both return a fully-populated view.
+const prFields = "number,state,title,url,headRefName,baseRefName,headRefOid,mergeStateStatus,mergedAt,body"
+
+// prJSON is the decode target for prFields.
+type prJSON struct {
+	Number           int    `json:"number"`
+	State            string `json:"state"`
+	Title            string `json:"title"`
+	URL              string `json:"url"`
+	HeadRefName      string `json:"headRefName"`
+	BaseRefName      string `json:"baseRefName"`
+	HeadRefOid       string `json:"headRefOid"`
+	MergeStateStatus string `json:"mergeStateStatus"`
+	MergedAt         string `json:"mergedAt"`
+	Body             string `json:"body"`
+}
+
+func (d prJSON) toPR() PR {
+	return PR{
+		Number:           d.Number,
+		State:            d.State,
+		Title:            d.Title,
+		URL:              d.URL,
+		HeadRefName:      d.HeadRefName,
+		BaseRefName:      d.BaseRefName,
+		HeadRefOid:       d.HeadRefOid,
+		MergeStateStatus: d.MergeStateStatus,
+		MergedAt:         d.MergedAt,
+		Body:             d.Body,
+	}
+}
+
 // PR reads one pull request; the run engine uses it for the
 // ready-to-merge report (PRD §12 step 14) and to obtain the
 // HeadRefOid a merge approval pins.
 func (g *GH) PR(ctx context.Context, number int) (PR, error) {
-	var decoded struct {
-		Number           int    `json:"number"`
-		State            string `json:"state"`
-		Title            string `json:"title"`
-		URL              string `json:"url"`
-		HeadRefName      string `json:"headRefName"`
-		BaseRefName      string `json:"baseRefName"`
-		HeadRefOid       string `json:"headRefOid"`
-		MergeStateStatus string `json:"mergeStateStatus"`
-		MergedAt         string `json:"mergedAt"`
-		Body             string `json:"body"`
-	}
-	if err := g.ghJSON(ctx, &decoded, "pr", "view", strconv.Itoa(number),
-		"--json", "number,state,title,url,headRefName,baseRefName,headRefOid,mergeStateStatus,mergedAt,body"); err != nil {
+	var decoded prJSON
+	if err := g.ghJSON(ctx, &decoded, "pr", "view", strconv.Itoa(number), "--json", prFields); err != nil {
 		return PR{}, err
 	}
 	if decoded.Number != number {
 		return PR{}, fmt.Errorf("gh pr view %d in %s returned PR %d", number, g.root, decoded.Number)
 	}
-	return PR{
-		Number:           decoded.Number,
-		State:            decoded.State,
-		Title:            decoded.Title,
-		URL:              decoded.URL,
-		HeadRefName:      decoded.HeadRefName,
-		BaseRefName:      decoded.BaseRefName,
-		HeadRefOid:       decoded.HeadRefOid,
-		MergeStateStatus: decoded.MergeStateStatus,
-		MergedAt:         decoded.MergedAt,
-		Body:             decoded.Body,
-	}, nil
+	return decoded.toPR(), nil
+}
+
+// PRForBranch returns the single open pull request whose head branch is
+// head, or nil when none exists (`gh pr list --head <branch> --state
+// open`). pr-open uses it to fail closed on an orphan PR left by a
+// crashed run (PRD §23 reconciliation); more than one open PR for a
+// branch is impossible on GitHub, so a longer list is an error.
+func (g *GH) PRForBranch(ctx context.Context, head string) (*PR, error) {
+	var decoded []prJSON
+	if err := g.ghJSON(ctx, &decoded, "pr", "list", "--head", head, "--state", "open", "--json", prFields); err != nil {
+		return nil, err
+	}
+	if len(decoded) == 0 {
+		return nil, nil
+	}
+	if len(decoded) > 1 {
+		return nil, fmt.Errorf("gh pr list --head %s in %s returned %d open PRs (want at most one)", head, g.root, len(decoded))
+	}
+	pr := decoded[0].toPR()
+	return &pr, nil
+}
+
+// SetPRBody replaces the PR body (the PRD §13 audit record is mirrored
+// onto the PR while it is the active surface). The body travels over
+// stdin, never the command line.
+func (g *GH) SetPRBody(ctx context.Context, number int, body string) error {
+	_, err := g.ghStdin(ctx, strings.NewReader(body), "pr", "edit", strconv.Itoa(number), "--body-file", "-")
+	return err
 }
 
 // MergePR merges an approved PR with the configured strategy. It is

--- a/internal/ghops/pr.go
+++ b/internal/ghops/pr.go
@@ -84,19 +84,10 @@ type prJSON struct {
 	Body             string `json:"body"`
 }
 
+// toPR converts to the exported view: the field sets are identical, so
+// this is a direct struct conversion (tags are ignored in conversions).
 func (d prJSON) toPR() PR {
-	return PR{
-		Number:           d.Number,
-		State:            d.State,
-		Title:            d.Title,
-		URL:              d.URL,
-		HeadRefName:      d.HeadRefName,
-		BaseRefName:      d.BaseRefName,
-		HeadRefOid:       d.HeadRefOid,
-		MergeStateStatus: d.MergeStateStatus,
-		MergedAt:         d.MergedAt,
-		Body:             d.Body,
-	}
+	return PR(d)
 }
 
 // PR reads one pull request; the run engine uses it for the

--- a/internal/ghops/pr_test.go
+++ b/internal/ghops/pr_test.go
@@ -87,6 +87,61 @@ func TestPRViewNumberMismatch(t *testing.T) {
 	}
 }
 
+func TestPRForBranch(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "gh",
+		Args: []string{"pr", "list", "--head", "orch/7-add-widget", "--state", "open", "--json", prFields},
+		Dir:  root,
+		Env:  ghTestEnv,
+		Stdout: `[{"number":43,"state":"OPEN","title":"Add widget","url":"https://github.com/o/r/pull/43",` +
+			`"headRefName":"orch/7-add-widget","baseRefName":"main","headRefOid":"abc123",` +
+			`"mergeStateStatus":"CLEAN","mergedAt":null,"body":"b"}]`,
+	})
+	pr, err := g.PRForBranch(context.Background(), "orch/7-add-widget")
+	if err != nil {
+		t.Fatalf("PRForBranch: %v", err)
+	}
+	script.AssertExhausted()
+	if pr == nil || pr.Number != 43 || pr.HeadRefOid != "abc123" {
+		t.Errorf("pr = %+v, want #43 headRefOid abc123", pr)
+	}
+}
+
+func TestPRForBranchNone(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name:   "gh",
+		Args:   []string{"pr", "list", "--head", "orch/gone", "--state", "open", "--json", prFields},
+		Dir:    root,
+		Env:    ghTestEnv,
+		Stdout: "[]",
+	})
+	pr, err := g.PRForBranch(context.Background(), "orch/gone")
+	if err != nil {
+		t.Fatalf("PRForBranch: %v", err)
+	}
+	script.AssertExhausted()
+	if pr != nil {
+		t.Errorf("pr = %+v, want nil", pr)
+	}
+}
+
+func TestSetPRBody(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name:  "gh",
+		Args:  []string{"pr", "edit", "43", "--body-file", "-"},
+		Dir:   root,
+		Env:   ghTestEnv,
+		Stdin: "updated body",
+	})
+	if err := g.SetPRBody(context.Background(), 43, "updated body"); err != nil {
+		t.Fatalf("SetPRBody: %v", err)
+	}
+	script.AssertExhausted()
+}
+
 func TestMergePR(t *testing.T) {
 	tests := map[string]struct {
 		strategy string

--- a/internal/gitops/branch.go
+++ b/internal/gitops/branch.go
@@ -3,6 +3,7 @@ package gitops
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -12,6 +13,57 @@ func (g *Git) Fetch(ctx context.Context, remote string, refspecs ...string) erro
 	args := append([]string{"fetch", remote}, refspecs...)
 	_, err := g.git(ctx, g.root, args...)
 	return err
+}
+
+// Push publishes branch to remote from the working tree at dir, setting
+// the upstream (`git push -u`). pr-open runs it inside the issue's
+// worktree so the push uses that checkout's commits (PRD §12 step 9).
+func (g *Git) Push(ctx context.Context, dir, remote, branch string) error {
+	_, err := g.git(ctx, dir, "push", "-u", remote, branch)
+	return err
+}
+
+// FastForwardIn advances the branch checked out in dir to ref with
+// `git merge --ff-only ref`. dispatch uses it to bring an issue branch
+// up to origin/<default> inside its worktree before work begins; a
+// pre-dispatch branch has no commits by construction, so any divergence
+// is a fail-closed signal (ErrNotFastForward) and nothing changes.
+func (g *Git) FastForwardIn(ctx context.Context, dir, ref string) error {
+	res, err := g.run(ctx, dir, "merge", "--ff-only", ref)
+	if err != nil {
+		return err
+	}
+	if res.ExitCode != 0 {
+		return fmt.Errorf("%w: %s in %s: %s", ErrNotFastForward, ref, dir, strings.TrimSpace(res.Stderr))
+	}
+	return nil
+}
+
+// RemoteBranchExists reports whether branch is present on remote, via
+// `git ls-remote --heads`. cleanup uses it to make remote-branch
+// deletion idempotent, so a crashed cleanup re-runs cleanly.
+func (g *Git) RemoteBranchExists(ctx context.Context, remote, branch string) (bool, error) {
+	out, err := g.git(ctx, g.root, "ls-remote", "--heads", remote, branch)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(out) != "", nil
+}
+
+// CommitsAhead returns how many commits branch carries that base does
+// not, as `git rev-list --count base..branch` run in dir. pr-open uses
+// it to refuse an empty PR (PRD §16: no PR without work) after
+// fast-forwarding the base at dispatch.
+func (g *Git) CommitsAhead(ctx context.Context, dir, base, branch string) (int, error) {
+	out, err := g.git(ctx, dir, "rev-list", "--count", base+".."+branch)
+	if err != nil {
+		return 0, err
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return 0, fmt.Errorf("parse rev-list count %q in %s: %w", out, dir, err)
+	}
+	return n, nil
 }
 
 // DeleteBranch deletes a local branch that is fully merged into the

--- a/internal/gitops/branch_test.go
+++ b/internal/gitops/branch_test.go
@@ -137,6 +137,74 @@ func currentBranchCall(branch string) execxtest.Call {
 	return execxtest.Call{Name: "git", Args: []string{"symbolic-ref", "--short", "HEAD"}, Stdout: branch + "\n"}
 }
 
+func TestPush(t *testing.T) {
+	root := tempRoot(t)
+	wt := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "git", Args: []string{"push", "-u", "origin", "orch/issue-4"}, Dir: wt,
+	})
+	if err := g.Push(context.Background(), wt, "origin", "orch/issue-4"); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestFastForwardIn(t *testing.T) {
+	root := tempRoot(t)
+	wt := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "git", Args: []string{"merge", "--ff-only", "origin/main"}, Dir: wt,
+	})
+	if err := g.FastForwardIn(context.Background(), wt, "origin/main"); err != nil {
+		t.Fatalf("FastForwardIn: %v", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestFastForwardInDiverged(t *testing.T) {
+	root := tempRoot(t)
+	wt := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "git", Args: []string{"merge", "--ff-only", "origin/main"}, Dir: wt,
+		Exit: 128, Stderr: "fatal: Not possible to fast-forward, aborting.",
+	})
+	err := g.FastForwardIn(context.Background(), wt, "origin/main")
+	script.AssertExhausted()
+	if !errors.Is(err, ErrNotFastForward) {
+		t.Fatalf("err = %v, want ErrNotFastForward", err)
+	}
+}
+
+func TestRemoteBranchExists(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root,
+		execxtest.Call{Name: "git", Args: []string{"ls-remote", "--heads", "origin", "orch/issue-4"}, Dir: root, Stdout: "abc123\trefs/heads/orch/issue-4\n"},
+		execxtest.Call{Name: "git", Args: []string{"ls-remote", "--heads", "origin", "orch/gone"}, Dir: root, Stdout: ""},
+	)
+	exists, err := g.RemoteBranchExists(context.Background(), "origin", "orch/issue-4")
+	if err != nil || !exists {
+		t.Fatalf("RemoteBranchExists(present) = %v, %v; want true, nil", exists, err)
+	}
+	exists, err = g.RemoteBranchExists(context.Background(), "origin", "orch/gone")
+	if err != nil || exists {
+		t.Fatalf("RemoteBranchExists(absent) = %v, %v; want false, nil", exists, err)
+	}
+	script.AssertExhausted()
+}
+
+func TestCommitsAhead(t *testing.T) {
+	root := tempRoot(t)
+	wt := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "git", Args: []string{"rev-list", "--count", "origin/main..orch/issue-4"}, Dir: wt, Stdout: "3\n",
+	})
+	n, err := g.CommitsAhead(context.Background(), wt, "origin/main", "orch/issue-4")
+	if err != nil || n != 3 {
+		t.Fatalf("CommitsAhead = %d, %v; want 3, nil", n, err)
+	}
+	script.AssertExhausted()
+}
+
 func TestFastForwardWrongBranch(t *testing.T) {
 	g, script := openScripted(t, tempRoot(t), currentBranchCall("orch/issue-4"))
 	err := g.FastForward(context.Background(), "origin", "main")

--- a/internal/gitops/integration_test.go
+++ b/internal/gitops/integration_test.go
@@ -285,6 +285,52 @@ func TestIntegrationRemoteFlow(t *testing.T) {
 	}
 }
 
+func TestIntegrationPushFastForwardInRemoteExists(t *testing.T) {
+	setupGitEnv(t)
+	g, root := newRepo(t)
+	ctx := context.Background()
+
+	origin := filepath.Join(t.TempDir(), "origin.git")
+	rawGit(t, filepath.Dir(origin), "init", "--bare", origin)
+	rawGit(t, root, "remote", "add", "origin", origin)
+	rawGit(t, root, "push", "origin", "main")
+	rawGit(t, root, "fetch", "origin")
+
+	wt, err := g.AddWorktree(ctx, filepath.Join(t.TempDir(), "issue-8"), "orch/issue-8", "main")
+	if err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+
+	// A pre-dispatch branch sits at origin/main: FastForwardIn is a no-op
+	// and CommitsAhead is 0 (no empty PR).
+	if err := g.FastForwardIn(ctx, wt.Path, "origin/main"); err != nil {
+		t.Fatalf("FastForwardIn (at tip): %v", err)
+	}
+	ahead, err := g.CommitsAhead(ctx, wt.Path, "origin/main", "orch/issue-8")
+	if err != nil || ahead != 0 {
+		t.Fatalf("CommitsAhead (no work) = %d, %v; want 0, nil", ahead, err)
+	}
+
+	// Add work, push it, and confirm the remote branch and the ahead count.
+	commitFile(t, wt.Path, "feature.go", "package feature\n")
+	if err := g.Push(ctx, wt.Path, "origin", "orch/issue-8"); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	exists, err := g.RemoteBranchExists(ctx, "origin", "orch/issue-8")
+	if err != nil || !exists {
+		t.Fatalf("RemoteBranchExists after push = %v, %v; want true, nil", exists, err)
+	}
+	ahead, err = g.CommitsAhead(ctx, wt.Path, "origin/main", "orch/issue-8")
+	if err != nil || ahead != 1 {
+		t.Fatalf("CommitsAhead (one commit) = %d, %v; want 1, nil", ahead, err)
+	}
+
+	gone, err := g.RemoteBranchExists(ctx, "origin", "orch/never")
+	if err != nil || gone {
+		t.Fatalf("RemoteBranchExists(absent) = %v, %v; want false, nil", gone, err)
+	}
+}
+
 func TestIntegrationAddWorktreeInsidePrimary(t *testing.T) {
 	setupGitEnv(t)
 	g, root := newRepo(t)

--- a/internal/run/abandon.go
+++ b/internal/run/abandon.go
@@ -1,0 +1,115 @@
+package run
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// AbandonSchemaVersion is the abandon request/result schema this build
+// accepts and emits.
+const AbandonSchemaVersion = 1
+
+// AbandonStatement is the exact confirmation abandonment requires:
+// closing a PR and issue without merging is destructive bookkeeping and
+// carries its own explicit approval (PRD §15).
+const AbandonStatement = "abandon-issue"
+
+// AbandonRequest abandons an in-flight issue without merging.
+type AbandonRequest struct {
+	SchemaVersion int    `json:"schema_version"`
+	IssueNumber   int    `json:"issue_number"`
+	Reason        string `json:"reason"`
+	Statement     string `json:"statement"`
+}
+
+// AbandonResult reports the abandonment.
+type AbandonResult struct {
+	SchemaVersion int         `json:"schema_version"`
+	IssueNumber   int         `json:"issue_number"`
+	Phase         state.Phase `json:"phase"`
+}
+
+// Abandon closes an issue's PR and the issue without merging (PRD §15),
+// recording the reason in the durable issue audit record. The branch and
+// worktree are preserved until cleanup. Each GitHub mutation is guarded
+// by a state read so a re-run after a partial failure converges; the
+// only state write is the final Save, so a failure before it leaves the
+// run unchanged.
+func Abandon(ctx context.Context, env Env, reqJSON []byte) (*AbandonResult, error) {
+	var req AbandonRequest
+	if err := decodeRequest(reqJSON, &req); err != nil {
+		return nil, err
+	}
+	if req.SchemaVersion != AbandonSchemaVersion {
+		return nil, fmt.Errorf("%w: schema_version %d is unsupported (this build supports %d)", ErrBadRequest, req.SchemaVersion, AbandonSchemaVersion)
+	}
+	if req.Statement != AbandonStatement {
+		return nil, fmt.Errorf("%w: abandon statement %q does not equal %q", ErrBadRequest, req.Statement, AbandonStatement)
+	}
+	if req.Reason == "" {
+		return nil, fmt.Errorf("%w: abandon reason must not be empty", ErrBadRequest)
+	}
+
+	c, err := loadVerb(env, req.IssueNumber, nonTerminalPhases, false)
+	if err != nil {
+		return nil, err
+	}
+	issue := c.issue()
+
+	gh, err := openGitHub(ctx, env)
+	if err != nil {
+		return nil, err
+	}
+
+	// Close an open PR (if any).
+	if issue.PRNumber > 0 {
+		pr, err := gh.PR(ctx, issue.PRNumber)
+		if err != nil {
+			return nil, err
+		}
+		if pr.State == "OPEN" {
+			if err := gh.ClosePR(ctx, issue.PRNumber, ghops.ExplicitConfirmation()); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Record the abandonment on the durable issue audit record.
+	iss, m, err := readIssueManifest(ctx, gh, issue.Number)
+	if err != nil {
+		return nil, err
+	}
+	setVerification(&m, manifest.Verification{
+		Name:   "abandoned",
+		Result: "abandoned",
+		Detail: truncateDetail(req.Reason),
+		At:     env.nowStamp(),
+	})
+	issueBody, err := upsertCapped(iss.Body, m)
+	if err != nil {
+		return nil, err
+	}
+	if err := gh.SetIssueBody(ctx, issue.Number, issueBody); err != nil {
+		return nil, err
+	}
+	if iss.State == "OPEN" {
+		if err := gh.CloseIssue(ctx, issue.Number, ghops.ExplicitConfirmation()); err != nil {
+			return nil, err
+		}
+	}
+
+	issue.Phase = state.PhaseAbandoned
+	if err := c.save(); err != nil {
+		return nil, wrapAfterMutation(err)
+	}
+
+	return &AbandonResult{
+		SchemaVersion: AbandonSchemaVersion,
+		IssueNumber:   issue.Number,
+		Phase:         state.PhaseAbandoned,
+	}, nil
+}

--- a/internal/run/activate.go
+++ b/internal/run/activate.go
@@ -212,7 +212,17 @@ func Activate(ctx context.Context, env Env, reqJSON []byte) (*ActivationResult, 
 	ordered := plan.issuesInWaveOrder()
 	stateIssues := make([]state.Issue, len(ordered))
 	for i, pi := range ordered {
-		stateIssues[i] = state.Issue{PlanID: pi.ID, Title: pi.Title, Phase: state.PhasePlanned}
+		// Persist the plan's dependency edges, wave, and the derived
+		// routing decision so the PR B verbs can enforce dependencies and
+		// spawn executors without re-taking the plan document.
+		stateIssues[i] = state.Issue{
+			PlanID:    pi.ID,
+			Title:     pi.Title,
+			Phase:     state.PhasePlanned,
+			DependsOn: pi.DependsOn,
+			Wave:      pi.Wave,
+			Decision:  fromRoutingDecision(decisionByID[pi.ID]),
+		}
 	}
 	planRef := state.PlanRef{
 		Title:          plan.Title,

--- a/internal/run/block.go
+++ b/internal/run/block.go
@@ -1,0 +1,96 @@
+package run
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// BlockSchemaVersion is the block request/result schema this build
+// accepts and emits.
+const BlockSchemaVersion = 1
+
+// blockClasses is the closed failure-class set (PRD §15's classes plus
+// secret and a catch-all). A secret block stops the whole run.
+var blockClasses = map[string]bool{
+	"secret":     true,
+	"hook":       true,
+	"auth":       true,
+	"github":     true,
+	"validation": true,
+	"other":      true,
+}
+
+// BlockRequest blocks an in-flight issue for human attention.
+type BlockRequest struct {
+	SchemaVersion int    `json:"schema_version"`
+	IssueNumber   int    `json:"issue_number"`
+	Class         string `json:"class"`
+	Detail        string `json:"detail"`
+}
+
+// BlockResult reports the block and whether it stopped the run.
+type BlockResult struct {
+	SchemaVersion int         `json:"schema_version"`
+	IssueNumber   int         `json:"issue_number"`
+	Phase         state.Phase `json:"phase"`
+	RunStopped    bool        `json:"run_stopped"`
+}
+
+// Block blocks an issue for human action (PRD §15), preserving its
+// branch and worktree. It is the only mutating verb allowed on a stopped
+// run, and it accepts any non-terminal phase including blocked (re-block
+// updates the reason). A secret block also stops the whole run (PRD §16),
+// after which every other mutating verb fails closed until the human
+// recovers. Unaffected issues continue unless the run stopped.
+func Block(ctx context.Context, env Env, reqJSON []byte) (*BlockResult, error) {
+	var req BlockRequest
+	if err := decodeRequest(reqJSON, &req); err != nil {
+		return nil, err
+	}
+	if req.SchemaVersion != BlockSchemaVersion {
+		return nil, fmt.Errorf("%w: schema_version %d is unsupported (this build supports %d)", ErrBadRequest, req.SchemaVersion, BlockSchemaVersion)
+	}
+	if !blockClasses[req.Class] {
+		return nil, fmt.Errorf("%w: class %q is not one of secret, hook, auth, github, validation, other", ErrBadRequest, req.Class)
+	}
+	if req.Detail == "" {
+		return nil, fmt.Errorf("%w: block detail must not be empty", ErrBadRequest)
+	}
+
+	c, err := loadVerb(env, req.IssueNumber, nonTerminalPhases, true)
+	if err != nil {
+		return nil, err
+	}
+	issue := c.issue()
+
+	// Open gh before mutating state so an unavailable GitHub leaves the
+	// run untouched (fail closed, no side effect).
+	gh, err := openGitHub(ctx, env)
+	if err != nil {
+		return nil, err
+	}
+
+	reason := fmt.Sprintf("%s: %s", req.Class, req.Detail)
+	issue.Phase = state.PhaseBlocked
+	issue.BlockedReason = reason
+	runStopped := req.Class == "secret"
+	if runStopped {
+		c.st.Run.StoppedReason = reason
+	}
+	if err := c.save(); err != nil {
+		return nil, err
+	}
+	if err := gh.SetStatus(ctx, issue.Number, ghops.StatusBlocked); err != nil {
+		return nil, wrapAfterMutation(err)
+	}
+
+	return &BlockResult{
+		SchemaVersion: BlockSchemaVersion,
+		IssueNumber:   issue.Number,
+		Phase:         state.PhaseBlocked,
+		RunStopped:    runStopped,
+	}, nil
+}

--- a/internal/run/civerb.go
+++ b/internal/run/civerb.go
@@ -1,0 +1,120 @@
+package run
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// CISchemaVersion is the ci request/result schema this build accepts and
+// emits.
+const CISchemaVersion = 1
+
+// CIRequest asks for the current required-CI state of an issue's PR.
+type CIRequest struct {
+	SchemaVersion int `json:"schema_version"`
+	IssueNumber   int `json:"issue_number"`
+}
+
+// CICheck is one required check in the CI result.
+type CICheck struct {
+	Name   string `json:"name"`
+	State  string `json:"state"`
+	Bucket string `json:"bucket"`
+	Link   string `json:"link,omitempty"`
+}
+
+// CIResult is the honest tri-state required-CI report (PRD §16); a
+// no-checks state is explicit, never conflated with passing.
+type CIResult struct {
+	SchemaVersion int       `json:"schema_version"`
+	IssueNumber   int       `json:"issue_number"`
+	State         string    `json:"state"`
+	Required      []CICheck `json:"required"`
+	Total         int       `json:"total"`
+}
+
+// CI reads the required-CI state of an issue's PR and folds it into the
+// audit record under the singleton verification "required-ci", replacing
+// the previous entry by name so polling never grows the body. It makes
+// no phase change; the only mutations are the two body writes, so a
+// failure leaves the run unchanged and a re-run converges.
+func CI(ctx context.Context, env Env, reqJSON []byte) (*CIResult, error) {
+	var req CIRequest
+	if err := decodeRequest(reqJSON, &req); err != nil {
+		return nil, err
+	}
+	if req.SchemaVersion != CISchemaVersion {
+		return nil, fmt.Errorf("%w: schema_version %d is unsupported (this build supports %d)", ErrBadRequest, req.SchemaVersion, CISchemaVersion)
+	}
+
+	c, err := loadVerb(env, req.IssueNumber, []state.Phase{state.PhasePROpen, state.PhaseInReview, state.PhaseAwaitingMerge}, false)
+	if err != nil {
+		return nil, err
+	}
+	issue := c.issue()
+
+	gh, err := openGitHub(ctx, env)
+	if err != nil {
+		return nil, err
+	}
+	summary, err := gh.RequiredCI(ctx, issue.PRNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	iss, m, err := readIssueManifest(ctx, gh, issue.Number)
+	if err != nil {
+		return nil, err
+	}
+	setVerification(&m, manifest.Verification{
+		Name:   "required-ci",
+		Result: string(summary.State),
+		Detail: truncateDetail(ciDetail(summary)),
+		At:     env.nowStamp(),
+	})
+	pr, err := prForIssue(ctx, gh, issue)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeManifest(ctx, gh, iss, pr, m); err != nil {
+		return nil, err
+	}
+
+	return &CIResult{
+		SchemaVersion: CISchemaVersion,
+		IssueNumber:   issue.Number,
+		State:         string(summary.State),
+		Required:      ciChecks(summary),
+		Total:         summary.Total,
+	}, nil
+}
+
+// ciDetail renders the required checks as "name=bucket" pairs for the
+// manifest detail, or a plain statement when none are required.
+func ciDetail(s ghops.CISummary) string {
+	if len(s.Required) == 0 {
+		return "no required checks"
+	}
+	parts := make([]string, len(s.Required))
+	for i, ch := range s.Required {
+		parts[i] = ch.Name + "=" + ch.Bucket
+	}
+	return strings.Join(parts, ", ")
+}
+
+// ciChecks converts the ghops checks into the JSON result shape.
+func ciChecks(s ghops.CISummary) []CICheck {
+	if len(s.Required) == 0 {
+		return nil
+	}
+	out := make([]CICheck, len(s.Required))
+	for i, ch := range s.Required {
+		out[i] = CICheck{Name: ch.Name, State: ch.State, Bucket: ch.Bucket, Link: ch.Link}
+	}
+	return out
+}

--- a/internal/run/cleanup.go
+++ b/internal/run/cleanup.go
@@ -1,0 +1,101 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/kninetimmy/orch/internal/gitops"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// CleanupSchemaVersion is the cleanup request/result schema this build
+// accepts and emits.
+const CleanupSchemaVersion = 1
+
+// CleanupStatement is the exact confirmation cleanup requires: one
+// statement covers the verb's three deletions — remote branch, worktree,
+// and local branch — because they are one act (PRD §15).
+const CleanupStatement = "cleanup-issue"
+
+// CleanupRequest removes a merged or abandoned issue's git artifacts.
+type CleanupRequest struct {
+	SchemaVersion int    `json:"schema_version"`
+	IssueNumber   int    `json:"issue_number"`
+	Statement     string `json:"statement"`
+}
+
+// CleanupResult reports the completed cleanup.
+type CleanupResult struct {
+	SchemaVersion int         `json:"schema_version"`
+	IssueNumber   int         `json:"issue_number"`
+	Phase         state.Phase `json:"phase"`
+}
+
+// Cleanup deletes a merged or abandoned issue's remote branch, worktree,
+// and local branch (PRD §12 steps 18-19), then marks the issue cleaned
+// (terminal). Each deletion is pre-checked so a crashed cleanup re-runs
+// cleanly; the only state write is the final Save. A failure mid-cleanup
+// leaves the run incomplete (PRD §16) — the phase stays put and cleanup
+// re-runs.
+func Cleanup(ctx context.Context, env Env, reqJSON []byte) (*CleanupResult, error) {
+	var req CleanupRequest
+	if err := decodeRequest(reqJSON, &req); err != nil {
+		return nil, err
+	}
+	if req.SchemaVersion != CleanupSchemaVersion {
+		return nil, fmt.Errorf("%w: schema_version %d is unsupported (this build supports %d)", ErrBadRequest, req.SchemaVersion, CleanupSchemaVersion)
+	}
+	if req.Statement != CleanupStatement {
+		return nil, fmt.Errorf("%w: cleanup statement %q does not equal %q", ErrBadRequest, req.Statement, CleanupStatement)
+	}
+
+	c, err := loadVerb(env, req.IssueNumber, []state.Phase{state.PhaseMerged, state.PhaseAbandoned}, false)
+	if err != nil {
+		return nil, err
+	}
+	issue := c.issue()
+
+	git, err := gitops.Open(ctx, env.Runner, env.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+	confirm := gitops.ExplicitConfirmation()
+
+	// 1. Remote branch (idempotent: only delete when present).
+	exists, err := git.RemoteBranchExists(ctx, "origin", issue.Branch)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		if err := git.DeleteRemoteBranch(ctx, "origin", issue.Branch, confirm); err != nil {
+			return nil, err
+		}
+	}
+
+	// 2. Worktree (idempotent: an already-removed worktree is not
+	// registered, so RemoveWorktree reports ErrUnknownWorktree, which we
+	// tolerate). RemoveWorktree prunes stale metadata itself.
+	if err := git.RemoveWorktree(ctx, c.worktreeAbs(), confirm); err != nil && !errors.Is(err, gitops.ErrUnknownWorktree) {
+		return nil, err
+	}
+
+	// 3. Local branch (idempotent: only force-delete when it still
+	// resolves — a squash merge leaves it unmerged by design).
+	if _, err := git.RevParse(ctx, issue.Branch); err == nil {
+		if err := git.ForceDeleteBranch(ctx, issue.Branch, confirm); err != nil {
+			return nil, err
+		}
+	}
+
+	issue.Phase = state.PhaseCleaned
+	if err := c.save(); err != nil {
+		return nil, wrapAfterMutation(err)
+	}
+
+	return &CleanupResult{
+		SchemaVersion: CleanupSchemaVersion,
+		IssueNumber:   issue.Number,
+		Phase:         state.PhaseCleaned,
+	}, nil
+}

--- a/internal/run/complete.go
+++ b/internal/run/complete.go
@@ -1,0 +1,115 @@
+package run
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kninetimmy/orch/internal/gitops"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// CompleteSchemaVersion is the complete request/result schema this build
+// accepts and emits.
+const CompleteSchemaVersion = 1
+
+// CompleteRequest finishes a Delivery run. It carries no issue — complete
+// is run-level.
+type CompleteRequest struct {
+	SchemaVersion int `json:"schema_version"`
+}
+
+// CompleteResult reports the finished run and hands the adapter the
+// memhub wrap-up cue (PRD §20: only the Architect initiates memory
+// writes, so the engine never runs them itself).
+type CompleteResult struct {
+	SchemaVersion   int    `json:"schema_version"`
+	RunID           string `json:"run_id"`
+	Merged          int    `json:"merged"`
+	Abandoned       int    `json:"abandoned"`
+	ReturnedTo      string `json:"returned_to"`
+	MemhubWrapupDue bool   `json:"memhub_wrapup_due"`
+}
+
+// Complete finishes a Delivery run once every issue is cleaned (PRD §7
+// auto-return): it fast-forwards the primary checkout to origin/<default>
+// (PRD §12 step 20) and returns the repository to Assist with the lock
+// released. It never runs memhub itself — it only signals that a wrap-up
+// is due. The git preflights run before any state change, so a failure
+// leaves the run in Delivery.
+func Complete(ctx context.Context, env Env, reqJSON []byte) (*CompleteResult, error) {
+	var req CompleteRequest
+	if err := decodeRequest(reqJSON, &req); err != nil {
+		return nil, err
+	}
+	if req.SchemaVersion != CompleteSchemaVersion {
+		return nil, fmt.Errorf("%w: schema_version %d is unsupported (this build supports %d)", ErrBadRequest, req.SchemaVersion, CompleteSchemaVersion)
+	}
+
+	c, err := loadVerb(env, 0, nil, false)
+	if err != nil {
+		return nil, err
+	}
+	for i := range c.st.Run.Issues {
+		iss := &c.st.Run.Issues[i]
+		if iss.Phase != state.PhaseCleaned {
+			return nil, fmt.Errorf("%w: issue #%d is in phase %s, not cleaned", ErrNotAllCleaned, iss.Number, iss.Phase)
+		}
+	}
+
+	gh, err := openGitHub(ctx, env)
+	if err != nil {
+		return nil, err
+	}
+	repo, err := gh.Repo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	git, err := gitops.Open(ctx, env.Runner, env.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+	branch, err := git.CurrentBranch(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if branch != repo.DefaultBranch {
+		return nil, fmt.Errorf("primary checkout is on %s, not the default branch %s; completion requires the primary checkout on the default branch", branch, repo.DefaultBranch)
+	}
+	if err := git.RequireClean(ctx, ""); err != nil {
+		return nil, err
+	}
+	if err := git.FastForward(ctx, "origin", repo.DefaultBranch); err != nil {
+		return nil, err
+	}
+
+	runID := c.st.Run.ID
+	merged, abandoned := terminalCounts(c.st.Run)
+
+	if err := state.CompleteDelivery(env.RepoRoot); err != nil {
+		return nil, wrapAfterMutation(err)
+	}
+
+	return &CompleteResult{
+		SchemaVersion:   CompleteSchemaVersion,
+		RunID:           runID,
+		Merged:          merged,
+		Abandoned:       abandoned,
+		ReturnedTo:      string(state.ModeAssist),
+		MemhubWrapupDue: c.cfg.Memhub.Mode != "off",
+	}, nil
+}
+
+// terminalCounts splits the run's cleaned issues into those that merged
+// and those that were abandoned. An approved head OID (pinned only by
+// merge-report) marks a merged issue; every other cleaned issue was
+// abandoned.
+func terminalCounts(run *state.Run) (merged, abandoned int) {
+	for i := range run.Issues {
+		if run.Issues[i].ApprovedHeadOID != "" {
+			merged++
+		} else {
+			abandoned++
+		}
+	}
+	return merged, abandoned
+}

--- a/internal/run/decision.go
+++ b/internal/run/decision.go
@@ -1,0 +1,59 @@
+package run
+
+import (
+	"github.com/kninetimmy/orch/internal/routing"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// state mirrors routing's Decision and Attempt (state imports manifest,
+// never routing), so the escalate verb converts between the two forms
+// here. The field sets are identical; these helpers are the single seam.
+
+// fromRoutingDecision converts a routing.Decision into the persistable
+// state.Decision the run records on an issue.
+func fromRoutingDecision(d routing.Decision) *state.Decision {
+	return &state.Decision{
+		Role:               d.Role,
+		Executor:           d.Executor,
+		Reviewer:           d.Reviewer,
+		ReviewerDowngraded: d.ReviewerDowngraded,
+		Rationale:          d.Rationale,
+	}
+}
+
+// toRoutingDecision converts a persisted state.Decision back into the
+// routing.Decision the routing package consumes.
+func toRoutingDecision(d state.Decision) routing.Decision {
+	return routing.Decision{
+		Role:               d.Role,
+		Executor:           d.Executor,
+		Reviewer:           d.Reviewer,
+		ReviewerDowngraded: d.ReviewerDowngraded,
+		Rationale:          d.Rationale,
+	}
+}
+
+// fromRoutingHistory converts routing.History into the persistable
+// []state.Attempt an issue records.
+func fromRoutingHistory(h routing.History) []state.Attempt {
+	if len(h) == 0 {
+		return nil
+	}
+	out := make([]state.Attempt, len(h))
+	for i, a := range h {
+		out[i] = state.Attempt{Role: a.Role, Selection: a.Selection, Failed: a.Failed, Reason: a.Reason}
+	}
+	return out
+}
+
+// toRoutingHistory converts persisted attempts back into routing.History.
+func toRoutingHistory(as []state.Attempt) routing.History {
+	if len(as) == 0 {
+		return nil
+	}
+	out := make(routing.History, len(as))
+	for i, a := range as {
+		out[i] = routing.Attempt{Role: a.Role, Selection: a.Selection, Failed: a.Failed, Reason: a.Reason}
+	}
+	return out
+}

--- a/internal/run/dispatch.go
+++ b/internal/run/dispatch.go
@@ -1,0 +1,130 @@
+package run
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/gitops"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// DispatchSchemaVersion is the dispatch request/result schema this build
+// accepts and emits.
+const DispatchSchemaVersion = 1
+
+// DispatchRequest asks to hand one worktree-ready issue to its executor.
+type DispatchRequest struct {
+	SchemaVersion int `json:"schema_version"`
+	IssueNumber   int `json:"issue_number"`
+}
+
+// DispatchResult carries what the adapter needs to spawn the executor
+// into the issue's worktree (PRD §12 step 8): the branch, the
+// repo-relative worktree, and the routing selection.
+type DispatchResult struct {
+	SchemaVersion int                `json:"schema_version"`
+	IssueNumber   int                `json:"issue_number"`
+	Branch        string             `json:"branch"`
+	Worktree      string             `json:"worktree"`
+	Executor      manifest.Selection `json:"executor"`
+	Reviewer      manifest.Selection `json:"reviewer"`
+	Rationale     string             `json:"rationale"`
+}
+
+// Dispatch moves a worktree-ready issue to dispatched: it enforces the
+// issue's dependencies (every DependsOn issue merged or cleaned; an
+// abandoned dependency returns the plan to the gate), fetches origin and
+// fast-forwards the issue branch to origin/<default> inside its worktree
+// (closing the activation and inter-wave staleness windows), sets the
+// issue status to in-progress, and records the phase. The only state
+// write is the final Save, so any failure before it leaves the run
+// unchanged.
+func Dispatch(ctx context.Context, env Env, reqJSON []byte) (*DispatchResult, error) {
+	var req DispatchRequest
+	if err := decodeRequest(reqJSON, &req); err != nil {
+		return nil, err
+	}
+	if req.SchemaVersion != DispatchSchemaVersion {
+		return nil, fmt.Errorf("%w: schema_version %d is unsupported (this build supports %d)", ErrBadRequest, req.SchemaVersion, DispatchSchemaVersion)
+	}
+
+	c, err := loadVerb(env, req.IssueNumber, []state.Phase{state.PhaseWorktreeReady}, false)
+	if err != nil {
+		return nil, err
+	}
+	issue := c.issue()
+	if issue.Decision == nil {
+		return nil, fmt.Errorf("issue #%d has no routing decision; run `orch abort`", issue.Number)
+	}
+	if err := checkDependencies(c.st.Run, issue); err != nil {
+		return nil, err
+	}
+
+	gh, err := openGitHub(ctx, env)
+	if err != nil {
+		return nil, err
+	}
+	repo, err := gh.Repo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	git, err := gitops.Open(ctx, env.Runner, env.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := git.Fetch(ctx, "origin"); err != nil {
+		return nil, err
+	}
+	if err := git.FastForwardIn(ctx, c.worktreeAbs(), "origin/"+repo.DefaultBranch); err != nil {
+		return nil, err
+	}
+	if err := gh.SetStatus(ctx, issue.Number, ghops.StatusInProgress); err != nil {
+		return nil, err
+	}
+
+	issue.Phase = state.PhaseDispatched
+	if err := c.save(); err != nil {
+		return nil, err
+	}
+
+	return &DispatchResult{
+		SchemaVersion: DispatchSchemaVersion,
+		IssueNumber:   issue.Number,
+		Branch:        issue.Branch,
+		Worktree:      issue.Worktree,
+		Executor:      issue.Decision.Executor,
+		Reviewer:      issue.Decision.Reviewer,
+		Rationale:     issue.Decision.Rationale,
+	}, nil
+}
+
+// checkDependencies fails closed unless every issue in issue.DependsOn is
+// merged or cleaned. An abandoned dependency is a material scope change
+// that must return through the plan gate (PRD §8/§16); an in-flight
+// dependency is an ordering violation naming the blocking issue (PRD
+// §11 wave order).
+func checkDependencies(run *state.Run, issue *state.Issue) error {
+	byPlanID := make(map[string]*state.Issue, len(run.Issues))
+	for i := range run.Issues {
+		byPlanID[strings.ToLower(run.Issues[i].PlanID)] = &run.Issues[i]
+	}
+	for _, dep := range issue.DependsOn {
+		d, ok := byPlanID[strings.ToLower(dep)]
+		if !ok {
+			return fmt.Errorf("%w: dependency %q does not resolve to a run issue; run `orch abort`", ErrDependencyUnmet, dep)
+		}
+		switch d.Phase {
+		case state.PhaseMerged, state.PhaseCleaned:
+			// Satisfied.
+		case state.PhaseAbandoned:
+			return fmt.Errorf("%w: dependency %s (#%d) was abandoned; the plan's scope changed materially and must return through the plan gate (PRD §8/§16)", ErrDependencyAbandoned, d.PlanID, d.Number)
+		default:
+			return fmt.Errorf("%w: dependency %s (#%d) is in phase %s, not yet merged or cleaned", ErrDependencyUnmet, d.PlanID, d.Number, d.Phase)
+		}
+	}
+	return nil
+}

--- a/internal/run/errors.go
+++ b/internal/run/errors.go
@@ -27,4 +27,55 @@ var (
 	// (or the state/lock pair is inconsistent) when a verb requires
 	// Assist with no lock held.
 	ErrDeliveryActive = errors.New("a delivery run is already active")
+
+	// ErrNoDeliveryRun reports that a lifecycle verb ran without an
+	// active Delivery run to act on (the repository is in Assist).
+	ErrNoDeliveryRun = errors.New("no delivery run is active")
+	// ErrConfigDrift reports that the committed configuration changed
+	// mid-run (its revision no longer matches the run's): config changes
+	// ship via their own Delivery run, so drift fails closed.
+	ErrConfigDrift = errors.New("configuration changed mid-run")
+	// ErrRunStopped reports that the run was stopped by a secret block
+	// (PRD §16); every mutating verb but block itself is denied until
+	// `orch abort` or a future `orch resume`.
+	ErrRunStopped = errors.New("delivery run is stopped")
+	// ErrUnknownIssue reports an issue_number that matches no run issue.
+	ErrUnknownIssue = errors.New("issue number does not match any run issue")
+	// ErrWrongPhase reports an issue whose phase is not in the verb's
+	// allowed set.
+	ErrWrongPhase = errors.New("issue is not in a phase this verb accepts")
+	// ErrBadRequest reports a malformed verb request document: an
+	// unsupported schema, unparsable or unknown-field JSON, a wrong
+	// confirmation statement, or a value outside a closed set.
+	ErrBadRequest = errors.New("verb request document is invalid")
+	// ErrDependencyUnmet reports a dispatch blocked by a dependency issue
+	// that is not yet merged or cleaned (PRD §11 wave ordering).
+	ErrDependencyUnmet = errors.New("a dependency issue is not yet merged")
+	// ErrDependencyAbandoned reports a dispatch blocked by an abandoned
+	// dependency: the plan's scope changed materially and must go back
+	// through the plan gate (PRD §8/§16).
+	ErrDependencyAbandoned = errors.New("a dependency issue was abandoned")
+	// ErrPRExists reports an open pull request already present for a
+	// branch at pr-open — an orphan from a crashed run (PRD §23).
+	ErrPRExists = errors.New("an open pull request already exists for the branch")
+	// ErrReviewStale reports a review whose reviewed head OID no longer
+	// matches the PR's live head: the PR changed under the reviewer.
+	ErrReviewStale = errors.New("review does not match the pull request head")
+	// ErrReviewerMismatch reports a review performed by a selection other
+	// than the issue's routed reviewer (PRD §13: the audit record's
+	// reviewer is the one that reviewed).
+	ErrReviewerMismatch = errors.New("reviewer is not the routed reviewer")
+	// ErrCINotReady reports required CI that is pending or failing where
+	// a mergeable state (passing or no-checks) is required (PRD §16).
+	ErrCINotReady = errors.New("required CI is not in a mergeable state")
+	// ErrMergeApproval reports a merge approval that does not authorize
+	// the merge: a wrong statement, a PR/head mismatch, or drift after
+	// approval (PRD §8: approval pins one PR state).
+	ErrMergeApproval = errors.New("merge approval does not authorize this merge")
+	// ErrBodyTooLarge reports an audit body that cannot be brought under
+	// GitHub's 65,536-character limit even after dropping detail text.
+	ErrBodyTooLarge = errors.New("audit body exceeds GitHub's size limit")
+	// ErrNotAllCleaned reports a complete attempted before every issue
+	// reached the cleaned phase (PRD §7).
+	ErrNotAllCleaned = errors.New("not every issue is cleaned")
 )

--- a/internal/run/escalate.go
+++ b/internal/run/escalate.go
@@ -1,0 +1,174 @@
+package run
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/routing"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// EscalateSchemaVersion is the escalate request/result schema this build
+// accepts and emits.
+const EscalateSchemaVersion = 1
+
+// EscalateRequest raises a PRD §11 escalation on an in-flight issue.
+// Trigger is the closed routing.Trigger set; the engine passes it
+// through and lets routing reject a mismatch.
+type EscalateRequest struct {
+	SchemaVersion int    `json:"schema_version"`
+	IssueNumber   int    `json:"issue_number"`
+	Trigger       string `json:"trigger"`
+	Detail        string `json:"detail"`
+}
+
+// EscalateResult reports the escalation outcome: a reroute (with the new
+// executor/reviewer for the adapter to spawn into the same worktree) or a
+// return-to-architect (the issue is blocked for human design work).
+type EscalateResult struct {
+	SchemaVersion int                 `json:"schema_version"`
+	IssueNumber   int                 `json:"issue_number"`
+	Kind          string              `json:"kind"`
+	Executor      *manifest.Selection `json:"executor,omitempty"`
+	Reviewer      *manifest.Selection `json:"reviewer,omitempty"`
+	Rationale     string              `json:"rationale,omitempty"`
+	Reason        string              `json:"reason"`
+}
+
+// Escalate applies a PRD §11 escalation to an in-flight issue. It builds
+// the routing profile and history from config and the issue's persisted
+// state and runs routing.Escalate (an unknown or mismatched trigger is
+// an error). A reroute updates the routing decision, attempts, role
+// label, and audit records, transferring the work to a stronger executor
+// in place (PRD §11). A return-to-architect blocks the issue for human
+// design work.
+func Escalate(ctx context.Context, env Env, reqJSON []byte) (*EscalateResult, error) {
+	var req EscalateRequest
+	if err := decodeRequest(reqJSON, &req); err != nil {
+		return nil, err
+	}
+	if req.SchemaVersion != EscalateSchemaVersion {
+		return nil, fmt.Errorf("%w: schema_version %d is unsupported (this build supports %d)", ErrBadRequest, req.SchemaVersion, EscalateSchemaVersion)
+	}
+
+	c, err := loadVerb(env, req.IssueNumber, []state.Phase{state.PhaseDispatched, state.PhasePROpen, state.PhaseInReview}, false)
+	if err != nil {
+		return nil, err
+	}
+	issue := c.issue()
+	if issue.Decision == nil {
+		return nil, fmt.Errorf("issue #%d has no routing decision; run `orch abort`", issue.Number)
+	}
+
+	profile, err := hostProfile(c.cfg, c.st.Run.Host)
+	if err != nil {
+		return nil, err
+	}
+	outcome, err := routing.Escalate(
+		profile,
+		toRoutingDecision(*issue.Decision),
+		toRoutingHistory(issue.Attempts),
+		routing.Trigger(req.Trigger),
+		req.Detail,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	gh, err := openGitHub(ctx, env)
+	if err != nil {
+		return nil, err
+	}
+
+	switch outcome.Kind {
+	case routing.OutcomeReturnToArchitect:
+		return escalateReturnToArchitect(ctx, c, gh, outcome)
+	case routing.OutcomeReroute:
+		return escalateReroute(ctx, env, c, gh, outcome)
+	default:
+		return nil, fmt.Errorf("routing returned an unknown escalation outcome %q", outcome.Kind)
+	}
+}
+
+// escalateReroute persists the new decision and attempts, then updates
+// the role label and audit records to reflect the transfer (PRD §11).
+func escalateReroute(ctx context.Context, env Env, c *verbCtx, gh *ghops.GH, outcome routing.Outcome) (*EscalateResult, error) {
+	issue := c.issue()
+	stamp := env.nowStamp()
+	for i := range outcome.Escalations {
+		outcome.Escalations[i].At = stamp
+	}
+	oldRole := ghRoleLabel(issue.Decision.Role)
+
+	issue.Decision = fromRoutingDecision(outcome.Decision)
+	issue.Attempts = fromRoutingHistory(outcome.History)
+	if err := c.save(); err != nil {
+		return nil, err
+	}
+
+	newRole := ghRoleLabel(outcome.Decision.Role)
+	if newRole != oldRole {
+		if err := gh.SetRole(ctx, issue.Number, newRole); err != nil {
+			return nil, wrapAfterMutation(err)
+		}
+	}
+
+	iss, m, err := readIssueManifest(ctx, gh, issue.Number)
+	if err != nil {
+		return nil, wrapAfterMutation(err)
+	}
+	applyDecision(&m, *issue.Decision)
+	m.Escalations = append(m.Escalations, outcome.Escalations...)
+	pr, err := prForIssue(ctx, gh, issue)
+	if err != nil {
+		return nil, wrapAfterMutation(err)
+	}
+	if err := writeManifest(ctx, gh, iss, pr, m); err != nil {
+		return nil, wrapAfterMutation(err)
+	}
+
+	executor := outcome.Decision.Executor
+	reviewer := outcome.Decision.Reviewer
+	return &EscalateResult{
+		SchemaVersion: EscalateSchemaVersion,
+		IssueNumber:   issue.Number,
+		Kind:          string(routing.OutcomeReroute),
+		Executor:      &executor,
+		Reviewer:      &reviewer,
+		Rationale:     outcome.Decision.Rationale,
+		Reason:        outcome.Reason,
+	}, nil
+}
+
+// escalateReturnToArchitect records the exhausted history, blocks the
+// issue, and flags it for human design work (PRD §11).
+func escalateReturnToArchitect(ctx context.Context, c *verbCtx, gh *ghops.GH, outcome routing.Outcome) (*EscalateResult, error) {
+	issue := c.issue()
+	issue.Attempts = fromRoutingHistory(outcome.History)
+	issue.Phase = state.PhaseBlocked
+	issue.BlockedReason = outcome.Reason
+	if err := c.save(); err != nil {
+		return nil, err
+	}
+	if err := gh.SetStatus(ctx, issue.Number, ghops.StatusNeedsHuman); err != nil {
+		return nil, wrapAfterMutation(err)
+	}
+	return &EscalateResult{
+		SchemaVersion: EscalateSchemaVersion,
+		IssueNumber:   issue.Number,
+		Kind:          string(routing.OutcomeReturnToArchitect),
+		Reason:        outcome.Reason,
+	}, nil
+}
+
+// ghRoleLabel maps a routed role to its GitHub role label: specialist
+// for the specialist role, implementer for every other executor role
+// (matching issueLabels).
+func ghRoleLabel(r manifest.Role) ghops.Role {
+	if r == manifest.RoleSpecialist {
+		return ghops.RoleSpecialist
+	}
+	return ghops.RoleImplementer
+}

--- a/internal/run/lifecycle.go
+++ b/internal/run/lifecycle.go
@@ -1,47 +1,212 @@
-// This file sketches PR B's per-issue lifecycle verbs as doc comments
-// only — nothing here is implemented in PR A. Every field these verbs
-// will need already exists in state schema v2 (Issue's PR B fields;
-// Phase's PR B values), so PR B needs no v3 migration.
+// This file holds the shared infrastructure for the per-issue Delivery
+// lifecycle verbs (PRD §12 steps 8-22), each in its own file:
 //
-// orch run dispatch
+//	dispatch      worktree-ready → dispatched
+//	pr-open       dispatched     → pr-open
+//	review        pr-open/in-review → in-review
+//	escalate      dispatched/pr-open/in-review → reroute (same) or blocked
+//	ci            pr-open/in-review/awaiting-merge → same (manifest only)
+//	merge-report  in-review      → awaiting-merge
+//	merge         awaiting-merge → merged
+//	block         any non-terminal → blocked
+//	abandon       any non-terminal → abandoned
+//	cleanup       merged/abandoned → cleaned
+//	complete      run-level; requires every issue cleaned
 //
-//	Phase → dispatched, SetStatus in-progress, emits the worktree and
-//	branch plus the routing selection for the adapter to spawn the
-//	executor into.
-//
-// orch run pr-open
-//
-//	CreatePR with the manifest (Verifications recorded), persists
-//	PRNumber/PRURL, moves to awaiting-review.
-//
-// orch run review
-//
-//	ReviewCycles++, one consolidated review cycle per PRD §12.11;
-//	escalations feed the persisted Attempts (↔ routing.History) into
-//	routing.Escalate.
-//
-// orch run ci
-//
-//	Folds ghops.RequiredCI's tri-state into the manifest.
-//
-// orch run merge-report
-//
-//	Pins PR.HeadRefOid → ApprovedHeadOID, moves to awaiting-merge.
-//
-// orch run merge
-//
-//	The per-PR human approval assertion plus the pinned head OID drive
-//	ghops.MergePR(strategy, headOID, ExplicitConfirmation()), then
-//	confirm issue closure.
-//
-// orch run cleanup
-//
-//	Explicit confirmation: DeleteRemoteBranch, RemoveWorktree,
-//	ForceDeleteBranch.
-//
-// orch run complete
-//
-//	Once every issue is merged/abandoned and cleaned: FastForward the
-//	primary checkout, run the memhub wrap-up hook, and return state to
-//	Assist with the lock released (auto-return, PRD §7).
+// Failure semantics are pure (PRD §15, resolved 2026-07-11): no verb
+// mutates phase, state, GitHub, or git as a side effect of failing.
+// State advances only on the success path, persisted after each
+// sub-step; a post-mutation error is wrapped (wrapAfterMutation) with
+// the `orch abort`/resume remediation, exactly as activation wraps
+// errors after EnterDelivery. Every mutating verb runs the shared
+// preconditions in loadVerb before touching anything.
 package run
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// now returns the verb's timestamp source as UTC (PRD §23: every
+// engine-stamped At is RFC3339 UTC; tests inject a fixed clock). Verb
+// logic never reads the wall clock directly — it always goes through
+// here so a fixed Env.Now makes every stamped body deterministic.
+func (e Env) now() time.Time {
+	if e.Now != nil {
+		return e.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+// nowStamp is now() formatted as the RFC3339 UTC string the manifest
+// records carry.
+func (e Env) nowStamp() string {
+	return e.now().Format(time.RFC3339)
+}
+
+// verbCtx is the loaded, validated context every mutating lifecycle verb
+// shares: the config, the delivery state, the lock owner, and the index
+// of the target issue (-1 for run-level verbs like complete). The verb
+// mutates c.st.Run and persists with state.Save(c.env.RepoRoot, c.st).
+type verbCtx struct {
+	env   Env
+	cfg   *config.Config
+	st    *state.State
+	owner *lockfile.Owner
+	idx   int
+}
+
+// issue returns a pointer to the target issue within c.st.Run.Issues, so
+// verb mutations land in the value state.Save persists.
+func (c *verbCtx) issue() *state.Issue {
+	return &c.st.Run.Issues[c.idx]
+}
+
+// save persists c.st after a verb sub-step (PRD §23 incremental
+// persistence).
+func (c *verbCtx) save() error {
+	return state.Save(c.env.RepoRoot, c.st)
+}
+
+// worktreeAbs is the target issue's worktree as an absolute filesystem
+// path, from its repo-relative slash form.
+func (c *verbCtx) worktreeAbs() string {
+	return filepath.Join(c.env.RepoRoot, filepath.FromSlash(c.issue().Worktree))
+}
+
+// loadVerb runs the preconditions every mutating lifecycle verb shares,
+// in order (PRD §14 concurrency invariant, §16 config-drift and
+// stopped-run fail-closed):
+//
+//  1. Consistent delivery state owned by this run's lock.
+//  2. Delivery mode.
+//  3. Config that has not drifted from the run's ConfigRevision.
+//  4. The run is not stopped (unless exemptStop — only block is exempt).
+//  5. When issueNumber > 0, exactly one matching run issue whose phase is
+//     in allowed; issueNumber == 0 is a run-level verb with no issue.
+//
+// It returns the loaded context; the verb performs its ordered
+// operations and persists on the success path.
+func loadVerb(env Env, issueNumber int, allowed []state.Phase, exemptStop bool) (*verbCtx, error) {
+	st, err := state.Load(env.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+	owner, err := lockfile.Inspect(env.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+	if err := state.CheckConsistent(st, owner); err != nil {
+		return nil, err
+	}
+	if st.Mode != state.ModeDelivery {
+		return nil, fmt.Errorf("%w; run `orch run activate` to enter Delivery first", ErrNoDeliveryRun)
+	}
+	// CheckConsistent + validate guarantee st.Run is non-nil and its ID
+	// matches the lock owner here (the PR A concurrency invariant).
+	cfg, err := config.Load(env.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.ConfigRevision != st.Run.Plan.ConfigRevision {
+		return nil, fmt.Errorf("%w: config revision %q does not match the run's %q; run `orch abort`, ship the config change on its own Delivery run, then re-plan", ErrConfigDrift, cfg.ConfigRevision, st.Run.Plan.ConfigRevision)
+	}
+	if !exemptStop && st.Run.StoppedReason != "" {
+		return nil, fmt.Errorf("%w (%s); run `orch abort` to return to assist, or a future `orch resume` to continue", ErrRunStopped, st.Run.StoppedReason)
+	}
+
+	c := &verbCtx{env: env, cfg: cfg, st: st, owner: owner, idx: -1}
+	if issueNumber <= 0 {
+		return c, nil
+	}
+
+	idx := -1
+	for i := range st.Run.Issues {
+		if st.Run.Issues[i].Number == issueNumber {
+			if idx != -1 {
+				return nil, fmt.Errorf("%w: issue_number %d matches more than one run issue; run `orch abort`", ErrUnknownIssue, issueNumber)
+			}
+			idx = i
+		}
+	}
+	if idx == -1 {
+		return nil, fmt.Errorf("%w: issue_number %d", ErrUnknownIssue, issueNumber)
+	}
+	c.idx = idx
+	if !phaseAllowed(st.Run.Issues[idx].Phase, allowed) {
+		return nil, fmt.Errorf("%w: issue #%d is in phase %s; this verb requires one of %s", ErrWrongPhase, issueNumber, st.Run.Issues[idx].Phase, phaseList(allowed))
+	}
+	return c, nil
+}
+
+// phaseAllowed reports whether p is in allowed.
+func phaseAllowed(p state.Phase, allowed []state.Phase) bool {
+	for _, a := range allowed {
+		if p == a {
+			return true
+		}
+	}
+	return false
+}
+
+// phaseList renders allowed as a comma-separated list for error text.
+func phaseList(allowed []state.Phase) string {
+	parts := make([]string, len(allowed))
+	for i, a := range allowed {
+		parts[i] = string(a)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// nonTerminalPhases is the set block and abandon accept: every phase an
+// in-flight issue can hold, including blocked (re-block / abandon a
+// blocked issue). The terminal phases merged, cleaned, and abandoned are
+// excluded — there is nothing left to block or abandon there.
+var nonTerminalPhases = []state.Phase{
+	state.PhaseWorktreeReady, state.PhaseDispatched, state.PhasePROpen,
+	state.PhaseInReview, state.PhaseAwaitingMerge, state.PhaseBlocked,
+}
+
+// decodeRequest decodes data into v, rejecting unknown fields at any
+// level and trailing data (the DecodeActivation pattern). The caller
+// checks the schema_version field after decoding.
+func decodeRequest(data []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
+		return fmt.Errorf("%w: %v", ErrBadRequest, err)
+	}
+	if dec.More() {
+		return fmt.Errorf("%w: trailing data after request document", ErrBadRequest)
+	}
+	return nil
+}
+
+// wrapAfterMutation marks an error that occurred after a lifecycle verb
+// already advanced persisted state or a GitHub/git surface: the run is
+// mid-step, so the remediation is `orch abort` or a future `orch resume`
+// (the verb re-runs cleanly from the last completed sub-step), never a
+// bare retry. It mirrors activation's wrapAfterEnter for the per-issue
+// verbs.
+func wrapAfterMutation(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%w (state advanced; run `orch abort` to return to assist, or a future `orch resume` to continue from the last completed step)", err)
+}
+
+// openGitHub opens the authenticated gh handle every verb that touches
+// GitHub shares.
+func openGitHub(ctx context.Context, env Env) (*ghops.GH, error) {
+	return ghops.Open(ctx, env.Runner, env.RepoRoot)
+}

--- a/internal/run/lifecycle_test.go
+++ b/internal/run/lifecycle_test.go
@@ -1,0 +1,264 @@
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// prFieldsRun mirrors ghops's unexported prFields, pinned here so PR
+// reads in the scripted transcript match exactly.
+const prFieldsRun = "number,state,title,url,headRefName,baseRefName,headRefOid,mergeStateStatus,mergedAt,body"
+
+// baseManifestBody renders a minimal valid audit record on some prose, so
+// a scripted issue view returns a body manifest.Parse accepts.
+func baseManifestBody(t *testing.T) string {
+	t.Helper()
+	body, err := manifest.Upsert("**Objective**\n\ndo it\n", manifest.Manifest{
+		SchemaVersion:    manifest.SchemaVersion,
+		Role:             manifest.RoleImplementer,
+		Executor:         manifest.Selection{Model: "claude-sonnet-5", Effort: "xhigh"},
+		RoutingRationale: "impl",
+		Reviewer:         manifest.Selection{Model: "claude-opus-4-8", Effort: "high"},
+		ConfigRevision:   "r1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func jsonQuote(t *testing.T, s string) string {
+	t.Helper()
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func ghAuth() execxtest.Call { return execxtest.Call{Name: "gh", Args: []string{"auth", "status"}} }
+
+func ghIssueViewCall(t *testing.T, number int, stateStr, body string) execxtest.Call {
+	return execxtest.Call{
+		Name: "gh", Args: []string{"issue", "view", strconv.Itoa(number), "--json", "number,state,title,url,labels,body"},
+		Stdout: fmt.Sprintf(`{"number":%d,"state":%q,"title":"t","url":"u","labels":[],"body":%s}`, number, stateStr, jsonQuote(t, body)),
+	}
+}
+
+func ghPRViewCall(number int, prState, headOID string) execxtest.Call {
+	return execxtest.Call{
+		Name: "gh", Args: []string{"pr", "view", strconv.Itoa(number), "--json", prFieldsRun},
+		Stdout: fmt.Sprintf(`{"number":%d,"state":%q,"title":"t","url":"https://github.com/o/r/pull/%d","headRefName":"b","baseRefName":"main","headRefOid":%q,"mergeStateStatus":"CLEAN","mergedAt":null,"body":"pr body"}`, number, prState, number, headOID),
+	}
+}
+
+func ghPRListEmptyCall(branch string) execxtest.Call {
+	return execxtest.Call{Name: "gh", Args: []string{"pr", "list", "--head", branch, "--state", "open", "--json", prFieldsRun}, Stdout: "[]"}
+}
+
+func ghRollupEmptyCall(number int) execxtest.Call {
+	return execxtest.Call{Name: "gh", Args: []string{"pr", "view", strconv.Itoa(number), "--json", "statusCheckRollup"}, Stdout: `{"statusCheckRollup":[]}`}
+}
+
+func ghSetIssueBodyCall(number int) execxtest.Call {
+	return execxtest.Call{Name: "gh", Args: []string{"issue", "edit", strconv.Itoa(number), "--body-file", "-"}}
+}
+
+func ghSetPRBodyCall(number int) execxtest.Call {
+	return execxtest.Call{Name: "gh", Args: []string{"pr", "edit", strconv.Itoa(number), "--body-file", "-"}}
+}
+
+func ghCreatePRCall(branch, title string, number int) execxtest.Call {
+	return execxtest.Call{
+		Name:   "gh",
+		Args:   []string{"pr", "create", "--head", branch, "--base", "main", "--title", title, "--body-file", "-"},
+		Stdout: fmt.Sprintf("https://github.com/o/r/pull/%d\n", number),
+	}
+}
+
+func ghMergePRCall(number int, headOID string) execxtest.Call {
+	return execxtest.Call{Name: "gh", Args: []string{"pr", "merge", strconv.Itoa(number), "--squash", "--match-head-commit", headOID}}
+}
+
+func ghCloseIssueCall(number int) execxtest.Call {
+	return execxtest.Call{Name: "gh", Args: []string{"issue", "close", strconv.Itoa(number)}}
+}
+
+func ghSetStatusCall(number int, to ghops.Status) execxtest.Call {
+	args := []string{"issue", "edit", strconv.Itoa(number)}
+	for _, s := range []ghops.Status{ghops.StatusReady, ghops.StatusInProgress, ghops.StatusBlocked, ghops.StatusNeedsHuman, ghops.StatusAwaitingReview} {
+		if s != to {
+			args = append(args, "--remove-label", string(s))
+		}
+	}
+	args = append(args, "--add-label", string(to))
+	return execxtest.Call{Name: "gh", Args: args}
+}
+
+func ghSetRoleCall(number int, to ghops.Role) execxtest.Call {
+	args := []string{"issue", "edit", strconv.Itoa(number)}
+	for _, r := range []ghops.Role{ghops.RoleImplementer, ghops.RoleSpecialist} {
+		if r != to {
+			args = append(args, "--remove-label", string(r))
+		}
+	}
+	args = append(args, "--add-label", string(to))
+	return execxtest.Call{Name: "gh", Args: args}
+}
+
+// newLifecycleRepo builds an activation sandbox with a bare origin remote
+// and main pushed, so the dispatch/pr-open/cleanup git paths have a
+// remote to work against.
+func newLifecycleRepo(t *testing.T) string {
+	t.Helper()
+	root := newActivateRepo(t)
+	origin := filepath.Join(t.TempDir(), "origin.git")
+	rawGit(t, filepath.Dir(origin), "init", "--bare", origin)
+	rawGit(t, root, "remote", "add", "origin", origin)
+	rawGit(t, root, "push", "origin", "main")
+	return root
+}
+
+// runVerb runs one lifecycle verb against a mux runner (real git,
+// scripted gh) and asserts the scripted gh transcript was fully consumed.
+func runVerb[T any](t *testing.T, root string, fn func(context.Context, Env, []byte) (T, error), reqJSON string, calls ...execxtest.Call) T {
+	t.Helper()
+	script := &execxtest.Script{T: t, Calls: calls}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+	out, err := fn(context.Background(), env, []byte(reqJSON))
+	if err != nil {
+		t.Fatalf("verb: %v", err)
+	}
+	script.AssertExhausted()
+	return out
+}
+
+func loadRun(t *testing.T, root string) *state.State {
+	t.Helper()
+	st, err := state.Load(root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return st
+}
+
+func wantPhase(t *testing.T, root string, number int, want state.Phase) {
+	t.Helper()
+	st := loadRun(t, root)
+	for i := range st.Run.Issues {
+		if st.Run.Issues[i].Number == number {
+			if st.Run.Issues[i].Phase != want {
+				t.Fatalf("issue #%d phase = %s, want %s", number, st.Run.Issues[i].Phase, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("issue #%d not found", number)
+}
+
+// TestLifecycleWalk drives one issue from activation through cleanup and
+// run completion in a real git sandbox with scripted gh, asserting the
+// phase after every verb, the exact status transitions (via the scripted
+// SetStatus calls), and assist with no lock at the end.
+func TestLifecycleWalk(t *testing.T) {
+	root := newLifecycleRepo(t)
+	body := baseManifestBody(t)
+	const branch = "orch/issue-1-fix-the-status-lock-race"
+	const title = "Fix the status lock race"
+
+	// Activate the single-issue plan.
+	activateCalls := append(fullTaxonomyScript(), ghIssueCreateCall(title, []string{"ready", "bug", "implementer", "standard"}, 1))
+	script := &execxtest.Script{T: t, Calls: activateCalls}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+	if _, err := Activate(context.Background(), env, activationJSON(t, validPlanJSON())); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	script.AssertExhausted()
+	wantPhase(t, root, 1, state.PhaseWorktreeReady)
+
+	// dispatch.
+	runVerb(t, root, Dispatch, `{"schema_version":1,"issue_number":1}`,
+		ghAuth(), ghRepoViewCall("main"), ghSetStatusCall(1, ghops.StatusInProgress))
+	wantPhase(t, root, 1, state.PhaseDispatched)
+
+	// The executor commits work into the worktree.
+	wtDir := filepath.Join(root, ".orchestrator", "worktrees", "issue-1")
+	if err := os.WriteFile(filepath.Join(wtDir, "feature.go"), []byte("package feature\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rawGit(t, wtDir, "add", "-A")
+	rawGit(t, wtDir, "commit", "-m", "work")
+
+	// pr-open.
+	runVerb(t, root, PROpen, `{"schema_version":1,"issue_number":1,"verifications":[{"name":"go test","result":"pass"}]}`,
+		ghAuth(), ghRepoViewCall("main"), ghPRListEmptyCall(branch),
+		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1),
+		ghCreatePRCall(branch, title, 10), ghSetStatusCall(1, ghops.StatusAwaitingReview))
+	wantPhase(t, root, 1, state.PhasePROpen)
+
+	// review: request-changes.
+	runVerb(t, root, Review, `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"request-changes","summary":"fix things","reviewer":{"model":"claude-opus-4-8","effort":"high"}}`,
+		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-1"),
+		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghSetPRBodyCall(10),
+		ghSetStatusCall(1, ghops.StatusInProgress))
+	wantPhase(t, root, 1, state.PhaseInReview)
+
+	// review: approve (PR moved to a new head).
+	runVerb(t, root, Review, `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-2","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"}}`,
+		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-2"),
+		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghSetPRBodyCall(10))
+	wantPhase(t, root, 1, state.PhaseInReview)
+
+	// ci (no required checks).
+	runVerb(t, root, CI, `{"schema_version":1,"issue_number":1}`,
+		ghAuth(), ghRollupEmptyCall(10), ghIssueViewCall(t, 1, "OPEN", body),
+		ghPRViewCall(10, "OPEN", "head-oid-2"), ghSetIssueBodyCall(1), ghSetPRBodyCall(10))
+	wantPhase(t, root, 1, state.PhaseInReview)
+
+	// merge-report.
+	report := runVerb(t, root, MergeReport, `{"schema_version":1,"issue_number":1}`,
+		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-2"), ghRollupEmptyCall(10),
+		ghSetStatusCall(1, ghops.StatusNeedsHuman))
+	wantPhase(t, root, 1, state.PhaseAwaitingMerge)
+	if report.HeadOID != "head-oid-2" || report.NoCIStatement == "" {
+		t.Errorf("report = %+v, want head-oid-2 and a no-CI statement", report)
+	}
+
+	// merge.
+	runVerb(t, root, Merge, `{"schema_version":1,"issue_number":1,"approval":{"pr_number":10,"head_oid":"head-oid-2","approved_by":"alice","approved_at":"2026-07-11T12:00:00Z","statement":"approve-merge"}}`,
+		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-2"), ghRollupEmptyCall(10),
+		ghMergePRCall(10, "head-oid-2"), ghPRViewCall(10, "MERGED", "head-oid-2"),
+		ghIssueViewCall(t, 1, "OPEN", body), ghCloseIssueCall(1), ghSetIssueBodyCall(1))
+	wantPhase(t, root, 1, state.PhaseMerged)
+
+	// cleanup (git only).
+	runVerb(t, root, Cleanup, `{"schema_version":1,"issue_number":1,"statement":"cleanup-issue"}`)
+	wantPhase(t, root, 1, state.PhaseCleaned)
+
+	// complete.
+	result := runVerb(t, root, Complete, `{"schema_version":1}`, ghAuth(), ghRepoViewCall("main"))
+	if result.Merged != 1 || result.Abandoned != 0 || result.ReturnedTo != "assist" {
+		t.Errorf("complete result = %+v, want merged 1", result)
+	}
+
+	// The run returned to assist with no lock held.
+	st := loadRun(t, root)
+	if st.Mode != state.ModeAssist || st.Run != nil {
+		t.Errorf("state after complete = %+v, want assist", st)
+	}
+	if owner, err := lockfile.Inspect(root); owner != nil || err != nil {
+		t.Errorf("lock present after complete: %+v, %v", owner, err)
+	}
+}

--- a/internal/run/manifestbody.go
+++ b/internal/run/manifestbody.go
@@ -1,0 +1,149 @@
+package run
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// Body-cap policy (task 24), kept engine-side so internal/manifest stays
+// policy-free: every Verification.Detail is truncated at ingestion, and
+// before any body write the rendered body is kept under GitHub's limit
+// by dropping detail text from the oldest verifications first.
+const (
+	// verificationDetailCap bounds one Verification.Detail (characters).
+	verificationDetailCap = 2000
+	// verificationTruncationMarker flags a detail cut to the cap.
+	verificationTruncationMarker = " … [truncated by orch]"
+	// bodyCapHeadroom is the rendered-body ceiling the engine keeps under
+	// GitHub's hard limit; over it, oldest verification details are
+	// dropped before writing.
+	bodyCapHeadroom = 60000
+	// githubBodyLimit is GitHub's hard issue/PR body limit, named in the
+	// hard-failure error.
+	githubBodyLimit = 65536
+)
+
+// truncateDetail caps one detail string at verificationDetailCap runes,
+// appending the truncation marker when it cuts (PRD §23: the canonical
+// Name/Result/At always survive; only free-text detail is bounded).
+func truncateDetail(detail string) string {
+	r := []rune(detail)
+	if len(r) <= verificationDetailCap {
+		return detail
+	}
+	return string(r[:verificationDetailCap]) + verificationTruncationMarker
+}
+
+// applyDecision overwrites m's current routing fields (role, executor,
+// reviewer, rationale) with d, so the audit record reflects the live
+// decision after an escalation reroute. Escalations accumulate
+// separately as history.
+func applyDecision(m *manifest.Manifest, d state.Decision) {
+	m.Role = d.Role
+	m.Executor = d.Executor
+	m.Reviewer = d.Reviewer
+	m.RoutingRationale = d.Rationale
+}
+
+// setVerification replaces the verification named v.Name in m or appends
+// it when absent. The engine-owned singletons (required-ci, merge,
+// abandoned) use this so polling and terminal writes do not grow the
+// body; review cycles append under unique per-cycle names.
+func setVerification(m *manifest.Manifest, v manifest.Verification) {
+	for i := range m.Verifications {
+		if m.Verifications[i].Name == v.Name {
+			m.Verifications[i] = v
+			return
+		}
+	}
+	m.Verifications = append(m.Verifications, v)
+}
+
+// prForIssue reads the issue's PR when it has one (PRNumber > 0), or
+// returns nil when it does not. Verbs that mirror the manifest onto an
+// open PR use it before writeManifest.
+func prForIssue(ctx context.Context, gh *ghops.GH, issue *state.Issue) (*ghops.PR, error) {
+	if issue.PRNumber == 0 {
+		return nil, nil
+	}
+	pr, err := gh.PR(ctx, issue.PRNumber)
+	if err != nil {
+		return nil, err
+	}
+	return &pr, nil
+}
+
+// readIssueManifest fetches the GitHub issue and parses its audit
+// record. A drifted, malformed, or missing record fails closed (PRD
+// §15/§23: resume rebuilds from these bodies, so they must stay
+// trustworthy).
+func readIssueManifest(ctx context.Context, gh *ghops.GH, number int) (ghops.Issue, manifest.Manifest, error) {
+	iss, err := gh.Issue(ctx, number)
+	if err != nil {
+		return ghops.Issue{}, manifest.Manifest{}, err
+	}
+	m, err := manifest.Parse(iss.Body)
+	if err != nil {
+		return ghops.Issue{}, manifest.Manifest{}, fmt.Errorf("read issue #%d audit record: %w", number, err)
+	}
+	return iss, m, nil
+}
+
+// upsertCapped renders m into existing (preserving prose outside the
+// managed region) under the body-cap policy: if the rendered body
+// exceeds the headroom, it drops Detail text from the oldest
+// verifications first; if it still will not fit it fails closed naming
+// GitHub's hard limit and the offending size.
+func upsertCapped(existing string, m manifest.Manifest) (string, error) {
+	body, err := manifest.Upsert(existing, m)
+	if err != nil {
+		return "", err
+	}
+	if len(body) <= bodyCapHeadroom {
+		return body, nil
+	}
+	trimmed := m
+	trimmed.Verifications = append([]manifest.Verification(nil), m.Verifications...)
+	for i := range trimmed.Verifications {
+		if trimmed.Verifications[i].Detail == "" {
+			continue
+		}
+		trimmed.Verifications[i].Detail = ""
+		body, err = manifest.Upsert(existing, trimmed)
+		if err != nil {
+			return "", err
+		}
+		if len(body) <= bodyCapHeadroom {
+			return body, nil
+		}
+	}
+	return "", fmt.Errorf("%w: rendered body is %d characters after dropping every verification detail; GitHub rejects bodies over %d", ErrBodyTooLarge, len(body), githubBodyLimit)
+}
+
+// writeManifest applies m to the issue body (the durable audit home) and,
+// when pr is open, mirrors it onto the PR body (the active surface),
+// each under the body cap. A nil pr, or a non-open PR, writes only the
+// issue body.
+func writeManifest(ctx context.Context, gh *ghops.GH, issue ghops.Issue, pr *ghops.PR, m manifest.Manifest) error {
+	issueBody, err := upsertCapped(issue.Body, m)
+	if err != nil {
+		return err
+	}
+	if err := gh.SetIssueBody(ctx, issue.Number, issueBody); err != nil {
+		return err
+	}
+	if pr != nil && pr.State == "OPEN" {
+		prBody, err := upsertCapped(pr.Body, m)
+		if err != nil {
+			return err
+		}
+		if err := gh.SetPRBody(ctx, pr.Number, prBody); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/run/merge.go
+++ b/internal/run/merge.go
@@ -1,0 +1,150 @@
+package run
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// MergeSchemaVersion is the merge request/result schema this build
+// accepts and emits.
+const MergeSchemaVersion = 1
+
+// MergeApprovalStatement is the exact assertion a human merge approval
+// must carry (PRD §8): a fresh approval per PR, pinned to the head OID
+// the human saw. The engine cannot verify a human, so this recorded
+// string is the proof one approved this specific merge.
+const MergeApprovalStatement = "approve-merge"
+
+// MergeApproval is the adapter's record of the human's merge approval,
+// pinned to one PR at one head commit.
+type MergeApproval struct {
+	PRNumber   int       `json:"pr_number"`
+	HeadOID    string    `json:"head_oid"`
+	ApprovedBy string    `json:"approved_by"`
+	ApprovedAt time.Time `json:"approved_at"`
+	Statement  string    `json:"statement"`
+}
+
+// MergeRequest asks to merge an approved, awaiting-merge issue.
+type MergeRequest struct {
+	SchemaVersion int           `json:"schema_version"`
+	IssueNumber   int           `json:"issue_number"`
+	Approval      MergeApproval `json:"approval"`
+}
+
+// MergeResult reports the completed merge.
+type MergeResult struct {
+	SchemaVersion int  `json:"schema_version"`
+	IssueNumber   int  `json:"issue_number"`
+	PRNumber      int  `json:"pr_number"`
+	Merged        bool `json:"merged"`
+}
+
+// Merge merges an approved PR at the human merge gate (PRD §12 steps
+// 16-17). The approval must carry the exact statement and pin the PR and
+// head OID the engine recorded at merge-report, which must still equal
+// the PR's live head — any drift fails closed. The verb is re-runnable
+// after a crash: if the PR already reads MERGED it skips the merge and
+// proceeds to closure confirmation and the phase transition.
+func Merge(ctx context.Context, env Env, reqJSON []byte) (*MergeResult, error) {
+	var req MergeRequest
+	if err := decodeRequest(reqJSON, &req); err != nil {
+		return nil, err
+	}
+	if req.SchemaVersion != MergeSchemaVersion {
+		return nil, fmt.Errorf("%w: schema_version %d is unsupported (this build supports %d)", ErrBadRequest, req.SchemaVersion, MergeSchemaVersion)
+	}
+	if req.Approval.Statement != MergeApprovalStatement {
+		return nil, fmt.Errorf("%w: approval statement %q does not equal %q", ErrMergeApproval, req.Approval.Statement, MergeApprovalStatement)
+	}
+
+	c, err := loadVerb(env, req.IssueNumber, []state.Phase{state.PhaseAwaitingMerge}, false)
+	if err != nil {
+		return nil, err
+	}
+	issue := c.issue()
+	if req.Approval.PRNumber != issue.PRNumber {
+		return nil, fmt.Errorf("%w: approval pr_number %d does not match issue #%d's PR %d", ErrMergeApproval, req.Approval.PRNumber, issue.Number, issue.PRNumber)
+	}
+	if req.Approval.HeadOID != issue.ApprovedHeadOID {
+		return nil, fmt.Errorf("%w: approval head_oid %q does not match the approved head %q pinned at merge-report; re-run merge-report", ErrMergeApproval, req.Approval.HeadOID, issue.ApprovedHeadOID)
+	}
+
+	gh, err := openGitHub(ctx, env)
+	if err != nil {
+		return nil, err
+	}
+	pr, err := gh.PR(ctx, issue.PRNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	if pr.State != "MERGED" {
+		if req.Approval.HeadOID != pr.HeadRefOid {
+			return nil, fmt.Errorf("%w: the PR moved to head %q after approval of %q; re-run merge-report", ErrMergeApproval, pr.HeadRefOid, req.Approval.HeadOID)
+		}
+		summary, err := gh.RequiredCI(ctx, issue.PRNumber)
+		if err != nil {
+			return nil, err
+		}
+		if err := requireMergeableCI(summary.State); err != nil {
+			return nil, err
+		}
+		if err := gh.MergePR(ctx, issue.PRNumber, c.cfg.Merge.Strategy, issue.ApprovedHeadOID, ghops.ExplicitConfirmation()); err != nil {
+			return nil, err
+		}
+		merged, err := gh.PR(ctx, issue.PRNumber)
+		if err != nil {
+			return nil, wrapAfterMutation(err)
+		}
+		if merged.State != "MERGED" {
+			return nil, wrapAfterMutation(fmt.Errorf("PR #%d did not reach MERGED (state %s) after merge", merged.Number, merged.State))
+		}
+		pr = merged
+	}
+
+	// Confirm issue closure (PRD §12 step 17): the Closes link usually
+	// fires on merge, but the human merge approval covers closing it if
+	// it did not.
+	iss, m, err := readIssueManifest(ctx, gh, issue.Number)
+	if err != nil {
+		return nil, wrapAfterMutation(err)
+	}
+	if iss.State == "OPEN" {
+		if err := gh.CloseIssue(ctx, issue.Number, ghops.ExplicitConfirmation()); err != nil {
+			return nil, wrapAfterMutation(err)
+		}
+	}
+
+	// The issue body is the durable audit home once the PR is merged.
+	setVerification(&m, manifest.Verification{
+		Name:   "merge",
+		Result: "merged",
+		Detail: truncateDetail(fmt.Sprintf("%s merge at %s", c.cfg.Merge.Strategy, pr.HeadRefOid)),
+		At:     env.nowStamp(),
+	})
+	issueBody, err := upsertCapped(iss.Body, m)
+	if err != nil {
+		return nil, wrapAfterMutation(err)
+	}
+	if err := gh.SetIssueBody(ctx, issue.Number, issueBody); err != nil {
+		return nil, wrapAfterMutation(err)
+	}
+
+	issue.Phase = state.PhaseMerged
+	if err := c.save(); err != nil {
+		return nil, wrapAfterMutation(err)
+	}
+
+	return &MergeResult{
+		SchemaVersion: MergeSchemaVersion,
+		IssueNumber:   issue.Number,
+		PRNumber:      issue.PRNumber,
+		Merged:        true,
+	}, nil
+}

--- a/internal/run/mergereport.go
+++ b/internal/run/mergereport.go
@@ -1,0 +1,122 @@
+package run
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// MergeReportSchemaVersion is the merge-report request/result schema this
+// build accepts and emits.
+const MergeReportSchemaVersion = 1
+
+// MergeReportRequest asks to pin an approved PR at the merge gate.
+type MergeReportRequest struct {
+	SchemaVersion int `json:"schema_version"`
+	IssueNumber   int `json:"issue_number"`
+}
+
+// MergeReportCI is the CI evidence carried in the ready-to-merge report.
+type MergeReportCI struct {
+	State    string    `json:"state"`
+	Required []CICheck `json:"required"`
+	Total    int       `json:"total"`
+}
+
+// MergeReportResult is the ready-to-merge report the adapter shows at the
+// human merge gate (PRD §8, §16).
+type MergeReportResult struct {
+	SchemaVersion  int           `json:"schema_version"`
+	IssueNumber    int           `json:"issue_number"`
+	PRNumber       int           `json:"pr_number"`
+	PRURL          string        `json:"pr_url"`
+	HeadOID        string        `json:"head_oid"`
+	MergeStrategy  string        `json:"merge_strategy"`
+	CI             MergeReportCI `json:"ci"`
+	ReviewCycles   int           `json:"review_cycles"`
+	ConfigRevision string        `json:"config_revision"`
+	NoCIStatement  string        `json:"no_ci_statement,omitempty"`
+}
+
+// MergeReport moves an approved, mergeable issue to awaiting-merge and
+// pins the PR's live head OID as the approved head (PRD §8: approval pins
+// one PR state). It requires the last review to have approved, the PR to
+// be open, and required CI to be passing or absent — a pending or failing
+// state fails closed. No-checks is allowed but stated explicitly in the
+// report (PRD §16).
+func MergeReport(ctx context.Context, env Env, reqJSON []byte) (*MergeReportResult, error) {
+	var req MergeReportRequest
+	if err := decodeRequest(reqJSON, &req); err != nil {
+		return nil, err
+	}
+	if req.SchemaVersion != MergeReportSchemaVersion {
+		return nil, fmt.Errorf("%w: schema_version %d is unsupported (this build supports %d)", ErrBadRequest, req.SchemaVersion, MergeReportSchemaVersion)
+	}
+
+	c, err := loadVerb(env, req.IssueNumber, []state.Phase{state.PhaseInReview}, false)
+	if err != nil {
+		return nil, err
+	}
+	issue := c.issue()
+	if issue.LastReviewVerdict != VerdictApprove {
+		return nil, fmt.Errorf("issue #%d has no approving review (last verdict %q); cannot report it ready to merge", issue.Number, issue.LastReviewVerdict)
+	}
+
+	gh, err := openGitHub(ctx, env)
+	if err != nil {
+		return nil, err
+	}
+	pr, err := gh.PR(ctx, issue.PRNumber)
+	if err != nil {
+		return nil, err
+	}
+	if pr.State != "OPEN" {
+		return nil, fmt.Errorf("PR #%d is %s, not OPEN; cannot report it ready to merge", pr.Number, pr.State)
+	}
+	summary, err := gh.RequiredCI(ctx, issue.PRNumber)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireMergeableCI(summary.State); err != nil {
+		return nil, err
+	}
+
+	issue.ApprovedHeadOID = pr.HeadRefOid
+	issue.Phase = state.PhaseAwaitingMerge
+	if err := c.save(); err != nil {
+		return nil, err
+	}
+	if err := gh.SetStatus(ctx, issue.Number, ghops.StatusNeedsHuman); err != nil {
+		return nil, wrapAfterMutation(err)
+	}
+
+	result := &MergeReportResult{
+		SchemaVersion:  MergeReportSchemaVersion,
+		IssueNumber:    issue.Number,
+		PRNumber:       pr.Number,
+		PRURL:          pr.URL,
+		HeadOID:        pr.HeadRefOid,
+		MergeStrategy:  c.cfg.Merge.Strategy,
+		CI:             MergeReportCI{State: string(summary.State), Required: ciChecks(summary), Total: summary.Total},
+		ReviewCycles:   issue.ReviewCycles,
+		ConfigRevision: c.cfg.ConfigRevision,
+	}
+	if summary.State == ghops.CINoChecks {
+		result.NoCIStatement = "no required CI checks gate this merge (PRD §16)"
+	}
+	return result, nil
+}
+
+// requireMergeableCI fails closed unless state is passing or no-checks
+// (PRD §16): a pending or failing required-CI state blocks the merge
+// report, naming the state.
+func requireMergeableCI(state ghops.CIState) error {
+	switch state {
+	case ghops.CIPassing, ghops.CINoChecks:
+		return nil
+	default:
+		return fmt.Errorf("%w: required CI is %s", ErrCINotReady, state)
+	}
+}

--- a/internal/run/propen.go
+++ b/internal/run/propen.go
@@ -1,0 +1,197 @@
+package run
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/gitops"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// PROpenSchemaVersion is the pr-open request/result schema this build
+// accepts and emits.
+const PROpenSchemaVersion = 1
+
+// VerificationInput is one required-test evidence entry the executor
+// supplies (PRD §15: completion requires targeted-test evidence). A
+// missing At is stamped by the engine.
+type VerificationInput struct {
+	Name    string `json:"name"`
+	Command string `json:"command,omitempty"`
+	Result  string `json:"result"`
+	Detail  string `json:"detail,omitempty"`
+	At      string `json:"at,omitempty"`
+}
+
+// PROpenRequest opens the PR for a dispatched issue, carrying the
+// executor's verification evidence.
+type PROpenRequest struct {
+	SchemaVersion int                 `json:"schema_version"`
+	IssueNumber   int                 `json:"issue_number"`
+	Verifications []VerificationInput `json:"verifications"`
+}
+
+// PROpenResult reports the opened PR.
+type PROpenResult struct {
+	SchemaVersion int    `json:"schema_version"`
+	IssueNumber   int    `json:"issue_number"`
+	PRNumber      int    `json:"pr_number"`
+	PRURL         string `json:"pr_url"`
+}
+
+// PROpen opens a pull request for a dispatched issue (PRD §12 step 9).
+// Preconditions: the worktree is clean, the branch is strictly ahead of
+// origin/<default> (no empty PRs), and no open PR already exists for the
+// branch (an orphan from a crashed run fails closed naming resume/abort).
+// It pushes the branch, records the verification evidence in the issue
+// and PR audit records, creates the PR, and moves the issue to pr-open /
+// awaiting-review. The verification set is written (not appended) so a
+// pre-CreatePR crash re-runs cleanly.
+func PROpen(ctx context.Context, env Env, reqJSON []byte) (*PROpenResult, error) {
+	var req PROpenRequest
+	if err := decodeRequest(reqJSON, &req); err != nil {
+		return nil, err
+	}
+	if req.SchemaVersion != PROpenSchemaVersion {
+		return nil, fmt.Errorf("%w: schema_version %d is unsupported (this build supports %d)", ErrBadRequest, req.SchemaVersion, PROpenSchemaVersion)
+	}
+	verifications, err := buildVerifications(req.Verifications, env.nowStamp())
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := loadVerb(env, req.IssueNumber, []state.Phase{state.PhaseDispatched}, false)
+	if err != nil {
+		return nil, err
+	}
+	issue := c.issue()
+
+	gh, err := openGitHub(ctx, env)
+	if err != nil {
+		return nil, err
+	}
+	repo, err := gh.Repo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	git, err := gitops.Open(ctx, env.Runner, env.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+	worktree := c.worktreeAbs()
+	if err := git.RequireClean(ctx, worktree); err != nil {
+		return nil, err
+	}
+	ahead, err := git.CommitsAhead(ctx, worktree, "origin/"+repo.DefaultBranch, issue.Branch)
+	if err != nil {
+		return nil, err
+	}
+	if ahead == 0 {
+		return nil, fmt.Errorf("branch %s has no commits beyond origin/%s; refusing to open an empty PR (PRD §16)", issue.Branch, repo.DefaultBranch)
+	}
+	existing, err := gh.PRForBranch(ctx, issue.Branch)
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		return nil, fmt.Errorf("%w: PR #%d for branch %s; run `orch abort` or a future `orch resume` to adopt it", ErrPRExists, existing.Number, issue.Branch)
+	}
+
+	// Push the branch, then record the verifications on the issue body
+	// (its manifest, seeded at activation, carries no verifications yet,
+	// so a write is idempotent on retry) before creating the PR.
+	if err := git.Push(ctx, worktree, "origin", issue.Branch); err != nil {
+		return nil, err
+	}
+	iss, m, err := readIssueManifest(ctx, gh, issue.Number)
+	if err != nil {
+		return nil, err
+	}
+	m.Verifications = verifications
+	issueBody, err := upsertCapped(iss.Body, m)
+	if err != nil {
+		return nil, err
+	}
+	if err := gh.SetIssueBody(ctx, issue.Number, issueBody); err != nil {
+		return nil, err
+	}
+	prBody, err := upsertCapped(prProse(issue, c.st.Run.Plan.Digest), m)
+	if err != nil {
+		return nil, err
+	}
+	prNumber, prURL, err := gh.CreatePR(ctx, ghops.PRSpec{
+		Head:  issue.Branch,
+		Base:  repo.DefaultBranch,
+		Title: issue.Title,
+		Body:  prBody,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	issue.PRNumber = prNumber
+	issue.PRURL = prURL
+	issue.Phase = state.PhasePROpen
+	if err := c.save(); err != nil {
+		return nil, wrapAfterMutation(err)
+	}
+	if err := gh.SetStatus(ctx, issue.Number, ghops.StatusAwaitingReview); err != nil {
+		return nil, wrapAfterMutation(err)
+	}
+	if err := c.save(); err != nil {
+		return nil, wrapAfterMutation(err)
+	}
+
+	return &PROpenResult{
+		SchemaVersion: PROpenSchemaVersion,
+		IssueNumber:   issue.Number,
+		PRNumber:      prNumber,
+		PRURL:         prURL,
+	}, nil
+}
+
+// buildVerifications converts the supplied inputs into manifest
+// verifications, requiring at least one (PRD §15), stamping missing At
+// with stamp, and truncating each Detail to the body-cap ceiling.
+func buildVerifications(inputs []VerificationInput, stamp string) ([]manifest.Verification, error) {
+	if len(inputs) == 0 {
+		return nil, fmt.Errorf("%w: pr-open requires at least one verification (PRD §15: completion needs targeted-test evidence)", ErrBadRequest)
+	}
+	out := make([]manifest.Verification, len(inputs))
+	for i, in := range inputs {
+		if in.Name == "" {
+			return nil, fmt.Errorf("%w: verifications[%d] name is empty", ErrBadRequest, i)
+		}
+		if in.Result == "" {
+			return nil, fmt.Errorf("%w: verifications[%d] result is empty", ErrBadRequest, i)
+		}
+		at := in.At
+		if at == "" {
+			at = stamp
+		}
+		out[i] = manifest.Verification{
+			Name:    in.Name,
+			Command: in.Command,
+			Result:  in.Result,
+			Detail:  truncateDetail(in.Detail),
+			At:      at,
+		}
+	}
+	return out, nil
+}
+
+// prProse is the human-readable portion of a PR body: a one-line summary,
+// the Closes link that closes the issue on merge (PRD §12 step 17), and
+// the plan digest. The full objective and acceptance criteria live on
+// the linked issue.
+func prProse(issue *state.Issue, digest string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Delivers issue #%d: %s\n\n", issue.Number, issue.Title)
+	fmt.Fprintf(&b, "Closes #%d\n\n", issue.Number)
+	fmt.Fprintf(&b, "**Plan digest:** `%s`\n\n", digest)
+	b.WriteString("The full objective and acceptance criteria are on the linked issue.\n")
+	return b.String()
+}

--- a/internal/run/review.go
+++ b/internal/run/review.go
@@ -1,0 +1,126 @@
+package run
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// ReviewSchemaVersion is the review request/result schema this build
+// accepts and emits.
+const ReviewSchemaVersion = 1
+
+// The two review verdicts (PRD §12 step 11).
+const (
+	VerdictApprove        = "approve"
+	VerdictRequestChanges = "request-changes"
+)
+
+// ReviewRequest records one consolidated review cycle for an open PR.
+// Reviewer is the selection that actually performed the review; it must
+// equal the issue's routed reviewer, so a review run on the wrong model
+// fails closed instead of polluting the audit record.
+type ReviewRequest struct {
+	SchemaVersion   int                `json:"schema_version"`
+	IssueNumber     int                `json:"issue_number"`
+	ReviewedHeadOID string             `json:"reviewed_head_oid"`
+	Verdict         string             `json:"verdict"`
+	Summary         string             `json:"summary"`
+	Reviewer        manifest.Selection `json:"reviewer"`
+}
+
+// ReviewResult reports the recorded review cycle.
+type ReviewResult struct {
+	SchemaVersion int    `json:"schema_version"`
+	IssueNumber   int    `json:"issue_number"`
+	ReviewCycles  int    `json:"review_cycles"`
+	Verdict       string `json:"verdict"`
+}
+
+// Review records one consolidated review cycle (PRD §12 step 11). It
+// requires the reporting reviewer to be the issue's routed reviewer
+// (PRD §13: the audit record's reviewer is the one that reviewed), and
+// enforces PRD §14's "review begins only after the PR stops changing" by
+// requiring the reviewed head OID to equal the PR's live head — a stale
+// review is rejected so the reviewer re-reads. It advances the issue to
+// in-review, appends the cycle to the issue and PR audit records, and,
+// on request-changes, sets the status back to in-progress.
+func Review(ctx context.Context, env Env, reqJSON []byte) (*ReviewResult, error) {
+	var req ReviewRequest
+	if err := decodeRequest(reqJSON, &req); err != nil {
+		return nil, err
+	}
+	if req.SchemaVersion != ReviewSchemaVersion {
+		return nil, fmt.Errorf("%w: schema_version %d is unsupported (this build supports %d)", ErrBadRequest, req.SchemaVersion, ReviewSchemaVersion)
+	}
+	if req.Verdict != VerdictApprove && req.Verdict != VerdictRequestChanges {
+		return nil, fmt.Errorf("%w: verdict %q is not one of %s, %s", ErrBadRequest, req.Verdict, VerdictApprove, VerdictRequestChanges)
+	}
+	if req.Summary == "" {
+		return nil, fmt.Errorf("%w: review summary must not be empty (PRD §12.11: one consolidated report per cycle)", ErrBadRequest)
+	}
+
+	c, err := loadVerb(env, req.IssueNumber, []state.Phase{state.PhasePROpen, state.PhaseInReview}, false)
+	if err != nil {
+		return nil, err
+	}
+	issue := c.issue()
+	if issue.Decision == nil {
+		return nil, fmt.Errorf("issue #%d has no routing decision; run `orch abort`", issue.Number)
+	}
+	if req.Reviewer != issue.Decision.Reviewer {
+		return nil, fmt.Errorf("%w: reviewer %s@%s is not the routed reviewer %s@%s; review with the routed selection, or run `orch run escalate` to reroute first", ErrReviewerMismatch, req.Reviewer.Model, req.Reviewer.Effort, issue.Decision.Reviewer.Model, issue.Decision.Reviewer.Effort)
+	}
+
+	gh, err := openGitHub(ctx, env)
+	if err != nil {
+		return nil, err
+	}
+	pr, err := gh.PR(ctx, issue.PRNumber)
+	if err != nil {
+		return nil, err
+	}
+	if pr.State != "OPEN" {
+		return nil, fmt.Errorf("PR #%d is %s, not OPEN; cannot review it", pr.Number, pr.State)
+	}
+	if req.ReviewedHeadOID != pr.HeadRefOid {
+		return nil, fmt.Errorf("%w: reviewed head %q is not the PR's live head %q; the PR changed under the reviewer, re-review", ErrReviewStale, req.ReviewedHeadOID, pr.HeadRefOid)
+	}
+
+	issue.ReviewCycles++
+	issue.LastReviewVerdict = req.Verdict
+	issue.Phase = state.PhaseInReview
+	if err := c.save(); err != nil {
+		return nil, err
+	}
+
+	iss, m, err := readIssueManifest(ctx, gh, issue.Number)
+	if err != nil {
+		return nil, wrapAfterMutation(err)
+	}
+	m.Verifications = append(m.Verifications, manifest.Verification{
+		Name:   fmt.Sprintf("review-cycle-%d", issue.ReviewCycles),
+		Result: req.Verdict,
+		Detail: truncateDetail(req.Summary),
+		At:     env.nowStamp(),
+	})
+	if err := writeManifest(ctx, gh, iss, &pr, m); err != nil {
+		return nil, wrapAfterMutation(err)
+	}
+
+	if req.Verdict == VerdictRequestChanges {
+		if err := gh.SetStatus(ctx, issue.Number, ghops.StatusInProgress); err != nil {
+			return nil, wrapAfterMutation(err)
+		}
+	}
+
+	return &ReviewResult{
+		SchemaVersion: ReviewSchemaVersion,
+		IssueNumber:   issue.Number,
+		ReviewCycles:  issue.ReviewCycles,
+		Verdict:       req.Verdict,
+	}, nil
+}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -11,14 +11,21 @@
 //	orch run activate        # activation request JSON on stdin → activation result JSON on stdout
 //	orch run status --json   # run-state JSON on stdout
 //
-// Concurrency invariant: plan and status are read-only. activate is
-// the only PR A mutator, and it acquires the cross-host Delivery lock
-// via state.EnterDelivery before any mutation except the idempotent
-// label-taxonomy ensure (PRD §14 F6). Every future mutating verb (PR
-// B) must verify state.Load + lockfile.Inspect + state.CheckConsistent
-// and st.Run.ID == owner.RunID before touching anything. Within one
-// invocation writes are sequential, so PRD §14's serialization
-// requirement holds trivially.
+// The per-issue lifecycle verbs (see lifecycle.go) extend the surface —
+// dispatch, pr-open, review, escalate, ci, merge-report, merge, block,
+// abandon, cleanup — plus the run-level complete. Each reads a
+// schema-versioned request document on stdin and writes a
+// schema-versioned result on stdout.
+//
+// Concurrency invariant: plan and status are read-only. Every mutating
+// verb acquires or re-verifies the cross-host Delivery lock: activate
+// enters Delivery via state.EnterDelivery, and each lifecycle verb runs
+// the shared preconditions in loadVerb (state.Load + lockfile.Inspect +
+// state.CheckConsistent with st.Run.ID == owner.RunID, plus config-drift
+// and stopped-run gates) before touching anything. Within one invocation
+// writes are sequential, so PRD §14's serialization requirement holds
+// trivially. Failure semantics are pure: a verb never mutates phase,
+// state, GitHub, or git as a side effect of failing.
 //
 // All documents this package accepts are schema-versioned
 // (exact-match, fail closed) and decoded with DisallowUnknownFields:

--- a/internal/run/status.go
+++ b/internal/run/status.go
@@ -25,13 +25,17 @@ type StatusDoc struct {
 	Run           *RunView        `json:"run,omitempty"`
 }
 
-// RunView is the active Delivery run's status view.
+// RunView is the active Delivery run's status view. Issues carry the
+// full state.Issue shape, so the PR B per-issue lifecycle fields (phase,
+// PR number, decision, review cycles, ...) are reported as-is.
 type RunView struct {
 	ID        string        `json:"id"`
 	Host      string        `json:"host"`
 	StartedAt time.Time     `json:"started_at"`
 	Plan      state.PlanRef `json:"plan"`
 	Issues    []state.Issue `json:"issues"`
+	// StoppedReason is non-empty when a secret block stopped the run.
+	StoppedReason string `json:"stopped_reason,omitempty"`
 }
 
 // Status reports the run-state document.
@@ -57,11 +61,12 @@ func Status(ctx context.Context, env Env) (*StatusDoc, error) {
 	}
 	if st.Run != nil {
 		doc.Run = &RunView{
-			ID:        st.Run.ID,
-			Host:      st.Run.Host,
-			StartedAt: st.Run.StartedAt,
-			Plan:      st.Run.Plan,
-			Issues:    st.Run.Issues,
+			ID:            st.Run.ID,
+			Host:          st.Run.Host,
+			StartedAt:     st.Run.StartedAt,
+			Plan:          st.Run.Plan,
+			Issues:        st.Run.Issues,
+			StoppedReason: st.Run.StoppedReason,
 		}
 	}
 	return doc, nil

--- a/internal/run/verb_unit_test.go
+++ b/internal/run/verb_unit_test.go
@@ -1,0 +1,529 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+func implementerDecision() *state.Decision {
+	return &state.Decision{
+		Role:      manifest.RoleImplementer,
+		Executor:  manifest.Selection{Model: "claude-sonnet-5", Effort: "xhigh"},
+		Reviewer:  manifest.Selection{Model: "claude-opus-4-8", Effort: "high"},
+		Rationale: "impl",
+	}
+}
+
+func specialistDecision() *state.Decision {
+	return &state.Decision{
+		Role:      manifest.RoleSpecialist,
+		Executor:  manifest.Selection{Model: "claude-opus-4-8", Effort: "high"},
+		Reviewer:  manifest.Selection{Model: "claude-opus-4-8", Effort: "high"},
+		Rationale: "spec",
+	}
+}
+
+func downgradedDecision() *state.Decision {
+	return &state.Decision{
+		Role:               manifest.RoleImplementer,
+		Executor:           manifest.Selection{Model: "claude-sonnet-5", Effort: "xhigh"},
+		Reviewer:           manifest.Selection{Model: "claude-sonnet-5", Effort: "high"},
+		ReviewerDowngraded: true,
+		Rationale:          "downgrade",
+	}
+}
+
+// fixtureIssue builds a state.Issue satisfying validateIssues for phase,
+// with the routing fields populated for the dispatched-onward phases.
+func fixtureIssue(planID string, number int, phase state.Phase) state.Issue {
+	iss := state.Issue{
+		PlanID:   planID,
+		Title:    "T",
+		Phase:    phase,
+		Number:   number,
+		Branch:   fmt.Sprintf("orch/issue-%d", number),
+		Worktree: fmt.Sprintf(".orchestrator/worktrees/issue-%d", number),
+		Decision: implementerDecision(),
+	}
+	switch phase {
+	case state.PhasePROpen, state.PhaseInReview:
+		iss.PRNumber = 10 * number
+		iss.PRURL = fmt.Sprintf("https://github.com/o/r/pull/%d", 10*number)
+	case state.PhaseAwaitingMerge, state.PhaseMerged:
+		iss.PRNumber = 10 * number
+		iss.PRURL = fmt.Sprintf("https://github.com/o/r/pull/%d", 10*number)
+		iss.ApprovedHeadOID = "head-oid"
+	case state.PhaseBlocked:
+		iss.BlockedReason = "seed"
+	}
+	return iss
+}
+
+// setupDeliveryRepo writes a delivery state with the given issues on disk
+// (no git), with the plan config revision planRev.
+func setupDeliveryRepo(t *testing.T, planRev string, issues []state.Issue) string {
+	t.Helper()
+	root := setupRepo(t, testConfigTOML)
+	planned := make([]state.Issue, len(issues))
+	for i := range issues {
+		planned[i] = state.Issue{PlanID: issues[i].PlanID, Phase: state.PhasePlanned}
+	}
+	st, err := state.EnterDelivery(root, "claude", state.PlanRef{Title: "t", Digest: "sha256:x", ConfigRevision: planRev}, planned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Run.Issues = issues
+	if err := state.Save(root, st); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func ghEnv(root string, script *execxtest.Script) Env {
+	return Env{RepoRoot: root, Runner: script, Now: fixedNow}
+}
+
+func stateBytes(t *testing.T, root string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(root, ".orchestrator", "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// --- Wave / dependency enforcement ---
+
+func TestDispatchDependencyEnforcement(t *testing.T) {
+	a := fixtureIssue("a", 1, state.PhaseWorktreeReady)
+	b := fixtureIssue("b", 2, state.PhaseWorktreeReady)
+	b.DependsOn = []string{"a"}
+	root := setupDeliveryRepo(t, "r1", []state.Issue{a, b})
+
+	// Unmet: a is not merged/cleaned.
+	script := &execxtest.Script{T: t}
+	_, err := Dispatch(context.Background(), ghEnv(root, script), []byte(`{"schema_version":1,"issue_number":2}`))
+	if !errors.Is(err, ErrDependencyUnmet) {
+		t.Fatalf("err = %v, want ErrDependencyUnmet", err)
+	}
+	script.AssertExhausted() // failed before any git/gh call
+
+	// Abandoned dependency: distinct message.
+	st := loadRun(t, root)
+	st.Run.Issues[0].Phase = state.PhaseAbandoned
+	if err := state.Save(root, st); err != nil {
+		t.Fatal(err)
+	}
+	script = &execxtest.Script{T: t}
+	_, err = Dispatch(context.Background(), ghEnv(root, script), []byte(`{"schema_version":1,"issue_number":2}`))
+	if !errors.Is(err, ErrDependencyAbandoned) {
+		t.Fatalf("err = %v, want ErrDependencyAbandoned", err)
+	}
+	script.AssertExhausted()
+}
+
+// --- Config drift ---
+
+func TestConfigDriftFailsClosed(t *testing.T) {
+	root := setupDeliveryRepo(t, "r2", []state.Issue{fixtureIssue("a", 1, state.PhaseWorktreeReady)})
+	script := &execxtest.Script{T: t}
+	_, err := Dispatch(context.Background(), ghEnv(root, script), []byte(`{"schema_version":1,"issue_number":1}`))
+	if !errors.Is(err, ErrConfigDrift) {
+		t.Fatalf("err = %v, want ErrConfigDrift", err)
+	}
+	script.AssertExhausted()
+}
+
+// --- Secret stop ---
+
+func TestSecretBlockStopsRun(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{
+		fixtureIssue("a", 1, state.PhaseDispatched),
+		fixtureIssue("b", 2, state.PhaseDispatched),
+	})
+
+	// A secret block stops the whole run.
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{ghAuth(), ghSetStatusCall(1, ghops.StatusBlocked)}}
+	res, err := Block(context.Background(), ghEnv(root, script), []byte(`{"schema_version":1,"issue_number":1,"class":"secret","detail":"found a key"}`))
+	if err != nil {
+		t.Fatalf("Block: %v", err)
+	}
+	script.AssertExhausted()
+	if !res.RunStopped {
+		t.Error("secret block did not stop the run")
+	}
+	if st := loadRun(t, root); st.Run.StoppedReason == "" {
+		t.Error("StoppedReason not set after secret block")
+	}
+
+	// Every other mutating verb now fails closed.
+	empty := &execxtest.Script{T: t}
+	_, err = CI(context.Background(), ghEnv(root, empty), []byte(`{"schema_version":1,"issue_number":2}`))
+	if !errors.Is(err, ErrRunStopped) {
+		t.Fatalf("CI on stopped run = %v, want ErrRunStopped", err)
+	}
+	empty.AssertExhausted()
+
+	// block itself is exempt: it can still record another block.
+	script2 := &execxtest.Script{T: t, Calls: []execxtest.Call{ghAuth(), ghSetStatusCall(2, ghops.StatusBlocked)}}
+	res2, err := Block(context.Background(), ghEnv(root, script2), []byte(`{"schema_version":1,"issue_number":2,"class":"hook","detail":"pre-commit failed"}`))
+	if err != nil {
+		t.Fatalf("Block (exempt) on stopped run: %v", err)
+	}
+	script2.AssertExhausted()
+	if res2.RunStopped { // a non-secret block does not itself stop
+		t.Error("non-secret block reported run_stopped")
+	}
+}
+
+// --- Escalation ---
+
+func TestEscalateReroute(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhaseDispatched)})
+	body := baseManifestBody(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(),
+		ghSetRoleCall(1, ghops.RoleSpecialist),
+		ghIssueViewCall(t, 1, "OPEN", body),
+		ghSetIssueBodyCall(1),
+	}}
+	res, err := Escalate(context.Background(), ghEnv(root, script), []byte(`{"schema_version":1,"issue_number":1,"trigger":"implementer-hard-execution","detail":"stuck"}`))
+	if err != nil {
+		t.Fatalf("Escalate: %v", err)
+	}
+	script.AssertExhausted()
+	if res.Kind != "reroute" || res.Executor == nil || res.Executor.Model != "claude-opus-4-8" {
+		t.Fatalf("result = %+v, want reroute to specialist", res)
+	}
+	st := loadRun(t, root)
+	iss := st.Run.Issues[0]
+	if iss.Decision.Role != manifest.RoleSpecialist || iss.Decision.Executor.Model != "claude-opus-4-8" {
+		t.Errorf("decision = %+v, want specialist", iss.Decision)
+	}
+	if len(iss.Attempts) != 1 || !iss.Attempts[0].Failed || iss.Attempts[0].Role != manifest.RoleImplementer {
+		t.Errorf("attempts = %+v, want one failed implementer", iss.Attempts)
+	}
+	if iss.Phase != state.PhaseDispatched {
+		t.Errorf("phase = %s, want dispatched (reroute keeps the phase)", iss.Phase)
+	}
+}
+
+func TestEscalateReturnToArchitect(t *testing.T) {
+	iss := fixtureIssue("a", 1, state.PhaseDispatched)
+	iss.Decision = specialistDecision()
+	root := setupDeliveryRepo(t, "r1", []state.Issue{iss})
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{ghAuth(), ghSetStatusCall(1, ghops.StatusNeedsHuman)}}
+	res, err := Escalate(context.Background(), ghEnv(root, script), []byte(`{"schema_version":1,"issue_number":1,"trigger":"weak-model-failure","detail":"exhausted"}`))
+	if err != nil {
+		t.Fatalf("Escalate: %v", err)
+	}
+	script.AssertExhausted()
+	if res.Kind != "return-to-architect" || res.Reason == "" {
+		t.Fatalf("result = %+v, want return-to-architect", res)
+	}
+	st := loadRun(t, root)
+	if st.Run.Issues[0].Phase != state.PhaseBlocked || st.Run.Issues[0].BlockedReason == "" {
+		t.Errorf("issue = %+v, want blocked with a reason", st.Run.Issues[0])
+	}
+}
+
+func TestEscalateRestoresDowngradedReviewer(t *testing.T) {
+	iss := fixtureIssue("a", 1, state.PhaseDispatched)
+	iss.Decision = downgradedDecision()
+	root := setupDeliveryRepo(t, "r1", []state.Issue{iss})
+	body := baseManifestBody(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(),
+		ghSetRoleCall(1, ghops.RoleSpecialist),
+		ghIssueViewCall(t, 1, "OPEN", body),
+		ghSetIssueBodyCall(1),
+	}}
+	if _, err := Escalate(context.Background(), ghEnv(root, script), []byte(`{"schema_version":1,"issue_number":1,"trigger":"implementer-hard-execution","detail":"stuck"}`)); err != nil {
+		t.Fatalf("Escalate: %v", err)
+	}
+	script.AssertExhausted()
+	d := loadRun(t, root).Run.Issues[0].Decision
+	if d.ReviewerDowngraded || d.Reviewer.Model != "claude-opus-4-8" {
+		t.Errorf("decision = %+v, want the strong reviewer restored", d)
+	}
+}
+
+func TestEscalateBadTrigger(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhaseDispatched)})
+	before := stateBytes(t, root)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{ghAuth()}}
+	_, err := Escalate(context.Background(), ghEnv(root, script), []byte(`{"schema_version":1,"issue_number":1,"trigger":"reviewer-uncertainty","detail":"x"}`))
+	if err == nil {
+		t.Fatal("Escalate accepted a mismatched trigger")
+	}
+	// A non-downgraded implementer decision cannot take reviewer-uncertainty.
+	if !strings.Contains(err.Error(), "trigger") {
+		t.Errorf("err = %v, want a trigger mismatch", err)
+	}
+	if got := stateBytes(t, root); string(got) != string(before) {
+		t.Error("state changed on a rejected escalation")
+	}
+}
+
+// --- Abandon ---
+
+func TestAbandonClosesPRAndIssue(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
+	body := baseManifestBody(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(),
+		ghPRViewCall(10, "OPEN", "head"),
+		{Name: "gh", Args: []string{"pr", "close", "10"}},
+		ghIssueViewCall(t, 1, "OPEN", body),
+		ghSetIssueBodyCall(1),
+		ghCloseIssueCall(1),
+	}}
+	res, err := Abandon(context.Background(), ghEnv(root, script), []byte(`{"schema_version":1,"issue_number":1,"reason":"scope dropped","statement":"abandon-issue"}`))
+	if err != nil {
+		t.Fatalf("Abandon: %v", err)
+	}
+	script.AssertExhausted()
+	if res.Phase != state.PhaseAbandoned {
+		t.Errorf("phase = %s, want abandoned", res.Phase)
+	}
+	wantPhase(t, root, 1, state.PhaseAbandoned)
+}
+
+func TestAbandonWrongStatement(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhaseDispatched)})
+	script := &execxtest.Script{T: t}
+	_, err := Abandon(context.Background(), ghEnv(root, script), []byte(`{"schema_version":1,"issue_number":1,"reason":"x","statement":"nope"}`))
+	if !errors.Is(err, ErrBadRequest) {
+		t.Fatalf("err = %v, want ErrBadRequest", err)
+	}
+	script.AssertExhausted()
+}
+
+// --- Purity: failure paths mutate nothing before a persisted step ---
+
+func TestReviewStaleHeadIsPure(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
+	before := stateBytes(t, root)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{ghAuth(), ghPRViewCall(10, "OPEN", "real-head")}}
+	_, err := Review(context.Background(), ghEnv(root, script), []byte(`{"schema_version":1,"issue_number":1,"reviewed_head_oid":"stale-head","verdict":"approve","summary":"s","reviewer":{"model":"claude-opus-4-8","effort":"high"}}`))
+	if !errors.Is(err, ErrReviewStale) {
+		t.Fatalf("err = %v, want ErrReviewStale", err)
+	}
+	script.AssertExhausted()
+	if got := stateBytes(t, root); string(got) != string(before) {
+		t.Error("state changed on a stale review")
+	}
+}
+
+func TestReviewWrongReviewerIsPure(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
+	before := stateBytes(t, root)
+	script := &execxtest.Script{T: t} // fails before any gh call
+	_, err := Review(context.Background(), ghEnv(root, script), []byte(`{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head","verdict":"approve","summary":"s","reviewer":{"model":"claude-haiku-4-5","effort":"low"}}`))
+	if !errors.Is(err, ErrReviewerMismatch) {
+		t.Fatalf("err = %v, want ErrReviewerMismatch", err)
+	}
+	script.AssertExhausted()
+	if got := stateBytes(t, root); string(got) != string(before) {
+		t.Error("state changed on a reviewer mismatch")
+	}
+}
+
+func TestBlockGitHubUnavailableIsPure(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhaseDispatched)})
+	before := stateBytes(t, root)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{Name: "gh", Args: []string{"auth", "status"}, Exit: 1}}}
+	_, err := Block(context.Background(), ghEnv(root, script), []byte(`{"schema_version":1,"issue_number":1,"class":"hook","detail":"x"}`))
+	if !errors.Is(err, ghops.ErrNotAuthenticated) {
+		t.Fatalf("err = %v, want ErrNotAuthenticated", err)
+	}
+	script.AssertExhausted()
+	if got := stateBytes(t, root); string(got) != string(before) {
+		t.Error("state changed though GitHub was unavailable before any mutation")
+	}
+}
+
+func TestMergeCIFailingIsPure(t *testing.T) {
+	iss := fixtureIssue("a", 1, state.PhaseAwaitingMerge)
+	iss.ApprovedHeadOID = "head-oid-2"
+	root := setupDeliveryRepo(t, "r1", []state.Issue{iss})
+	before := stateBytes(t, root)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(),
+		ghPRViewCall(10, "OPEN", "head-oid-2"),
+		{Name: "gh", Args: []string{"pr", "view", "10", "--json", "statusCheckRollup"}, Stdout: `{"statusCheckRollup":[{}]}`},
+		{Name: "gh", Args: []string{"pr", "checks", "10", "--required", "--json", "name,state,bucket,link"}, Exit: 1,
+			Stdout: `[{"name":"build","state":"FAILURE","bucket":"fail","link":""}]`},
+	}}
+	req := `{"schema_version":1,"issue_number":1,"approval":{"pr_number":10,"head_oid":"head-oid-2","approved_by":"a","approved_at":"2026-07-11T12:00:00Z","statement":"approve-merge"}}`
+	_, err := Merge(context.Background(), ghEnv(root, script), []byte(req))
+	if !errors.Is(err, ErrCINotReady) {
+		t.Fatalf("err = %v, want ErrCINotReady", err)
+	}
+	script.AssertExhausted() // stopped before pr merge
+	if got := stateBytes(t, root); string(got) != string(before) {
+		t.Error("state changed though CI blocked the merge")
+	}
+}
+
+func TestMergeWrongStatementIsPure(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{func() state.Issue {
+		iss := fixtureIssue("a", 1, state.PhaseAwaitingMerge)
+		iss.ApprovedHeadOID = "head-oid-2"
+		return iss
+	}()})
+	before := stateBytes(t, root)
+	script := &execxtest.Script{T: t}
+	req := `{"schema_version":1,"issue_number":1,"approval":{"pr_number":10,"head_oid":"head-oid-2","approved_by":"a","approved_at":"2026-07-11T12:00:00Z","statement":"wrong"}}`
+	_, err := Merge(context.Background(), ghEnv(root, script), []byte(req))
+	if !errors.Is(err, ErrMergeApproval) {
+		t.Fatalf("err = %v, want ErrMergeApproval", err)
+	}
+	script.AssertExhausted() // rejected before opening gh
+	if got := stateBytes(t, root); string(got) != string(before) {
+		t.Error("state changed on a wrong merge statement")
+	}
+}
+
+// --- Body-cap policy ---
+
+func TestTruncateDetail(t *testing.T) {
+	if got := truncateDetail("short"); got != "short" {
+		t.Errorf("truncateDetail(short) = %q, want unchanged", got)
+	}
+	long := strings.Repeat("x", verificationDetailCap+500)
+	got := truncateDetail(long)
+	if !strings.HasSuffix(got, verificationTruncationMarker) {
+		t.Errorf("truncated detail missing marker: %q", got[len(got)-40:])
+	}
+	if len([]rune(got)) != verificationDetailCap+len([]rune(verificationTruncationMarker)) {
+		t.Errorf("truncated length = %d, want cap + marker", len([]rune(got)))
+	}
+}
+
+func TestUpsertCappedDropsOldestDetails(t *testing.T) {
+	big := strings.Repeat("x", 25000)
+	m := manifest.Manifest{
+		SchemaVersion:    manifest.SchemaVersion,
+		Role:             manifest.RoleImplementer,
+		Executor:         manifest.Selection{Model: "m", Effort: "e"},
+		RoutingRationale: "r",
+		Reviewer:         manifest.Selection{Model: "m", Effort: "e"},
+		ConfigRevision:   "r1",
+		Verifications: []manifest.Verification{
+			{Name: "v1", Result: "pass", Detail: big, At: "t1"},
+			{Name: "v2", Result: "pass", Detail: big, At: "t2"},
+			{Name: "v3", Result: "pass", Detail: big, At: "t3"},
+		},
+	}
+	body, err := upsertCapped("prose", m)
+	if err != nil {
+		t.Fatalf("upsertCapped: %v", err)
+	}
+	if len(body) > bodyCapHeadroom {
+		t.Fatalf("body length %d over headroom %d", len(body), bodyCapHeadroom)
+	}
+	parsed, err := manifest.Parse(body)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	// The oldest verification lost its detail; the newest kept theirs; all
+	// names survive (the canonical record stays intact).
+	if parsed.Verifications[0].Detail != "" {
+		t.Error("oldest detail not dropped")
+	}
+	if parsed.Verifications[2].Detail == "" {
+		t.Error("newest detail dropped unnecessarily")
+	}
+	for i, v := range parsed.Verifications {
+		if v.Name == "" || v.Result == "" {
+			t.Errorf("verification %d lost its name/result: %+v", i, v)
+		}
+	}
+}
+
+func TestUpsertCappedHardFails(t *testing.T) {
+	prose := strings.Repeat("y", githubBodyLimit)
+	m := manifest.Manifest{
+		SchemaVersion:    manifest.SchemaVersion,
+		Role:             manifest.RoleImplementer,
+		Executor:         manifest.Selection{Model: "m", Effort: "e"},
+		RoutingRationale: "r",
+		Reviewer:         manifest.Selection{Model: "m", Effort: "e"},
+		ConfigRevision:   "r1",
+		Verifications:    []manifest.Verification{{Name: "v", Result: "pass", Detail: "d", At: "t"}},
+	}
+	_, err := upsertCapped(prose, m)
+	if !errors.Is(err, ErrBodyTooLarge) {
+		t.Fatalf("err = %v, want ErrBodyTooLarge", err)
+	}
+	if !strings.Contains(err.Error(), fmt.Sprint(githubBodyLimit)) {
+		t.Errorf("err %v does not name GitHub's limit %d", err, githubBodyLimit)
+	}
+}
+
+// --- Schema v3 persistence ---
+
+func TestActivatePersistsV3Fields(t *testing.T) {
+	root := newActivateRepo(t)
+	calls := append(fullTaxonomyScript(),
+		ghIssueCreateCall("Issue A", []string{"ready", "feature", "implementer", "standard"}, 1),
+		ghIssueCreateCall("Issue B", []string{"ready", "feature", "specialist", "critical"}, 2),
+	)
+	script := &execxtest.Script{T: t, Calls: calls}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+	if _, err := Activate(context.Background(), env, activationJSON(t, twoIssuePlanJSON())); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	script.AssertExhausted()
+
+	st := loadRun(t, root)
+	b := st.Run.Issues[1]
+	if b.PlanID != "b" || b.Wave != 2 || len(b.DependsOn) != 1 || b.DependsOn[0] != "a" {
+		t.Errorf("issue b = %+v, want wave 2 depends_on a", b)
+	}
+	if b.Decision == nil || b.Decision.Role != manifest.RoleSpecialist {
+		t.Errorf("issue b decision = %+v, want a persisted specialist decision", b.Decision)
+	}
+}
+
+// --- Abort safe at every new phase ---
+
+func TestAbortSafeAtEveryPhase(t *testing.T) {
+	phases := []state.Phase{
+		state.PhaseDispatched, state.PhasePROpen, state.PhaseInReview,
+		state.PhaseAwaitingMerge, state.PhaseMerged, state.PhaseAbandoned,
+		state.PhaseCleaned, state.PhaseBlocked,
+	}
+	for _, ph := range phases {
+		t.Run(string(ph), func(t *testing.T) {
+			root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, ph)})
+			res, err := state.Abort(root)
+			if err != nil {
+				t.Fatalf("Abort at %s: %v", ph, err)
+			}
+			if res.PriorRun == nil {
+				t.Errorf("Abort at %s did not report the prior run", ph)
+			}
+			after := loadRun(t, root)
+			if after.Mode != state.ModeAssist {
+				t.Errorf("mode after abort at %s = %s, want assist", ph, after.Mode)
+			}
+			if o, _ := lockfile.Inspect(root); o != nil {
+				t.Errorf("lock survived abort at %s", ph)
+			}
+		})
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -20,9 +20,12 @@ import (
 const Path = ".orchestrator/state.json"
 
 // SchemaVersion is the state-file schema this build reads and writes.
-// v1 never ran a real Delivery (Task 11 is the first slice that
-// activates one), so a v1 file on disk can only be a test artifact.
-const SchemaVersion = 2
+// v3 adds the PR B per-issue lifecycle fields (Issue.Decision,
+// DependsOn, Wave, LastReviewVerdict) and Run.StoppedReason. There is no
+// migration from earlier versions: Load fails closed on a version
+// mismatch with the `orch abort` remediation, and no real run persists
+// across builds, so an out-of-version file on disk is a test artifact.
+const SchemaVersion = 3
 
 // Mode is the operating mode (PRD §7).
 type Mode string
@@ -44,10 +47,9 @@ type PlanRef struct {
 }
 
 // Phase is one issue's position in the Delivery lifecycle (PRD §12).
-// The set is closed. PR A (this slice) only ever writes Planned,
-// IssueCreated, and WorktreeReady; the remaining values belong to PR B
-// and are declared now so the schema needs no v3 migration when PR B
-// lands.
+// The set is closed. Activation (PR A) writes Planned, IssueCreated, and
+// WorktreeReady; the per-issue lifecycle verbs (PR B) drive the rest.
+// PhaseCleaned is terminal.
 type Phase string
 
 const (
@@ -61,15 +63,27 @@ const (
 	// dispatch.
 	PhaseWorktreeReady Phase = "worktree-ready"
 
-	// PR B values, declared now:
-	PhaseDispatched    Phase = "dispatched"
-	PhasePROpen        Phase = "pr-open"
-	PhaseInReview      Phase = "in-review"
+	// PhaseDispatched marks an issue handed to an executor (branch
+	// fast-forwarded, status in-progress).
+	PhaseDispatched Phase = "dispatched"
+	// PhasePROpen marks an opened pull request awaiting review.
+	PhasePROpen Phase = "pr-open"
+	// PhaseInReview marks an issue in a review cycle.
+	PhaseInReview Phase = "in-review"
+	// PhaseAwaitingMerge marks an approved PR pinned to its head OID,
+	// waiting at the human merge gate.
 	PhaseAwaitingMerge Phase = "awaiting-merge"
-	PhaseMerged        Phase = "merged"
-	PhaseCleaned       Phase = "cleaned"
-	PhaseAbandoned     Phase = "abandoned"
-	PhaseBlocked       Phase = "blocked"
+	// PhaseMerged marks a merged PR with its issue closed.
+	PhaseMerged Phase = "merged"
+	// PhaseCleaned is terminal: remote branch, worktree, and local
+	// branch removed.
+	PhaseCleaned Phase = "cleaned"
+	// PhaseAbandoned marks an issue closed without merging; its branch
+	// and worktree are preserved until cleanup.
+	PhaseAbandoned Phase = "abandoned"
+	// PhaseBlocked marks an issue awaiting human action; recovery is
+	// `orch resume` or `orch abort`.
+	PhaseBlocked Phase = "blocked"
 )
 
 // Valid reports whether p is a member of the closed Phase set.
@@ -95,6 +109,19 @@ type Attempt struct {
 	Reason    string             `json:"reason,omitempty"`
 }
 
+// Decision mirrors routing.Decision in persistable form: the current
+// routing chosen for an issue, set at activation and updated by
+// escalate. Like Attempt it keeps this package off the routing policy
+// dependency edge — state imports manifest, never routing, and the run
+// engine converts between the two.
+type Decision struct {
+	Role               manifest.Role      `json:"role"`
+	Executor           manifest.Selection `json:"executor"`
+	Reviewer           manifest.Selection `json:"reviewer"`
+	ReviewerDowngraded bool               `json:"reviewer_downgraded"`
+	Rationale          string             `json:"rationale"`
+}
+
 // Issue is one plan issue's persisted Delivery state.
 type Issue struct {
 	PlanID string `json:"plan_id"`
@@ -107,14 +134,26 @@ type Issue struct {
 	Branch   string `json:"branch,omitempty"`
 	Worktree string `json:"worktree,omitempty"`
 
-	// PR B fields, declared now to avoid a v3 (see lifecycle.go in
-	// internal/run for the verb sketch that will populate them).
-	PRNumber        int       `json:"pr_number,omitempty"`
-	PRURL           string    `json:"pr_url,omitempty"`
-	ApprovedHeadOID string    `json:"approved_head_oid,omitempty"`
-	ReviewCycles    int       `json:"review_cycles,omitempty"`
-	BlockedReason   string    `json:"blocked_reason,omitempty"`
-	Attempts        []Attempt `json:"attempts,omitempty"`
+	// DependsOn (plan ids) and Wave are copied from the plan at
+	// EnterDelivery so dispatch can enforce dependencies — every
+	// DependsOn issue merged or cleaned — without re-taking the plan.
+	DependsOn []string `json:"depends_on,omitempty"`
+	Wave      int      `json:"wave,omitempty"`
+
+	// Decision is the current routing for the issue, set at activation
+	// and updated by escalate. Required from the dispatched phase onward.
+	Decision *Decision `json:"decision,omitempty"`
+
+	// PR B lifecycle fields.
+	PRNumber        int    `json:"pr_number,omitempty"`
+	PRURL           string `json:"pr_url,omitempty"`
+	ApprovedHeadOID string `json:"approved_head_oid,omitempty"`
+	ReviewCycles    int    `json:"review_cycles,omitempty"`
+	// LastReviewVerdict is "", "approve", or "request-changes": the gate
+	// merge-report checks without parsing bodies.
+	LastReviewVerdict string    `json:"last_review_verdict,omitempty"`
+	BlockedReason     string    `json:"blocked_reason,omitempty"`
+	Attempts          []Attempt `json:"attempts,omitempty"`
 }
 
 // Run describes the active Delivery run.
@@ -124,6 +163,10 @@ type Run struct {
 	StartedAt time.Time `json:"started_at"`
 	Plan      PlanRef   `json:"plan"`
 	Issues    []Issue   `json:"issues"`
+	// StoppedReason is non-empty when a secret block stopped the whole
+	// run (PRD §16): every mutating verb but block itself then fails
+	// closed until `orch abort` or a future `orch resume`.
+	StoppedReason string `json:"stopped_reason,omitempty"`
 }
 
 // State is the persisted operating state.
@@ -187,9 +230,13 @@ func (st *State) validate() error {
 }
 
 // validateIssues checks every issue's phase is a member of the closed
-// set and that Number/Branch/Worktree were populated once the
-// lifecycle reached the phase that requires them: Number from
-// issue-created onward, Branch/Worktree from worktree-ready onward.
+// set and that each field was populated once the lifecycle reached the
+// phase that requires it: Number from issue-created onward,
+// Branch/Worktree from worktree-ready onward, a routing Decision from
+// dispatched onward, a PR number from pr-open through merged, an
+// approved head OID at awaiting-merge and merged, and a blocked reason
+// while blocked. Abandoned issues stay exempt from PR fields — an issue
+// can be abandoned before its PR ever opened.
 func (r *Run) validateIssues() error {
 	for i, iss := range r.Issues {
 		if !iss.Phase.Valid() {
@@ -203,8 +250,50 @@ func (r *Run) validateIssues() error {
 				return fmt.Errorf("issue %d (%s): phase %s requires branch and worktree", i, iss.PlanID, iss.Phase)
 			}
 		}
+		if phaseRequiresDecision(iss.Phase) && iss.Decision == nil {
+			return fmt.Errorf("issue %d (%s): phase %s requires a routing decision", i, iss.PlanID, iss.Phase)
+		}
+		if phaseRequiresPR(iss.Phase) && iss.PRNumber <= 0 {
+			return fmt.Errorf("issue %d (%s): phase %s requires a positive PR number", i, iss.PlanID, iss.Phase)
+		}
+		if phaseRequiresApprovedHead(iss.Phase) && iss.ApprovedHeadOID == "" {
+			return fmt.Errorf("issue %d (%s): phase %s requires an approved head OID", i, iss.PlanID, iss.Phase)
+		}
+		if iss.Phase == PhaseBlocked && iss.BlockedReason == "" {
+			return fmt.Errorf("issue %d (%s): blocked phase requires a blocked reason", i, iss.PlanID)
+		}
 	}
 	return nil
+}
+
+// phaseRequiresDecision reports the phases from dispatched onward that a
+// routing decision must accompany. Abandoned and cleaned are exempt: an
+// issue can be abandoned before dispatch ever routed it.
+func phaseRequiresDecision(p Phase) bool {
+	switch p {
+	case PhaseDispatched, PhasePROpen, PhaseInReview, PhaseAwaitingMerge, PhaseMerged, PhaseBlocked:
+		return true
+	default:
+		return false
+	}
+}
+
+// phaseRequiresPR reports the phases a positive PR number must
+// accompany: pr-open through merged. Cleaned is exempt because it can be
+// reached from an abandoned issue that never opened a PR.
+func phaseRequiresPR(p Phase) bool {
+	switch p {
+	case PhasePROpen, PhaseInReview, PhaseAwaitingMerge, PhaseMerged:
+		return true
+	default:
+		return false
+	}
+}
+
+// phaseRequiresApprovedHead reports the phases a pinned approved head OID
+// must accompany (PRD §8: approval pins one PR state).
+func phaseRequiresApprovedHead(p Phase) bool {
+	return p == PhaseAwaitingMerge || p == PhaseMerged
 }
 
 // Save persists st under repoRoot: it stamps UpdatedAt, validates (the

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -56,20 +56,32 @@ func TestLoadRejectsBadState(t *testing.T) {
 		"corrupt json":    {"{broken", "parse"},
 		"wrong schema":    {`{"schema_version": 99, "mode": "assist"}`, "schema_version 99"},
 		"v1 rejected":     {`{"schema_version": 1, "mode": "assist"}`, "schema_version 1"},
-		"unknown mode":    {`{"schema_version": 2, "mode": "turbo"}`, `unknown mode "turbo"`},
-		"delivery no run": {`{"schema_version": 2, "mode": "delivery"}`, "without a recorded run"},
-		"assist with run": {`{"schema_version": 2, "mode": "assist", "run": {"id": "r", "host": "claude", "started_at": "2026-07-10T12:00:00Z", "plan": {}, "issues": null}}`, "assist mode with a recorded run"},
+		"unknown mode":    {`{"schema_version": 3, "mode": "turbo"}`, `unknown mode "turbo"`},
+		"delivery no run": {`{"schema_version": 3, "mode": "delivery"}`, "without a recorded run"},
+		"assist with run": {`{"schema_version": 3, "mode": "assist", "run": {"id": "r", "host": "claude", "started_at": "2026-07-10T12:00:00Z", "plan": {}, "issues": null}}`, "assist mode with a recorded run"},
 		"invalid phase": {
-			`{"schema_version": 2, "mode": "delivery", "run": {"id": "r", "host": "claude", "started_at": "2026-07-10T12:00:00Z", "plan": {"digest": "sha256:x"}, "issues": [{"plan_id": "a", "phase": "bogus"}]}}`,
+			`{"schema_version": 3, "mode": "delivery", "run": {"id": "r", "host": "claude", "started_at": "2026-07-10T12:00:00Z", "plan": {"digest": "sha256:x"}, "issues": [{"plan_id": "a", "phase": "bogus"}]}}`,
 			`invalid phase "bogus"`,
 		},
 		"issue-created without number": {
-			`{"schema_version": 2, "mode": "delivery", "run": {"id": "r", "host": "claude", "started_at": "2026-07-10T12:00:00Z", "plan": {"digest": "sha256:x"}, "issues": [{"plan_id": "a", "phase": "issue-created"}]}}`,
+			`{"schema_version": 3, "mode": "delivery", "run": {"id": "r", "host": "claude", "started_at": "2026-07-10T12:00:00Z", "plan": {"digest": "sha256:x"}, "issues": [{"plan_id": "a", "phase": "issue-created"}]}}`,
 			"requires a positive issue number",
 		},
 		"worktree-ready without branch": {
-			`{"schema_version": 2, "mode": "delivery", "run": {"id": "r", "host": "claude", "started_at": "2026-07-10T12:00:00Z", "plan": {"digest": "sha256:x"}, "issues": [{"plan_id": "a", "phase": "worktree-ready", "number": 4}]}}`,
+			`{"schema_version": 3, "mode": "delivery", "run": {"id": "r", "host": "claude", "started_at": "2026-07-10T12:00:00Z", "plan": {"digest": "sha256:x"}, "issues": [{"plan_id": "a", "phase": "worktree-ready", "number": 4}]}}`,
 			"requires branch and worktree",
+		},
+		"dispatched without decision": {
+			`{"schema_version": 3, "mode": "delivery", "run": {"id": "r", "host": "claude", "started_at": "2026-07-10T12:00:00Z", "plan": {"digest": "sha256:x"}, "issues": [{"plan_id": "a", "phase": "dispatched", "number": 4, "branch": "b", "worktree": "w"}]}}`,
+			"requires a routing decision",
+		},
+		"blocked without reason": {
+			`{"schema_version": 3, "mode": "delivery", "run": {"id": "r", "host": "claude", "started_at": "2026-07-10T12:00:00Z", "plan": {"digest": "sha256:x"}, "issues": [{"plan_id": "a", "phase": "blocked", "number": 4, "branch": "b", "worktree": "w", "decision": {"role": "implementer", "executor": {"model": "m", "effort": "e"}, "reviewer": {"model": "m", "effort": "e"}, "rationale": "r"}}]}}`,
+			"blocked phase requires a blocked reason",
+		},
+		"awaiting-merge without approved head": {
+			`{"schema_version": 3, "mode": "delivery", "run": {"id": "r", "host": "claude", "started_at": "2026-07-10T12:00:00Z", "plan": {"digest": "sha256:x"}, "issues": [{"plan_id": "a", "phase": "awaiting-merge", "number": 4, "branch": "b", "worktree": "w", "pr_number": 5, "decision": {"role": "implementer", "executor": {"model": "m", "effort": "e"}, "reviewer": {"model": "m", "effort": "e"}, "rationale": "r"}}]}}`,
+			"requires an approved head OID",
 		},
 	}
 	for name, tc := range cases {
@@ -87,7 +99,7 @@ func TestLoadRejectsBadState(t *testing.T) {
 	}
 }
 
-func TestLoadAcceptsV2RoundTrip(t *testing.T) {
+func TestLoadAcceptsRoundTrip(t *testing.T) {
 	root := stateDir(t)
 	st, err := EnterDelivery(root, "claude", testPlanRef(), testIssues())
 	if err != nil {
@@ -354,6 +366,45 @@ func TestAbortResetsV1State(t *testing.T) {
 	}
 	if after.Mode != ModeAssist {
 		t.Errorf("mode = %s, want assist", after.Mode)
+	}
+}
+
+func TestCompleteDelivery(t *testing.T) {
+	root := stateDir(t)
+	if _, err := EnterDelivery(root, "claude", testPlanRef(), testIssues()); err != nil {
+		t.Fatal(err)
+	}
+	if err := CompleteDelivery(root); err != nil {
+		t.Fatalf("CompleteDelivery: %v", err)
+	}
+	after, err := Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Mode != ModeAssist || after.Run != nil {
+		t.Errorf("state after complete = %+v, want assist with no run", after)
+	}
+	if o, err := lockfile.Inspect(root); o != nil || err != nil {
+		t.Errorf("lock still present after complete: %+v, %v", o, err)
+	}
+}
+
+func TestCompleteDeliveryRejectsAssist(t *testing.T) {
+	root := stateDir(t)
+	if err := CompleteDelivery(root); err == nil {
+		t.Error("CompleteDelivery succeeded from assist, want error")
+	}
+}
+
+func TestCompleteDeliveryRejectsInconsistentState(t *testing.T) {
+	root := stateDir(t)
+	// A delivery lock with no delivery state is inconsistent: complete is
+	// not a repair path, so it must refuse.
+	if err := lockfile.Acquire(root, lockfile.Owner{RunID: "run-orphan", Host: "codex", Hostname: "h", PID: 1, AcquiredAt: time.Now().UTC()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := CompleteDelivery(root); err == nil {
+		t.Error("CompleteDelivery succeeded over an orphaned lock, want error")
 	}
 }
 

--- a/internal/state/transition.go
+++ b/internal/state/transition.go
@@ -118,6 +118,36 @@ func Abort(repoRoot string) (*AbortResult, error) {
 	return res, nil
 }
 
+// CompleteDelivery returns a finished Delivery run to Assist and
+// releases the lock (PRD §7 auto-return). Unlike Abort it is not a
+// repair path: it requires a consistent delivery state owned by a
+// matching lock and fails closed otherwise, so a caller cannot complete
+// over a broken or already-assist state. Ordering matches
+// EnterDelivery/Abort — state first, lock second — so a crash between
+// the two leaves an orphaned lock that denies new runs (fail closed)
+// until `orch abort` clears it.
+func CompleteDelivery(repoRoot string) error {
+	st, err := Load(repoRoot)
+	if err != nil {
+		return err
+	}
+	owner, err := lockfile.Inspect(repoRoot)
+	if err != nil {
+		return err
+	}
+	if err := CheckConsistent(st, owner); err != nil {
+		return err
+	}
+	if st.Mode != ModeDelivery {
+		return fmt.Errorf("CompleteDelivery: not in delivery mode (mode %q); nothing to complete", st.Mode)
+	}
+	assist := &State{SchemaVersion: SchemaVersion, Mode: ModeAssist, UpdatedAt: time.Now().UTC()}
+	if err := write(repoRoot, assist); err != nil {
+		return err
+	}
+	return lockfile.Release(repoRoot)
+}
+
 // CheckConsistent verifies the invariant that delivery mode and the
 // Delivery lock exist together and describe the same run. st and owner
 // come from Load and lockfile.Inspect.


### PR DESCRIPTION
## What

Completes roadmap task 11 (PR B of the two-PR split; PR A was #11): the Delivery run engine's per-issue lifecycle, PRD §12 steps 8–22, as eleven new `orch run` plumbing verbs — `dispatch`, `pr-open`, `review`, `escalate`, `ci`, `merge-report`, `merge`, `block`, `abandon`, `cleanup`, `complete` (JSON documents on stdin/stdout; PRD §22 still has no manual human Delivery command).

- **State schema v3**: Issue gains `DependsOn`/`Wave` (dispatch enforces dependency order engine-side), the current routing `Decision` (escalate's input), and `LastReviewVerdict`; Run gains `StoppedReason`. `CompleteDelivery` is the non-repair auto-return counterpart to `Abort`. No migration — Load already fails closed on version mismatch with the `orch abort` remediation.
- **Pure failure semantics**: no verb mutates phase, state, GitHub, or git on the failure path; state advances only on success, persisted after every sub-step. Blocking is explicit (`block`, with a closed failure-class set); a `secret` block stops the entire run (PRD §16) and gates every other mutating verb.
- **Human gates preserved mechanically**: review requires the routed reviewer and the PR's live head OID; merge takes a fresh per-PR `approve-merge` assertion pinned to the head OID from merge-report and re-checks it against the live PR plus required CI (`--match-head-commit` remains the backstop). Merge is re-runnable after a crash.
- **Escalation**: `escalate` feeds persisted attempts through `routing.Escalate`; reroutes update the decision, role label, and audit record in place; return-to-architect blocks the issue as needs-human.
- **Stale-base handling**: dispatch fetches origin and fast-forwards the issue branch to `origin/<default>` (`--ff-only`, safe pre-dispatch by construction), closing both the activation staleness window and inter-wave staleness.
- **Audit record**: the issue body stays the durable home, mirrored onto open PRs, under the task-24 body cap (per-detail truncation, oldest-detail rotation, fail-closed hard limit naming GitHub's 65,536).
- New helpers: `ghops.PRForBranch`/`SetPRBody`/`SetRole`; `gitops.Push`/`FastForwardIn`/`RemoteBranchExists`/`CommitsAhead`.

## Why

PR A landed plan gate + activation; the run could enter Delivery but not deliver. This slice carries every issue from executor dispatch through merged/abandoned + cleaned to the PRD §7 auto-return to Assist. Design questions were resolved in a spec pass first (working spec: `.memhub/docs/task11-pr-b-plan.md` — schema v3, pure-error verbs + explicit block, dispatch-time fetch/ff, separate escalate verb).

## Test plan

- [x] `gofmt` clean, `go build ./...`, `go vet ./...`, `go test -count=1 ./...` all green locally (Windows)
- [x] Full lifecycle walk in a real git sandbox with scripted gh: activate → dispatch → pr-open → review (request-changes) → review (approve) → ci → merge-report → merge → cleanup → complete, asserting phase/status per verb and assist+no-lock at the end
- [x] Per-verb failure injection proving errors are pure (byte-identical state)
- [x] Escalation reroute / return-to-architect / downgraded-reviewer restoration; secret-stop gating; wave enforcement; body-cap truncation/rotation/hard-fail; abort safe at every new phase
- [ ] 3-OS CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)