### PR TITLE
Add orch resume: reconcile and recover interrupted Delivery runs

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -71,7 +71,7 @@ func commands() []command {
 		{"doctor", "Check environment and configuration health", noArgs("doctor", runDoctor)},
 		{"configure", "Change committed configuration (not implemented)", noArgs("configure", notImplemented("configure"))},
 		{"configure-local", "Change machine-local overrides (not implemented)", noArgs("configure-local", notImplemented("configure-local"))},
-		{"resume", "Resume an interrupted Delivery run (not implemented)", noArgs("resume", notImplemented("resume"))},
+		{"resume", "Reconcile an interrupted Delivery run against GitHub and continue", runResume},
 		{"abort", "Stop dispatch and return to Assist", noArgs("abort", runAbort)},
 		{"metrics", "Show local metrics (not implemented)", noArgs("metrics", notImplemented("metrics"))},
 		{"run", "Adapter plumbing: Delivery run verbs (JSON stdin/stdout; not a human command)", runRunVerb},

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -174,7 +174,7 @@ func TestRunUnexpectedArgument(t *testing.T) {
 }
 
 func TestNotImplementedCommandsFailClosed(t *testing.T) {
-	for _, name := range []string{"init", "configure", "configure-local", "resume", "metrics"} {
+	for _, name := range []string{"init", "configure", "configure-local", "metrics"} {
 		t.Run(name, func(t *testing.T) {
 			env, _, stderr := testEnv(t)
 			if code := Run([]string{name}, env); code != ExitError {

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/run"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// resumeUsage is the one-line usage for the human resume command.
+const resumeUsage = "orch resume: usage: orch resume [--json] [--dry-run] [--resume-stopped-run]"
+
+// runResume reconciles an interrupted Delivery run against GitHub and
+// continues it (PRD §23). Unlike the adapter-plumbing `run` verbs it is a
+// human command, so it parses its own flags and renders a human report by
+// default.
+func runResume(env Env, args []string) error {
+	var (
+		asJSON  bool
+		dryRun  bool
+		stopped bool
+	)
+	for _, a := range args {
+		switch a {
+		case "--json":
+			asJSON = true
+		case "--dry-run":
+			dryRun = true
+		case "--resume-stopped-run":
+			stopped = true
+		default:
+			return usageError(resumeUsage)
+		}
+	}
+
+	req := run.ResumeRequest{DryRun: dryRun}
+	if stopped {
+		req.Statement = run.ResumeStoppedRunStatement
+	}
+
+	runEnv := run.Env{RepoRoot: env.RepoRoot, Runner: env.Runner, Now: time.Now}
+	doc, err := run.Resume(context.Background(), runEnv, req)
+	if err != nil {
+		return err
+	}
+
+	if asJSON {
+		data, err := json.MarshalIndent(doc, "", "  ")
+		if err != nil {
+			return fmt.Errorf("encode resume result: %w", err)
+		}
+		_, err = fmt.Fprintf(env.Stdout, "%s\n", data)
+		return err
+	}
+	return renderResume(env, doc)
+}
+
+// renderResume prints the human report the resume example in PRD §23
+// describes: a run header, one line per issue, the stopped-run outcome,
+// and any run-level warnings.
+func renderResume(env Env, doc *run.ResumeDoc) error {
+	if doc.Mode != state.ModeDelivery {
+		fmt.Fprintln(env.Stdout, "no delivery run to resume; already in assist")
+		return nil
+	}
+
+	fmt.Fprintf(env.Stdout, "run:     %s\n", doc.RunID)
+	for _, iss := range doc.Issues {
+		transition := string(iss.PhaseBefore)
+		if iss.PhaseAfter != iss.PhaseBefore {
+			transition = fmt.Sprintf("%s → %s", iss.PhaseBefore, iss.PhaseAfter)
+		}
+		// A planned issue never got a GitHub number; label it by plan ID.
+		label := iss.PlanID
+		if iss.Number > 0 {
+			label = fmt.Sprintf("#%d %s", iss.Number, iss.PlanID)
+		}
+		fmt.Fprintf(env.Stdout, "%-8s %-24s %s\n", label+":", transition, iss.Reason)
+	}
+
+	switch {
+	case doc.StoppedReasonBefore == "":
+		// Nothing to report about a run that was never stopped.
+	case doc.Applied && doc.StoppedReasonAfter == "":
+		fmt.Fprintf(env.Stdout, "stopped: cleared (was %q)\n", doc.StoppedReasonBefore)
+	default:
+		fmt.Fprintf(env.Stdout, "stopped: run is stopped (%s); nothing written — re-run with --resume-stopped-run\n", doc.StoppedReasonBefore)
+	}
+
+	if !doc.Applied && doc.StoppedReasonBefore == "" {
+		fmt.Fprintln(env.Stdout, "note:    dry run; nothing written")
+	}
+	for _, w := range doc.Warnings {
+		fmt.Fprintf(env.Stdout, "warning: %s\n", w)
+	}
+	return nil
+}

--- a/internal/cli/resume_test.go
+++ b/internal/cli/resume_test.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// TestResumeUnknownFlag proves an unrecognized flag is a usage mistake
+// (exit 2) naming the usage line, not an operational failure.
+func TestResumeUnknownFlag(t *testing.T) {
+	env, _, stderr := testEnv(t)
+	if code := Run([]string{"resume", "--bogus"}, env); code != ExitUsage {
+		t.Fatalf("exit = %d, want %d", code, ExitUsage)
+	}
+	if !strings.Contains(stderr.String(), "usage: orch resume") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+// TestResumeJSON proves `--json` emits the schema-versioned report.
+func TestResumeJSON(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	if _, err := state.EnterDelivery(env.RepoRoot, "claude", testPlanRef(), testIssues()); err != nil {
+		t.Fatal(err)
+	}
+	if code := Run([]string{"resume", "--json"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d", code, ExitOK)
+	}
+	out := stdout.String()
+	for _, want := range []string{`"schema_version": 1`, `"mode": "delivery"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("json output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestResumeHumanRender proves the default rendering names the run and
+// each issue line.
+func TestResumeHumanRender(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	st, err := state.EnterDelivery(env.RepoRoot, "claude", testPlanRef(), testIssues())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code := Run([]string{"resume"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d", code, ExitOK)
+	}
+	out := stdout.String()
+	for _, want := range []string{"run:", st.Run.ID, "iss-a"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestResumeImplemented is the regression guard: resume is a real command
+// now, never the "not implemented" stub.
+func TestResumeImplemented(t *testing.T) {
+	env, stdout, stderr := testEnv(t)
+	if code := Run([]string{"resume"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr %q)", code, ExitOK, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "not implemented") || strings.Contains(stderr.String(), "not implemented") {
+		t.Errorf("resume still reports not implemented:\nstdout %q\nstderr %q", stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "no delivery run to resume") {
+		t.Errorf("assist resume output = %q", stdout.String())
+	}
+}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 )
 
-// TestEightCommandsRejectTrailingArgs proves noArgs still rejects a
-// trailing argument for every PRD §22 command except the adapter-
-// plumbing `run` verb, which parses its own argv.
-func TestEightCommandsRejectTrailingArgs(t *testing.T) {
-	for _, name := range []string{"init", "status", "doctor", "configure", "configure-local", "resume", "abort", "metrics"} {
+// TestNoArgCommandsRejectTrailingArgs proves noArgs still rejects a
+// trailing argument for every PRD §22 command except the ones that parse
+// their own argv: the adapter-plumbing `run` verb and `resume` (which
+// takes flags).
+func TestNoArgCommandsRejectTrailingArgs(t *testing.T) {
+	for _, name := range []string{"init", "status", "doctor", "configure", "configure-local", "abort", "metrics"} {
 		t.Run(name, func(t *testing.T) {
 			env, _, stderr := testEnv(t)
 			if code := Run([]string{name, "extra"}, env); code != ExitUsage {

--- a/internal/run/activate.go
+++ b/internal/run/activate.go
@@ -96,12 +96,12 @@ func DecodeActivation(data []byte) (*ActivationRequest, error) {
 // wrapAfterEnter marks an error that occurred after state.EnterDelivery
 // succeeded: state and the Delivery lock are held, so the remediation
 // is `orch abort` (safe — it never touches branches, issues, or
-// worktrees) or a future `orch resume`, never a bare retry.
+// worktrees) or `orch resume`, never a bare retry.
 func wrapAfterEnter(err error) error {
 	if err == nil {
 		return nil
 	}
-	return fmt.Errorf("%w (state and the delivery lock are preserved; run `orch abort` to return to assist, or a future `orch resume` to continue)", err)
+	return fmt.Errorf("%w (state and the delivery lock are preserved; run `orch abort` to return to assist, or `orch resume` to continue)", err)
 }
 
 // Activate validates a plan and its approval, runs the read-only

--- a/internal/run/errors.go
+++ b/internal/run/errors.go
@@ -37,7 +37,7 @@ var (
 	ErrConfigDrift = errors.New("configuration changed mid-run")
 	// ErrRunStopped reports that the run was stopped by a secret block
 	// (PRD §16); every mutating verb but block itself is denied until
-	// `orch abort` or a future `orch resume`.
+	// `orch abort` or `orch resume`.
 	ErrRunStopped = errors.New("delivery run is stopped")
 	// ErrUnknownIssue reports an issue_number that matches no run issue.
 	ErrUnknownIssue = errors.New("issue number does not match any run issue")

--- a/internal/run/lifecycle.go
+++ b/internal/run/lifecycle.go
@@ -122,7 +122,7 @@ func loadVerb(env Env, issueNumber int, allowed []state.Phase, exemptStop bool) 
 		return nil, fmt.Errorf("%w: config revision %q does not match the run's %q; run `orch abort`, ship the config change on its own Delivery run, then re-plan", ErrConfigDrift, cfg.ConfigRevision, st.Run.Plan.ConfigRevision)
 	}
 	if !exemptStop && st.Run.StoppedReason != "" {
-		return nil, fmt.Errorf("%w (%s); run `orch abort` to return to assist, or a future `orch resume` to continue", ErrRunStopped, st.Run.StoppedReason)
+		return nil, fmt.Errorf("%w (%s); run `orch abort` to return to assist, or `orch resume` to continue", ErrRunStopped, st.Run.StoppedReason)
 	}
 
 	c := &verbCtx{env: env, cfg: cfg, st: st, owner: owner, idx: -1}
@@ -194,7 +194,7 @@ func decodeRequest(data []byte, v any) error {
 
 // wrapAfterMutation marks an error that occurred after a lifecycle verb
 // already advanced persisted state or a GitHub/git surface: the run is
-// mid-step, so the remediation is `orch abort` or a future `orch resume`
+// mid-step, so the remediation is `orch abort` or `orch resume`
 // (the verb re-runs cleanly from the last completed sub-step), never a
 // bare retry. It mirrors activation's wrapAfterEnter for the per-issue
 // verbs.
@@ -202,7 +202,7 @@ func wrapAfterMutation(err error) error {
 	if err == nil {
 		return nil
 	}
-	return fmt.Errorf("%w (state advanced; run `orch abort` to return to assist, or a future `orch resume` to continue from the last completed step)", err)
+	return fmt.Errorf("%w (state advanced; run `orch abort` to return to assist, or `orch resume` to continue from the last completed step)", err)
 }
 
 // openGitHub opens the authenticated gh handle every verb that touches

--- a/internal/run/propen.go
+++ b/internal/run/propen.go
@@ -97,7 +97,7 @@ func PROpen(ctx context.Context, env Env, reqJSON []byte) (*PROpenResult, error)
 		return nil, err
 	}
 	if existing != nil {
-		return nil, fmt.Errorf("%w: PR #%d for branch %s; run `orch abort` or a future `orch resume` to adopt it", ErrPRExists, existing.Number, issue.Branch)
+		return nil, fmt.Errorf("%w: PR #%d for branch %s; run `orch abort` or `orch resume` to adopt it", ErrPRExists, existing.Number, issue.Branch)
 	}
 
 	// Push the branch, then record the verifications on the issue body

--- a/internal/run/resume.go
+++ b/internal/run/resume.go
@@ -1,0 +1,913 @@
+// resume.go reconciles an interrupted Delivery run against GitHub and
+// git, then advances, adopts, blocks, or unblocks each issue by state
+// alone (PRD §23). It is the recovery path a crashed lifecycle verb, an
+// out-of-band GitHub action, or a secret-stopped run returns through.
+//
+// Three strictly separated stages keep the decision auditable and the
+// failure semantics pure:
+//
+//   - observe: every gh/git read is batched up front (one ListWorktrees
+//     call total; per-issue reads scoped by phase). Any transport error
+//     aborts before a single write.
+//   - classify: reconcileIssue is a pure function over the observations —
+//     the whole decision table lives there, with no I/O.
+//   - apply: outcomes mutate a deep working copy, persisted with ONE
+//     state.Save at the end (skipped entirely when nothing changed, so a
+//     converged resume is a byte-level no-op).
+//
+// Resume performs zero external mutations: it never pushes, merges,
+// closes, or edits labels or bodies. It only rewrites state.json to match
+// what GitHub already proves. Labels self-heal when the next lifecycle
+// verb runs.
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/gitops"
+	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// ResumeSchemaVersion is the resume-document schema this build emits.
+const ResumeSchemaVersion = 1
+
+// ResumeStoppedRunStatement is the exact statement that authorizes resume
+// to clear a secret-stopped run's StoppedReason. A stopped run is fully
+// observed, classified, and reported without it, but nothing is written.
+const ResumeStoppedRunStatement = "resume-stopped-run"
+
+// ResumeRequest is built by the CLI from flags; it never crosses a
+// process boundary, so it carries no schema_version and is never JSON
+// decoded.
+type ResumeRequest struct {
+	// Statement must be "" or ResumeStoppedRunStatement.
+	Statement string
+	// DryRun observes, classifies, and reports without writing.
+	DryRun bool
+}
+
+// ResumeAction names what resume did to one issue.
+type ResumeAction string
+
+const (
+	// ActionKept leaves the issue's phase unchanged.
+	ActionKept ResumeAction = "kept"
+	// ActionAdvanced moves an issue forward across a crash window GitHub
+	// proves complete (activation's AddWorktree→Save gap).
+	ActionAdvanced ResumeAction = "advanced"
+	// ActionAdoptedPR adopts an orphan PR a crashed pr-open left, moving
+	// the issue to pr-open.
+	ActionAdoptedPR ResumeAction = "adopted-pr"
+	// ActionDemoted returns an awaiting-merge issue to in-review after its
+	// PR head moved past the recorded approval.
+	ActionDemoted ResumeAction = "demoted"
+	// ActionBlocked routes an issue to the blocked phase for human action.
+	ActionBlocked ResumeAction = "blocked"
+	// ActionUnblocked recovers a blocked issue to a re-derived phase.
+	ActionUnblocked ResumeAction = "unblocked"
+)
+
+// ResumeObserved records the GitHub/git facts resume read for one issue.
+// Pointer fields are nil when the fact was not checked for that phase, so
+// the report never conflates "absent" with "not observed".
+type ResumeObserved struct {
+	IssueState   string `json:"issue_state,omitempty"` // OPEN/CLOSED
+	PRNumber     int    `json:"pr_number,omitempty"`
+	PRState      string `json:"pr_state,omitempty"` // OPEN/CLOSED/MERGED
+	PRHeadOID    string `json:"pr_head_oid,omitempty"`
+	CIState      string `json:"ci_state,omitempty"`     // no-checks|pending|failing|passing
+	LocalBranch  *bool  `json:"local_branch,omitempty"` // nil = not checked
+	Worktree     *bool  `json:"worktree,omitempty"`
+	RemoteBranch *bool  `json:"remote_branch,omitempty"`
+	ManifestOK   *bool  `json:"manifest_ok,omitempty"`
+}
+
+// IssueResume is the per-issue line of the resume report.
+type IssueResume struct {
+	PlanID      string         `json:"plan_id"`
+	Number      int            `json:"number,omitempty"`
+	Title       string         `json:"title"`
+	PhaseBefore state.Phase    `json:"phase_before"`
+	PhaseAfter  state.Phase    `json:"phase_after"`
+	Action      ResumeAction   `json:"action"`
+	Reason      string         `json:"reason,omitempty"`
+	Observed    ResumeObserved `json:"observed"`
+}
+
+// ResumeDoc is the report resume returns and the CLI renders. Applied is
+// false whenever resume declined to write: on a dry run, or on a stopped
+// run reached without the statement.
+type ResumeDoc struct {
+	SchemaVersion       int           `json:"schema_version"`
+	Mode                state.Mode    `json:"mode"`
+	RunID               string        `json:"run_id,omitempty"`
+	DryRun              bool          `json:"dry_run"`
+	Applied             bool          `json:"applied"`
+	StoppedReasonBefore string        `json:"stopped_reason_before,omitempty"`
+	StoppedReasonAfter  string        `json:"stopped_reason_after,omitempty"`
+	Issues              []IssueResume `json:"issues,omitempty"`
+	Warnings            []string      `json:"warnings,omitempty"`
+}
+
+// issueObservations is one issue's observed GitHub/git facts, the pure
+// input reconcileIssue classifies. read is false for the phases that make
+// zero API calls (planned, cleaned, abandoned).
+type issueObservations struct {
+	read          bool
+	issueState    string    // "" when the issue was not read
+	manifestOK    *bool     // nil when the manifest was not parsed
+	manifestErr   error     // set when manifestOK points to false
+	verifications int       // verification count in the audit record
+	pr            *ghops.PR // issue.PRNumber read (pr-open onward)
+	prForBranch   *ghops.PR // open PR for the branch (worktree-ready/dispatched)
+	ciRead        bool
+	ci            ghops.CIState
+	localBranch   *bool
+	worktree      *bool
+	remoteBranch  *bool
+}
+
+// outcome is reconcileIssue's verdict for one issue: the resulting action
+// and phase, a human reason, and the field mutations apply performs.
+type outcome struct {
+	action        ResumeAction
+	phase         state.Phase
+	reason        string
+	adoptPRNumber int
+	adoptPRURL    string
+	adoptBranch   string
+	adoptWorktree string
+	// clearApproval drops ApprovedHeadOID and LastReviewVerdict (demotion).
+	clearApproval bool
+	// warnings are run-level notices appended to ResumeDoc.Warnings.
+	warnings []string
+}
+
+// resumeCtx is the loaded, validated context resume reconciles from.
+type resumeCtx struct {
+	env   Env
+	cfg   *config.Config
+	st    *state.State
+	owner *lockfile.Owner
+}
+
+// Resume reconciles the active Delivery run against GitHub and continues
+// it. It never mutates GitHub or git; the only write is state.json, and
+// only when reality and state actually disagree.
+func Resume(ctx context.Context, env Env, req ResumeRequest) (*ResumeDoc, error) {
+	if req.Statement != "" && req.Statement != ResumeStoppedRunStatement {
+		return nil, fmt.Errorf("%w: statement %q is not recognized; the only statement resume accepts is %q", ErrBadRequest, req.Statement, ResumeStoppedRunStatement)
+	}
+
+	rc, err := resumeLoad(env)
+	if err != nil {
+		return nil, err
+	}
+	if rc == nil {
+		// Assist with no lock: nothing to resume, mirroring abort's
+		// idempotence (PRD §14).
+		return &ResumeDoc{SchemaVersion: ResumeSchemaVersion, Mode: state.ModeAssist, DryRun: req.DryRun}, nil
+	}
+
+	issues := rc.st.Run.Issues
+
+	// observe: open gh/git once (only when at least one issue needs a
+	// read), then batch every read before classifying.
+	observations := make([]issueObservations, len(issues))
+	if anyObserves(issues) {
+		gh, err := openGitHub(ctx, env)
+		if err != nil {
+			return nil, err
+		}
+		git, err := gitops.Open(ctx, env.Runner, env.RepoRoot)
+		if err != nil {
+			return nil, err
+		}
+		worktrees, err := git.ListWorktrees(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for i := range issues {
+			if !phaseObserves(effectiveObsPhase(issues[i])) {
+				continue
+			}
+			obs, err := observeIssue(ctx, gh, git, worktrees, issues[i])
+			if err != nil {
+				return nil, err
+			}
+			observations[i] = obs
+		}
+	}
+
+	// classify: pure, no I/O.
+	outcomes := make([]outcome, len(issues))
+	for i := range issues {
+		outcomes[i] = reconcileIssue(issues[i], observations[i])
+	}
+
+	// Build the report from the pre-resume issues and the outcomes; the
+	// working copy is only needed to persist.
+	doc := &ResumeDoc{
+		SchemaVersion:       ResumeSchemaVersion,
+		Mode:                rc.st.Mode,
+		RunID:               rc.st.Run.ID,
+		DryRun:              req.DryRun,
+		StoppedReasonBefore: rc.st.Run.StoppedReason,
+		StoppedReasonAfter:  rc.st.Run.StoppedReason,
+	}
+	for i := range issues {
+		doc.Issues = append(doc.Issues, IssueResume{
+			PlanID:      issues[i].PlanID,
+			Number:      issues[i].Number,
+			Title:       issues[i].Title,
+			PhaseBefore: issues[i].Phase,
+			PhaseAfter:  outcomes[i].phase,
+			Action:      outcomes[i].action,
+			Reason:      outcomes[i].reason,
+			Observed:    buildObserved(observations[i]),
+		})
+		doc.Warnings = append(doc.Warnings, outcomes[i].warnings...)
+	}
+	if allCleaned(issues) {
+		doc.Warnings = append(doc.Warnings, "every issue is cleaned; run `orch run complete` to return to assist")
+	}
+
+	// apply: a stopped run without the statement, or any dry run, is
+	// observed and reported but never written.
+	authorized := !req.DryRun && (rc.st.Run.StoppedReason == "" || req.Statement == ResumeStoppedRunStatement)
+	doc.Applied = authorized
+	if !authorized {
+		return doc, nil
+	}
+
+	work, err := cloneState(rc.st)
+	if err != nil {
+		return nil, err
+	}
+	changed := false
+	for i := range outcomes {
+		if applyOutcome(&work.Run.Issues[i], outcomes[i]) {
+			changed = true
+		}
+	}
+	if work.Run.StoppedReason != "" && req.Statement == ResumeStoppedRunStatement {
+		work.Run.StoppedReason = ""
+		doc.StoppedReasonAfter = ""
+		changed = true
+	}
+	if changed {
+		if err := state.Save(env.RepoRoot, work); err != nil {
+			return nil, err
+		}
+	}
+	return doc, nil
+}
+
+// resumeLoad runs resume's preconditions, mirroring loadVerb but
+// resume-specific: it fails closed on any inconsistency (that is abort's
+// territory), returns a nil ctx with a nil error for the assist +
+// no-lock idempotent no-op, and — unlike loadVerb — applies NO stopped-run
+// gate and NO per-issue phase gate, because resume must run on stopped and
+// blocked runs.
+func resumeLoad(env Env) (*resumeCtx, error) {
+	st, err := state.Load(env.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+	owner, err := lockfile.Inspect(env.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+	if err := state.CheckConsistent(st, owner); err != nil {
+		return nil, err
+	}
+	if st.Mode != state.ModeDelivery {
+		// CheckConsistent passed, so assist implies no lock: nothing to
+		// resume.
+		return nil, nil
+	}
+	cfg, err := config.Load(env.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.ConfigRevision != st.Run.Plan.ConfigRevision {
+		return nil, fmt.Errorf("%w: config revision %q does not match the run's %q; run `orch abort`, ship the config change on its own Delivery run, then re-plan", ErrConfigDrift, cfg.ConfigRevision, st.Run.Plan.ConfigRevision)
+	}
+	return &resumeCtx{env: env, cfg: cfg, st: st, owner: owner}, nil
+}
+
+// cloneState returns a deep copy of st via its own persistence encoding,
+// so apply mutates a working copy and the loaded state stays intact until
+// the single terminal Save.
+func cloneState(st *state.State) (*state.State, error) {
+	data, err := json.Marshal(st)
+	if err != nil {
+		return nil, fmt.Errorf("clone state: %w", err)
+	}
+	var cp state.State
+	if err := json.Unmarshal(data, &cp); err != nil {
+		return nil, fmt.Errorf("clone state: %w", err)
+	}
+	return &cp, nil
+}
+
+// applyOutcome mutates one issue with o and reports whether anything
+// changed, so a converged resume can skip Save entirely. Only the fields
+// resume ever rewrites are compared.
+func applyOutcome(iss *state.Issue, o outcome) bool {
+	changed := false
+	if iss.Phase != o.phase {
+		iss.Phase = o.phase
+		changed = true
+	}
+	if o.adoptBranch != "" && iss.Branch != o.adoptBranch {
+		iss.Branch = o.adoptBranch
+		changed = true
+	}
+	if o.adoptWorktree != "" && iss.Worktree != o.adoptWorktree {
+		iss.Worktree = o.adoptWorktree
+		changed = true
+	}
+	if o.adoptPRNumber != 0 && iss.PRNumber != o.adoptPRNumber {
+		iss.PRNumber = o.adoptPRNumber
+		iss.PRURL = o.adoptPRURL
+		changed = true
+	}
+	if o.clearApproval && (iss.ApprovedHeadOID != "" || iss.LastReviewVerdict != "") {
+		iss.ApprovedHeadOID = ""
+		iss.LastReviewVerdict = ""
+		changed = true
+	}
+	// A blocked outcome records its reason; every other outcome clears any
+	// stale BlockedReason so an unblocked issue leaves the phase cleanly.
+	reason := ""
+	if o.action == ActionBlocked {
+		reason = o.reason
+	}
+	if iss.BlockedReason != reason {
+		iss.BlockedReason = reason
+		changed = true
+	}
+	return changed
+}
+
+// --- classify (pure) ---
+
+// reconcileIssue is the pure classifier: it maps one issue and its
+// observations onto an outcome via the reconciliation table. A blocked
+// issue re-derives an effective phase first (row 30); every emitted
+// blocked outcome is guarded so it can only land on an issue that
+// satisfies validateIssues (R1).
+func reconcileIssue(iss state.Issue, obs issueObservations) outcome {
+	var o outcome
+	if iss.Phase == state.PhaseBlocked {
+		o = rederive(iss, obs)
+	} else {
+		o = reconcileCore(iss, obs)
+	}
+	if o.action == ActionBlocked && !canBlock(iss) {
+		// R1: planned and issue-created issues (and any issue missing the
+		// fields a blocked phase requires) can never be blocked — fall back
+		// to keep plus a run-level warning.
+		return outcome{
+			action: ActionKept, phase: iss.Phase,
+			reason:   "kept; classification wanted to block but the issue lacks the number, branch, worktree, or routing decision a blocked phase requires",
+			warnings: []string{fmt.Sprintf("issue %s (%s) could not be blocked (missing number, branch, worktree, or routing decision); run `orch abort`", iss.PlanID, iss.Phase)},
+		}
+	}
+	return o
+}
+
+// rederive recovers a blocked issue: it hypothesizes an effective phase
+// from the populated fields (row 30), reconciles against that phase, and
+// — when the result is not itself blocked — applies it with BlockedReason
+// cleared. A dispatched-keep hypothesis drops to worktree-ready, the
+// deliberate lower bound (re-running dispatch is proven safe and restores
+// the staleness-closing fast-forward before pr-open).
+func rederive(iss state.Issue, obs issueObservations) outcome {
+	hyp := derivedPhase(iss)
+	syn := iss
+	syn.Phase = hyp
+	core := reconcileCore(syn, obs)
+	if hyp == state.PhaseDispatched && core.action == ActionKept {
+		core.phase = state.PhaseWorktreeReady
+		core.reason = "worktree-ready; no PR found — re-run `orch run dispatch` to continue"
+	}
+	if core.action == ActionBlocked {
+		// Stays blocked, but with a freshly derived reason.
+		return outcome{action: ActionBlocked, phase: state.PhaseBlocked, reason: core.reason}
+	}
+	act := ActionUnblocked
+	if core.action == ActionAdoptedPR {
+		act = ActionAdoptedPR
+	}
+	return outcome{
+		action: act, phase: core.phase, reason: core.reason,
+		adoptPRNumber: core.adoptPRNumber, adoptPRURL: core.adoptPRURL,
+		adoptBranch: core.adoptBranch, adoptWorktree: core.adoptWorktree,
+		clearApproval: core.clearApproval, warnings: core.warnings,
+	}
+}
+
+// derivedPhase is the effective phase a blocked issue is observed and
+// reconciled as, from its populated fields (row 30 re-derivation). The
+// no-PR case maps to dispatched so observation reads PRForBranch and the
+// row 12 adopt path stays reachable; rederive then lowers a plain
+// dispatched keep to worktree-ready.
+func derivedPhase(iss state.Issue) state.Phase {
+	switch {
+	case iss.ApprovedHeadOID != "":
+		return state.PhaseAwaitingMerge
+	case iss.PRNumber > 0:
+		if iss.LastReviewVerdict != "" || iss.ReviewCycles > 0 {
+			return state.PhaseInReview
+		}
+		return state.PhasePROpen
+	default:
+		return state.PhaseDispatched
+	}
+}
+
+// reconcileCore runs the reconciliation table for a non-blocked phase.
+func reconcileCore(iss state.Issue, obs issueObservations) outcome {
+	switch iss.Phase {
+	case state.PhasePlanned:
+		// Row 1: activation never created the issue; resume cannot.
+		return outcome{
+			action: ActionKept, phase: state.PhasePlanned,
+			reason:   "kept; still planned",
+			warnings: []string{fmt.Sprintf("activation did not complete for plan issue %s; resume cannot create issues — run `orch abort` and re-activate", iss.PlanID)},
+		}
+	case state.PhaseIssueCreated:
+		return reconcileIssueCreated(iss, obs)
+	case state.PhaseWorktreeReady:
+		return reconcileWorktreeReady(iss, obs)
+	case state.PhaseDispatched:
+		return reconcileDispatched(iss, obs)
+	case state.PhasePROpen, state.PhaseInReview:
+		return reconcilePROpen(iss, obs)
+	case state.PhaseAwaitingMerge:
+		return reconcileAwaitingMerge(iss, obs)
+	case state.PhaseMerged:
+		return reconcileMerged(iss, obs)
+	case state.PhaseCleaned, state.PhaseAbandoned:
+		// Row 29: terminal, nothing read, nothing to do.
+		return outcome{action: ActionKept, phase: iss.Phase, reason: "kept; terminal phase"}
+	default:
+		return outcome{action: ActionKept, phase: iss.Phase, reason: "kept"}
+	}
+}
+
+// reconcileIssueCreated handles rows 2-4.
+func reconcileIssueCreated(iss state.Issue, obs issueObservations) outcome {
+	if obs.issueState == "CLOSED" || manifestBad(obs) {
+		// Row 4: a closed issue or an unusable audit record — keep (R1
+		// forbids blocking an issue-created issue) with a warning.
+		return outcome{
+			action: ActionKept, phase: state.PhaseIssueCreated,
+			reason:   "kept; issue closed or audit record unusable",
+			warnings: []string{fmt.Sprintf("issue #%d is closed outside orch or its audit record is unusable; activation did not finish — run `orch abort` and re-activate", iss.Number)},
+		}
+	}
+	br := present(obs.localBranch)
+	wt := present(obs.worktree)
+	if br && wt {
+		// Row 2: activation crashed between AddWorktree and Save; adopt the
+		// derived branch and worktree it already created.
+		return outcome{
+			action: ActionAdvanced, phase: state.PhaseWorktreeReady,
+			adoptBranch:   branchName(iss.Number, iss.Title),
+			adoptWorktree: worktreeRel(iss.Number),
+			reason:        "advanced to worktree-ready; adopted the branch and worktree activation created",
+		}
+	}
+	// Row 3: keep, naming which half exists.
+	return outcome{
+		action: ActionKept, phase: state.PhaseIssueCreated,
+		reason:   "kept; branch/worktree creation incomplete",
+		warnings: []string{fmt.Sprintf("issue #%d has %s; activation did not finish creating its branch and worktree — run `orch abort` and re-activate", iss.Number, halfExists(br, wt))},
+	}
+}
+
+// reconcileWorktreeReady handles rows 5-9.
+func reconcileWorktreeReady(iss state.Issue, obs issueObservations) outcome {
+	if o, ok := manifestBlock(iss, obs); ok {
+		return o // row 6
+	}
+	if obs.issueState == "CLOSED" {
+		return closedBlock(iss) // row 7
+	}
+	if o, ok := artifactBlock(iss, obs); ok {
+		return o // row 8
+	}
+	if obs.prForBranch != nil {
+		// Row 9: an open PR for a branch the issue never dispatched.
+		return blockOut(fmt.Sprintf("open PR #%d exists for branch %s but the issue was never dispatched (out-of-band PR)", obs.prForBranch.Number, iss.Branch))
+	}
+	// Row 5.
+	return outcome{action: ActionKept, phase: state.PhaseWorktreeReady, reason: "kept; branch and worktree present, no PR yet"}
+}
+
+// reconcileDispatched handles rows 10-13.
+func reconcileDispatched(iss state.Issue, obs issueObservations) outcome {
+	if o, ok := manifestBlock(iss, obs); ok {
+		return o // row 11 (drift)
+	}
+	if obs.issueState == "CLOSED" {
+		return closedBlock(iss) // row 11 (closed)
+	}
+	if o, ok := artifactBlock(iss, obs); ok {
+		return o // row 11 (missing)
+	}
+	if obs.prForBranch != nil {
+		if obs.verifications >= 1 {
+			// Row 12: adopt the ErrPRExists orphan. pr-open writes
+			// verifications to the issue body BEFORE CreatePR, so a genuine
+			// orphan always carries evidence.
+			return outcome{
+				action: ActionAdoptedPR, phase: state.PhasePROpen,
+				adoptPRNumber: obs.prForBranch.Number, adoptPRURL: obs.prForBranch.URL,
+				reason: fmt.Sprintf("adopted PR #%d (open PR for %s with recorded verification evidence)", obs.prForBranch.Number, iss.Branch),
+			}
+		}
+		// Row 13: an open PR with no verification evidence was not orch's.
+		return blockOut(fmt.Sprintf("open PR #%d for branch was not opened by orch (audit record carries no verification evidence)", obs.prForBranch.Number))
+	}
+	// Row 10: a pushed remote branch is a benign pr-open crash window.
+	return outcome{action: ActionKept, phase: state.PhaseDispatched, reason: "kept; awaiting pr-open (any pushed remote branch is a benign crash window)"}
+}
+
+// reconcilePROpen handles rows 14-19 for pr-open and in-review.
+func reconcilePROpen(iss state.Issue, obs issueObservations) outcome {
+	if o, ok := manifestBlock(iss, obs); ok {
+		return o // row 18
+	}
+	if o, ok := artifactBlock(iss, obs); ok {
+		return o // row 18
+	}
+	pr := obs.pr
+	if pr == nil {
+		return blockOut(fmt.Sprintf("PR #%d could not be read", iss.PRNumber))
+	}
+	switch pr.State {
+	case "MERGED":
+		// Row 15: never adopt HeadRefOid as ApprovedHeadOID (R2/R3).
+		return blockOut(fmt.Sprintf("PR #%d merged out of band; the human merge gate (merge-report + approve-merge) was bypassed", pr.Number))
+	case "CLOSED":
+		// Row 16.
+		return blockOut(fmt.Sprintf("PR #%d closed without merge outside orch; run `orch run abandon` or reopen the PR, then run `orch resume`", pr.Number))
+	case "OPEN":
+		if obs.issueState == "CLOSED" {
+			// Row 17.
+			return blockOut(fmt.Sprintf("issue #%d was closed outside orch while its PR #%d is still open", iss.Number, pr.Number))
+		}
+		// Rows 14/19: keep. CI is reported as observation only — resume
+		// never gates on CI.
+		return outcome{action: ActionKept, phase: iss.Phase, reason: fmt.Sprintf("kept; PR #%d open (CI %s)", pr.Number, obs.ci)}
+	default:
+		return blockOut(fmt.Sprintf("PR #%d reads unexpected state %q", pr.Number, pr.State))
+	}
+}
+
+// reconcileAwaitingMerge handles rows 20-26. A missing branch or worktree
+// is observation only here (row 26): cleanup already tolerates absent
+// artifacts.
+func reconcileAwaitingMerge(iss state.Issue, obs issueObservations) outcome {
+	pr := obs.pr
+	if pr == nil {
+		return blockOut(fmt.Sprintf("PR #%d could not be read", iss.PRNumber))
+	}
+	switch pr.State {
+	case "MERGED":
+		if pr.HeadRefOid == iss.ApprovedHeadOID {
+			// Row 20: merged at the approved head. A closed issue here is
+			// normal (the Closes link), not a contradiction.
+			return outcome{action: ActionKept, phase: state.PhaseAwaitingMerge, reason: fmt.Sprintf("kept; PR #%d merged — re-run `orch run merge` with the recorded approval to finish issue closure", pr.Number)}
+		}
+		// Row 21.
+		return blockOut(fmt.Sprintf("PR #%d merged at %s but approval pinned %s; the merged commit was never approved", pr.Number, pr.HeadRefOid, iss.ApprovedHeadOID))
+	case "CLOSED":
+		// Row 24.
+		return blockOut(fmt.Sprintf("PR #%d closed without merge outside orch; run `orch run abandon` or reopen the PR, then run `orch resume`", pr.Number))
+	case "OPEN":
+		if obs.issueState == "CLOSED" {
+			// Row 25.
+			return blockOut(fmt.Sprintf("issue #%d was closed outside orch before its PR #%d merged", iss.Number, pr.Number))
+		}
+		if pr.HeadRefOid == iss.ApprovedHeadOID {
+			// Row 22.
+			return outcome{action: ActionKept, phase: state.PhaseAwaitingMerge, reason: fmt.Sprintf("kept; PR #%d open at the approved head", pr.Number)}
+		}
+		// Row 23: the head moved after approval. Demote to in-review,
+		// clearing the approval and the stale verdict — the one deliberate
+		// backwards move (blocked would be a permanent trap, and a stale
+		// approve verdict is the dangerous option: merge-report pins the
+		// live head from it).
+		return outcome{
+			action: ActionDemoted, phase: state.PhaseInReview, clearApproval: true,
+			reason: fmt.Sprintf("PR #%d head moved after approval (%s → %s); cleared the approval and returned to review", pr.Number, iss.ApprovedHeadOID, pr.HeadRefOid),
+		}
+	default:
+		return blockOut(fmt.Sprintf("PR #%d reads unexpected state %q", pr.Number, pr.State))
+	}
+}
+
+// reconcileMerged handles rows 27-28. Branch/worktree presence is
+// observation only (row 26); cleanup is next and tolerates their absence.
+func reconcileMerged(iss state.Issue, obs issueObservations) outcome {
+	pr := obs.pr
+	if pr == nil {
+		return blockOut(fmt.Sprintf("PR #%d could not be read", iss.PRNumber))
+	}
+	if pr.State == "MERGED" {
+		// Row 27.
+		o := outcome{action: ActionKept, phase: state.PhaseMerged, reason: fmt.Sprintf("kept; PR #%d merged", pr.Number)}
+		if obs.issueState == "OPEN" {
+			o.warnings = []string{fmt.Sprintf("issue #%d reads merged but its GitHub issue is still open; re-run `orch run merge` to finish closure", iss.Number)}
+		}
+		return o
+	}
+	// Row 28: GitHub cannot un-merge, so state and GitHub disagree.
+	return blockOut(fmt.Sprintf("state records merged but PR #%d reads %s; state and GitHub disagree — investigate before cleanup", pr.Number, pr.State))
+}
+
+// manifestBlock returns a blocked outcome and true when the audit record
+// is drifted or malformed (rows 6/11/18).
+func manifestBlock(iss state.Issue, obs issueObservations) (outcome, bool) {
+	if manifestBad(obs) {
+		return blockOut(fmt.Sprintf("audit record on issue #%d is %s (%v); repair the managed region by hand, then run `orch resume`", iss.Number, manifestProblem(obs.manifestErr), obs.manifestErr)), true
+	}
+	return outcome{}, false
+}
+
+// artifactBlock returns a blocked outcome and true when the local branch
+// or worktree is missing (rows 8/11/18). Resume never recreates git
+// artifacts.
+func artifactBlock(iss state.Issue, obs issueObservations) (outcome, bool) {
+	if !present(obs.localBranch) || !present(obs.worktree) {
+		return blockOut(fmt.Sprintf("branch/worktree %s missing; resume never recreates git artifacts — recreate manually or run `orch abort`", iss.Branch)), true
+	}
+	return outcome{}, false
+}
+
+// closedBlock is row 7/11's out-of-band issue-closure block.
+func closedBlock(iss state.Issue) outcome {
+	return blockOut(fmt.Sprintf("issue #%d was closed outside orch without an abandon statement; reopen it or run `orch run abandon`", iss.Number))
+}
+
+func blockOut(reason string) outcome {
+	return outcome{action: ActionBlocked, phase: state.PhaseBlocked, reason: reason}
+}
+
+// manifestBad reports a parsed-but-unusable audit record.
+func manifestBad(obs issueObservations) bool {
+	return obs.manifestOK != nil && !*obs.manifestOK
+}
+
+// manifestProblem names the manifest fault for the blocked reason.
+func manifestProblem(err error) string {
+	if errors.Is(err, manifest.ErrDrift) {
+		return "drifted"
+	}
+	return "malformed"
+}
+
+// present reports a checked-and-true boolean observation.
+func present(p *bool) bool { return p != nil && *p }
+
+// canBlock reports whether iss carries the fields validateIssues requires
+// of a blocked issue (R1).
+func canBlock(iss state.Issue) bool {
+	return iss.Number > 0 && iss.Branch != "" && iss.Worktree != "" && iss.Decision != nil
+}
+
+// halfExists names which of the branch/worktree pair activation created,
+// for the row 3 warning.
+func halfExists(branch, worktree bool) string {
+	switch {
+	case branch && !worktree:
+		return "its branch but no worktree"
+	case !branch && worktree:
+		return "its worktree but no branch"
+	default:
+		return "neither its branch nor its worktree"
+	}
+}
+
+// --- observe (I/O) ---
+
+// anyObserves reports whether at least one issue needs a GitHub/git read,
+// so a run made only of planned/cleaned/abandoned issues opens neither.
+func anyObserves(issues []state.Issue) bool {
+	for i := range issues {
+		if phaseObserves(effectiveObsPhase(issues[i])) {
+			return true
+		}
+	}
+	return false
+}
+
+// effectiveObsPhase is the phase an issue is observed as: a blocked issue
+// observes as its re-derived hypothesis so the right facts are read.
+func effectiveObsPhase(iss state.Issue) state.Phase {
+	if iss.Phase == state.PhaseBlocked {
+		return derivedPhase(iss)
+	}
+	return iss.Phase
+}
+
+// phaseObserves reports whether a phase makes any GitHub/git read. The
+// planned, cleaned, and abandoned phases make zero API calls.
+func phaseObserves(p state.Phase) bool {
+	switch p {
+	case state.PhasePlanned, state.PhaseCleaned, state.PhaseAbandoned:
+		return false
+	default:
+		return true
+	}
+}
+
+// observeIssue batches every read one issue's classification needs, scoped
+// by its effective phase. A transport error aborts the whole resume (R5);
+// a drifted or malformed audit record is a classification fact, not an
+// error.
+func observeIssue(ctx context.Context, gh *ghops.GH, git *gitops.Git, worktrees []gitops.Worktree, iss state.Issue) (issueObservations, error) {
+	obs := issueObservations{read: true}
+	p := effectiveObsPhase(iss)
+
+	// At issue-created the stored Branch/Worktree are not yet written, so
+	// presence is checked against the names activation derives.
+	branch := iss.Branch
+	if iss.Phase == state.PhaseIssueCreated {
+		branch = branchName(iss.Number, iss.Title)
+	}
+
+	// Every observing phase reads the issue for its OPEN/CLOSED state; the
+	// audit record is parsed only through awaiting-merge (cleanup never
+	// parses bodies, so merged skips it).
+	gi, err := gh.Issue(ctx, iss.Number)
+	if err != nil {
+		return obs, err
+	}
+	obs.issueState = gi.State
+	if parsesManifest(p) {
+		m, perr := manifest.Parse(gi.Body)
+		if perr != nil {
+			no := false
+			obs.manifestOK = &no
+			obs.manifestErr = perr
+		} else {
+			yes := true
+			obs.manifestOK = &yes
+			obs.verifications = len(m.Verifications)
+		}
+	}
+
+	if readsPRByNumber(p) {
+		pr, err := gh.PR(ctx, iss.PRNumber)
+		if err != nil {
+			return obs, err
+		}
+		obs.pr = &pr
+	}
+	if readsPRForBranch(p) {
+		pr, err := gh.PRForBranch(ctx, branch)
+		if err != nil {
+			return obs, err
+		}
+		obs.prForBranch = pr
+	}
+	if readsCI(p) {
+		ci, err := gh.RequiredCI(ctx, iss.PRNumber)
+		if err != nil {
+			return obs, err
+		}
+		obs.ciRead = true
+		obs.ci = ci.State
+	}
+
+	lb := localBranchPresent(ctx, git, branch)
+	obs.localBranch = &lb
+	wt := worktreePresent(worktrees, branch)
+	obs.worktree = &wt
+	if readsRemote(p) {
+		rb, err := git.RemoteBranchExists(ctx, "origin", branch)
+		if err != nil {
+			return obs, err
+		}
+		obs.remoteBranch = &rb
+	}
+	return obs, nil
+}
+
+// parsesManifest reports the phases whose audit record resume parses:
+// issue-created through awaiting-merge.
+func parsesManifest(p state.Phase) bool {
+	switch p {
+	case state.PhaseIssueCreated, state.PhaseWorktreeReady, state.PhaseDispatched,
+		state.PhasePROpen, state.PhaseInReview, state.PhaseAwaitingMerge:
+		return true
+	default:
+		return false
+	}
+}
+
+// readsPRByNumber reports the phases that read the issue's recorded PR.
+func readsPRByNumber(p state.Phase) bool {
+	switch p {
+	case state.PhasePROpen, state.PhaseInReview, state.PhaseAwaitingMerge, state.PhaseMerged:
+		return true
+	default:
+		return false
+	}
+}
+
+// readsPRForBranch reports the phases that probe for an orphan PR on the
+// branch (no recorded PR number yet).
+func readsPRForBranch(p state.Phase) bool {
+	return p == state.PhaseWorktreeReady || p == state.PhaseDispatched
+}
+
+// readsCI reports the phases whose CI state is reported (observation
+// only): pr-open and in-review.
+func readsCI(p state.Phase) bool {
+	return p == state.PhasePROpen || p == state.PhaseInReview
+}
+
+// readsRemote reports the phases whose remote branch presence is reported
+// (observation only), from the first push at pr-open — plus dispatched,
+// where a pushed remote is a benign pr-open crash window.
+func readsRemote(p state.Phase) bool {
+	switch p {
+	case state.PhaseDispatched, state.PhasePROpen, state.PhaseInReview,
+		state.PhaseAwaitingMerge, state.PhaseMerged:
+		return true
+	default:
+		return false
+	}
+}
+
+// localBranchPresent reports whether branch resolves locally. Conservative
+// conflation: any rev-parse failure — a missing branch or a git error —
+// reads as absent, because resume never recreates a branch, so the worst
+// case is a keep or block the human re-runs (ListWorktrees already proved
+// git works, so a real git fault would have aborted earlier).
+func localBranchPresent(ctx context.Context, git *gitops.Git, branch string) bool {
+	_, err := git.RevParse(ctx, "refs/heads/"+branch)
+	return err == nil
+}
+
+// worktreePresent reports whether a worktree is checked out on branch. A
+// worktree on a different branch reads as absent (the safe reading).
+func worktreePresent(worktrees []gitops.Worktree, branch string) bool {
+	for _, wt := range worktrees {
+		if wt.Branch == branch {
+			return true
+		}
+	}
+	return false
+}
+
+// --- report helpers ---
+
+// buildObserved renders the observations into the report's observed view.
+func buildObserved(obs issueObservations) ResumeObserved {
+	o := ResumeObserved{IssueState: obs.issueState}
+	pr := obs.pr
+	if pr == nil {
+		pr = obs.prForBranch
+	}
+	if pr != nil {
+		o.PRNumber = pr.Number
+		o.PRState = pr.State
+		o.PRHeadOID = pr.HeadRefOid
+	}
+	if obs.ciRead {
+		o.CIState = string(obs.ci)
+	}
+	o.LocalBranch = obs.localBranch
+	o.Worktree = obs.worktree
+	o.RemoteBranch = obs.remoteBranch
+	o.ManifestOK = obs.manifestOK
+	return o
+}
+
+// allCleaned reports whether every issue reached the cleaned phase.
+func allCleaned(issues []state.Issue) bool {
+	if len(issues) == 0 {
+		return false
+	}
+	for i := range issues {
+		if issues[i].Phase != state.PhaseCleaned {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/run/resume_test.go
+++ b/internal/run/resume_test.go
@@ -1,0 +1,608 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+func pbool(b bool) *bool { return &b }
+
+// blockedFrom turns an in-flight fixture into a blocked issue that keeps
+// its populated fields, so re-derivation (row 30) has something to work
+// from.
+func blockedFrom(base state.Issue) state.Issue {
+	base.Phase = state.PhaseBlocked
+	base.BlockedReason = "seed"
+	return base
+}
+
+// okManifest is the observation of a healthy audit record with n
+// verifications.
+func okManifest(n int) issueObservations {
+	return issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(true), verifications: n, localBranch: pbool(true), worktree: pbool(true)}
+}
+
+// --- Pure decision table (rows 1-30) ---
+
+func TestReconcileIssue(t *testing.T) {
+	ic := fixtureIssue("a", 1, state.PhaseIssueCreated)
+	wr := fixtureIssue("a", 1, state.PhaseWorktreeReady)
+	di := fixtureIssue("a", 1, state.PhaseDispatched)
+	po := fixtureIssue("a", 1, state.PhasePROpen)
+	ir := fixtureIssue("a", 1, state.PhaseInReview)
+	ir.LastReviewVerdict = "approve"
+	am := fixtureIssue("a", 1, state.PhaseAwaitingMerge) // ApprovedHeadOID = "head-oid"
+
+	openPR := func(head string) *ghops.PR { return &ghops.PR{Number: 10, State: "OPEN", HeadRefOid: head} }
+
+	cases := []struct {
+		name       string
+		iss        state.Issue
+		obs        issueObservations
+		wantAction ResumeAction
+		wantPhase  state.Phase
+		wantReason string
+		wantClear  bool
+		wantAdopt  int
+	}{
+		// Row 1.
+		{"planned", state.Issue{PlanID: "a", Phase: state.PhasePlanned}, issueObservations{}, ActionKept, state.PhasePlanned, "still planned", false, 0},
+		// Row 2.
+		{"issue-created advance", ic, issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(true), localBranch: pbool(true), worktree: pbool(true)}, ActionAdvanced, state.PhaseWorktreeReady, "adopted the branch", false, 0},
+		// Row 3.
+		{"issue-created half", ic, issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(true), localBranch: pbool(true), worktree: pbool(false)}, ActionKept, state.PhaseIssueCreated, "incomplete", false, 0},
+		// Row 4.
+		{"issue-created closed", ic, issueObservations{read: true, issueState: "CLOSED", manifestOK: pbool(true)}, ActionKept, state.PhaseIssueCreated, "closed", false, 0},
+		{"issue-created drift", ic, issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(false), manifestErr: manifest.ErrDrift}, ActionKept, state.PhaseIssueCreated, "unusable", false, 0},
+		// Row 5.
+		{"worktree-ready keep", wr, okManifest(0), ActionKept, state.PhaseWorktreeReady, "no PR yet", false, 0},
+		// Row 6.
+		{"worktree-ready drift", wr, issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(false), manifestErr: manifest.ErrDrift, localBranch: pbool(true), worktree: pbool(true)}, ActionBlocked, state.PhaseBlocked, "drifted", false, 0},
+		{"worktree-ready malformed", wr, issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(false), manifestErr: manifest.ErrBadManifest, localBranch: pbool(true), worktree: pbool(true)}, ActionBlocked, state.PhaseBlocked, "malformed", false, 0},
+		// Row 7.
+		{"worktree-ready closed", wr, issueObservations{read: true, issueState: "CLOSED", manifestOK: pbool(true), localBranch: pbool(true), worktree: pbool(true)}, ActionBlocked, state.PhaseBlocked, "closed outside orch", false, 0},
+		// Row 8.
+		{"worktree-ready branch missing", wr, issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(true), localBranch: pbool(false), worktree: pbool(true)}, ActionBlocked, state.PhaseBlocked, "missing", false, 0},
+		// Row 9.
+		{"worktree-ready orphan PR", wr, issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(true), localBranch: pbool(true), worktree: pbool(true), prForBranch: &ghops.PR{Number: 7}}, ActionBlocked, state.PhaseBlocked, "never dispatched", false, 0},
+		// Row 10.
+		{"dispatched keep", di, okManifest(0), ActionKept, state.PhaseDispatched, "awaiting pr-open", false, 0},
+		// Row 11.
+		{"dispatched drift", di, issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(false), manifestErr: manifest.ErrDrift, localBranch: pbool(true), worktree: pbool(true)}, ActionBlocked, state.PhaseBlocked, "drifted", false, 0},
+		// Row 12.
+		{"dispatched adopt", di, issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(true), verifications: 1, localBranch: pbool(true), worktree: pbool(true), prForBranch: &ghops.PR{Number: 34, URL: "u34"}}, ActionAdoptedPR, state.PhasePROpen, "adopted PR #34", false, 34},
+		// Row 13.
+		{"dispatched no evidence", di, issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(true), verifications: 0, localBranch: pbool(true), worktree: pbool(true), prForBranch: &ghops.PR{Number: 34}}, ActionBlocked, state.PhaseBlocked, "no verification evidence", false, 0},
+		// Row 14.
+		{"pr-open keep", po, issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(true), localBranch: pbool(true), worktree: pbool(true), pr: openPR("h"), ciRead: true, ci: ghops.CIPassing}, ActionKept, state.PhasePROpen, "PR #10 open", false, 0},
+		// Row 15.
+		{"pr-open merged oob", po, issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(true), localBranch: pbool(true), worktree: pbool(true), pr: &ghops.PR{Number: 10, State: "MERGED", HeadRefOid: "h"}}, ActionBlocked, state.PhaseBlocked, "merged out of band", false, 0},
+		// Row 16.
+		{"pr-open closed", po, issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(true), localBranch: pbool(true), worktree: pbool(true), pr: &ghops.PR{Number: 10, State: "CLOSED"}}, ActionBlocked, state.PhaseBlocked, "closed without merge", false, 0},
+		// Row 17.
+		{"pr-open issue closed", po, issueObservations{read: true, issueState: "CLOSED", manifestOK: pbool(true), localBranch: pbool(true), worktree: pbool(true), pr: openPR("h")}, ActionBlocked, state.PhaseBlocked, "closed outside orch while", false, 0},
+		// Row 18.
+		{"pr-open drift", po, issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(false), manifestErr: manifest.ErrDrift, localBranch: pbool(true), worktree: pbool(true), pr: openPR("h")}, ActionBlocked, state.PhaseBlocked, "drifted", false, 0},
+		// Row 19.
+		{"in-review approve keep", ir, issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(true), localBranch: pbool(true), worktree: pbool(true), pr: openPR("h"), ciRead: true, ci: ghops.CIPassing}, ActionKept, state.PhaseInReview, "PR #10 open", false, 0},
+		// Row 20.
+		{"awaiting merged match", am, issueObservations{read: true, issueState: "CLOSED", pr: &ghops.PR{Number: 10, State: "MERGED", HeadRefOid: "head-oid"}}, ActionKept, state.PhaseAwaitingMerge, "merged", false, 0},
+		// Row 21.
+		{"awaiting merged mismatch", am, issueObservations{read: true, issueState: "CLOSED", pr: &ghops.PR{Number: 10, State: "MERGED", HeadRefOid: "other"}}, ActionBlocked, state.PhaseBlocked, "never approved", false, 0},
+		// Row 22.
+		{"awaiting open match", am, issueObservations{read: true, issueState: "OPEN", pr: openPR("head-oid")}, ActionKept, state.PhaseAwaitingMerge, "approved head", false, 0},
+		// Row 23.
+		{"awaiting head moved", am, issueObservations{read: true, issueState: "OPEN", pr: openPR("moved")}, ActionDemoted, state.PhaseInReview, "head moved", true, 0},
+		// Row 24.
+		{"awaiting closed", am, issueObservations{read: true, issueState: "OPEN", pr: &ghops.PR{Number: 10, State: "CLOSED"}}, ActionBlocked, state.PhaseBlocked, "closed without merge", false, 0},
+		// Row 25.
+		{"awaiting issue closed", am, issueObservations{read: true, issueState: "CLOSED", pr: openPR("head-oid")}, ActionBlocked, state.PhaseBlocked, "before its PR", false, 0},
+		// Row 26 (missing artifacts ignored at awaiting-merge).
+		{"awaiting missing artifacts", am, issueObservations{read: true, issueState: "OPEN", pr: openPR("head-oid"), localBranch: pbool(false), worktree: pbool(false)}, ActionKept, state.PhaseAwaitingMerge, "approved head", false, 0},
+		// Row 27.
+		{"merged keep", fixtureIssue("a", 1, state.PhaseMerged), issueObservations{read: true, issueState: "CLOSED", pr: &ghops.PR{Number: 10, State: "MERGED"}}, ActionKept, state.PhaseMerged, "merged", false, 0},
+		// Row 28.
+		{"merged disagree", fixtureIssue("a", 1, state.PhaseMerged), issueObservations{read: true, issueState: "OPEN", pr: &ghops.PR{Number: 10, State: "OPEN"}}, ActionBlocked, state.PhaseBlocked, "disagree", false, 0},
+		// Row 29.
+		{"cleaned leave", fixtureIssue("a", 1, state.PhaseCleaned), issueObservations{}, ActionKept, state.PhaseCleaned, "terminal", false, 0},
+		{"abandoned leave", fixtureIssue("a", 1, state.PhaseAbandoned), issueObservations{}, ActionKept, state.PhaseAbandoned, "terminal", false, 0},
+
+		// Row 30 re-derivation.
+		{"blocked → awaiting keep", blockedFrom(am), issueObservations{read: true, issueState: "OPEN", pr: openPR("head-oid")}, ActionUnblocked, state.PhaseAwaitingMerge, "approved head", false, 0},
+		{"blocked → demote", blockedFrom(am), issueObservations{read: true, issueState: "OPEN", pr: openPR("moved")}, ActionUnblocked, state.PhaseInReview, "head moved", true, 0},
+		{"blocked → pr-open", blockedFrom(po), issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(true), localBranch: pbool(true), worktree: pbool(true), pr: openPR("h")}, ActionUnblocked, state.PhasePROpen, "PR #10 open", false, 0},
+		{"blocked → in-review", blockedFrom(ir), issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(true), localBranch: pbool(true), worktree: pbool(true), pr: openPR("h")}, ActionUnblocked, state.PhaseInReview, "PR #10 open", false, 0},
+		{"blocked → worktree-ready", blockedFrom(wr), okManifest(0), ActionUnblocked, state.PhaseWorktreeReady, "re-run `orch run dispatch`", false, 0},
+		{"blocked → adopt", blockedFrom(wr), issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(true), verifications: 1, localBranch: pbool(true), worktree: pbool(true), prForBranch: &ghops.PR{Number: 34, URL: "u34"}}, ActionAdoptedPR, state.PhasePROpen, "adopted PR #34", false, 34},
+		{"blocked stays blocked", blockedFrom(po), issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(true), localBranch: pbool(true), worktree: pbool(true), pr: &ghops.PR{Number: 10, State: "MERGED", HeadRefOid: "h"}}, ActionBlocked, state.PhaseBlocked, "merged out of band", false, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := reconcileIssue(tc.iss, tc.obs)
+			if o.action != tc.wantAction {
+				t.Errorf("action = %q, want %q", o.action, tc.wantAction)
+			}
+			if o.phase != tc.wantPhase {
+				t.Errorf("phase = %q, want %q", o.phase, tc.wantPhase)
+			}
+			if tc.wantReason != "" && !strings.Contains(o.reason, tc.wantReason) {
+				t.Errorf("reason = %q, want substring %q", o.reason, tc.wantReason)
+			}
+			if o.clearApproval != tc.wantClear {
+				t.Errorf("clearApproval = %v, want %v", o.clearApproval, tc.wantClear)
+			}
+			if tc.wantAdopt != 0 && o.adoptPRNumber != tc.wantAdopt {
+				t.Errorf("adoptPRNumber = %d, want %d", o.adoptPRNumber, tc.wantAdopt)
+			}
+		})
+	}
+}
+
+// TestReconcileR1Fallback proves a blocked outcome an issue cannot satisfy
+// (no routing decision) falls back to keep plus a run-level warning.
+func TestReconcileR1Fallback(t *testing.T) {
+	iss := fixtureIssue("a", 1, state.PhaseWorktreeReady)
+	iss.Decision = nil // a blocked phase requires a decision; this issue lacks one.
+	obs := issueObservations{read: true, issueState: "OPEN", manifestOK: pbool(false), manifestErr: manifest.ErrDrift, localBranch: pbool(true), worktree: pbool(true)}
+	o := reconcileIssue(iss, obs)
+	if o.action != ActionKept || o.phase != state.PhaseWorktreeReady {
+		t.Fatalf("outcome = %+v, want kept worktree-ready", o)
+	}
+	if len(o.warnings) == 0 || !strings.Contains(o.warnings[0], "could not be blocked") {
+		t.Errorf("warnings = %v, want a could-not-be-blocked notice", o.warnings)
+	}
+}
+
+// --- Observation scope ---
+
+// TestResumeZeroCallsForTerminalPhases proves a run made only of planned,
+// cleaned, and abandoned issues opens neither GitHub nor git.
+func TestResumeZeroCallsForTerminalPhases(t *testing.T) {
+	issues := []state.Issue{
+		{PlanID: "a", Phase: state.PhasePlanned},
+		fixtureIssue("b", 2, state.PhaseCleaned),
+		fixtureIssue("c", 3, state.PhaseAbandoned),
+	}
+	root := setupDeliveryRepo(t, "r1", issues)
+	script := &execxtest.Script{T: t} // empty: any gh or git call fails the test
+	env := Env{RepoRoot: root, Runner: script, Now: fixedNow}
+	doc, err := Resume(context.Background(), env, ResumeRequest{})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	script.AssertExhausted()
+	for _, iss := range doc.Issues {
+		if iss.Action != ActionKept {
+			t.Errorf("issue %s action = %q, want kept", iss.PlanID, iss.Action)
+		}
+	}
+}
+
+// TestResumeObservesPROpenScope pins the exact gh transcript resume reads
+// for a pr-open issue.
+func TestResumeObservesPROpenScope(t *testing.T) {
+	root := setupDeliveryGitRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
+	createBranchWorktree(t, root, "orch/issue-1")
+	body := baseManifestBody(t)
+	doc, script := resumeMux(t, root, ResumeRequest{},
+		ghAuth(),
+		ghIssueViewCall(t, 1, "OPEN", body),
+		ghPRViewCall(10, "OPEN", "head"),
+		ghRollupEmptyCall(10),
+	)
+	script.AssertExhausted()
+	if doc.Issues[0].Action != ActionKept {
+		t.Errorf("action = %q, want kept", doc.Issues[0].Action)
+	}
+	if doc.Issues[0].Observed.CIState != string(ghops.CINoChecks) {
+		t.Errorf("ci = %q, want no-checks", doc.Issues[0].Observed.CIState)
+	}
+}
+
+// --- Purity ---
+
+// TestResumeDryRunIsPure proves a dry run classifies a change but writes
+// nothing.
+func TestResumeDryRunIsPure(t *testing.T) {
+	root := setupDeliveryGitRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhaseAwaitingMerge)})
+	before := stateBytes(t, root)
+	body := baseManifestBody(t)
+	doc, script := resumeMux(t, root, ResumeRequest{DryRun: true},
+		ghAuth(),
+		ghIssueViewCall(t, 1, "OPEN", body),
+		ghPRViewCall(10, "OPEN", "moved-head"),
+	)
+	script.AssertExhausted()
+	if doc.Applied {
+		t.Error("dry run reported applied")
+	}
+	if doc.Issues[0].PhaseAfter != state.PhaseInReview {
+		t.Errorf("classified phase = %q, want in-review (demotion)", doc.Issues[0].PhaseAfter)
+	}
+	if string(stateBytes(t, root)) != string(before) {
+		t.Error("dry run changed state")
+	}
+}
+
+// TestResumeMidTranscriptFailureIsPure proves a gh transport error mid-
+// observation aborts before any write.
+func TestResumeMidTranscriptFailureIsPure(t *testing.T) {
+	root := setupDeliveryGitRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
+	createBranchWorktree(t, root, "orch/issue-1")
+	before := stateBytes(t, root)
+	body := baseManifestBody(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(),
+		ghIssueViewCall(t, 1, "OPEN", body),
+		{Name: "gh", Args: []string{"pr", "view", "10", "--json", prFieldsRun}, Exit: 1, Stderr: "boom"},
+	}}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+	if _, err := Resume(context.Background(), env, ResumeRequest{}); err == nil {
+		t.Fatal("Resume accepted a gh failure")
+	}
+	script.AssertExhausted()
+	if string(stateBytes(t, root)) != string(before) {
+		t.Error("state changed on an observation failure")
+	}
+}
+
+// TestResumeConvergedSkipsSave proves a converged resume is a byte-level
+// no-op (the skip-save path).
+func TestResumeConvergedSkipsSave(t *testing.T) {
+	root := setupDeliveryGitRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhaseMerged)})
+	before := stateBytes(t, root)
+	body := baseManifestBody(t)
+	doc, script := resumeMux(t, root, ResumeRequest{},
+		ghAuth(),
+		ghIssueViewCall(t, 1, "CLOSED", body),
+		ghPRViewCall(10, "MERGED", "head"),
+	)
+	script.AssertExhausted()
+	if !doc.Applied {
+		t.Error("converged resume reported not applied")
+	}
+	if doc.Issues[0].Action != ActionKept {
+		t.Errorf("action = %q, want kept", doc.Issues[0].Action)
+	}
+	if string(stateBytes(t, root)) != string(before) {
+		t.Error("converged resume rewrote state")
+	}
+}
+
+// --- Stopped runs ---
+
+func stoppedAwaitingRepo(t *testing.T) string {
+	t.Helper()
+	root := setupDeliveryGitRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhaseAwaitingMerge)})
+	st := loadRun(t, root)
+	st.Run.StoppedReason = "secret: token in diff"
+	if err := state.Save(root, st); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// TestResumeStoppedWithoutStatement proves a stopped run is fully reported
+// but never written without the statement.
+func TestResumeStoppedWithoutStatement(t *testing.T) {
+	root := stoppedAwaitingRepo(t)
+	before := stateBytes(t, root)
+	body := baseManifestBody(t)
+	doc, script := resumeMux(t, root, ResumeRequest{},
+		ghAuth(),
+		ghIssueViewCall(t, 1, "OPEN", body),
+		ghPRViewCall(10, "OPEN", "head-oid"),
+	)
+	script.AssertExhausted()
+	if doc.Applied {
+		t.Error("stopped run without the statement reported applied")
+	}
+	if doc.StoppedReasonAfter == "" {
+		t.Error("stopped reason cleared without the statement")
+	}
+	if string(stateBytes(t, root)) != string(before) {
+		t.Error("stopped run without the statement wrote state")
+	}
+}
+
+// TestResumeStoppedWithStatement proves the statement clears the stop and
+// persists.
+func TestResumeStoppedWithStatement(t *testing.T) {
+	root := stoppedAwaitingRepo(t)
+	body := baseManifestBody(t)
+	doc, script := resumeMux(t, root, ResumeRequest{Statement: ResumeStoppedRunStatement},
+		ghAuth(),
+		ghIssueViewCall(t, 1, "OPEN", body),
+		ghPRViewCall(10, "OPEN", "head-oid"),
+	)
+	script.AssertExhausted()
+	if !doc.Applied || doc.StoppedReasonAfter != "" {
+		t.Fatalf("doc = %+v, want applied with the stop cleared", doc)
+	}
+	if st := loadRun(t, root); st.Run.StoppedReason != "" {
+		t.Error("stop not cleared on disk")
+	}
+}
+
+// TestResumeBadStatement proves any statement but the exact one is
+// ErrBadRequest, before any read.
+func TestResumeBadStatement(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhaseAwaitingMerge)})
+	script := &execxtest.Script{T: t}
+	env := Env{RepoRoot: root, Runner: script, Now: fixedNow}
+	_, err := Resume(context.Background(), env, ResumeRequest{Statement: "nope"})
+	if !errors.Is(err, ErrBadRequest) {
+		t.Fatalf("err = %v, want ErrBadRequest", err)
+	}
+	script.AssertExhausted()
+}
+
+// TestResumeStatementOnNonStoppedRun proves the statement is a reported
+// no-op on a run that was never stopped.
+func TestResumeStatementOnNonStoppedRun(t *testing.T) {
+	root := setupDeliveryGitRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhaseAwaitingMerge)})
+	body := baseManifestBody(t)
+	doc, script := resumeMux(t, root, ResumeRequest{Statement: ResumeStoppedRunStatement},
+		ghAuth(),
+		ghIssueViewCall(t, 1, "OPEN", body),
+		ghPRViewCall(10, "OPEN", "head-oid"),
+	)
+	script.AssertExhausted()
+	if !doc.Applied || doc.StoppedReasonBefore != "" || doc.StoppedReasonAfter != "" {
+		t.Errorf("doc = %+v, want applied no-op with no stop", doc)
+	}
+}
+
+// --- Fail-closed preconditions ---
+
+func TestResumeConfigDrift(t *testing.T) {
+	root := setupDeliveryRepo(t, "r-different", []state.Issue{fixtureIssue("a", 1, state.PhaseDispatched)})
+	script := &execxtest.Script{T: t}
+	env := Env{RepoRoot: root, Runner: script, Now: fixedNow}
+	_, err := Resume(context.Background(), env, ResumeRequest{})
+	if !errors.Is(err, ErrConfigDrift) {
+		t.Fatalf("err = %v, want ErrConfigDrift", err)
+	}
+	script.AssertExhausted() // fail closed before opening GitHub
+}
+
+func TestResumeOrphanedLockFailsClosed(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhaseDispatched)})
+	if err := lockfile.Release(root); err != nil {
+		t.Fatal(err)
+	}
+	script := &execxtest.Script{T: t}
+	env := Env{RepoRoot: root, Runner: script, Now: fixedNow}
+	if _, err := Resume(context.Background(), env, ResumeRequest{}); err == nil {
+		t.Fatal("Resume accepted a delivery state with no lock")
+	}
+	script.AssertExhausted()
+}
+
+func TestResumeAssistNoLock(t *testing.T) {
+	root := setupRepo(t, testConfigTOML)
+	script := &execxtest.Script{T: t}
+	env := Env{RepoRoot: root, Runner: script, Now: fixedNow}
+	doc, err := Resume(context.Background(), env, ResumeRequest{})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	script.AssertExhausted()
+	if doc.Mode != state.ModeAssist || doc.Applied {
+		t.Errorf("doc = %+v, want an assist no-op", doc)
+	}
+}
+
+// --- Safe at every phase ---
+
+// TestResumeSafeAtEveryPhase drives a reality-consistent resume for each
+// phase and proves the saved state loads back cleanly.
+func TestResumeSafeAtEveryPhase(t *testing.T) {
+	body := baseManifestBody(t)
+	phases := []state.Phase{
+		state.PhasePlanned, state.PhaseIssueCreated, state.PhaseWorktreeReady,
+		state.PhaseDispatched, state.PhasePROpen, state.PhaseInReview,
+		state.PhaseAwaitingMerge, state.PhaseMerged, state.PhaseAbandoned,
+		state.PhaseCleaned, state.PhaseBlocked,
+	}
+	for _, ph := range phases {
+		t.Run(string(ph), func(t *testing.T) {
+			iss := fixtureIssue("a", 1, ph)
+			if ph == state.PhasePlanned {
+				iss = state.Issue{PlanID: "a", Phase: state.PhasePlanned}
+			}
+			root := setupDeliveryGitRepo(t, "r1", []state.Issue{iss})
+
+			var calls []execxtest.Call
+			switch ph {
+			case state.PhasePlanned, state.PhaseAbandoned, state.PhaseCleaned:
+				// No reads.
+			case state.PhaseIssueCreated:
+				calls = []execxtest.Call{ghAuth(), ghIssueViewCall(t, 1, "OPEN", body)}
+			case state.PhaseWorktreeReady:
+				createBranchWorktree(t, root, "orch/issue-1")
+				calls = []execxtest.Call{ghAuth(), ghIssueViewCall(t, 1, "OPEN", body), ghPRListEmptyCall("orch/issue-1")}
+			case state.PhaseDispatched, state.PhaseBlocked:
+				createBranchWorktree(t, root, "orch/issue-1")
+				calls = []execxtest.Call{ghAuth(), ghIssueViewCall(t, 1, "OPEN", body), ghPRListEmptyCall("orch/issue-1")}
+			case state.PhasePROpen, state.PhaseInReview:
+				createBranchWorktree(t, root, "orch/issue-1")
+				calls = []execxtest.Call{ghAuth(), ghIssueViewCall(t, 1, "OPEN", body), ghPRViewCall(10, "OPEN", "head"), ghRollupEmptyCall(10)}
+			case state.PhaseAwaitingMerge:
+				calls = []execxtest.Call{ghAuth(), ghIssueViewCall(t, 1, "OPEN", body), ghPRViewCall(10, "OPEN", "head-oid")}
+			case state.PhaseMerged:
+				calls = []execxtest.Call{ghAuth(), ghIssueViewCall(t, 1, "CLOSED", body), ghPRViewCall(10, "MERGED", "head-oid")}
+			}
+
+			doc, script := resumeMux(t, root, ResumeRequest{}, calls...)
+			script.AssertExhausted()
+			if !doc.Applied {
+				t.Error("resume did not apply")
+			}
+			// The saved state must load (and therefore validate) cleanly.
+			if _, err := state.Load(root); err != nil {
+				t.Fatalf("state does not load after resume at %s: %v", ph, err)
+			}
+			if ph == state.PhaseBlocked && doc.Issues[0].PhaseAfter != state.PhaseWorktreeReady {
+				t.Errorf("blocked re-derived to %s, want worktree-ready", doc.Issues[0].PhaseAfter)
+			}
+		})
+	}
+}
+
+// --- Integration: adopt an orphan PR left by a crashed pr-open ---
+
+// TestResumeAdoptsOrphanPR simulates a pr-open that created the PR but
+// crashed before Save, then proves resume adopts the orphan and advances
+// the issue to pr-open.
+func TestResumeAdoptsOrphanPR(t *testing.T) {
+	root := newLifecycleRepo(t)
+	body := baseManifestBody(t)
+	const branch = "orch/issue-1-fix-the-status-lock-race"
+	const title = "Fix the status lock race"
+
+	activateCalls := append(fullTaxonomyScript(), ghIssueCreateCall(title, []string{"ready", "bug", "implementer", "standard"}, 1))
+	script := &execxtest.Script{T: t, Calls: activateCalls}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+	if _, err := Activate(context.Background(), env, activationJSON(t, validPlanJSON())); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	script.AssertExhausted()
+
+	runVerb(t, root, Dispatch, `{"schema_version":1,"issue_number":1}`,
+		ghAuth(), ghRepoViewCall("main"), ghSetStatusCall(1, ghops.StatusInProgress))
+
+	wtDir := filepath.Join(root, ".orchestrator", "worktrees", "issue-1")
+	writeWork(t, wtDir)
+
+	// A real pr-open opens PR #10 and pushes the branch.
+	runVerb(t, root, PROpen, `{"schema_version":1,"issue_number":1,"verifications":[{"name":"go test","result":"pass"}]}`,
+		ghAuth(), ghRepoViewCall("main"), ghPRListEmptyCall(branch),
+		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1),
+		ghCreatePRCall(branch, title, 10), ghSetStatusCall(1, ghops.StatusAwaitingReview))
+	wantPhase(t, root, 1, state.PhasePROpen)
+
+	// Simulate the crash window: the PR exists on GitHub, but state was
+	// never advanced past dispatched.
+	st := loadRun(t, root)
+	st.Run.Issues[0].Phase = state.PhaseDispatched
+	st.Run.Issues[0].PRNumber = 0
+	st.Run.Issues[0].PRURL = ""
+	if err := state.Save(root, st); err != nil {
+		t.Fatal(err)
+	}
+
+	// Resume observes the orphan PR (with recorded verification evidence)
+	// and adopts it.
+	orphanBody := manifestBodyWithVerification(t)
+	doc, resumeScript := resumeMux(t, root, ResumeRequest{},
+		ghAuth(),
+		ghIssueViewCall(t, 1, "OPEN", orphanBody),
+		prListForBranchCall(branch, 10, "head"),
+	)
+	resumeScript.AssertExhausted()
+	if doc.Issues[0].Action != ActionAdoptedPR {
+		t.Fatalf("action = %q, want adopted-pr", doc.Issues[0].Action)
+	}
+	wantPhase(t, root, 1, state.PhasePROpen)
+	if st := loadRun(t, root); st.Run.Issues[0].PRNumber != 10 {
+		t.Errorf("adopted PR number = %d, want 10", st.Run.Issues[0].PRNumber)
+	}
+}
+
+// --- Shared helpers ---
+
+// setupDeliveryGitRepo writes a delivery state onto a real git sandbox
+// with an origin remote, so resume's git probes run against real git.
+func setupDeliveryGitRepo(t *testing.T, planRev string, issues []state.Issue) string {
+	t.Helper()
+	root := newLifecycleRepo(t)
+	planned := make([]state.Issue, len(issues))
+	for i := range issues {
+		planned[i] = state.Issue{PlanID: issues[i].PlanID, Phase: state.PhasePlanned}
+	}
+	st, err := state.EnterDelivery(root, "claude", state.PlanRef{Title: "t", Digest: "sha256:x", ConfigRevision: planRev}, planned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Run.Issues = issues
+	if err := state.Save(root, st); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// createBranchWorktree materializes the fixture issue's branch and a
+// worktree checked out on it, so resume's presence probes read them.
+func createBranchWorktree(t *testing.T, root, branch string) {
+	t.Helper()
+	rawGit(t, root, "branch", branch)
+	wt := filepath.Join(root, ".orchestrator", "worktrees", "issue-1")
+	rawGit(t, root, "worktree", "add", wt, branch)
+}
+
+func writeWork(t *testing.T, wtDir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(wtDir, "feature.go"), []byte("package feature\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rawGit(t, wtDir, "add", "-A")
+	rawGit(t, wtDir, "commit", "-m", "work")
+}
+
+// resumeMux runs Resume against real git and a scripted gh, returning the
+// report and the script for exhaustion checks.
+func resumeMux(t *testing.T, root string, req ResumeRequest, calls ...execxtest.Call) (*ResumeDoc, *execxtest.Script) {
+	t.Helper()
+	script := &execxtest.Script{T: t, Calls: calls}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+	doc, err := Resume(context.Background(), env, req)
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	return doc, script
+}
+
+// prListForBranchCall scripts a PRForBranch probe that finds one open PR.
+func prListForBranchCall(branch string, number int, headOID string) execxtest.Call {
+	return execxtest.Call{
+		Name: "gh", Args: []string{"pr", "list", "--head", branch, "--state", "open", "--json", prFieldsRun},
+		Stdout: "[" + prJSONStdout(number, "OPEN", headOID) + "]",
+	}
+}
+
+func prJSONStdout(number int, prState, headOID string) string {
+	return `{"number":` + strconv.Itoa(number) + `,"state":"` + prState + `","title":"t","url":"https://github.com/o/r/pull/` + strconv.Itoa(number) + `","headRefName":"b","baseRefName":"main","headRefOid":"` + headOID + `","mergeStateStatus":"CLEAN","mergedAt":null,"body":"pr body"}`
+}
+
+// manifestBodyWithVerification renders an audit record carrying one
+// verification, the evidence resume requires to adopt an orphan PR.
+func manifestBodyWithVerification(t *testing.T) string {
+	t.Helper()
+	body, err := manifest.Upsert("**Objective**\n\ndo it\n", manifest.Manifest{
+		SchemaVersion:    manifest.SchemaVersion,
+		Role:             manifest.RoleImplementer,
+		Executor:         manifest.Selection{Model: "claude-sonnet-5", Effort: "xhigh"},
+		RoutingRationale: "impl",
+		Reviewer:         manifest.Selection{Model: "claude-opus-4-8", Effort: "high"},
+		ConfigRevision:   "r1",
+		Verifications:    []manifest.Verification{{Name: "go test", Result: "pass", At: "2026-07-11T12:00:00Z"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -165,7 +165,8 @@ type Run struct {
 	Issues    []Issue   `json:"issues"`
 	// StoppedReason is non-empty when a secret block stopped the whole
 	// run (PRD §16): every mutating verb but block itself then fails
-	// closed until `orch abort` or a future `orch resume`.
+	// closed until `orch abort` or `orch resume` (with its explicit
+	// resume-stopped-run statement).
 	StoppedReason string `json:"stopped_reason,omitempty"`
 }
 


### PR DESCRIPTION
## What

Implements task 13, the last Phase 2 item: `orch resume` replaces its fail-closed stub and becomes the recovery path for interrupted Delivery runs — crashed lifecycle verbs, out-of-band GitHub actions, and secret-stopped runs.

- **`internal/run/resume.go`** — three strictly separated stages: **observe** (every gh/git read batched up front; per-issue reads scoped by phase, zero API calls for planned/cleaned/abandoned), **classify** (`reconcileIssue`, a pure function holding the full 30-row reconciliation table), **apply** (deep working copy, one `state.Save` at the end, skipped when converged). Any observation error aborts before a single write.
- **`internal/cli/resume.go`** — the PRD §22 human command: `orch resume [--json] [--dry-run] [--resume-stopped-run]`; human report by default, schema-versioned JSON document with `--json`; unknown flags exit 2.
- Message texts that referenced "a future `orch resume`" (loadVerb, wrapAfterMutation, wrapAfterEnter, propen's ErrPRExists) now name the real command.

## Why / design

Every lifecycle verb already has pure failure semantics and is crash-re-runnable from its last completed sub-step, so resume's job is reconciliation, not per-step repair. The binding reconciliation notes from the PR B spec are honored: dispatch re-runs safely, the pr-open orphan PR is adopted here, merge convergence stays with the re-runnable merge verb, and assist+lock inconsistencies remain `orch abort` territory (resume fails closed on them).

Contract decisions (approved at planning):
1. **state.json only** — resume never pushes, merges, deletes, or edits labels/bodies; labels self-heal at the next verb.
2. **Explicit statement for stopped runs** — a secret-stopped run is fully observed and reported, but nothing is written without `--resume-stopped-run` (the flag is the `approve-merge`-style human assertion).
3. **Resume is the blocked-issue exit** — blocked issues re-derive an effective phase from populated fields (ApprovedHeadOID → awaiting-merge; PRNumber → in-review/pr-open; else worktree-ready as the conservative lower bound, keeping the orphan-adopt path reachable) and unblock on a confident classification.
4. **Human command + `--json`**, no new `orch run` plumbing verb.

Notable table calls: orphan adoption requires verification evidence in the audit record (pr-open writes verifications before CreatePR, so a genuine orphan always has them — the discriminator vs. out-of-band PRs); an out-of-band merge **blocks** rather than fabricating `ApprovedHeadOID` (that field means "a human approved this head"); awaiting-merge with a moved head **demotes to in-review clearing the stale approval** — the one deliberate backwards move, since blocked would be a permanent trap and a stale approve verdict would let merge-report pin unreviewed commits.

## Testing

38-case pure table test over every row incl. the adoption discriminator and demotion; byte-level purity tests (dry-run, mid-transcript gh failure, stopped-without-statement, converged skip-save); `TestResumeSafeAtEveryPhase`; fail-closed precondition tests (config drift, orphaned lock, assist no-op); an integration walk driving a real pr-open crash window through adoption; CLI flag/rendering tests. `gofmt`/`go build`/`go vet`/`go test ./...` all green locally, plus a live smoke test of the assist no-op, `--json`, and exit-2 paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7LU4KkTJuD91bLy64C3Bm
