### PR TITLE
Add orch guard: mechanical write enforcement for adapter hooks

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -41,6 +41,19 @@ type usageError string
 
 func (e usageError) Error() string { return string(e) }
 
+// exitCodeError lets a command choose its own process exit code instead
+// of the ExitError default. `orch guard claude` returns it to exit 2 on
+// an internal failure: that is the PreToolUse hook protocol's blocking
+// code, where exit 1 is non-blocking (a fail-open trap), so the claude
+// verb must never exit 1.
+type exitCodeError struct {
+	code int
+	err  error
+}
+
+func (e exitCodeError) Error() string { return e.err.Error() }
+func (e exitCodeError) Unwrap() error { return e.err }
+
 type command struct {
 	name    string
 	summary string
@@ -62,6 +75,7 @@ func commands() []command {
 		{"abort", "Stop dispatch and return to Assist", noArgs("abort", runAbort)},
 		{"metrics", "Show local metrics (not implemented)", noArgs("metrics", notImplemented("metrics"))},
 		{"run", "Adapter plumbing: Delivery run verbs (JSON stdin/stdout; not a human command)", runRunVerb},
+		{"guard", "Adapter plumbing: pre-write enforcement for host hooks (not a human command)", runGuard},
 	}
 }
 
@@ -116,6 +130,11 @@ func Run(args []string, env Env) int {
 		if errors.As(err, &ue) {
 			fmt.Fprintf(env.Stderr, "%s\n", err)
 			return ExitUsage
+		}
+		var ce exitCodeError
+		if errors.As(err, &ce) {
+			fmt.Fprintf(env.Stderr, "orch %s: %v\n", c.name, err)
+			return ce.code
 		}
 		fmt.Fprintf(env.Stderr, "orch %s: %v\n", c.name, err)
 		return ExitError

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -85,11 +85,17 @@ type fakeRunner struct {
 	authExit  int
 	repoExit  int
 	repoJSON  string
+	// checkIgnoreExit scripts `git check-ignore`: 0 ignored, 1 not
+	// ignored, anything else an error (the guard ignore probe).
+	checkIgnoreExit int
 }
 
 func (f fakeRunner) Run(_ context.Context, c execx.Cmd) (execx.Result, error) {
 	switch c.Name {
 	case "git":
+		if len(c.Args) > 0 && c.Args[0] == "check-ignore" {
+			return execx.Result{ExitCode: f.checkIgnoreExit}, nil
+		}
 		if f.gitExit != 0 {
 			return execx.Result{Stderr: f.gitStderr, ExitCode: f.gitExit}, nil
 		}

--- a/internal/cli/guard.go
+++ b/internal/cli/guard.go
@@ -1,0 +1,173 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/kninetimmy/orch/internal/guard"
+	"github.com/kninetimmy/orch/internal/manifest"
+)
+
+// guardUsage is the one-line usage for the adapter plumbing surface,
+// mirroring runUsage.
+const guardUsage = "orch guard: usage: orch guard check [--role <role>] [--issue <n>] [--] <path>... | orch guard claude [--role <role>] [--issue <n>] (PreToolUse JSON on stdin)"
+
+// runGuard dispatches the pre-write enforcement verbs (PRD §23): `orch
+// guard check` (host-neutral argv) and `orch guard claude` (Claude Code
+// PreToolUse JSON on stdin). Host adapters call it from their own
+// PreToolUse hooks before every agent write; it is never invoked by a
+// human directly.
+func runGuard(env Env, args []string) error {
+	if len(args) == 0 {
+		return usageError(guardUsage)
+	}
+	switch args[0] {
+	case "check":
+		return guardCheck(env, args[1:])
+	case "claude":
+		return guardClaude(env, args[1:])
+	default:
+		return usageError(guardUsage)
+	}
+}
+
+// guardCheck answers a host-neutral argv invocation. It never reads
+// stdin (the same console-hang concern as `run status --json`). Exit 0
+// allows silently; a policy denial or an operational failure is returned
+// as an error so Run exits 1 with a one-line reason on stderr; a usage
+// mistake returns usageError for exit 2.
+func guardCheck(env Env, args []string) error {
+	role, issue, paths, err := parseGuardFlags(args)
+	if err != nil {
+		return err
+	}
+	if len(paths) == 0 {
+		return usageError(guardUsage)
+	}
+	v, err := guard.NewChecker(env.Runner).Check(context.Background(), guard.Request{
+		Paths: paths,
+		Role:  role,
+		Issue: issue,
+	})
+	if err != nil {
+		return err // operational failure → exit 1, one-line reason
+	}
+	if v.Allow {
+		return nil // exit 0, silent
+	}
+	return fmt.Errorf("%s: %s", v.Path, v.Reason) // exit 1, names path + reason
+}
+
+// guardClaude answers a Claude Code PreToolUse event read from stdin. It
+// never emits a permissionDecision of "allow" — an allow is silence, so
+// guard never bypasses the user's own permission prompts. A denial exits
+// 0 with the hook's deny document on stdout. Any internal failure exits
+// 2 (the hook protocol's blocking code); the verb never exits 1.
+func guardClaude(env Env, args []string) error {
+	role, issue, rest, err := parseGuardFlags(args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 0 {
+		return usageError(guardUsage)
+	}
+
+	payload, err := io.ReadAll(env.Stdin)
+	if err != nil {
+		return exitCodeError{code: ExitUsage, err: fmt.Errorf("read stdin: %w", err)}
+	}
+
+	targets, err := guard.PathsFromClaudeEvent(payload)
+	if err != nil {
+		if errors.Is(err, guard.ErrUnknownTool) {
+			return emitClaudeDeny(env.Stdout, err.Error())
+		}
+		return exitCodeError{code: ExitUsage, err: err}
+	}
+
+	v, err := guard.NewChecker(env.Runner).Check(context.Background(), guard.Request{
+		Paths: targets,
+		Role:  role,
+		Issue: issue,
+	})
+	if err != nil {
+		return exitCodeError{code: ExitUsage, err: err} // operational → blocking exit 2
+	}
+	if v.Allow {
+		return nil // exit 0, no output, no opinion
+	}
+	return emitClaudeDeny(env.Stdout, v.Reason)
+}
+
+// hookOutput is the PreToolUse response guard writes on a denial. Its
+// shape is fixed by the Claude Code hook protocol.
+type hookOutput struct {
+	HookSpecificOutput hookSpecificOutput `json:"hookSpecificOutput"`
+}
+
+type hookSpecificOutput struct {
+	HookEventName            string `json:"hookEventName"`
+	PermissionDecision       string `json:"permissionDecision"`
+	PermissionDecisionReason string `json:"permissionDecisionReason"`
+}
+
+// emitClaudeDeny writes the deny document to stdout and returns nil so
+// the verb exits 0 (the denial is carried by the document, not the exit
+// code). A stdout write failure is an internal failure → blocking exit 2.
+func emitClaudeDeny(w io.Writer, reason string) error {
+	data, err := json.Marshal(hookOutput{HookSpecificOutput: hookSpecificOutput{
+		HookEventName:            "PreToolUse",
+		PermissionDecision:       "deny",
+		PermissionDecisionReason: reason,
+	}})
+	if err != nil {
+		return exitCodeError{code: ExitUsage, err: fmt.Errorf("encode deny document: %w", err)}
+	}
+	if _, err := fmt.Fprintf(w, "%s\n", data); err != nil {
+		return exitCodeError{code: ExitUsage, err: fmt.Errorf("write deny document: %w", err)}
+	}
+	return nil
+}
+
+// parseGuardFlags parses the shared --role and --issue narrowing flags
+// and returns the remaining positional arguments. Parse errors, an
+// unknown role, or a negative issue map to a usage error. The FlagSet
+// discards its own output so the dispatcher owns all user-facing text.
+func parseGuardFlags(args []string) (manifest.Role, int, []string, error) {
+	fs := flag.NewFlagSet("guard", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var roleStr string
+	var issue int
+	fs.StringVar(&roleStr, "role", "", "narrowing role assertion")
+	fs.IntVar(&issue, "issue", 0, "narrowing issue-number assertion")
+	if err := fs.Parse(args); err != nil {
+		return "", 0, nil, usageError(guardUsage)
+	}
+	if issue < 0 {
+		return "", 0, nil, usageError(guardUsage)
+	}
+	var role manifest.Role
+	if roleStr != "" {
+		role = manifest.Role(roleStr)
+		if !validGuardRole(role) {
+			return "", 0, nil, usageError(guardUsage)
+		}
+	}
+	return role, issue, fs.Args(), nil
+}
+
+// validGuardRole reports whether r is one of the five routed roles guard
+// accepts as a narrowing assertion (PRD §13 role set).
+func validGuardRole(r manifest.Role) bool {
+	switch r {
+	case manifest.RoleArchitect, manifest.RoleScout, manifest.RoleImplementer,
+		manifest.RoleSpecialist, manifest.RoleReviewer:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/cli/guard_test.go
+++ b/internal/cli/guard_test.go
@@ -1,0 +1,262 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/paths"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// guardRepo makes env.RepoRoot an Assist orch repo (an .orchestrator
+// directory, no state.json) and returns the root plus a target path
+// under it. The check-ignore probe is scripted by checkIgnoreExit.
+func guardRepo(t *testing.T, checkIgnoreExit int) (Env, *bytes.Buffer, *bytes.Buffer, string) {
+	t.Helper()
+	env, stdout, stderr := testEnv(t)
+	root := env.RepoRoot
+	if err := os.Mkdir(filepath.Join(root, paths.OrchestratorDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	env.Runner = fakeRunner{toplevel: root, checkIgnoreExit: checkIgnoreExit}
+	return env, stdout, stderr, root
+}
+
+// claudePayload marshals a minimal PreToolUse event.
+func claudePayload(t *testing.T, tool, pathKey, pathVal, cwd string) string {
+	t.Helper()
+	m := map[string]any{
+		"tool_name":  tool,
+		"tool_input": map[string]string{pathKey: pathVal},
+	}
+	if cwd != "" {
+		m["cwd"] = cwd
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func TestGuardCheckAllowIgnored(t *testing.T) {
+	env, stdout, stderr, root := guardRepo(t, 0) // 0 = ignored
+	target := filepath.Join(root, "build", "out.o")
+	if code := Run([]string{"guard", "check", target}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr %q)", code, ExitOK, stderr.String())
+	}
+	if stdout.String() != "" || stderr.String() != "" {
+		t.Errorf("allow was not silent: stdout %q stderr %q", stdout.String(), stderr.String())
+	}
+}
+
+func TestGuardCheckDenyTracked(t *testing.T) {
+	env, _, stderr, root := guardRepo(t, 1) // 1 = not ignored
+	target := filepath.Join(root, "src", "x.go")
+	if code := Run([]string{"guard", "check", target}, env); code != ExitError {
+		t.Fatalf("exit = %d, want %d", code, ExitError)
+	}
+	if !strings.Contains(stderr.String(), "assist is read-only") {
+		t.Errorf("stderr missing deny reason: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), target) {
+		t.Errorf("stderr does not name the path: %q", stderr.String())
+	}
+}
+
+func TestGuardCheckUsage(t *testing.T) {
+	cases := map[string][]string{
+		"no verb":      {"guard"},
+		"unknown verb": {"guard", "frobnicate"},
+		"no paths":     {"guard", "check"},
+		"bad flag":     {"guard", "check", "--nope", "x"},
+		"bad role":     {"guard", "check", "--role", "wizard", "x"},
+		"bad issue":    {"guard", "check", "--issue", "-2", "x"},
+	}
+	for name, args := range cases {
+		t.Run(name, func(t *testing.T) {
+			env, _, stderr, _ := guardRepo(t, 1)
+			if code := Run(args, env); code != ExitUsage {
+				t.Fatalf("exit = %d, want %d", code, ExitUsage)
+			}
+			if !strings.Contains(stderr.String(), "orch guard: usage") {
+				t.Errorf("stderr missing guardUsage: %q", stderr.String())
+			}
+		})
+	}
+}
+
+func TestGuardClaudeAllowSilent(t *testing.T) {
+	env, stdout, stderr, root := guardRepo(t, 0) // ignored → allow
+	target := filepath.Join(root, "build", "out.o")
+	env.Stdin = strings.NewReader(claudePayload(t, "Write", "file_path", target, ""))
+	if code := Run([]string{"guard", "claude"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr %q)", code, ExitOK, stderr.String())
+	}
+	if stdout.String() != "" {
+		t.Errorf("allow emitted output: %q", stdout.String())
+	}
+}
+
+func TestGuardClaudeDenyJSON(t *testing.T) {
+	tools := map[string][2]string{
+		"Write":        {"Write", "file_path"},
+		"Edit":         {"Edit", "file_path"},
+		"NotebookEdit": {"NotebookEdit", "notebook_path"},
+	}
+	const wantReason = "assist is read-only for repository files; ask for a Delivery plan"
+	want := `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"` + wantReason + `"}}`
+	for name, tk := range tools {
+		t.Run(name, func(t *testing.T) {
+			env, stdout, _, root := guardRepo(t, 1) // not ignored → deny
+			target := filepath.Join(root, "src", "x.go")
+			env.Stdin = strings.NewReader(claudePayload(t, tk[0], tk[1], target, ""))
+			if code := Run([]string{"guard", "claude"}, env); code != ExitOK {
+				t.Fatalf("exit = %d, want %d", code, ExitOK)
+			}
+			if strings.TrimSpace(stdout.String()) != want {
+				t.Errorf("stdout = %q, want %q", stdout.String(), want)
+			}
+		})
+	}
+}
+
+func TestGuardClaudeUnknownToolDenies(t *testing.T) {
+	env, stdout, _, _ := guardRepo(t, 1)
+	env.Stdin = strings.NewReader(`{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}`)
+	if code := Run([]string{"guard", "claude"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d", code, ExitOK)
+	}
+	var out struct {
+		HookSpecificOutput struct {
+			PermissionDecision       string `json:"permissionDecision"`
+			PermissionDecisionReason string `json:"permissionDecisionReason"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("stdout is not the deny document: %q (%v)", stdout.String(), err)
+	}
+	if out.HookSpecificOutput.PermissionDecision != "deny" {
+		t.Errorf("permissionDecision = %q, want deny", out.HookSpecificOutput.PermissionDecision)
+	}
+	if !strings.Contains(out.HookSpecificOutput.PermissionDecisionReason, "unrecognized tool_name") {
+		t.Errorf("reason = %q, want unrecognized tool_name", out.HookSpecificOutput.PermissionDecisionReason)
+	}
+}
+
+func TestGuardClaudeMalformedJSONExits2(t *testing.T) {
+	env, stdout, _, _ := guardRepo(t, 1)
+	env.Stdin = strings.NewReader(`{ not json`)
+	if code := Run([]string{"guard", "claude"}, env); code != ExitUsage {
+		t.Fatalf("exit = %d, want %d", code, ExitUsage)
+	}
+	if stdout.String() != "" {
+		t.Errorf("internal failure emitted a decision: %q", stdout.String())
+	}
+}
+
+func TestGuardClaudeRelativePathNoCWDExits2(t *testing.T) {
+	env, _, _, _ := guardRepo(t, 1)
+	env.Stdin = strings.NewReader(claudePayload(t, "Write", "file_path", "src/x.go", ""))
+	if code := Run([]string{"guard", "claude"}, env); code != ExitUsage {
+		t.Fatalf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+// TestGuardClaudeNeverExitsOne feeds a state-corruption scenario that
+// `check` would surface as exit 1; `claude` must instead exit 2 (the
+// hook's blocking code — exit 1 there is a fail-open trap).
+func TestGuardClaudeNeverExitsOne(t *testing.T) {
+	env, stdout, _, root := guardRepo(t, 1)
+	if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(state.Path)), []byte("{ not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "src", "x.go")
+	env.Stdin = strings.NewReader(claudePayload(t, "Write", "file_path", target, ""))
+	if code := Run([]string{"guard", "claude"}, env); code != ExitUsage {
+		t.Fatalf("exit = %d, want %d (blocking)", code, ExitUsage)
+	}
+	if stdout.String() != "" {
+		t.Errorf("corruption emitted a decision instead of blocking: %q", stdout.String())
+	}
+	// The same corruption through `check` is exit 1, confirming the split.
+	env2, _, _, root2 := guardRepo(t, 1)
+	if err := os.WriteFile(filepath.Join(root2, filepath.FromSlash(state.Path)), []byte("{ not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if code := Run([]string{"guard", "check", filepath.Join(root2, "src", "x.go")}, env2); code != ExitError {
+		t.Fatalf("check exit = %d, want %d", code, ExitError)
+	}
+}
+
+func TestGuardCheckDeliveryAllows(t *testing.T) {
+	env, _, stderr, root := guardRepo(t, 1)
+	// Enter Delivery with one dispatched issue and a matching worktree.
+	planned := []state.Issue{{PlanID: "a", Title: "A", Phase: state.PhasePlanned}}
+	plan := state.PlanRef{Title: "t", Digest: "sha256:x", ConfigRevision: "r1"}
+	if _, err := state.EnterDelivery(root, "claude", plan, planned); err != nil {
+		t.Fatal(err)
+	}
+	st, err := state.Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Run.Issues = []state.Issue{deliveryIssue()}
+	if err := state.Save(root, st); err != nil {
+		t.Fatal(err)
+	}
+
+	worktreeAbs := filepath.Join(root, "wt")
+	writeGitPointer(t, worktreeAbs, "ref: refs/heads/feature-3\n")
+	target := filepath.Join(worktreeAbs, "src", "x.go")
+
+	if code := Run([]string{"guard", "check", "--role", "implementer", "--issue", "3", target}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr %q)", code, ExitOK, stderr.String())
+	}
+}
+
+func deliveryIssue() state.Issue {
+	return state.Issue{
+		PlanID:   "a",
+		Title:    "A",
+		Phase:    state.PhaseDispatched,
+		Number:   3,
+		Branch:   "feature-3",
+		Worktree: "wt",
+		Decision: &state.Decision{
+			Role:      manifest.RoleImplementer,
+			Executor:  manifest.Selection{Model: "m", Effort: "e"},
+			Reviewer:  manifest.Selection{Model: "m", Effort: "e"},
+			Rationale: "r",
+		},
+	}
+}
+
+func writeGitPointer(t *testing.T, worktreeAbs, head string) {
+	t.Helper()
+	gitMeta := filepath.Join(worktreeAbs, ".git-meta")
+	if err := os.MkdirAll(gitMeta, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gitMeta, "HEAD"), []byte(head), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(worktreeAbs, ".git"), []byte("gitdir: "+gitMeta+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHelpListsGuard(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	if code := Run([]string{"help"}, env); code != ExitOK {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(stdout.String(), "guard") {
+		t.Errorf("help does not list guard: %q", stdout.String())
+	}
+}

--- a/internal/cli/guard_test.go
+++ b/internal/cli/guard_test.go
@@ -64,8 +64,15 @@ func TestGuardCheckDenyTracked(t *testing.T) {
 	if !strings.Contains(stderr.String(), "assist is read-only") {
 		t.Errorf("stderr missing deny reason: %q", stderr.String())
 	}
-	if !strings.Contains(stderr.String(), target) {
-		t.Errorf("stderr does not name the path: %q", stderr.String())
+	// The verdict names the canonical path, which can differ from the
+	// raw temp path (8.3 short segments on Windows, /var symlinks on
+	// macOS), so canonicalize before comparing.
+	canon, err := paths.Canonical(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stderr.String(), canon) {
+		t.Errorf("stderr does not name the path %q: %q", canon, stderr.String())
 	}
 }
 

--- a/internal/guard/claude.go
+++ b/internal/guard/claude.go
@@ -1,0 +1,83 @@
+package guard
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+)
+
+// ErrUnknownTool reports a PreToolUse event whose tool_name guard does
+// not extract a write target from. It is a deny (fail closed; adapters
+// scope their hook matchers), not an internal failure — callers test for
+// it with errors.Is and answer the hook with a denial rather than the
+// blocking error exit.
+var ErrUnknownTool = errors.New("unrecognized tool_name")
+
+// claudeEvent is the subset of a Claude Code PreToolUse hook payload
+// guard reads. It is decoded WITHOUT DisallowUnknownFields: host
+// payloads carry many fields guard does not consume, unlike orch's own
+// schema-versioned documents that reject unknown fields on principle.
+type claudeEvent struct {
+	ToolName  string          `json:"tool_name"`
+	ToolInput json.RawMessage `json:"tool_input"`
+	CWD       string          `json:"cwd"`
+}
+
+// PathsFromClaudeEvent decodes a raw PreToolUse event and returns the
+// absolute write targets it declares. Targets are taken by tool_name:
+// Write/Edit/MultiEdit from tool_input.file_path, NotebookEdit from
+// tool_input.notebook_path. A relative target is resolved against the
+// payload's cwd; a relative target with no cwd is an internal failure.
+// An unrecognized tool_name returns an error wrapping ErrUnknownTool so
+// the caller can deny by default.
+func PathsFromClaudeEvent(payload []byte) ([]string, error) {
+	var ev claudeEvent
+	if err := json.Unmarshal(payload, &ev); err != nil {
+		return nil, fmt.Errorf("parse PreToolUse event: %w", err)
+	}
+
+	raw, err := toolTargets(ev)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]string, 0, len(raw))
+	for _, p := range raw {
+		if p == "" {
+			return nil, fmt.Errorf("PreToolUse %s: empty write path", ev.ToolName)
+		}
+		if !filepath.IsAbs(p) {
+			if ev.CWD == "" {
+				return nil, fmt.Errorf("PreToolUse %s: relative path %q with no cwd in payload", ev.ToolName, p)
+			}
+			p = filepath.Join(ev.CWD, p)
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// toolTargets extracts the raw path field(s) each write tool carries.
+func toolTargets(ev claudeEvent) ([]string, error) {
+	switch ev.ToolName {
+	case "Write", "Edit", "MultiEdit":
+		var in struct {
+			FilePath string `json:"file_path"`
+		}
+		if err := json.Unmarshal(ev.ToolInput, &in); err != nil {
+			return nil, fmt.Errorf("parse %s tool_input: %w", ev.ToolName, err)
+		}
+		return []string{in.FilePath}, nil
+	case "NotebookEdit":
+		var in struct {
+			NotebookPath string `json:"notebook_path"`
+		}
+		if err := json.Unmarshal(ev.ToolInput, &in); err != nil {
+			return nil, fmt.Errorf("parse %s tool_input: %w", ev.ToolName, err)
+		}
+		return []string{in.NotebookPath}, nil
+	default:
+		return nil, fmt.Errorf("%w %q; guard denies by default", ErrUnknownTool, ev.ToolName)
+	}
+}

--- a/internal/guard/guard.go
+++ b/internal/guard/guard.go
@@ -1,0 +1,178 @@
+// Package guard is the mechanical write-enforcement core behind the
+// host-adapter PreToolUse hooks (PRD §23: "Assist reliably blocks
+// tracked-file changes" and "Delivery cannot write outside registered
+// worktrees"). Adapters shell out to `orch guard` before every agent
+// file write; guard answers allow/deny and fails closed on any
+// ambiguity — an unreadable state or an unverifiable path is a deny,
+// never a permissive default.
+//
+// All decision logic lives here in the Go core, not in adapter shell
+// (PRD §6: adapters stay thin). The package is policy-mechanical: it
+// enforces the Assist read-only rule (PRD §7), the Delivery
+// containment/branch/phase rules and role read-only-ness (PRD §15), and
+// treats orchestrator internals and git internals as never writable.
+//
+// The verdict is split into a pure decision (evaluate, over a resolved
+// facts value, no I/O — the normative decision table as data) and the
+// I/O that resolves those facts (resolve.go). Rows the table classifies
+// as "cannot verify" or "propagate message" surface as a Go error from
+// Check, so the CLI can map them to the hook protocol's blocking exit;
+// every genuine allow/deny decision is a Verdict.
+package guard
+
+import (
+	"fmt"
+
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// Request is one guard invocation: the write targets, plus the optional
+// narrowing assertions an adapter may pass. Role and Issue are
+// narrowing-only — they can only ever deny more, never grant. The empty
+// Role asserts nothing and falls through to the pure containment rule.
+type Request struct {
+	Paths []string
+	Role  manifest.Role
+	Issue int
+}
+
+// Verdict is guard's answer for a Request. Path names the target the
+// verdict is about (the first denial for a multi-path Request); Reason
+// is the one-line human explanation for a denial and is empty on allow.
+type Verdict struct {
+	Allow  bool
+	Path   string
+	Reason string
+}
+
+// facts are the resolved, decision-relevant inputs for one path, filled
+// by resolve. Fields that require I/O the decision table classifies as
+// "cannot verify" (rows 1, 2, 5) never reach here — resolve returns those
+// as errors — so evaluate stays pure and total over what remains.
+type facts struct {
+	// path is the canonical target, used in every reason.
+	path string
+
+	// inRepo is false when no .orchestrator ancestor governs path
+	// (row 3: allow, guard governs this repo only).
+	inRepo bool
+	// gitSeg reports a .git segment between the root and the target
+	// (row 4: git internals).
+	gitSeg bool
+
+	// mode is the operating mode read from state (assist or delivery).
+	mode state.Mode
+
+	// Assist facts.
+	underOrch bool  // row 6: path under <root>/.orchestrator/
+	ignored   bool  // row 7: git says path is ignored
+	ignoreErr error // row 8: the ignore probe failed to run
+
+	// Delivery facts.
+	stopped         string      // row 9: Run.StoppedReason
+	worktreeMatched bool        // row 11: a registered worktree contains path
+	worktreeIssue   int         // row 12: containing issue's number
+	worktreePhase   state.Phase // row 13: containing issue's phase
+	worktreeBranch  string      // row 14: containing issue's registered branch
+	headRef         string      // row 14: the worktree's actual HEAD ref line
+	headErr         error       // row 14: HEAD was unreadable
+}
+
+// evaluate is the pure decision core: the normative decision table
+// (rows 3, 4, 6–15) as a precedence-ordered switch over resolved facts.
+// It performs no I/O. Rows 1, 2, and 5 are resolved as errors by Check
+// and never reach here.
+func evaluate(req Request, f facts) Verdict {
+	// Row 3: outside any orch repo — guard governs this repo only.
+	if !f.inRepo {
+		return allow(f.path)
+	}
+	// Row 4: git internals are never writable (covers <root>/.git/** and
+	// a worktree's own .git).
+	if f.gitSeg {
+		return deny(f.path, "git internals are never writable")
+	}
+
+	switch f.mode {
+	case state.ModeAssist:
+		// Row 6: orchestrator internals are not writable. state.json is
+		// gitignored, so blocking it here blocks self-promotion to
+		// Delivery from a guarded write.
+		if f.underOrch {
+			return deny(f.path, "orchestrator internals are not writable")
+		}
+		// Row 7: an ignored in-repo path is local scratch — allow.
+		if f.ignored {
+			return allow(f.path)
+		}
+		// Row 8: not ignored, or the ignore check could not run — assist
+		// is read-only for repository files.
+		if f.ignoreErr != nil {
+			return deny(f.path, fmt.Sprintf("cannot confirm ignore status (%v); assist is read-only for repository files", f.ignoreErr))
+		}
+		return deny(f.path, "assist is read-only for repository files; ask for a Delivery plan")
+
+	case state.ModeDelivery:
+		// Row 9: a secret block stopped the run; it gates all agent writes.
+		if f.stopped != "" {
+			return deny(f.path, "run stopped: "+f.stopped)
+		}
+		// Row 10: an asserted role outside {implementer, specialist} is
+		// mechanically read-only (§15). No assertion falls through.
+		if req.Role != "" && req.Role != manifest.RoleImplementer && req.Role != manifest.RoleSpecialist {
+			return deny(f.path, fmt.Sprintf("role %s is mechanically read-only", req.Role))
+		}
+		// Row 11: outside every registered worktree.
+		if !f.worktreeMatched {
+			return deny(f.path, "outside every registered worktree")
+		}
+		// Row 12: an asserted --issue must own the containing worktree.
+		if req.Issue != 0 && f.worktreeIssue != req.Issue {
+			return deny(f.path, fmt.Sprintf("worktree belongs to issue #%d, not the asserted #%d", f.worktreeIssue, req.Issue))
+		}
+		// Row 13: only dispatched, pr-open, and in-review worktrees are
+		// writable. awaiting-merge is OID-pinned; blocked/abandoned
+		// preserve work.
+		if !writablePhase(f.worktreePhase) {
+			return deny(f.path, "worktree not writable in phase "+string(f.worktreePhase))
+		}
+		// Row 14: the worktree must be on its registered branch, checked
+		// with zero subprocesses (§15 "never on main", strictly).
+		if f.headErr != nil || f.headRef != headRefFor(f.worktreeBranch) {
+			return deny(f.path, "worktree not on its registered branch "+f.worktreeBranch)
+		}
+		// Row 15: every check passed.
+		return allow(f.path)
+
+	default:
+		// resolve rejects any mode state.validate would not, so this is
+		// unreachable; deny to stay closed regardless.
+		return deny(f.path, "unknown operating mode "+string(f.mode))
+	}
+}
+
+// writablePhase reports the Delivery phases in which a registered
+// worktree accepts agent writes: dispatched, pr-open, and in-review.
+func writablePhase(p state.Phase) bool {
+	switch p {
+	case state.PhaseDispatched, state.PhasePROpen, state.PhaseInReview:
+		return true
+	default:
+		return false
+	}
+}
+
+// headRefFor is the exact symbolic-ref line a worktree's HEAD must hold
+// to be considered on its registered branch.
+func headRefFor(branch string) string {
+	return "ref: refs/heads/" + branch
+}
+
+func allow(path string) Verdict {
+	return Verdict{Allow: true, Path: path}
+}
+
+func deny(path, reason string) Verdict {
+	return Verdict{Allow: false, Path: path, Reason: reason}
+}

--- a/internal/guard/guard_test.go
+++ b/internal/guard/guard_test.go
@@ -1,0 +1,277 @@
+package guard
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// deliveredFacts is a fully-passing Delivery facts value (row 15) that
+// each case mutates to isolate one decision-table row.
+func deliveredFacts() facts {
+	return facts{
+		path:            "/repo/.orchestrator/worktrees/issue-3/src/x.go",
+		inRepo:          true,
+		mode:            state.ModeDelivery,
+		worktreeMatched: true,
+		worktreeIssue:   3,
+		worktreePhase:   state.PhaseDispatched,
+		worktreeBranch:  "feature-3",
+		headRef:         "ref: refs/heads/feature-3",
+	}
+}
+
+func TestEvaluate(t *testing.T) {
+	implementer := manifest.RoleImplementer
+
+	cases := map[string]struct {
+		req       Request
+		facts     facts
+		wantAllow bool
+		reasonHas string
+	}{
+		// Row 3: outside any orch repo.
+		"outside repo allows": {
+			facts:     facts{path: "/etc/hosts", inRepo: false},
+			wantAllow: true,
+		},
+		// Row 4: git internals.
+		"git segment denies": {
+			facts:     facts{path: "/repo/.git/config", inRepo: true, gitSeg: true},
+			reasonHas: "git internals",
+		},
+		// Row 6: orchestrator internals in assist.
+		"assist orchestrator internals deny": {
+			facts:     facts{path: "/repo/.orchestrator/state.json", inRepo: true, mode: state.ModeAssist, underOrch: true},
+			reasonHas: "orchestrator internals",
+		},
+		// Row 7: ignored path in assist.
+		"assist ignored allows": {
+			facts:     facts{path: "/repo/build/out", inRepo: true, mode: state.ModeAssist, ignored: true},
+			wantAllow: true,
+		},
+		// Row 8: not ignored in assist.
+		"assist tracked denies": {
+			facts:     facts{path: "/repo/src/x.go", inRepo: true, mode: state.ModeAssist},
+			reasonHas: "assist is read-only",
+		},
+		// Row 8: ignore probe failed in assist.
+		"assist ignore probe error denies": {
+			facts:     facts{path: "/repo/src/x.go", inRepo: true, mode: state.ModeAssist, ignoreErr: errors.New("git boom")},
+			reasonHas: "cannot confirm ignore status",
+		},
+		// Row 9: stopped run.
+		"delivery stopped denies": {
+			req:       Request{Role: implementer},
+			facts:     withStopped(deliveredFacts(), "secret in diff"),
+			reasonHas: "run stopped",
+		},
+		// Row 10: read-only roles deny even inside a valid worktree.
+		"delivery reviewer denies": {
+			req:       Request{Role: manifest.RoleReviewer},
+			facts:     deliveredFacts(),
+			reasonHas: "mechanically read-only",
+		},
+		"delivery scout denies": {
+			req:       Request{Role: manifest.RoleScout},
+			facts:     deliveredFacts(),
+			reasonHas: "mechanically read-only",
+		},
+		"delivery architect denies": {
+			req:       Request{Role: manifest.RoleArchitect},
+			facts:     deliveredFacts(),
+			reasonHas: "mechanically read-only",
+		},
+		// Row 10: specialist and implementer are allowed executors.
+		"delivery specialist allows": {
+			req:       Request{Role: manifest.RoleSpecialist},
+			facts:     deliveredFacts(),
+			wantAllow: true,
+		},
+		"delivery implementer allows": {
+			req:       Request{Role: implementer},
+			facts:     deliveredFacts(),
+			wantAllow: true,
+		},
+		// Empty role falls through to the pure containment rule.
+		"delivery empty role allows": {
+			facts:     deliveredFacts(),
+			wantAllow: true,
+		},
+		// Row 11: outside every registered worktree.
+		"delivery outside worktree denies": {
+			facts:     withNoWorktree(deliveredFacts()),
+			reasonHas: "outside every registered worktree",
+		},
+		// Row 12: issue assertion mismatch.
+		"delivery issue mismatch denies": {
+			req:       Request{Issue: 4},
+			facts:     deliveredFacts(),
+			reasonHas: "belongs to issue #3",
+		},
+		"delivery issue match allows": {
+			req:       Request{Issue: 3},
+			facts:     deliveredFacts(),
+			wantAllow: true,
+		},
+		// Row 13: every non-writable phase denies.
+		"delivery worktree-ready phase denies": {
+			facts:     withPhase(deliveredFacts(), state.PhaseWorktreeReady),
+			reasonHas: "not writable in phase worktree-ready",
+		},
+		"delivery awaiting-merge phase denies": {
+			facts:     withPhase(deliveredFacts(), state.PhaseAwaitingMerge),
+			reasonHas: "not writable in phase awaiting-merge",
+		},
+		"delivery blocked phase denies": {
+			facts:     withPhase(deliveredFacts(), state.PhaseBlocked),
+			reasonHas: "not writable in phase blocked",
+		},
+		"delivery abandoned phase denies": {
+			facts:     withPhase(deliveredFacts(), state.PhaseAbandoned),
+			reasonHas: "not writable in phase abandoned",
+		},
+		"delivery merged phase denies": {
+			facts:     withPhase(deliveredFacts(), state.PhaseMerged),
+			reasonHas: "not writable in phase merged",
+		},
+		// Row 13 writable phases pass.
+		"delivery pr-open phase allows": {
+			facts:     withPhase(deliveredFacts(), state.PhasePROpen),
+			wantAllow: true,
+		},
+		"delivery in-review phase allows": {
+			facts:     withPhase(deliveredFacts(), state.PhaseInReview),
+			wantAllow: true,
+		},
+		// Row 14: HEAD mismatch and unreadable HEAD both deny.
+		"delivery head mismatch denies": {
+			facts:     withHead(deliveredFacts(), "ref: refs/heads/main", nil),
+			reasonHas: "not on its registered branch",
+		},
+		"delivery detached head denies": {
+			facts:     withHead(deliveredFacts(), "0123456789abcdef", nil),
+			reasonHas: "not on its registered branch",
+		},
+		"delivery unreadable head denies": {
+			facts:     withHead(deliveredFacts(), "", errors.New("no HEAD")),
+			reasonHas: "not on its registered branch",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			v := evaluate(tc.req, tc.facts)
+			if v.Allow != tc.wantAllow {
+				t.Fatalf("Allow = %v, want %v (reason %q)", v.Allow, tc.wantAllow, v.Reason)
+			}
+			if tc.wantAllow {
+				if v.Reason != "" {
+					t.Errorf("allow carried a reason: %q", v.Reason)
+				}
+				return
+			}
+			if !strings.Contains(v.Reason, tc.reasonHas) {
+				t.Errorf("reason = %q, want containing %q", v.Reason, tc.reasonHas)
+			}
+			if v.Path != tc.facts.path {
+				t.Errorf("Path = %q, want %q", v.Path, tc.facts.path)
+			}
+		})
+	}
+}
+
+func withStopped(f facts, reason string) facts { f.stopped = reason; return f }
+func withNoWorktree(f facts) facts             { f.worktreeMatched = false; return f }
+func withPhase(f facts, p state.Phase) facts   { f.worktreePhase = p; return f }
+func withHead(f facts, ref string, err error) facts {
+	f.headRef = ref
+	f.headErr = err
+	return f
+}
+
+// fakeChecker builds a Checker whose function fields are all stubbed, so
+// Check can be exercised without a filesystem or git.
+func fakeChecker() *Checker {
+	return &Checker{
+		canonical:       func(p string) (string, error) { return p, nil },
+		inside:          func(root, path string) (bool, error) { return false, nil },
+		findRoot:        func(startDir string) (string, error) { return "/repo", nil },
+		loadState:       func(string) (*state.State, error) { return &state.State{Mode: state.ModeAssist}, nil },
+		inspectLock:     func(string) (*lockfile.Owner, error) { return nil, nil },
+		checkConsistent: func(*state.State, *lockfile.Owner) error { return nil },
+		readHead:        func(string) (string, error) { return "", nil },
+		ignored:         func(context.Context, string, string) (bool, error) { return false, nil },
+	}
+}
+
+// TestCheckOperationalRowsError covers rows 1, 2, and 5: the "cannot
+// verify" / "propagate message" rows surface as an error from Check,
+// distinct from a policy denial.
+func TestCheckOperationalRowsError(t *testing.T) {
+	t.Run("row1 canonical failure", func(t *testing.T) {
+		c := fakeChecker()
+		c.canonical = func(string) (string, error) { return "", errors.New("bad path") }
+		_, err := c.Check(context.Background(), Request{Paths: []string{"/repo/x"}})
+		if err == nil || !strings.Contains(err.Error(), "cannot verify path") {
+			t.Fatalf("err = %v, want cannot-verify-path", err)
+		}
+	})
+	t.Run("row2 root walk failure", func(t *testing.T) {
+		c := fakeChecker()
+		c.findRoot = func(string) (string, error) { return "", errors.New("permission denied") }
+		_, err := c.Check(context.Background(), Request{Paths: []string{"/repo/x"}})
+		if err == nil || !strings.Contains(err.Error(), "cannot verify repository root") {
+			t.Fatalf("err = %v, want cannot-verify-root", err)
+		}
+	})
+	t.Run("row5 state failure", func(t *testing.T) {
+		c := fakeChecker()
+		c.loadState = func(string) (*state.State, error) { return nil, errors.New("corrupt state") }
+		_, err := c.Check(context.Background(), Request{Paths: []string{"/repo/x"}})
+		if err == nil || !strings.Contains(err.Error(), "corrupt state") {
+			t.Fatalf("err = %v, want propagated state error", err)
+		}
+	})
+}
+
+// TestCheckMultiPathFirstDenyWins confirms the first denied path denies
+// the whole invocation and names that path.
+func TestCheckMultiPathFirstDenyWins(t *testing.T) {
+	c := fakeChecker()
+	// Assist mode, not under .orchestrator, not ignored → every in-repo
+	// path denies (row 8).
+	v, err := c.Check(context.Background(), Request{Paths: []string{"/repo/a.go", "/repo/b.go"}})
+	if err != nil {
+		t.Fatalf("Check err = %v", err)
+	}
+	if v.Allow {
+		t.Fatal("Allow = true, want deny")
+	}
+	if v.Path != "/repo/a.go" {
+		t.Errorf("Path = %q, want first path /repo/a.go", v.Path)
+	}
+}
+
+func TestCheckAllPathsAllow(t *testing.T) {
+	c := fakeChecker()
+	c.ignored = func(context.Context, string, string) (bool, error) { return true, nil }
+	v, err := c.Check(context.Background(), Request{Paths: []string{"/repo/a", "/repo/b"}})
+	if err != nil {
+		t.Fatalf("Check err = %v", err)
+	}
+	if !v.Allow {
+		t.Fatalf("Allow = false, reason %q", v.Reason)
+	}
+}
+
+func TestCheckNoPaths(t *testing.T) {
+	if _, err := fakeChecker().Check(context.Background(), Request{}); err == nil {
+		t.Fatal("Check with no paths returned nil error")
+	}
+}

--- a/internal/guard/resolve.go
+++ b/internal/guard/resolve.go
@@ -1,0 +1,258 @@
+package guard
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/paths"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// gitDirName is the git metadata directory/file name whose presence in a
+// path segment marks git internals (row 4).
+const gitDirName = ".git"
+
+// gitEnv keeps every git invocation fail-closed and locale-stable, the
+// same environment gitops applies: GIT_TERMINAL_PROMPT=0 makes git error
+// instead of prompting (never hang), LC_ALL=C stabilizes output.
+var gitEnv = []string{"GIT_TERMINAL_PROMPT=0", "LC_ALL=C"}
+
+// Checker resolves the facts behind a guard Verdict. Its function fields
+// are injected so tests drive the decision without a real filesystem or
+// git; NewChecker wires the production implementations.
+type Checker struct {
+	canonical       func(string) (string, error)
+	inside          func(root, path string) (bool, error)
+	findRoot        func(startDir string) (string, error)
+	loadState       func(repoRoot string) (*state.State, error)
+	inspectLock     func(repoRoot string) (*lockfile.Owner, error)
+	checkConsistent func(*state.State, *lockfile.Owner) error
+	readHead        func(worktreeAbs string) (string, error)
+	ignored         func(ctx context.Context, repoRoot, canonPath string) (bool, error)
+}
+
+// NewChecker returns a Checker wired to the production path, state, lock,
+// and git implementations. The ignore probe runs through runner, the
+// only place guard shells out (and only on the rare Assist in-repo
+// write); every other row is resolved from state, the lock, and a small
+// number of file reads and lstats.
+func NewChecker(runner execx.Runner) *Checker {
+	return &Checker{
+		canonical:       paths.Canonical,
+		inside:          paths.Inside,
+		findRoot:        paths.FindOutermostRoot,
+		loadState:       state.Load,
+		inspectLock:     lockfile.Inspect,
+		checkConsistent: state.CheckConsistent,
+		readHead:        readWorktreeHead,
+		ignored:         gitCheckIgnore(runner),
+	}
+}
+
+// Check evaluates req and returns the verdict for the first path that is
+// not allowed, or an allow when every path passes. Multiple paths are
+// all-or-nothing: the first denial denies the whole invocation. A
+// non-nil error reports an operational failure the caller must treat as
+// "cannot decide" (decision-table rows 1, 2, and 5): an unverifiable
+// path, an unwalkable root, or unreadable/inconsistent state. Those are
+// distinct from a policy denial, which is a Verdict with Allow false.
+func (c *Checker) Check(ctx context.Context, req Request) (Verdict, error) {
+	if len(req.Paths) == 0 {
+		return Verdict{}, errors.New("no paths to check")
+	}
+	for _, p := range req.Paths {
+		f, err := c.resolve(ctx, p)
+		if err != nil {
+			return Verdict{}, err
+		}
+		if v := evaluate(req, f); !v.Allow {
+			return v, nil
+		}
+	}
+	return Verdict{Allow: true}, nil
+}
+
+// resolve gathers the facts for one path, short-circuiting its own I/O in
+// the decision table's order so an early terminal condition never pays
+// for later work. It returns an error for the "cannot verify" /
+// "propagate message" rows (1, 2, 5, and any containment check that
+// cannot complete); every other outcome is a fully-populated facts.
+func (c *Checker) resolve(ctx context.Context, path string) (facts, error) {
+	f := facts{path: path}
+
+	// Row 1: canonicalize the target (works for a not-yet-existing file).
+	canon, err := c.canonical(path)
+	if err != nil {
+		return f, fmt.Errorf("cannot verify path %s: %w", path, err)
+	}
+	f.path = canon
+
+	// Rows 2/3: the governing root is the outermost .orchestrator
+	// ancestor. No such ancestor means the path is outside any orch repo.
+	// The walk starts at the directory the write lands in, never the
+	// target itself: for an existing file, probing <file>/.orchestrator
+	// returns ENOTDIR on Unix, which is not fs.ErrNotExist and would turn
+	// every edit of an existing file into a spurious operational deny.
+	root, err := c.findRoot(filepath.Dir(canon))
+	if err != nil {
+		if errors.Is(err, paths.ErrNotFound) {
+			return f, nil // row 3: inRepo stays false → allow
+		}
+		return f, fmt.Errorf("cannot verify repository root for %s: %w", canon, err)
+	}
+	f.inRepo = true
+
+	// Row 4: a .git segment anywhere between the root and the target.
+	rel, err := filepath.Rel(root, canon)
+	if err != nil {
+		return f, fmt.Errorf("cannot place %s under %s: %w", canon, root, err)
+	}
+	for _, seg := range strings.Split(filepath.ToSlash(rel), "/") {
+		if strings.EqualFold(seg, gitDirName) {
+			f.gitSeg = true
+			return f, nil // evaluate denies; no state read needed
+		}
+	}
+
+	// Row 5: load state, inspect the lock, and verify they agree.
+	st, err := c.loadState(root)
+	if err != nil {
+		return f, err
+	}
+	owner, err := c.inspectLock(root)
+	if err != nil {
+		return f, err
+	}
+	if err := c.checkConsistent(st, owner); err != nil {
+		return f, err
+	}
+	f.mode = st.Mode
+
+	switch st.Mode {
+	case state.ModeAssist:
+		orchDir := filepath.Join(root, paths.OrchestratorDir)
+		under, err := c.inside(orchDir, canon)
+		if err != nil {
+			return f, fmt.Errorf("cannot verify %s against %s: %w", canon, orchDir, err)
+		}
+		if under {
+			f.underOrch = true
+			return f, nil // row 6 denies; skip the ignore probe
+		}
+		// Row 7/8: the sole subprocess on any path, and only here.
+		ignored, ierr := c.ignored(ctx, root, canon)
+		f.ignored = ignored
+		f.ignoreErr = ierr
+		return f, nil
+
+	case state.ModeDelivery:
+		f.stopped = st.Run.StoppedReason
+		for i := range st.Run.Issues {
+			iss := &st.Run.Issues[i]
+			if iss.Worktree == "" {
+				continue
+			}
+			wtAbs := filepath.Join(root, filepath.FromSlash(iss.Worktree))
+			in, err := c.inside(wtAbs, canon)
+			if err != nil {
+				return f, fmt.Errorf("cannot verify %s against worktree %s: %w", canon, wtAbs, err)
+			}
+			if !in {
+				continue
+			}
+			f.worktreeMatched = true
+			f.worktreeIssue = iss.Number
+			f.worktreePhase = iss.Phase
+			f.worktreeBranch = iss.Branch
+			// Row 14 is only reached for a writable phase (row 13 denies
+			// first otherwise), so the HEAD read is skipped elsewhere.
+			if writablePhase(iss.Phase) {
+				head, herr := c.readHead(wtAbs)
+				f.headRef = head
+				f.headErr = herr
+			}
+			break
+		}
+		return f, nil
+
+	default:
+		// state.validate accepts only assist and delivery; fail closed.
+		return f, fmt.Errorf("state records unknown mode %q", st.Mode)
+	}
+}
+
+// readWorktreeHead reads a worktree's checked-out branch ref with zero
+// subprocesses: it resolves <worktree>/.git (a gitdir pointer file in a
+// linked worktree, or the directory itself in a primary checkout) and
+// returns the trimmed contents of that git directory's HEAD. A detached
+// HEAD returns a bare object id (no "ref:" prefix), which evaluate treats
+// as a branch mismatch.
+func readWorktreeHead(worktreeAbs string) (string, error) {
+	dotGit := filepath.Join(worktreeAbs, gitDirName)
+	info, err := os.Lstat(dotGit)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", dotGit, err)
+	}
+
+	gitDir := dotGit
+	if !info.IsDir() {
+		data, err := os.ReadFile(dotGit)
+		if err != nil {
+			return "", fmt.Errorf("read %s: %w", dotGit, err)
+		}
+		const prefix = "gitdir:"
+		line := strings.TrimSpace(string(data))
+		if !strings.HasPrefix(line, prefix) {
+			return "", fmt.Errorf("%s: not a gitdir pointer", dotGit)
+		}
+		gitDir = strings.TrimSpace(strings.TrimPrefix(line, prefix))
+		if !filepath.IsAbs(gitDir) {
+			gitDir = filepath.Join(worktreeAbs, gitDir)
+		}
+	}
+
+	headPath := filepath.Join(gitDir, "HEAD")
+	head, err := os.ReadFile(headPath)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", headPath, err)
+	}
+	return strings.TrimSpace(string(head)), nil
+}
+
+// gitCheckIgnore builds the production ignore probe: `git check-ignore
+// -q` on the path relative to the repo root, mirroring
+// gitops.RequireIgnored's exit-code handling but file-oriented (no
+// trailing slash, since a guard target is a concrete file). Exit 0 means
+// ignored, exit 1 means not ignored, anything else is an error.
+func gitCheckIgnore(runner execx.Runner) func(ctx context.Context, repoRoot, canonPath string) (bool, error) {
+	return func(ctx context.Context, repoRoot, canonPath string) (bool, error) {
+		rel, err := filepath.Rel(repoRoot, canonPath)
+		if err != nil {
+			return false, fmt.Errorf("compute path for %s relative to %s: %w", canonPath, repoRoot, err)
+		}
+		query := filepath.ToSlash(rel)
+		res, err := runner.Run(ctx, execx.Cmd{
+			Name: "git",
+			Args: []string{"check-ignore", "-q", "--", query},
+			Dir:  repoRoot,
+			Env:  gitEnv,
+		})
+		if err != nil {
+			return false, err
+		}
+		switch res.ExitCode {
+		case 0:
+			return true, nil
+		case 1:
+			return false, nil
+		default:
+			return false, fmt.Errorf("git check-ignore in %s exited %d: %s", repoRoot, res.ExitCode, strings.TrimSpace(res.Stderr))
+		}
+	}
+}

--- a/internal/guard/resolve_test.go
+++ b/internal/guard/resolve_test.go
@@ -1,0 +1,298 @@
+package guard
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/paths"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// realChecker wires the production path/state/lock/head implementations
+// and injects the ignore probe (real git is never run in these tests).
+func realChecker(ignored func(context.Context, string, string) (bool, error)) *Checker {
+	c := NewChecker(nil)
+	if ignored != nil {
+		c.ignored = ignored
+	}
+	return c
+}
+
+func mkdirAll(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	mkdirAll(t, filepath.Dir(path))
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// mkOrchDir creates root/.orchestrator so root reads as an orch repo.
+func mkOrchDir(t *testing.T, root string) {
+	t.Helper()
+	mkdirAll(t, filepath.Join(root, paths.OrchestratorDir))
+}
+
+// writeWorktreeGit fabricates a linked-worktree .git pointer file plus a
+// HEAD holding headContent, matching the on-disk shape row 14 reads.
+func writeWorktreeGit(t *testing.T, worktreeAbs, headContent string) {
+	t.Helper()
+	gitMeta := filepath.Join(worktreeAbs, ".git-meta")
+	writeFile(t, filepath.Join(gitMeta, "HEAD"), headContent)
+	writeFile(t, filepath.Join(worktreeAbs, ".git"), "gitdir: "+gitMeta+"\n")
+}
+
+// enterDeliveryWith puts root into a Delivery run holding a single
+// dispatched issue with the given worktree (repo-relative slash path)
+// and branch, leaving the matching lock in place.
+func enterDeliveryWith(t *testing.T, root, worktreeRel, branch string) {
+	t.Helper()
+	mkOrchDir(t, root)
+	planned := []state.Issue{{PlanID: "a", Title: "A", Phase: state.PhasePlanned}}
+	plan := state.PlanRef{Title: "t", Digest: "sha256:x", ConfigRevision: "r1"}
+	if _, err := state.EnterDelivery(root, "claude", plan, planned); err != nil {
+		t.Fatal(err)
+	}
+	st, err := state.Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Run.Issues = []state.Issue{{
+		PlanID:   "a",
+		Title:    "A",
+		Phase:    state.PhaseDispatched,
+		Number:   3,
+		Branch:   branch,
+		Worktree: worktreeRel,
+		Decision: &state.Decision{
+			Role:      manifest.RoleImplementer,
+			Executor:  manifest.Selection{Model: "m", Effort: "e"},
+			Reviewer:  manifest.Selection{Model: "m", Effort: "e"},
+			Rationale: "r",
+		},
+	}}
+	if err := state.Save(root, st); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustDeny(t *testing.T, v Verdict, err error, reasonHas string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("Check err = %v, want a Verdict deny", err)
+	}
+	if v.Allow {
+		t.Fatalf("Allow = true, want deny")
+	}
+	if !strings.Contains(v.Reason, reasonHas) {
+		t.Fatalf("reason = %q, want containing %q", v.Reason, reasonHas)
+	}
+}
+
+func mustAllow(t *testing.T, v Verdict, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("Check err = %v, want allow", err)
+	}
+	if !v.Allow {
+		t.Fatalf("Allow = false, reason %q", v.Reason)
+	}
+}
+
+// TestOutermostRootRegression is the key correctness test: a target
+// inside a worktree that itself carries a checked-out .orchestrator/ must
+// resolve to the PRIMARY root (outermost), whose Delivery state matches
+// the worktree — not to the worktree (innermost), whose missing state
+// would read as Assist and wrongly deny.
+func TestOutermostRootRegression(t *testing.T) {
+	root := t.TempDir()
+	worktreeRel := filepath.ToSlash(filepath.Join(paths.OrchestratorDir, "worktrees", "issue-3"))
+	enterDeliveryWith(t, root, worktreeRel, "feature-3")
+
+	worktreeAbs := filepath.Join(root, filepath.FromSlash(worktreeRel))
+	// The worktree carries a committed .orchestrator/ of its own.
+	mkdirAll(t, filepath.Join(worktreeAbs, paths.OrchestratorDir))
+	writeWorktreeGit(t, worktreeAbs, "ref: refs/heads/feature-3\n")
+
+	target := filepath.Join(worktreeAbs, "src", "x.go")
+	v, err := realChecker(nil).Check(context.Background(), Request{Paths: []string{target}})
+	mustAllow(t, v, err)
+}
+
+func TestDeliveryHeadVariants(t *testing.T) {
+	cases := map[string]struct {
+		head      string
+		writeHead bool
+		allow     bool
+	}{
+		"match":    {head: "ref: refs/heads/feature-3\n", writeHead: true, allow: true},
+		"mismatch": {head: "ref: refs/heads/other\n", writeHead: true},
+		"detached": {head: "0123456789abcdef0123456789abcdef01234567\n", writeHead: true},
+		"missing":  {writeHead: false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			enterDeliveryWith(t, root, "wt", "feature-3")
+			worktreeAbs := filepath.Join(root, "wt")
+			if tc.writeHead {
+				writeWorktreeGit(t, worktreeAbs, tc.head)
+			} else {
+				// A .git pointer to a gitdir with no HEAD file.
+				writeFile(t, filepath.Join(worktreeAbs, ".git"), "gitdir: "+filepath.Join(worktreeAbs, ".git-meta")+"\n")
+				mkdirAll(t, filepath.Join(worktreeAbs, ".git-meta"))
+			}
+			target := filepath.Join(worktreeAbs, "src", "x.go")
+			v, err := realChecker(nil).Check(context.Background(), Request{Paths: []string{target}})
+			if tc.allow {
+				mustAllow(t, v, err)
+				return
+			}
+			mustDeny(t, v, err, "not on its registered branch")
+		})
+	}
+}
+
+// TestDeliveryNotYetExisting confirms a target that does not exist yet is
+// still matched to its worktree (Canonical's deepest-ancestor behavior).
+func TestDeliveryNotYetExisting(t *testing.T) {
+	root := t.TempDir()
+	enterDeliveryWith(t, root, "wt", "feature-3")
+	worktreeAbs := filepath.Join(root, "wt")
+	writeWorktreeGit(t, worktreeAbs, "ref: refs/heads/feature-3\n")
+
+	target := filepath.Join(worktreeAbs, "brand", "new", "file.go")
+	v, err := realChecker(nil).Check(context.Background(), Request{Paths: []string{target}})
+	mustAllow(t, v, err)
+}
+
+func TestDeliveryOutsideWorktree(t *testing.T) {
+	root := t.TempDir()
+	enterDeliveryWith(t, root, "wt", "feature-3")
+	target := filepath.Join(root, "src", "x.go")
+	v, err := realChecker(nil).Check(context.Background(), Request{Paths: []string{target}})
+	mustDeny(t, v, err, "outside every registered worktree")
+}
+
+func TestGitSegmentDenies(t *testing.T) {
+	root := t.TempDir()
+	mkOrchDir(t, root)
+	target := filepath.Join(root, ".git", "config")
+	v, err := realChecker(nil).Check(context.Background(), Request{Paths: []string{target}})
+	mustDeny(t, v, err, "git internals")
+}
+
+func TestAssistMissingStateSelfPromotion(t *testing.T) {
+	root := t.TempDir()
+	mkOrchDir(t, root) // no state.json → assist
+	target := filepath.Join(root, paths.OrchestratorDir, "state.json")
+	v, err := realChecker(nil).Check(context.Background(), Request{Paths: []string{target}})
+	mustDeny(t, v, err, "orchestrator internals")
+}
+
+func TestCorruptStateErrors(t *testing.T) {
+	root := t.TempDir()
+	mkOrchDir(t, root)
+	writeFile(t, filepath.Join(root, filepath.FromSlash(state.Path)), "{ not json")
+	target := filepath.Join(root, "src", "x.go")
+	_, err := realChecker(nil).Check(context.Background(), Request{Paths: []string{target}})
+	if err == nil {
+		t.Fatal("corrupt state did not produce an operational error")
+	}
+}
+
+func TestVersionMismatchStateErrors(t *testing.T) {
+	root := t.TempDir()
+	mkOrchDir(t, root)
+	writeFile(t, filepath.Join(root, filepath.FromSlash(state.Path)), `{"schema_version":99,"mode":"assist"}`)
+	target := filepath.Join(root, "src", "x.go")
+	_, err := realChecker(nil).Check(context.Background(), Request{Paths: []string{target}})
+	if err == nil {
+		t.Fatal("version-mismatch state did not produce an operational error")
+	}
+}
+
+func TestOrphanedLockErrors(t *testing.T) {
+	root := t.TempDir()
+	mkOrchDir(t, root) // assist (no state.json)
+	if err := lockfile.Acquire(root, lockfile.Owner{RunID: "run-x", Host: "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "src", "x.go")
+	_, err := realChecker(nil).Check(context.Background(), Request{Paths: []string{target}})
+	if err == nil || !strings.Contains(err.Error(), "orch abort") {
+		t.Fatalf("err = %v, want an orphaned-lock error", err)
+	}
+}
+
+// TestAssistExistingFileTarget pins the root walk to the target's parent
+// directory: probing <existing-file>/.orchestrator returns ENOTDIR on
+// Unix (not fs.ErrNotExist), so walking from the file itself would deny
+// every edit of an existing file as "cannot verify repository root".
+func TestAssistExistingFileTarget(t *testing.T) {
+	root := t.TempDir()
+	mkOrchDir(t, root) // assist
+	target := filepath.Join(root, "src", "x.go")
+	writeFile(t, target, "package src\n")
+	probe := func(context.Context, string, string) (bool, error) { return false, nil }
+	v, err := realChecker(probe).Check(context.Background(), Request{Paths: []string{target}})
+	mustDeny(t, v, err, "read-only for repository files")
+}
+
+func TestOutsideRepoAllows(t *testing.T) {
+	outside := t.TempDir()
+	target := filepath.Join(outside, "x.go")
+	if _, err := paths.FindOutermostRoot(target); err == nil {
+		t.Skip("temp dir has an .orchestrator ancestor; outside-repo case not exercisable here")
+	}
+	v, err := realChecker(nil).Check(context.Background(), Request{Paths: []string{target}})
+	mustAllow(t, v, err)
+}
+
+func TestAssistIgnoreProbe(t *testing.T) {
+	cases := map[string]struct {
+		probe func(context.Context, string, string) (bool, error)
+		allow bool
+	}{
+		"ignored allows": {
+			probe: func(context.Context, string, string) (bool, error) { return true, nil },
+			allow: true,
+		},
+		"tracked denies": {
+			probe: func(context.Context, string, string) (bool, error) { return false, nil },
+		},
+		"probe error denies": {
+			probe: func(context.Context, string, string) (bool, error) { return false, errors.New("git missing") },
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			mkOrchDir(t, root) // assist
+			target := filepath.Join(root, "src", "x.go")
+			v, err := realChecker(tc.probe).Check(context.Background(), Request{Paths: []string{target}})
+			if tc.allow {
+				mustAllow(t, v, err)
+				return
+			}
+			if err != nil {
+				t.Fatalf("Check err = %v, want a Verdict deny", err)
+			}
+			if v.Allow {
+				t.Fatal("Allow = true, want deny")
+			}
+		})
+	}
+}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -131,3 +131,44 @@ func FindRoot(startDir string) (string, error) {
 		dir = parent
 	}
 }
+
+// FindOutermostRoot walks from startDir to the filesystem root and
+// returns the outermost ancestor that contains an .orchestrator
+// directory — the opposite selection from FindRoot, which stops at the
+// innermost. The guard (PRD §23) needs the outermost hit: a Delivery
+// worktree checkout carries the committed .orchestrator/config.toml, so
+// an innermost search would resolve a path under
+// <root>/.orchestrator/worktrees/issue-N/ to the worktree itself, whose
+// missing machine-local state.json would read as Assist and wrongly deny
+// every executor write. The same fail-closed rules as FindRoot apply: an
+// unreadable ancestor, or an .orchestrator entry that is not a real
+// directory (a symlink does not count), is an error; ErrNotFound wraps
+// when no ancestor qualifies.
+func FindOutermostRoot(startDir string) (string, error) {
+	dir, err := Canonical(startDir)
+	if err != nil {
+		return "", err
+	}
+	outermost := ""
+	for {
+		candidate := filepath.Join(dir, OrchestratorDir)
+		info, err := os.Lstat(candidate)
+		switch {
+		case err == nil && info.IsDir():
+			outermost = dir
+		case err == nil:
+			return "", fmt.Errorf("%s exists but is not a real directory", candidate)
+		case !errors.Is(err, fs.ErrNotExist):
+			return "", fmt.Errorf("find repo root: %w", err)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	if outermost == "" {
+		return "", fmt.Errorf("%w in %s or any parent", ErrNotFound, startDir)
+	}
+	return outermost, nil
+}

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -189,3 +189,77 @@ func TestFindRootRejectsNonDirectory(t *testing.T) {
 		t.Errorf("FindRoot error = %v, want 'not a real directory'", err)
 	}
 }
+
+// TestFindOutermostRootNested confirms the outermost .orchestrator ancestor
+// wins when roots nest, the opposite of FindRoot's innermost selection.
+func TestFindOutermostRootNested(t *testing.T) {
+	outer := t.TempDir()
+	inner := filepath.Join(outer, "a", "inner")
+	deep := filepath.Join(inner, "b", "c")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range []string{outer, inner} {
+		if err := os.Mkdir(filepath.Join(r, OrchestratorDir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := FindOutermostRoot(deep)
+	if err != nil {
+		t.Fatalf("FindOutermostRoot: %v", err)
+	}
+	if want := canonical(t, outer); got != want {
+		t.Errorf("FindOutermostRoot = %s, want outer %s", got, want)
+	}
+	// FindRoot picks the innermost, proving the two differ here.
+	if inRoot, err := FindRoot(deep); err != nil || inRoot != canonical(t, inner) {
+		t.Errorf("FindRoot = %s, %v; want inner %s", inRoot, err, canonical(t, inner))
+	}
+}
+
+// TestFindOutermostRootWorktreeShaped mirrors the guard regression: a
+// worktree checkout under the primary root carries its own committed
+// .orchestrator/, but the outermost root is still the primary checkout.
+func TestFindOutermostRootWorktreeShaped(t *testing.T) {
+	root := t.TempDir()
+	worktree := filepath.Join(root, OrchestratorDir, "worktrees", "issue-3")
+	target := filepath.Join(worktree, "src")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range []string{root, worktree} {
+		if err := os.MkdirAll(filepath.Join(r, OrchestratorDir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := FindOutermostRoot(filepath.Join(target, "x.go"))
+	if err != nil {
+		t.Fatalf("FindOutermostRoot: %v", err)
+	}
+	if want := canonical(t, root); got != want {
+		t.Errorf("FindOutermostRoot = %s, want primary root %s", got, want)
+	}
+}
+
+func TestFindOutermostRootNotFound(t *testing.T) {
+	got, err := FindOutermostRoot(t.TempDir())
+	if err == nil {
+		t.Skipf("ancestor %s contains %s", got, OrchestratorDir)
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("FindOutermostRoot error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestFindOutermostRootRejectsNonDirectory(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, OrchestratorDir), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := FindOutermostRoot(root)
+	if err == nil || !strings.Contains(err.Error(), "not a real directory") {
+		t.Errorf("FindOutermostRoot error = %v, want 'not a real directory'", err)
+	}
+}


### PR DESCRIPTION
## What

Task 12: `orch guard` — the mechanical pre-write enforcement subcommand host-adapter PreToolUse hooks call before every agent file write. New `internal/guard` package (pure 15-row decision core + fact resolution), `paths.FindOutermostRoot`, and two plumbing verbs wired into the CLI beside `orch run`.

```
orch guard check  [--role <role>] [--issue <n>] [--] <path>...   # host-neutral argv; 0 allow / 1 deny / 2 usage
orch guard claude [--role <role>] [--issue <n>]                  # Claude PreToolUse JSON on stdin
```

## Why

This is the mechanism behind PRD SS23 acceptance: "Assist reliably blocks tracked-file changes" and "Delivery cannot write outside registered worktrees" (SS15: only the registered executor writes, never on main, reviewers mechanically read-only, no bypass). All reasoning lives in the Go core so adapters stay thin (SS6) — the Claude hook becomes a one-line settings entry in task 17.

Design decisions (user-approved 2026-07-11):
- **No-role default = containment-only allow**: hooks cannot reliably attribute a tool call to a subagent, so the mechanical rule (mode x registered-worktree containment x writable phase x registered-branch HEAD) is the guarantee; `--role`/`--issue` assertions only ever narrow.
- **Writable phases**: dispatched, pr-open, in-review (awaiting-merge is pinned to the approved head OID; blocked/abandoned preserve work).
- **Assist allows git-ignored in-repo paths** (one `git check-ignore` on that rare path only); `.orchestrator/` and any `.git` segment are never writable — state.json is gitignored, so this also blocks self-promotion to Delivery.
- **Claude deny transport**: `permissionDecision:"deny"` JSON at exit 0; internal failures exit 2 (the hook protocol treats exit 1 as non-blocking, i.e. fail-open — the verb never exits 1). Allow is silence, never `"allow"`, so guard cannot bypass the user's own permission prompts.

Root discovery walks up from the write target's parent directory and takes the **outermost** `.orchestrator` ancestor: a worktree checkout carries the committed `.orchestrator/config.toml`, so innermost-wins would read the worktree as its own Assist-mode repo and deny every executor write. Main-thread review caught one defect in the delegated implementation: the walk originally started at the target itself, so `<existing-file>/.orchestrator` returned ENOTDIR on Unix (not `fs.ErrNotExist`) and every edit of an existing file on Linux/macOS became a spurious operational deny — fixed with a regression test.

Delivery hot path is zero-subprocess: state + lock + gitdir/HEAD file reads + path math.

## Testing

- `internal/guard/guard_test.go`: every decision-table row, role/issue narrowing, phase set, multi-path first-deny.
- `internal/guard/resolve_test.go`: outermost-root regression, existing-file-target regression, state variants (missing/corrupt/version-mismatch/orphaned lock), self-promotion attempt, `.git` segment, HEAD match/mismatch/detached/missing, ignore-probe injection.
- `internal/cli/guard_test.go`: exit-code golden cases for both verbs incl. "claude never exits 1".
- `go build` / `go vet` / `go test` / `gofmt -l` all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7LU4KkTJuD91bLy64C3Bm