### PR TITLE
Add orch init: bootstrap flow and CLI wiring

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@
 *.md text eol=lf
 *.diff text eol=lf
 *.json text eol=lf
+*.txt text eol=lf

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -1,0 +1,219 @@
+// Package bootstrap executes PRD §18 steps 10-15: given the answers an
+// interview (internal/interview, internal/question) collected, it
+// re-derives the terminal question.Complete document itself and
+// composes internal/config, internal/instructions, internal/gitops,
+// and internal/ghops into the one mechanical act that turns an
+// approved interview into an open bootstrap pull request — a
+// mechanical in-binary executor, no model subagent (decision 30).
+//
+// Execute is the package's only exported entry point and the whole
+// policy home for `orch init --bootstrap`; cli/init.go stays thin
+// dispatch (decode stdin into an AnswerSet, call Execute, encode the
+// result). Two design choices Stage 0 exists to enforce:
+//
+//   - Anti-forgery (spec pass 2026-07-11, contract call 4): Execute
+//     never trusts a caller-supplied Complete document — there is no
+//     such parameter. It re-runs interview.Detect and interview.Next
+//     itself from the raw answers in Deps.Answers and requires the
+//     result to be a DocComplete with BootstrapReady, so every byte it
+//     goes on to write is recomputed from validated answers, never
+//     injected by an adapter. Approval is itself an answer Next
+//     validates, and Blockers make approval an error, so a caller
+//     cannot skip either check by hand-crafting a document.
+//   - No Delivery lock (contract call 1): bootstrap never creates
+//     .orchestrator/ in the primary checkout and never touches
+//     internal/state or internal/lockfile. Mutual exclusion against a
+//     concurrent or crashed bootstrap comes entirely from fail-closed
+//     preflights against a fixed branch name, orch/bootstrap — not the
+//     per-issue orch/issue-<n>- scheme internal/run uses, because the
+//     issue number this branch will eventually close does not exist
+//     until Stage 1 creates it. A fixed name is what makes a crashed
+//     re-run collide with its own leftovers instead of sidestepping
+//     them under a fresh number (contract call 3).
+//
+// Stage 0 (preflights, see preflight.go) performs zero mutations: any
+// failure there changes nothing on disk or on GitHub. Stage 1
+// (mutations, see below) advances in a fixed order — label taxonomy,
+// issue, worktree, files, §18.13 validation, commit, push, PR, status
+// — and every failure after the issue is created is reported with the
+// exact artifacts it left behind and the shell commands that undo them
+// (contract call 3: re-running bootstrap from the same answers is the
+// recovery path, not `orch abort`, which this package never calls —
+// it never touches Delivery state to begin with).
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/gitops"
+	"github.com/kninetimmy/orch/internal/interview"
+	"github.com/kninetimmy/orch/internal/question"
+)
+
+// BootstrapBranch is the fixed branch name Stage 0's orphan preflights
+// guard and Stage 1 creates (see the package doc's "no Delivery lock"
+// note): deliberately not the Delivery orch/issue-<n>- scheme.
+const BootstrapBranch = "orch/bootstrap"
+
+// bootstrapTitle is the fixed issue and PR title (PRD §18 step 10).
+const bootstrapTitle = "Bootstrap orch configuration"
+
+// ReportSchemaVersion is the Report schema this build emits.
+const ReportSchemaVersion = 1
+
+// Deps carries Execute's injectable surface.
+type Deps struct {
+	// RepoRoot is the directory `orch init --bootstrap` was invoked
+	// from — the primary checkout. Detect probes git from here; the
+	// resulting Facts.GitRoot (not RepoRoot) is what every subsequent
+	// gitops/ghops/config/instructions call uses once Stage 0 confirms
+	// git is present (BootstrapReady already requires it).
+	RepoRoot string
+	// Answers is the adapter's raw AnswerSet.Answers — never a
+	// pre-built Complete document (see the package doc's anti-forgery
+	// note). A nil map is treated as empty, mirroring
+	// question.DecodeAnswers' own normalization.
+	Answers map[string]string
+	// Runner executes git and gh.
+	Runner execx.Runner
+	// LookPath resolves an executable name; a nil LookPath makes every
+	// host/git/gh/memhub fact false (interview.Deps precedent).
+	LookPath func(string) (string, error)
+	// Now returns the current time; nil defaults to time.Now
+	// (run.Env precedent). Stamps every §18.13 validation entry.
+	Now func() time.Time
+}
+
+// Report is Execute's success output, emitted by `orch init
+// --bootstrap` as schema-versioned JSON on stdout.
+type Report struct {
+	SchemaVersion int               `json:"schema_version"`
+	Issue         ReportRef         `json:"issue"`
+	PR            ReportRef         `json:"pr"`
+	Branch        string            `json:"branch"`
+	Validations   []ValidationEntry `json:"validations"`
+	NextSteps     []string          `json:"next_steps"`
+}
+
+// ReportRef names a created issue or PR.
+type ReportRef struct {
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+}
+
+// ValidationEntry is one §18.13 mechanical check's outcome, in the
+// shape manifest.Verification/run.VerificationInput already establish
+// for audit-record evidence: Name identifies the check, Result is a
+// short free-text verdict ("pass"/"fail"), Detail explains a failure,
+// and At is the RFC3339 UTC stamp from Deps.Now.
+type ValidationEntry struct {
+	Name   string `json:"name"`
+	Result string `json:"result"`
+	Detail string `json:"detail,omitempty"`
+	At     string `json:"at,omitempty"`
+}
+
+// now returns deps's timestamp source as UTC (run.Env.now precedent).
+func (d Deps) now() time.Time {
+	if d.Now != nil {
+		return d.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+// Execute runs the full bootstrap: Stage 0 re-derives and validates
+// the interview's terminal document from deps.Answers (zero
+// mutations; see preflight.go), then Stage 1 performs the ordered
+// mutation sequence PRD §18 steps 10-15 describe.
+func Execute(ctx context.Context, deps Deps) (Report, error) {
+	complete, gitRoot, err := stage0(ctx, deps)
+	if err != nil {
+		return Report{}, err
+	}
+
+	git, err := gitops.Open(ctx, deps.Runner, gitRoot)
+	if err != nil {
+		return Report{}, err
+	}
+	if err := git.RequireClean(ctx, ""); err != nil {
+		return Report{}, err
+	}
+	gh, err := ghops.Open(ctx, deps.Runner, gitRoot)
+	if err != nil {
+		return Report{}, err
+	}
+	repo, err := gh.Repo(ctx)
+	if err != nil {
+		return Report{}, err
+	}
+	if err := requireNoOrphans(ctx, git, gh); err != nil {
+		return Report{}, err
+	}
+
+	cfg, err := config.Parse([]byte(complete.Summary.ConfigTOML))
+	if err != nil {
+		// Unreachable in practice: materialize already round-trips this
+		// exact TOML through Parse before Next ever emits it.
+		return Report{}, fmt.Errorf("parse re-derived configuration: %w", err)
+	}
+
+	return stage1(ctx, deps, git, gh, repo, complete, cfg)
+}
+
+// stage0 re-derives Complete from deps.Answers and runs every
+// zero-mutation preflight up through "not already initialized" (the
+// gitops/ghops preflights that need an open handle live in Execute,
+// which shares that handle with Stage 1). It returns the validated
+// Complete document and the detected git root.
+func stage0(ctx context.Context, deps Deps) (*question.Complete, string, error) {
+	facts := interview.Detect(ctx, interview.Deps{RepoRoot: deps.RepoRoot, LookPath: deps.LookPath, Runner: deps.Runner})
+	root := facts.GitRoot
+	if root == "" {
+		root = deps.RepoRoot
+	}
+	doc, err := interview.Next(facts, deps.Answers, root)
+	if err != nil {
+		return nil, "", err
+	}
+	if doc.Kind != question.DocComplete {
+		return nil, "", fmt.Errorf("%w: re-derived document is %q, not %q; resubmit the same answers through `orch init --step` until the interview completes", ErrNotComplete, doc.Kind, question.DocComplete)
+	}
+	complete := doc.Complete
+	if !complete.BootstrapReady {
+		return nil, "", fmt.Errorf("%w: %s", ErrNotBootstrapReady, joinReasons(complete.NotReadyReasons))
+	}
+
+	gitRoot := facts.GitRoot
+	cfgPath := filepath.Join(gitRoot, filepath.FromSlash(config.Path))
+	switch _, err := os.Stat(cfgPath); {
+	case err == nil:
+		return nil, "", fmt.Errorf("%w; run `orch configure` to change it", ErrAlreadyInitialized)
+	case !errors.Is(err, os.ErrNotExist):
+		return nil, "", fmt.Errorf("check %s: %w", config.Path, err)
+	}
+
+	return complete, gitRoot, nil
+}
+
+// joinReasons renders NotReadyReasons for ErrNotBootstrapReady's
+// message; empty is unreachable (BootstrapReady false always carries
+// at least one reason — see interview.buildComplete) but handled
+// rather than assumed.
+func joinReasons(reasons []string) string {
+	if len(reasons) == 0 {
+		return "not ready"
+	}
+	out := reasons[0]
+	for _, r := range reasons[1:] {
+		out += "; " + r
+	}
+	return out
+}

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -1,0 +1,315 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/gitops"
+)
+
+func TestExecuteHappyPath(t *testing.T) {
+	root := newBootstrapRepo(t)
+	answers := fullAnswers(t, bothHostsFacts(root), root)
+
+	calls := taxonomyScript()
+	calls = append(calls, ghIssueCreateCall(1))
+	calls = append(calls, ghCreatePRCall(1))
+	calls = append(calls, ghSetStatusCall(1, ghops.StatusAwaitingReview))
+	script := &execxtest.Script{T: t, Calls: calls}
+	deps := testDeps(root, answers, script, muxRunner{git: execx.Local{}})
+
+	report, err := Execute(context.Background(), deps)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	script.AssertExhausted()
+
+	if report.SchemaVersion != ReportSchemaVersion {
+		t.Errorf("SchemaVersion = %d, want %d", report.SchemaVersion, ReportSchemaVersion)
+	}
+	if report.Issue.Number != 1 || report.Issue.URL != "https://github.com/o/r/issues/1" {
+		t.Errorf("Issue = %+v", report.Issue)
+	}
+	if report.PR.Number != 1 || report.PR.URL != "https://github.com/o/r/pull/1" {
+		t.Errorf("PR = %+v", report.PR)
+	}
+	if report.Branch != BootstrapBranch {
+		t.Errorf("Branch = %q, want %q", report.Branch, BootstrapBranch)
+	}
+	if len(report.Validations) == 0 {
+		t.Error("Validations is empty, want the §18.13 entries")
+	}
+	for _, v := range report.Validations {
+		if v.Result != "pass" {
+			t.Errorf("validation %s = %+v, want pass", v.Name, v)
+		}
+	}
+	wantNextSteps := []string{
+		"review and merge https://github.com/o/r/pull/1",
+		"git pull",
+		"optionally: git branch -d orch/bootstrap",
+		"orch status",
+	}
+	if len(report.NextSteps) != len(wantNextSteps) {
+		t.Fatalf("NextSteps = %v, want %v", report.NextSteps, wantNextSteps)
+	}
+	for i, want := range wantNextSteps {
+		if report.NextSteps[i] != want {
+			t.Errorf("NextSteps[%d] = %q, want %q", i, report.NextSteps[i], want)
+		}
+	}
+
+	// The primary checkout was never written (acceptance §23).
+	if _, err := os.Stat(filepath.Join(root, config.Path)); err == nil {
+		t.Error("primary checkout carries config.toml; bootstrap must never write it there")
+	}
+
+	git, err := gitops.Open(context.Background(), execx.Local{}, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worktrees, err := git.ListWorktrees(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(worktrees) != 1 {
+		t.Errorf("ListWorktrees = %+v, want only the primary checkout (disposable worktree removed)", worktrees)
+	}
+	head, err := git.RevParse(context.Background(), BootstrapBranch)
+	if err != nil || head == "" {
+		t.Errorf("local branch %s not preserved: %v", BootstrapBranch, err)
+	}
+	remoteHead := rawGit(t, root, "rev-parse", "refs/remotes/origin/"+BootstrapBranch)
+	if strings.TrimSpace(remoteHead) != head {
+		t.Errorf("origin/%s = %q, want %q (pushed)", BootstrapBranch, strings.TrimSpace(remoteHead), head)
+	}
+}
+
+func TestExecuteNotComplete(t *testing.T) {
+	root := newBootstrapRepo(t)
+	deps := testDeps(root, map[string]string{}, &execxtest.Script{T: t}, muxRunner{git: execx.Local{}})
+
+	_, err := Execute(context.Background(), deps)
+	if !errors.Is(err, ErrNotComplete) {
+		t.Fatalf("err = %v, want ErrNotComplete", err)
+	}
+}
+
+func TestExecuteNotBootstrapReady(t *testing.T) {
+	root := newBootstrapRepo(t)
+	// gh is never resolved, so BootstrapReady is false even though the
+	// interview otherwise completes; walk without fullAnswers' own
+	// BootstrapReady assertion, which this test deliberately violates.
+	facts := bothHostsFacts(root)
+	facts.Gh = false
+	answers := answersWithoutReadyCheck(t, facts, root)
+
+	lookPath := func(name string) (string, error) {
+		if name == "gh" {
+			return "", os.ErrNotExist
+		}
+		return fakeLookPath(name)
+	}
+	deps := Deps{RepoRoot: root, Answers: answers, Runner: muxRunner{git: execx.Local{}, gh: &execxtest.Script{T: t}}, LookPath: lookPath, Now: fixedNow}
+
+	_, err := Execute(context.Background(), deps)
+	if !errors.Is(err, ErrNotBootstrapReady) {
+		t.Fatalf("err = %v, want ErrNotBootstrapReady", err)
+	}
+	if !strings.Contains(err.Error(), "gh was not detected") {
+		t.Errorf("err = %v, want it to name gh", err)
+	}
+}
+
+func TestExecuteAlreadyInitialized(t *testing.T) {
+	root := newBootstrapRepo(t)
+	answers := fullAnswers(t, bothHostsFacts(root), root)
+
+	if err := os.MkdirAll(filepath.Join(root, ".orchestrator"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, config.Path), []byte("schema_version = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := testDeps(root, answers, &execxtest.Script{T: t}, muxRunner{git: execx.Local{}})
+	_, err := Execute(context.Background(), deps)
+	if !errors.Is(err, ErrAlreadyInitialized) {
+		t.Fatalf("err = %v, want ErrAlreadyInitialized", err)
+	}
+}
+
+func TestExecuteDirtyTreeFailsClosed(t *testing.T) {
+	root := newBootstrapRepo(t)
+	answers := fullAnswers(t, bothHostsFacts(root), root)
+
+	if err := os.WriteFile(filepath.Join(root, "untracked.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := testDeps(root, answers, &execxtest.Script{T: t}, muxRunner{git: execx.Local{}})
+	_, err := Execute(context.Background(), deps)
+	if !errors.Is(err, gitops.ErrNotClean) {
+		t.Fatalf("err = %v, want ErrNotClean", err)
+	}
+}
+
+func TestExecuteGhNotAuthenticated(t *testing.T) {
+	root := newBootstrapRepo(t)
+	answers := fullAnswers(t, bothHostsFacts(root), root)
+
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{ghAuthFailsCall()}}
+	deps := testDeps(root, answers, script, muxRunner{git: execx.Local{}})
+	_, err := Execute(context.Background(), deps)
+	if !errors.Is(err, ghops.ErrNotAuthenticated) {
+		t.Fatalf("err = %v, want ErrNotAuthenticated", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestExecuteLocalBranchOrphanFailsClosed(t *testing.T) {
+	root := newBootstrapRepo(t)
+	answers := fullAnswers(t, bothHostsFacts(root), root)
+	rawGit(t, root, "branch", BootstrapBranch)
+
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{ghAuthCall(), ghRepoViewCall("main")}}
+	deps := testDeps(root, answers, script, muxRunner{git: execx.Local{}})
+	_, err := Execute(context.Background(), deps)
+	if !errors.Is(err, ErrBranchExists) {
+		t.Fatalf("err = %v, want ErrBranchExists", err)
+	}
+	if !strings.Contains(err.Error(), "git branch -D orch/bootstrap") {
+		t.Errorf("err = %v, want the exact remediation command", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestExecuteRemoteBranchOrphanFailsClosed(t *testing.T) {
+	root := newBootstrapRepo(t)
+	answers := fullAnswers(t, bothHostsFacts(root), root)
+	rawGit(t, root, "branch", BootstrapBranch)
+	rawGit(t, root, "push", "origin", BootstrapBranch)
+	rawGit(t, root, "branch", "-D", BootstrapBranch)
+
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{ghAuthCall(), ghRepoViewCall("main")}}
+	deps := testDeps(root, answers, script, muxRunner{git: execx.Local{}})
+	_, err := Execute(context.Background(), deps)
+	if !errors.Is(err, ErrRemoteBranchExists) {
+		t.Fatalf("err = %v, want ErrRemoteBranchExists", err)
+	}
+	if !strings.Contains(err.Error(), "git push origin --delete orch/bootstrap") {
+		t.Errorf("err = %v, want the exact remediation command", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestExecuteOpenPROrphanFailsClosed(t *testing.T) {
+	root := newBootstrapRepo(t)
+	answers := fullAnswers(t, bothHostsFacts(root), root)
+
+	prJSON := `[{"number":9,"state":"OPEN","title":"t","url":"https://github.com/o/r/pull/9","headRefName":"orch/bootstrap","baseRefName":"main","headRefOid":"h","mergeStateStatus":"CLEAN","mergedAt":null,"body":""}]`
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{ghAuthCall(), ghRepoViewCall("main"), ghPRForBranchCall(BootstrapBranch, prJSON)}}
+	deps := testDeps(root, answers, script, muxRunner{git: execx.Local{}})
+	_, err := Execute(context.Background(), deps)
+	if !errors.Is(err, ErrOpenPRExists) {
+		t.Fatalf("err = %v, want ErrOpenPRExists", err)
+	}
+	if !strings.Contains(err.Error(), "PR #9") {
+		t.Errorf("err = %v, want it to name the PR", err)
+	}
+	script.AssertExhausted()
+}
+
+// TestExecutePreCommitFailureCleansUp forces writeFiles to fail
+// (corruptAfterAdd blocks os.MkdirAll inside the fresh worktree) and
+// asserts the worktree is removed, the just-created local branch is
+// force-deleted, the issue is marked needs-human, and the error names
+// the remediation.
+func TestExecutePreCommitFailureCleansUp(t *testing.T) {
+	root := newBootstrapRepo(t)
+	answers := fullAnswers(t, bothHostsFacts(root), root)
+
+	calls := taxonomyScript()
+	calls = append(calls, ghIssueCreateCall(1))
+	calls = append(calls, ghSetStatusCall(1, ghops.StatusNeedsHuman))
+	script := &execxtest.Script{T: t, Calls: calls}
+	deps := testDeps(root, answers, script, muxRunner{git: execx.Local{}, corruptAfterAdd: true})
+
+	_, err := Execute(context.Background(), deps)
+	if err == nil {
+		t.Fatal("Execute succeeded, want a pre-commit write failure")
+	}
+	script.AssertExhausted()
+	if !strings.Contains(err.Error(), "issue #1") {
+		t.Errorf("err = %v, want it to name issue #1", err)
+	}
+	if !strings.Contains(err.Error(), "re-run `orch init --bootstrap`") {
+		t.Errorf("err = %v, want the re-run remediation", err)
+	}
+
+	git, gerr := gitops.Open(context.Background(), execx.Local{}, root)
+	if gerr != nil {
+		t.Fatal(gerr)
+	}
+	worktrees, lerr := git.ListWorktrees(context.Background())
+	if lerr != nil {
+		t.Fatal(lerr)
+	}
+	if len(worktrees) != 1 {
+		t.Errorf("ListWorktrees = %+v, want only the primary checkout (worktree removed)", worktrees)
+	}
+	if _, perr := git.RevParse(context.Background(), BootstrapBranch); perr == nil {
+		t.Error("local branch still resolves; want it force-deleted (no commit was ever made)")
+	}
+}
+
+// TestExecutePushFailureLeavesArtifacts forces `git push` to fail
+// after the commit already succeeded, and asserts the issue and
+// branch are both named as preserved artifacts (the branch is real
+// work now, so it must not be deleted) and the issue is marked
+// needs-human.
+func TestExecutePushFailureLeavesArtifacts(t *testing.T) {
+	root := newBootstrapRepo(t)
+	answers := fullAnswers(t, bothHostsFacts(root), root)
+
+	calls := taxonomyScript()
+	calls = append(calls, ghIssueCreateCall(1))
+	calls = append(calls, ghSetStatusCall(1, ghops.StatusNeedsHuman))
+	script := &execxtest.Script{T: t, Calls: calls}
+	deps := testDeps(root, answers, script, muxRunner{git: execx.Local{}, pushFails: true})
+
+	_, err := Execute(context.Background(), deps)
+	if err == nil {
+		t.Fatal("Execute succeeded, want a push failure")
+	}
+	script.AssertExhausted()
+	if !strings.Contains(err.Error(), "issue #1") {
+		t.Errorf("err = %v, want it to name issue #1", err)
+	}
+	if !strings.Contains(err.Error(), "carries the bootstrap commit") {
+		t.Errorf("err = %v, want it to preserve (not delete) the branch carrying the commit", err)
+	}
+
+	git, gerr := gitops.Open(context.Background(), execx.Local{}, root)
+	if gerr != nil {
+		t.Fatal(gerr)
+	}
+	worktrees, lerr := git.ListWorktrees(context.Background())
+	if lerr != nil {
+		t.Fatal(lerr)
+	}
+	if len(worktrees) != 1 {
+		t.Errorf("ListWorktrees = %+v, want only the primary checkout (worktree removed)", worktrees)
+	}
+	if _, perr := git.RevParse(context.Background(), BootstrapBranch); perr != nil {
+		t.Errorf("local branch %s not preserved after a push failure: %v", BootstrapBranch, perr)
+	}
+}

--- a/internal/bootstrap/errors.go
+++ b/internal/bootstrap/errors.go
@@ -1,0 +1,35 @@
+package bootstrap
+
+import (
+	"errors"
+
+	"github.com/kninetimmy/orch/internal/config"
+)
+
+// Sentinel errors callers test with errors.Is. Specifics wrap these
+// with %w and detail (config/run house style) rather than replace
+// them.
+var (
+	// ErrNotComplete reports that Next did not re-derive a terminal
+	// DocComplete document from deps.Answers: either the interview is
+	// not finished (still questions/summary) or it was aborted.
+	ErrNotComplete = errors.New("interview has not reached the terminal complete document")
+	// ErrNotBootstrapReady reports a re-derived Complete document whose
+	// BootstrapReady is false (git or gh was not detected).
+	ErrNotBootstrapReady = errors.New("bootstrap readiness requirements are not met")
+	// ErrAlreadyInitialized reports a committed configuration already
+	// present at the git root.
+	ErrAlreadyInitialized = errors.New("already initialized: " + config.Path + " exists")
+	// ErrBranchExists reports the fixed bootstrap branch already
+	// resolving locally (contract call 3: an orphan preflight).
+	ErrBranchExists = errors.New("bootstrap branch already exists locally")
+	// ErrRemoteBranchExists reports the fixed bootstrap branch already
+	// present on the remote (contract call 3).
+	ErrRemoteBranchExists = errors.New("bootstrap branch already exists on the remote")
+	// ErrOpenPRExists reports an open PR already carrying the fixed
+	// bootstrap branch as its head (contract call 3).
+	ErrOpenPRExists = errors.New("an open bootstrap pull request already exists")
+	// ErrValidationFailed reports a §18.13 mechanical check that did
+	// not pass inside the freshly written worktree.
+	ErrValidationFailed = errors.New("bootstrap installation validation failed")
+)

--- a/internal/bootstrap/helpers_test.go
+++ b/internal/bootstrap/helpers_test.go
@@ -1,0 +1,305 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/interview"
+	"github.com/kninetimmy/orch/internal/paths"
+	"github.com/kninetimmy/orch/internal/question"
+)
+
+// setupGitEnv isolates every git invocation in the test process from
+// the developer's real configuration (internal/run/activate_test.go's
+// idiom, copied from internal/gitops's own integration-test idiom).
+func setupGitEnv(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("git not on PATH: %v", err)
+	}
+	cfg := filepath.Join(t.TempDir(), "gitconfig")
+	content := "[user]\n\tname = Orch Test\n\temail = orch-test@example.invalid\n"
+	if err := os.WriteFile(cfg, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", cfg)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+}
+
+func rawGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	res, err := (execx.Local{}).Run(context.Background(), execx.Cmd{
+		Name: "git", Args: args, Dir: dir, Env: []string{"GIT_TERMINAL_PROMPT=0", "LC_ALL=C"},
+	})
+	if err != nil {
+		t.Fatalf("git %v: %v", args, err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("git %v exited %d: %s", args, res.ExitCode, res.Stderr)
+	}
+	return res.Stdout
+}
+
+// newBootstrapRepo builds a real sandbox repository on branch main with
+// a committed README (no .orchestrator/, so bootstrap's
+// not-already-initialized preflight holds) and a bare origin remote
+// with main pushed, so the push/PR paths have a remote to work
+// against.
+func newBootstrapRepo(t *testing.T) string {
+	t.Helper()
+	setupGitEnv(t)
+	root, err := paths.Canonical(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawGit(t, root, "init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rawGit(t, root, "add", "-A")
+	rawGit(t, root, "commit", "-m", "initial")
+
+	origin := filepath.Join(t.TempDir(), "origin.git")
+	rawGit(t, filepath.Dir(origin), "init", "--bare", origin)
+	rawGit(t, root, "remote", "add", "origin", origin)
+	rawGit(t, root, "push", "origin", "main")
+	return root
+}
+
+// muxRunner sends "git" commands to a real runner and "gh" commands to
+// a scripted one (internal/run/activate_test.go's idiom): real git
+// sandboxes prove the actual argv sequence and filesystem effects,
+// scripted GitHub calls pin the exact gh invocations without a network.
+type muxRunner struct {
+	git execx.Runner
+	gh  *execxtest.Script
+	// pushFails, when true, fails `git push` without touching the real
+	// repository, so a push-failure test can exercise Stage 1's
+	// post-commit cleanup path deterministically.
+	pushFails bool
+	// corruptAfterAdd, when true, drops a file named ".orchestrator"
+	// (blocking os.MkdirAll) into the worktree directory immediately
+	// after `git worktree add` succeeds, so a pre-commit write failure
+	// can be forced deterministically.
+	corruptAfterAdd bool
+}
+
+func (m muxRunner) Run(ctx context.Context, c execx.Cmd) (execx.Result, error) {
+	if c.Name != "git" {
+		return m.gh.Run(ctx, c)
+	}
+	if m.pushFails && len(c.Args) > 0 && c.Args[0] == "push" {
+		return execx.Result{ExitCode: 1, Stderr: "fatal: unable to access '(simulated)': could not resolve host"}, nil
+	}
+	res, err := m.git.Run(ctx, c)
+	if m.corruptAfterAdd && err == nil && res.ExitCode == 0 &&
+		len(c.Args) >= 5 && c.Args[0] == "worktree" && c.Args[1] == "add" {
+		path := c.Args[4]
+		if werr := os.WriteFile(filepath.Join(path, ".orchestrator"), []byte("blocker"), 0o644); werr != nil {
+			return execx.Result{}, fmt.Errorf("test setup: corrupt worktree: %w", werr)
+		}
+	}
+	return res, err
+}
+
+// fakeLookPath resolves claude, codex, and gh (both host CLIs plus
+// GitHub, so BootstrapReady only ever turns on git/gh), and fails
+// closed on everything else — including memhub, so Detect's
+// memhub-probe path (a fake `memhub status` call) is never exercised
+// by these tests.
+func fakeLookPath(name string) (string, error) {
+	switch name {
+	case "claude", "codex", "gh", "git":
+		return "/fake/" + name, nil
+	default:
+		return "", fmt.Errorf("%s not found", name)
+	}
+}
+
+// fixedNow is the deterministic clock Deps.Now injects.
+func fixedNow() time.Time { return time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC) }
+
+// fullAnswers walks the interview to completion from an empty answer
+// set, answering every question with its Default and approving the
+// summary (interview's own answerAllWithDefaults/TestGoldenTranscript
+// idiom, duplicated here since it is unexported in internal/interview
+// and this package's tests need the walk to run against a real
+// sandbox root rather than the interview package's own fixtures).
+func fullAnswers(t *testing.T, facts interview.Facts, repoRoot string) map[string]string {
+	t.Helper()
+	answers := map[string]string{}
+	for i := 0; i < 100; i++ {
+		doc, err := interview.Next(facts, answers, repoRoot)
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		switch doc.Kind {
+		case question.DocQuestions:
+			for _, q := range doc.Questions {
+				if q.Default == "" {
+					t.Fatalf("question %s has no default", q.ID)
+				}
+				answers[q.ID] = q.Default
+			}
+		case question.DocSummary:
+			if len(doc.Summary.Blockers) != 0 {
+				t.Fatalf("unexpected blockers: %v", doc.Summary.Blockers)
+			}
+			answers["approval"] = "approve"
+		case question.DocComplete:
+			if !doc.Complete.BootstrapReady {
+				t.Fatalf("Complete.BootstrapReady = false, want true: %+v", doc.Complete)
+			}
+			return answers
+		default:
+			t.Fatalf("unexpected document kind %q", doc.Kind)
+		}
+	}
+	t.Fatal("interview did not reach a complete document within 100 steps")
+	return nil
+}
+
+// answersWithoutReadyCheck is fullAnswers without its BootstrapReady
+// assertion, for tests that deliberately drive the interview to
+// completion with a fact that makes BootstrapReady false (e.g. gh
+// undetected) and want to exercise Execute's own re-derived check.
+func answersWithoutReadyCheck(t *testing.T, facts interview.Facts, repoRoot string) map[string]string {
+	t.Helper()
+	answers := map[string]string{}
+	for i := 0; i < 100; i++ {
+		doc, err := interview.Next(facts, answers, repoRoot)
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		switch doc.Kind {
+		case question.DocQuestions:
+			for _, q := range doc.Questions {
+				answers[q.ID] = q.Default
+			}
+		case question.DocSummary:
+			answers["approval"] = "approve"
+		case question.DocComplete:
+			return answers
+		default:
+			t.Fatalf("unexpected document kind %q", doc.Kind)
+		}
+	}
+	t.Fatal("interview did not reach a complete document within 100 steps")
+	return nil
+}
+
+// bothHostsFacts mirrors interview's own fixture: both host CLIs, git,
+// and gh detected (no memhub — fakeLookPath never resolves it).
+func bothHostsFacts(repoRoot string) interview.Facts {
+	return interview.Facts{ClaudeCLI: true, CodexCLI: true, Git: true, GitRoot: repoRoot, Gh: true}
+}
+
+// --- gh call script helpers (internal/run/activate_test.go,
+// lifecycle_test.go idiom) ---
+
+const prFields = "number,state,title,url,headRefName,baseRefName,headRefOid,mergeStateStatus,mergedAt,body"
+
+func ghAuthCall() execxtest.Call { return execxtest.Call{Name: "gh", Args: []string{"auth", "status"}} }
+
+func ghAuthFailsCall() execxtest.Call {
+	return execxtest.Call{Name: "gh", Args: []string{"auth", "status"}, Exit: 1}
+}
+
+func ghRepoViewCall(defaultBranch string) execxtest.Call {
+	return execxtest.Call{
+		Name: "gh", Args: []string{"repo", "view", "--json", "nameWithOwner,defaultBranchRef,url"},
+		Stdout: fmt.Sprintf(`{"nameWithOwner":"o/r","defaultBranchRef":{"name":%q},"url":"https://github.com/o/r"}`, defaultBranch),
+	}
+}
+
+func ghPRForBranchCall(branch, stdout string) execxtest.Call {
+	return execxtest.Call{Name: "gh", Args: []string{"pr", "list", "--head", branch, "--state", "open", "--json", prFields}, Stdout: stdout}
+}
+
+func ghLabelListEmptyCall() execxtest.Call {
+	return execxtest.Call{Name: "gh", Args: []string{"label", "list", "--json", "name", "--limit", "1000"}, Stdout: "[]"}
+}
+
+var taxonomyLabels = []struct{ name, color, desc string }{
+	{"ready", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
+	{"in-progress", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
+	{"blocked", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
+	{"needs-human", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
+	{"awaiting-review", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
+	{"feature", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
+	{"bug", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
+	{"chore", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
+	{"infra", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
+	{"docs", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
+	{"research", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
+	{"implementer", "5319E7", "orch role label — exactly one per issue (PRD §13)"},
+	{"specialist", "5319E7", "orch role label — exactly one per issue (PRD §13)"},
+	{"standard", "FBCA04", "orch risk label — exactly one per issue (PRD §13)"},
+	{"critical", "B60205", "orch risk label — exactly one per issue (PRD §13)"},
+}
+
+func ghLabelCreateCalls() []execxtest.Call {
+	calls := make([]execxtest.Call, len(taxonomyLabels))
+	for i, l := range taxonomyLabels {
+		calls[i] = execxtest.Call{Name: "gh", Args: []string{"label", "create", l.name, "--color", l.color, "--description", l.desc}}
+	}
+	return calls
+}
+
+func ghIssueCreateCall(number int) execxtest.Call {
+	args := []string{"issue", "create", "--title", bootstrapTitle, "--body-file", "-"}
+	for _, l := range []string{"in-progress", "infra", "implementer", "standard"} {
+		args = append(args, "--label", l)
+	}
+	return execxtest.Call{Name: "gh", Args: args, Stdout: fmt.Sprintf("https://github.com/o/r/issues/%d\n", number)}
+}
+
+func ghCreatePRCall(number int) execxtest.Call {
+	return execxtest.Call{
+		Name:   "gh",
+		Args:   []string{"pr", "create", "--head", BootstrapBranch, "--base", "main", "--title", bootstrapTitle, "--body-file", "-"},
+		Stdout: fmt.Sprintf("https://github.com/o/r/pull/%d\n", number),
+	}
+}
+
+func ghSetStatusCall(number int, to ghops.Status) execxtest.Call {
+	all := []ghops.Status{ghops.StatusReady, ghops.StatusInProgress, ghops.StatusBlocked, ghops.StatusNeedsHuman, ghops.StatusAwaitingReview}
+	args := []string{"issue", "edit", strconv.Itoa(number)}
+	for _, s := range all {
+		if s != to {
+			args = append(args, "--remove-label", string(s))
+		}
+	}
+	args = append(args, "--add-label", string(to))
+	return execxtest.Call{Name: "gh", Args: args}
+}
+
+// preflightScript is the gh transcript every Stage-0-passing test
+// needs before EnsureLabelTaxonomy: auth, repo view, and an empty
+// open-PR list for the bootstrap branch.
+func preflightScript() []execxtest.Call {
+	return []execxtest.Call{ghAuthCall(), ghRepoViewCall("main"), ghPRForBranchCall(BootstrapBranch, "[]")}
+}
+
+// taxonomyScript appends the idempotent label-taxonomy calls
+// (list-then-create-every-missing) after preflightScript.
+func taxonomyScript() []execxtest.Call {
+	calls := preflightScript()
+	calls = append(calls, ghLabelListEmptyCall())
+	return append(calls, ghLabelCreateCalls()...)
+}
+
+// deps builds a Deps against root using script for every gh call.
+func testDeps(root string, answers map[string]string, script *execxtest.Script, mux muxRunner) Deps {
+	mux.gh = script
+	return Deps{RepoRoot: root, Answers: answers, Runner: mux, LookPath: fakeLookPath, Now: fixedNow}
+}

--- a/internal/bootstrap/preflight.go
+++ b/internal/bootstrap/preflight.go
@@ -1,0 +1,41 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/gitops"
+)
+
+// requireNoOrphans runs Stage 0's three orphan preflights against the
+// fixed BootstrapBranch, each failing closed with its exact
+// remediation command (contract call 3): a crashed or duplicate
+// bootstrap run leaves a leftover local branch, remote branch, or open
+// PR, and re-running must collide with it rather than silently
+// sidestep it.
+func requireNoOrphans(ctx context.Context, git *gitops.Git, gh *ghops.GH) error {
+	// RevParse's error is treated as "does not exist" rather than
+	// distinguished from a transport failure, mirroring
+	// run.Cleanup's own local-branch presence check.
+	if _, err := git.RevParse(ctx, BootstrapBranch); err == nil {
+		return fmt.Errorf("%w: local branch %s already exists; remove it with `git branch -D %s` and re-run `orch init --bootstrap`", ErrBranchExists, BootstrapBranch, BootstrapBranch)
+	}
+
+	remoteExists, err := git.RemoteBranchExists(ctx, "origin", BootstrapBranch)
+	if err != nil {
+		return err
+	}
+	if remoteExists {
+		return fmt.Errorf("%w: remote branch origin/%s already exists; remove it with `git push origin --delete %s` and re-run `orch init --bootstrap`", ErrRemoteBranchExists, BootstrapBranch, BootstrapBranch)
+	}
+
+	pr, err := gh.PRForBranch(ctx, BootstrapBranch)
+	if err != nil {
+		return err
+	}
+	if pr != nil {
+		return fmt.Errorf("%w: PR #%d (%s) is already open for branch %s; close or merge it and re-run `orch init --bootstrap`", ErrOpenPRExists, pr.Number, pr.URL, BootstrapBranch)
+	}
+	return nil
+}

--- a/internal/bootstrap/render.go
+++ b/internal/bootstrap/render.go
@@ -1,0 +1,96 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/kninetimmy/orch/internal/question"
+)
+
+// renderRecord renders the rendered bootstrap record (contract call
+// 4): human markdown sections — Detection, Configuration, Instruction
+// files, .gitignore additions, and (once available) Validations —
+// followed by the canonical question.Complete JSON in a fenced block.
+// There is deliberately no orch:manifest region: the free text here is
+// already constrained (detection values are boolean strings/paths,
+// configuration is orch-rendered TOML) and nothing ever parses this
+// body back (unlike internal/manifest's Delivery audit records).
+//
+// validations is nil when the record is rendered for the issue body
+// (validation has not run yet, since it happens inside the worktree
+// Stage 1 creates after the issue) and populated when re-rendered for
+// the PR body. closesIssue is the issue number to link with a "Closes
+// #<n>" line, or 0 to omit it — an issue cannot close itself, so the
+// issue body always passes 0; the PR body passes the real number.
+func renderRecord(complete *question.Complete, validations []ValidationEntry, closesIssue int) (string, error) {
+	var b strings.Builder
+
+	b.WriteString("## Detection\n\n")
+	for _, k := range sortedKeys(complete.Detection) {
+		fmt.Fprintf(&b, "- %s: %s\n", k, complete.Detection[k])
+	}
+
+	b.WriteString("\n## Configuration\n\n")
+	fmt.Fprintf(&b, "**Config revision:** `%s`\n\n", complete.Summary.ConfigRevision)
+	b.WriteString("```toml\n")
+	b.WriteString(complete.Summary.ConfigTOML)
+	if !strings.HasSuffix(complete.Summary.ConfigTOML, "\n") {
+		b.WriteByte('\n')
+	}
+	b.WriteString("```\n")
+
+	b.WriteString("\n## Instruction files\n\n")
+	if len(complete.Summary.Files) == 0 {
+		b.WriteString("_none_\n")
+	}
+	for _, f := range complete.Summary.Files {
+		fmt.Fprintf(&b, "- `%s` (existed: %t)\n", f.Path, f.Existed)
+	}
+
+	b.WriteString("\n## .gitignore additions\n\n")
+	if len(complete.Summary.GitignoreLines) == 0 {
+		b.WriteString("_none_\n")
+	}
+	for _, l := range complete.Summary.GitignoreLines {
+		fmt.Fprintf(&b, "- `%s`\n", l)
+	}
+
+	if len(validations) > 0 {
+		b.WriteString("\n## Validations\n\n")
+		for _, v := range validations {
+			if v.Detail != "" {
+				fmt.Fprintf(&b, "- %s: %s (%s)\n", v.Name, v.Result, v.Detail)
+			} else {
+				fmt.Fprintf(&b, "- %s: %s\n", v.Name, v.Result)
+			}
+		}
+	}
+
+	if closesIssue > 0 {
+		fmt.Fprintf(&b, "\nCloses #%d\n", closesIssue)
+	}
+
+	data, err := json.MarshalIndent(complete, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("render bootstrap record: encode complete document: %w", err)
+	}
+	b.WriteString("\n```json\n")
+	b.Write(data)
+	b.WriteByte('\n')
+	b.WriteString("```\n")
+
+	return b.String(), nil
+}
+
+// sortedKeys returns m's keys sorted, so the rendered Detection
+// section is byte-stable.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/bootstrap/stage1.go
+++ b/internal/bootstrap/stage1.go
@@ -1,0 +1,224 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/gitops"
+	"github.com/kninetimmy/orch/internal/paths"
+	"github.com/kninetimmy/orch/internal/question"
+)
+
+// stage1 runs the ordered mutation sequence (PRD §18 steps 10-15):
+// label taxonomy, issue, worktree, files, §18.13 validation, commit,
+// push, PR, status, worktree cleanup. State advances only on success;
+// every failure after the issue is created is reported through
+// failClosed with the artifacts it left behind and their exact
+// cleanup commands (contract call 3).
+func stage1(ctx context.Context, deps Deps, git *gitops.Git, gh *ghops.GH, repo ghops.Repo, complete *question.Complete, cfg *config.Config) (Report, error) {
+	if _, err := gh.EnsureLabelTaxonomy(ctx); err != nil {
+		return Report{}, err
+	}
+
+	issueBody, err := renderRecord(complete, nil, 0)
+	if err != nil {
+		return Report{}, err
+	}
+	labels := ghops.Labels{Status: ghops.StatusInProgress, Type: ghops.TypeInfra, Role: ghops.RoleImplementer, Risk: ghops.RiskStandard}
+	issueNumber, issueURL, err := gh.CreateIssue(ctx, bootstrapTitle, issueBody, labels, modelNames(cfg)...)
+	if err != nil {
+		return Report{}, err
+	}
+
+	return stage1AfterIssue(ctx, deps, git, gh, repo, complete, issueNumber, issueURL)
+}
+
+// stage1AfterIssue is stage1's tail, split out because every error
+// return from here on must go through failClosed: the issue already
+// exists.
+func stage1AfterIssue(ctx context.Context, deps Deps, git *gitops.Git, gh *ghops.GH, repo ghops.Repo, complete *question.Complete, issueNumber int, issueURL string) (Report, error) {
+	dir, err := newWorktreeDir()
+	if err != nil {
+		return Report{}, failClosed(ctx, git, gh, issueNumber, issueURL, "", false, fmt.Errorf("create bootstrap worktree directory: %w", err))
+	}
+
+	wt, err := git.AddWorktree(ctx, dir, BootstrapBranch, "HEAD")
+	if err != nil {
+		return Report{}, failClosed(ctx, git, gh, issueNumber, issueURL, "", false, err)
+	}
+
+	// From here, a branch and worktree exist but carry no commit yet:
+	// force-deleting the branch loses nothing (it is identical to
+	// HEAD), so every failure up through the commit itself cleans up
+	// both.
+	if err := writeFiles(wt.Path, complete); err != nil {
+		return Report{}, failClosed(ctx, git, gh, issueNumber, issueURL, wt.Path, true, err)
+	}
+
+	validations, err := validateInstallation(wt.Path, complete, deps.now())
+	if err != nil {
+		return Report{}, failClosed(ctx, git, gh, issueNumber, issueURL, wt.Path, true, err)
+	}
+
+	commitMessage := fmt.Sprintf("%s\n\nCloses #%d\n", bootstrapTitle, issueNumber)
+	if err := git.CommitAll(ctx, wt.Path, commitMessage); err != nil {
+		return Report{}, failClosed(ctx, git, gh, issueNumber, issueURL, wt.Path, true, err)
+	}
+
+	// A commit now exists on the branch: it is preserved work, not a
+	// leftover to auto-delete. Every failure from here removes only
+	// the disposable worktree.
+	if err := git.Push(ctx, wt.Path, "origin", BootstrapBranch); err != nil {
+		return Report{}, failClosed(ctx, git, gh, issueNumber, issueURL, wt.Path, false, err)
+	}
+
+	prBody, err := renderRecord(complete, validations, issueNumber)
+	if err != nil {
+		return Report{}, failClosed(ctx, git, gh, issueNumber, issueURL, wt.Path, false, err)
+	}
+	prNumber, prURL, err := gh.CreatePR(ctx, ghops.PRSpec{Head: BootstrapBranch, Base: repo.DefaultBranch, Title: bootstrapTitle, Body: prBody})
+	if err != nil {
+		return Report{}, failClosed(ctx, git, gh, issueNumber, issueURL, wt.Path, false, err)
+	}
+
+	if err := gh.SetStatus(ctx, issueNumber, ghops.StatusAwaitingReview); err != nil {
+		return Report{}, failClosed(ctx, git, gh, issueNumber, issueURL, wt.Path, false,
+			fmt.Errorf("PR #%d (%s) opened but marking issue #%d awaiting-review failed: %w", prNumber, prURL, issueNumber, err))
+	}
+
+	// Everything a human cares about (issue, commit, PR, status) is
+	// already correct; a failure to remove the disposable worktree
+	// here is reported as a plain cleanup note, not routed through
+	// failClosed — flipping the issue back to needs-human would
+	// misrepresent a fully successful bootstrap over a leftover local
+	// temp directory (a deliberate narrower reading of "any
+	// post-mutation failure").
+	if err := removeWorktree(ctx, git, wt.Path); err != nil {
+		return Report{}, fmt.Errorf("bootstrap succeeded (issue #%d %s, PR #%d %s) but the disposable worktree %s could not be removed: %w; remove it by hand and run `git worktree prune`", issueNumber, issueURL, prNumber, prURL, wt.Path, err)
+	}
+
+	return Report{
+		SchemaVersion: ReportSchemaVersion,
+		Issue:         ReportRef{Number: issueNumber, URL: issueURL},
+		PR:            ReportRef{Number: prNumber, URL: prURL},
+		Branch:        BootstrapBranch,
+		Validations:   validations,
+		NextSteps: []string{
+			fmt.Sprintf("review and merge %s", prURL),
+			"git pull",
+			fmt.Sprintf("optionally: git branch -d %s", BootstrapBranch),
+			"orch status",
+		},
+	}, nil
+}
+
+// newWorktreeDir returns a fresh, canonical, not-yet-existing
+// directory path for AddWorktree to create (WithBaseWorktree
+// precedent, base.go): os.MkdirTemp both generates a unique name and
+// creates it, but AddWorktree's own precondition refuses a path that
+// already exists (never clobber), so the directory is removed again
+// immediately before AddWorktree recreates it via `git worktree add`.
+// Canonicalizing first (while the directory still exists) resolves
+// any symlinked ancestor the same way WithBaseWorktree does.
+func newWorktreeDir() (string, error) {
+	tmp, err := os.MkdirTemp("", "orch-bootstrap-*")
+	if err != nil {
+		return "", err
+	}
+	dir, err := paths.Canonical(tmp)
+	if err != nil {
+		return "", errors.Join(err, os.RemoveAll(tmp))
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// removeWorktree deletes dir outright and prunes the now-stale
+// worktree registration (`git worktree prune`, no Confirmation
+// needed: it deletes no working files). This — rather than
+// gitops.RemoveWorktree, whose own RequireClean gate exists to
+// preserve blocked human work — is bootstrap's forced-removal
+// primitive: the worktree is disposable scratch by construction
+// (regenerable from the same answers), so os.RemoveAll followed by a
+// prune is the "forced removal is safe" cleanup the spec calls for,
+// without adding a second gitops primitive beyond CommitAll.
+func removeWorktree(ctx context.Context, git *gitops.Git, dir string) error {
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("remove worktree directory %s: %w", dir, err)
+	}
+	return git.PruneWorktrees(ctx)
+}
+
+// failClosed finishes a Stage 1 failure (contract call 3): it
+// best-effort marks the issue needs-human, attempts worktree removal
+// whenever worktreeDir is set, force-deletes the local bootstrap
+// branch when deleteBranch is true (only safe pre-commit, when the
+// branch carries no unique work), and returns cause wrapped with the
+// exact remediation commands for whatever it could not undo itself.
+// Cleanup always runs under context.WithoutCancel (WithBaseWorktree
+// precedent, base.go): a canceled ctx must not skip cleanup.
+func failClosed(ctx context.Context, git *gitops.Git, gh *ghops.GH, issueNumber int, issueURL, worktreeDir string, deleteBranch bool, cause error) error {
+	cleanupCtx := context.WithoutCancel(ctx)
+	problems := []error{cause}
+	remediation := []string{fmt.Sprintf("issue #%d (%s)", issueNumber, issueURL)}
+
+	if worktreeDir != "" {
+		if err := removeWorktree(cleanupCtx, git, worktreeDir); err != nil {
+			problems = append(problems, fmt.Errorf("remove worktree %s: %w", worktreeDir, err))
+			remediation = append(remediation, fmt.Sprintf("remove the leftover worktree by hand (`git worktree remove --force %s` or delete the directory, then `git worktree prune`)", worktreeDir))
+		}
+		if deleteBranch {
+			if err := git.ForceDeleteBranch(cleanupCtx, BootstrapBranch, gitops.ExplicitConfirmation()); err != nil {
+				problems = append(problems, fmt.Errorf("force-delete branch %s: %w", BootstrapBranch, err))
+				remediation = append(remediation, fmt.Sprintf("delete the leftover local branch by hand: `git branch -D %s`", BootstrapBranch))
+			}
+		} else {
+			// A commit exists on the branch: it is preserved work, not a
+			// leftover to auto-delete (contract call 3: an orphan
+			// artifact is tolerated and named, never destroyed).
+			remediation = append(remediation, fmt.Sprintf("the local branch %s carries the bootstrap commit; delete it by hand once you no longer need it (`git branch -D %s`)", BootstrapBranch, BootstrapBranch))
+		}
+	}
+
+	if err := gh.SetStatus(cleanupCtx, issueNumber, ghops.StatusNeedsHuman); err != nil {
+		remediation = append(remediation, fmt.Sprintf("mark issue #%d needs-human by hand: %v", issueNumber, err))
+	}
+
+	return fmt.Errorf("%w; re-run `orch init --bootstrap` from the same answers once cleaned up; %s", errors.Join(problems...), strings.Join(remediation, "; "))
+}
+
+// modelNames returns cfg's distinct enabled-host model strings
+// (run.modelDenylist precedent, duplicated in miniature here rather
+// than exported from internal/run, which stays Delivery-only): the
+// forbidden-areas denylist CreateIssue enforces so a model name can
+// never land as a GitHub label (PRD §13).
+func modelNames(cfg *config.Config) []string {
+	seen := map[string]bool{}
+	add := func(h *config.Host) {
+		if h == nil {
+			return
+		}
+		for _, rp := range []config.RoleProfile{
+			h.Roles.Architect, h.Roles.Scout, h.Roles.Implementer,
+			h.Roles.Specialist, h.Roles.Reviewer, h.Roles.ReviewDowngrade,
+		} {
+			if rp.Model != "" {
+				seen[rp.Model] = true
+			}
+		}
+	}
+	add(cfg.Hosts.Claude)
+	add(cfg.Hosts.Codex)
+	names := make([]string, 0, len(seen))
+	for m := range seen {
+		names = append(names, m)
+	}
+	return names
+}

--- a/internal/bootstrap/validate.go
+++ b/internal/bootstrap/validate.go
@@ -1,0 +1,100 @@
+package bootstrap
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/instructions"
+	"github.com/kninetimmy/orch/internal/question"
+)
+
+// validateInstallation runs the §18.13 mechanical validation inside
+// the freshly written worktree at dir, recording one ValidationEntry
+// per check, stamped with now: config.Load succeeds (the local
+// overlay is naturally absent in a fresh worktree), the recomputed
+// config.Revision matches Summary.ConfigRevision, every written
+// instruction file classifies as instructions.StatusCurrent, and
+// every proposed .gitignore line is present in the worktree's
+// .gitignore. It returns on the first failing check — every entry up
+// to and including the failure is returned alongside the wrapped
+// ErrValidationFailed, so the caller can still render what passed.
+func validateInstallation(dir string, complete *question.Complete, now time.Time) ([]ValidationEntry, error) {
+	stamp := now.UTC().Format(time.RFC3339)
+	var entries []ValidationEntry
+
+	if _, err := config.Load(dir); err != nil {
+		entries = append(entries, ValidationEntry{Name: "config.Load", Result: "fail", Detail: err.Error(), At: stamp})
+		return entries, fmt.Errorf("%w: config.Load: %v", ErrValidationFailed, err)
+	}
+	entries = append(entries, ValidationEntry{Name: "config.Load", Result: "pass", At: stamp})
+
+	cfg, err := config.Parse([]byte(complete.Summary.ConfigTOML))
+	if err != nil {
+		// Unreachable in practice: materialize already round-trips this
+		// exact TOML through Parse before Next ever emits it.
+		return entries, fmt.Errorf("%w: re-parse rendered configuration: %v", ErrValidationFailed, err)
+	}
+	rev, err := config.Revision(cfg)
+	if err != nil {
+		return entries, fmt.Errorf("%w: recompute configuration revision: %v", ErrValidationFailed, err)
+	}
+	if rev != complete.Summary.ConfigRevision {
+		entries = append(entries, ValidationEntry{Name: "config.Revision", Result: "fail", Detail: fmt.Sprintf("recomputed %s, want %s", rev, complete.Summary.ConfigRevision), At: stamp})
+		return entries, fmt.Errorf("%w: config.Revision recomputed %s, want %s", ErrValidationFailed, rev, complete.Summary.ConfigRevision)
+	}
+	entries = append(entries, ValidationEntry{Name: "config.Revision", Result: "pass", At: stamp})
+
+	for _, f := range complete.Summary.Files {
+		name := "instructions:" + f.Path
+		path := filepath.Join(dir, filepath.FromSlash(f.Path))
+		report, err := instructions.InspectFile(path)
+		if err != nil {
+			entries = append(entries, ValidationEntry{Name: name, Result: "fail", Detail: err.Error(), At: stamp})
+			return entries, fmt.Errorf("%w: %s: %v", ErrValidationFailed, name, err)
+		}
+		if report.Status != instructions.StatusCurrent {
+			detail := report.Detail
+			if detail == "" {
+				detail = fmt.Sprintf("status %d, want current", report.Status)
+			}
+			entries = append(entries, ValidationEntry{Name: name, Result: "fail", Detail: detail, At: stamp})
+			return entries, fmt.Errorf("%w: %s is not current: %s", ErrValidationFailed, name, detail)
+		}
+		entries = append(entries, ValidationEntry{Name: name, Result: "pass", At: stamp})
+	}
+
+	gitignoreData, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil && !os.IsNotExist(err) {
+		entries = append(entries, ValidationEntry{Name: "gitignore", Result: "fail", Detail: err.Error(), At: stamp})
+		return entries, fmt.Errorf("%w: gitignore: %v", ErrValidationFailed, err)
+	}
+	missing := missingLines(string(gitignoreData), complete.Summary.GitignoreLines)
+	if len(missing) > 0 {
+		detail := "missing: " + strings.Join(missing, ", ")
+		entries = append(entries, ValidationEntry{Name: "gitignore", Result: "fail", Detail: detail, At: stamp})
+		return entries, fmt.Errorf("%w: gitignore is missing %s", ErrValidationFailed, strings.Join(missing, ", "))
+	}
+	entries = append(entries, ValidationEntry{Name: "gitignore", Result: "pass", At: stamp})
+
+	return entries, nil
+}
+
+// missingLines returns the entries of want not present as an exact
+// line (CR trimmed) in content.
+func missingLines(content string, want []string) []string {
+	present := map[string]bool{}
+	for _, l := range strings.Split(content, "\n") {
+		present[strings.TrimRight(l, "\r")] = true
+	}
+	var missing []string
+	for _, l := range want {
+		if !present[l] {
+			missing = append(missing, l)
+		}
+	}
+	return missing
+}

--- a/internal/bootstrap/validate_test.go
+++ b/internal/bootstrap/validate_test.go
@@ -1,0 +1,180 @@
+package bootstrap
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/instructions"
+	"github.com/kninetimmy/orch/internal/question"
+)
+
+// validComplete builds a self-consistent Complete document (config
+// round-trips, revision matches, one current instruction file, one
+// gitignore line) so each test can corrupt exactly one aspect of the
+// worktree it validates against.
+func validComplete(t *testing.T) *question.Complete {
+	t.Helper()
+	cfg := &config.Config{
+		SchemaVersion: 1,
+		Concurrency:   config.Concurrency{MaxSubagents: 3},
+		Merge:         config.Merge{Strategy: "squash"},
+		Memhub:        config.Memhub{Mode: "off"},
+		Hosts: config.Hosts{Claude: &config.Host{Roles: config.Roles{
+			Architect:       config.RoleProfile{Model: "claude-opus-4-8", Effort: "xhigh"},
+			Scout:           config.RoleProfile{Model: "claude-sonnet-5", Effort: "low"},
+			Implementer:     config.RoleProfile{Model: "claude-sonnet-5", Effort: "xhigh"},
+			Specialist:      config.RoleProfile{Model: "claude-opus-4-8", Effort: "high"},
+			Reviewer:        config.RoleProfile{Model: "claude-opus-4-8", Effort: "high"},
+			ReviewDowngrade: config.RoleProfile{Model: "claude-sonnet-5", Effort: "high"},
+		}}},
+	}
+	rev, err := config.Revision(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.ConfigRevision = rev
+	rendered, err := config.Render(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, err := instructions.Render(instructions.CurrentVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &question.Complete{
+		Summary: question.Summary{
+			ConfigTOML:     string(rendered),
+			ConfigRevision: rev,
+			Files:          []question.FileChange{{Path: "CLAUDE.md", NewContent: block}},
+			GitignoreLines: []string{".orchestrator/state.json"},
+		},
+		Detection:      map[string]string{"git": "yes", "gh": "yes"},
+		BootstrapReady: true,
+	}
+}
+
+// installValid writes exactly what validComplete describes into dir,
+// so a passing baseline test can flip one aspect at a time.
+func installValid(t *testing.T, dir string, complete *question.Complete) {
+	t.Helper()
+	if err := writeFiles(dir, complete); err != nil {
+		t.Fatalf("writeFiles: %v", err)
+	}
+}
+
+func TestValidateInstallationPasses(t *testing.T) {
+	dir := t.TempDir()
+	complete := validComplete(t)
+	installValid(t, dir, complete)
+
+	entries, err := validateInstallation(dir, complete, time.Now())
+	if err != nil {
+		t.Fatalf("validateInstallation: %v", err)
+	}
+	if len(entries) != 4 {
+		t.Fatalf("entries = %+v, want 4 (config.Load, config.Revision, instructions:CLAUDE.md, gitignore)", entries)
+	}
+	for _, e := range entries {
+		if e.Result != "pass" {
+			t.Errorf("entry %s = %+v, want pass", e.Name, e)
+		}
+		if e.At == "" {
+			t.Errorf("entry %s carries no At stamp", e.Name)
+		}
+	}
+}
+
+func TestValidateInstallationConfigLoadFails(t *testing.T) {
+	dir := t.TempDir()
+	complete := validComplete(t)
+	installValid(t, dir, complete)
+	if err := os.Remove(filepath.Join(dir, config.Path)); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := validateInstallation(dir, complete, time.Now())
+	if !errors.Is(err, ErrValidationFailed) {
+		t.Fatalf("err = %v, want ErrValidationFailed", err)
+	}
+	if len(entries) != 1 || entries[0].Name != "config.Load" || entries[0].Result != "fail" {
+		t.Fatalf("entries = %+v, want a single failing config.Load entry", entries)
+	}
+}
+
+func TestValidateInstallationRevisionMismatch(t *testing.T) {
+	dir := t.TempDir()
+	complete := validComplete(t)
+	installValid(t, dir, complete)
+	complete.Summary.ConfigRevision = "sha256:deadbeefdead"
+
+	entries, err := validateInstallation(dir, complete, time.Now())
+	if !errors.Is(err, ErrValidationFailed) {
+		t.Fatalf("err = %v, want ErrValidationFailed", err)
+	}
+	last := entries[len(entries)-1]
+	if last.Name != "config.Revision" || last.Result != "fail" {
+		t.Fatalf("last entry = %+v, want a failing config.Revision", last)
+	}
+}
+
+func TestValidateInstallationInstructionsDrifted(t *testing.T) {
+	dir := t.TempDir()
+	complete := validComplete(t)
+	installValid(t, dir, complete)
+	drifted := strings.Replace(complete.Summary.Files[0].NewContent, "This file", "THIS FILE", 1)
+	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte(drifted), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := validateInstallation(dir, complete, time.Now())
+	if !errors.Is(err, ErrValidationFailed) {
+		t.Fatalf("err = %v, want ErrValidationFailed", err)
+	}
+	last := entries[len(entries)-1]
+	if last.Name != "instructions:CLAUDE.md" || last.Result != "fail" {
+		t.Fatalf("last entry = %+v, want a failing instructions:CLAUDE.md", last)
+	}
+}
+
+func TestValidateInstallationGitignoreMissingLine(t *testing.T) {
+	dir := t.TempDir()
+	complete := validComplete(t)
+	installValid(t, dir, complete)
+	if err := os.Remove(filepath.Join(dir, ".gitignore")); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := validateInstallation(dir, complete, time.Now())
+	if !errors.Is(err, ErrValidationFailed) {
+		t.Fatalf("err = %v, want ErrValidationFailed", err)
+	}
+	last := entries[len(entries)-1]
+	if last.Name != "gitignore" || last.Result != "fail" {
+		t.Fatalf("last entry = %+v, want a failing gitignore", last)
+	}
+	if !strings.Contains(last.Detail, ".orchestrator/state.json") {
+		t.Errorf("Detail = %q, want it to name the missing line", last.Detail)
+	}
+}
+
+func TestValidateInstallationStampsWithNow(t *testing.T) {
+	dir := t.TempDir()
+	complete := validComplete(t)
+	installValid(t, dir, complete)
+
+	entries, err := validateInstallation(dir, complete, fixedNow())
+	if err != nil {
+		t.Fatalf("validateInstallation: %v", err)
+	}
+	want := fixedNow().UTC().Format(time.RFC3339)
+	for _, e := range entries {
+		if e.At != want {
+			t.Errorf("entry %s At = %q, want %q", e.Name, e.At, want)
+		}
+	}
+}

--- a/internal/bootstrap/write.go
+++ b/internal/bootstrap/write.go
@@ -1,0 +1,69 @@
+package bootstrap
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/question"
+)
+
+// writeFiles writes complete's materialized artifacts into the
+// worktree at dir, verbatim and LF (PRD §18 step 12): the committed
+// configuration, every proposed instruction-file change, and the
+// .gitignore additions.
+func writeFiles(dir string, complete *question.Complete) error {
+	cfgPath := filepath.Join(dir, filepath.FromSlash(config.Path))
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		return fmt.Errorf("create directory for %s: %w", config.Path, err)
+	}
+	if err := os.WriteFile(cfgPath, []byte(complete.Summary.ConfigTOML), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", config.Path, err)
+	}
+
+	for _, f := range complete.Summary.Files {
+		path := filepath.Join(dir, filepath.FromSlash(f.Path))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return fmt.Errorf("create directory for %s: %w", f.Path, err)
+		}
+		if err := os.WriteFile(path, []byte(f.NewContent), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", f.Path, err)
+		}
+	}
+
+	return appendGitignore(dir, complete.Summary.GitignoreLines)
+}
+
+// appendGitignore appends lines to dir's .gitignore, creating the file
+// if absent and adding a trailing newline first if the existing file
+// lacks one — every line ends up on its own line, LF only. A nil or
+// empty lines is a no-op: it leaves an absent .gitignore absent rather
+// than create an empty one.
+func appendGitignore(dir string, lines []string) error {
+	if len(lines) == 0 {
+		return nil
+	}
+	path := filepath.Join(dir, ".gitignore")
+	data, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("read .gitignore: %w", err)
+	}
+
+	var b strings.Builder
+	b.Write(data)
+	if len(data) > 0 && !strings.HasSuffix(string(data), "\n") {
+		b.WriteByte('\n')
+	}
+	for _, l := range lines {
+		b.WriteString(l)
+		b.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		return fmt.Errorf("write .gitignore: %w", err)
+	}
+	return nil
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -66,7 +66,7 @@ type command struct {
 // JSON stdin/stdout, not a command a human runs directly.
 func commands() []command {
 	return []command{
-		{"init", "Interview and bootstrap this repository (not implemented)", noArgs("init", notImplemented("init"))},
+		{"init", "Interview and bootstrap this repository", runInit},
 		{"status", "Show mode and configuration summary", noArgs("status", runStatus)},
 		{"doctor", "Check environment and configuration health", noArgs("doctor", runDoctor)},
 		{"configure", "Change committed configuration (not implemented)", noArgs("configure", notImplemented("configure"))},

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -174,7 +174,7 @@ func TestRunUnexpectedArgument(t *testing.T) {
 }
 
 func TestNotImplementedCommandsFailClosed(t *testing.T) {
-	for _, name := range []string{"init", "configure", "configure-local", "metrics"} {
+	for _, name := range []string{"configure", "configure-local", "metrics"} {
 		t.Run(name, func(t *testing.T) {
 			env, _, stderr := testEnv(t)
 			if code := Run([]string{name}, env); code != ExitError {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1,0 +1,212 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/bootstrap"
+	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/interview"
+	"github.com/kninetimmy/orch/internal/question"
+)
+
+// initUsage is the one-line usage for `orch init`, which parses its
+// own flags (resume.go precedent) rather than using noArgs.
+const initUsage = "orch init: usage: orch init | orch init --step | orch init --bootstrap"
+
+// runInit dispatches the three `orch init` forms (PR B: PRD §18/§22).
+// --step and --bootstrap are mutually exclusive and any other
+// argument is a usage mistake, both exit 2.
+func runInit(env Env, args []string) error {
+	var step, doBootstrap bool
+	for _, a := range args {
+		switch a {
+		case "--step":
+			step = true
+		case "--bootstrap":
+			doBootstrap = true
+		default:
+			return usageError(initUsage)
+		}
+	}
+	if step && doBootstrap {
+		return usageError(initUsage)
+	}
+
+	switch {
+	case step:
+		return runInitStep(env)
+	case doBootstrap:
+		return runInitBootstrap(env)
+	default:
+		return runInitReport(env)
+	}
+}
+
+// initDetect runs interview.Detect against env, the shared probe every
+// `orch init` form starts from.
+func initDetect(env Env) interview.Facts {
+	return interview.Detect(context.Background(), interview.Deps{RepoRoot: env.RepoRoot, LookPath: env.LookPath, Runner: env.Runner})
+}
+
+// initRoot is the root Next consults once the question sequence is
+// answered (internal/interview's package doc): facts.GitRoot, falling
+// back to env.RepoRoot when git is absent.
+func initRoot(env Env, facts interview.Facts) string {
+	if facts.GitRoot != "" {
+		return facts.GitRoot
+	}
+	return env.RepoRoot
+}
+
+// configExists reports whether the committed configuration is already
+// present at root. Display-only: runInitReport uses it to pick a
+// report line, and a bare report always exits 0. The plumbing forms
+// fail closed through requireNotInitialized instead.
+func configExists(root string) bool {
+	_, err := os.Stat(filepath.Join(root, filepath.FromSlash(config.Path)))
+	return err == nil
+}
+
+// requireNotInitialized fails closed when the committed configuration
+// already exists at root — or when its presence cannot be determined
+// (bootstrap's stage0 discipline, mirrored: an unreadable check is a
+// denial, not a pass).
+func requireNotInitialized(root string) error {
+	switch _, err := os.Stat(filepath.Join(root, filepath.FromSlash(config.Path))); {
+	case err == nil:
+		return fmt.Errorf("already initialized (%s exists); run `orch configure` to change it", config.Path)
+	case !errors.Is(err, fs.ErrNotExist):
+		return fmt.Errorf("check %s: %w", config.Path, err)
+	}
+	return nil
+}
+
+// runInitReport prints the bare `orch init` human detection report
+// (PRD §22): host CLIs, git + root, gh, and memhub + health detail,
+// plus guidance pointing at the plumbing invocation. It never reads
+// stdin (the `orch run status` precedent: a command a human might run
+// directly must never block on a console that never reaches EOF) and
+// always exits 0 — it is a report, even when git is missing or the
+// repository is already initialized.
+func runInitReport(env Env) error {
+	facts := initDetect(env)
+
+	fmt.Fprintln(env.Stdout, "orch init: detection report")
+	fmt.Fprintf(env.Stdout, "  claude CLI:  %s\n", yesNo(facts.ClaudeCLI))
+	fmt.Fprintf(env.Stdout, "  codex CLI:   %s\n", yesNo(facts.CodexCLI))
+	fmt.Fprintf(env.Stdout, "  git:         %s\n", yesNo(facts.Git))
+	if facts.Git {
+		fmt.Fprintf(env.Stdout, "  git root:    %s\n", facts.GitRoot)
+	}
+	fmt.Fprintf(env.Stdout, "  gh:          %s\n", yesNo(facts.Gh))
+	fmt.Fprintf(env.Stdout, "  memhub CLI:  %s\n", yesNo(facts.MemhubCLI))
+	if facts.MemhubCLI {
+		fmt.Fprintf(env.Stdout, "  memhub:      %s\n", memhubStatus(facts))
+	}
+
+	root := initRoot(env, facts)
+	if configExists(root) {
+		fmt.Fprintf(env.Stdout, "\nalready initialized (%s exists); run `orch configure` to change it.\n", config.Path)
+		return nil
+	}
+
+	fmt.Fprintln(env.Stdout, "\nthis is a report only; an adapter drives the interactive interview through `orch init --step`.")
+	return nil
+}
+
+// yesNo renders a Go bool as the detection report's "yes"/"no".
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
+// memhubStatus renders the detection report's memhub health line.
+func memhubStatus(f interview.Facts) string {
+	if f.MemhubHealthy {
+		return "healthy"
+	}
+	if f.MemhubDetail != "" {
+		return fmt.Sprintf("unhealthy (%s)", f.MemhubDetail)
+	}
+	return "unhealthy"
+}
+
+// runInitStep is the adapter plumbing step-loop endpoint
+// (internal/interview's package doc): decode one AnswerSet from
+// stdin, re-run Detect, call Next, and write the resulting Document
+// to stdout. Interview errors and stdin decode errors exit 1 with the
+// message on stderr so the adapter can re-ask.
+func runInitStep(env Env) error {
+	data, err := io.ReadAll(env.Stdin)
+	if err != nil {
+		return fmt.Errorf("read stdin: %w", err)
+	}
+	answers, err := question.DecodeAnswers(data)
+	if err != nil {
+		return err
+	}
+
+	facts := initDetect(env)
+	root := initRoot(env, facts)
+	if err := requireNotInitialized(root); err != nil {
+		return err
+	}
+
+	doc, err := interview.Next(facts, answers.Answers, root)
+	if err != nil {
+		return err
+	}
+
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode step document: %w", err)
+	}
+	_, err = fmt.Fprintf(env.Stdout, "%s\n", out)
+	return err
+}
+
+// runInitBootstrap is `orch init --bootstrap`'s adapter plumbing
+// endpoint: decode one AnswerSet from stdin (never a Complete
+// document — internal/bootstrap re-derives and validates it itself,
+// the anti-forgery property its package doc describes) and hand it to
+// bootstrap.Execute, the whole policy home for the bootstrap. This
+// function stays thin dispatch.
+func runInitBootstrap(env Env) error {
+	data, err := io.ReadAll(env.Stdin)
+	if err != nil {
+		return fmt.Errorf("read stdin: %w", err)
+	}
+	answers, err := question.DecodeAnswers(data)
+	if err != nil {
+		return err
+	}
+
+	deps := bootstrap.Deps{
+		RepoRoot: env.RepoRoot,
+		Answers:  answers.Answers,
+		Runner:   env.Runner,
+		LookPath: env.LookPath,
+		Now:      time.Now,
+	}
+	report, err := bootstrap.Execute(context.Background(), deps)
+	if err != nil {
+		return err
+	}
+
+	out, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode bootstrap report: %w", err)
+	}
+	_, err = fmt.Fprintf(env.Stdout, "%s\n", out)
+	return err
+}

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -1,0 +1,273 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/question"
+)
+
+// update regenerates golden files instead of comparing against them
+// (internal/interview's -update convention).
+var update = flag.Bool("update", false, "regenerate golden files")
+
+// initLookPath resolves claude, codex, git, and gh — but never memhub,
+// so Detect's fake `memhub status` probe (fakeRunner has no case for
+// it) is never exercised by these tests.
+func initLookPath(name string) (string, error) {
+	switch name {
+	case "claude", "codex", "git", "gh":
+		return "/fake/" + name, nil
+	default:
+		return "", fmt.Errorf("%s not found", name)
+	}
+}
+
+// initEnv returns a testEnv wired so Detect finds both host CLIs, git
+// (rooted at RepoRoot), and gh — the fixture every init test not
+// specifically probing detection gaps starts from.
+func initEnv(t *testing.T) (Env, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	env, stdout, stderr := testEnv(t)
+	env.LookPath = initLookPath
+	env.Runner = fakeRunner{toplevel: env.RepoRoot}
+	return env, stdout, stderr
+}
+
+func TestInitBareDetectionReportGolden(t *testing.T) {
+	env, stdout, stderr := initEnv(t)
+	if code := Run([]string{"init"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d; stderr = %s", code, ExitOK, stderr.String())
+	}
+	got := strings.ReplaceAll(stdout.String(), env.RepoRoot, "<ROOT>")
+	checkGolden(t, filepath.Join("testdata", "init_report.golden.txt"), []byte(got))
+}
+
+func TestInitBareNeverReadsStdin(t *testing.T) {
+	env, _, stderr := initEnv(t)
+	env.Stdin = blockingReader{t: t}
+	if code := Run([]string{"init"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d; stderr = %s", code, ExitOK, stderr.String())
+	}
+}
+
+func TestInitBareAlreadyInitializedStillExitsOK(t *testing.T) {
+	env, stdout, stderr := initEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	if code := Run([]string{"init"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d; stderr = %s", code, ExitOK, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "already initialized") || !strings.Contains(stdout.String(), "orch configure") {
+		t.Errorf("stdout = %q, want the already-initialized note pointing at orch configure", stdout.String())
+	}
+}
+
+func TestInitMutuallyExclusiveFlagsIsUsageError(t *testing.T) {
+	env, _, stderr := initEnv(t)
+	if code := Run([]string{"init", "--step", "--bootstrap"}, env); code != ExitUsage {
+		t.Fatalf("exit = %d, want %d", code, ExitUsage)
+	}
+	if !strings.Contains(stderr.String(), "usage: orch init") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestInitTrailingArgumentIsUsageError(t *testing.T) {
+	env, _, stderr := initEnv(t)
+	if code := Run([]string{"init", "extra"}, env); code != ExitUsage {
+		t.Fatalf("exit = %d, want %d", code, ExitUsage)
+	}
+	if !strings.Contains(stderr.String(), "usage: orch init") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestInitStepMalformedStdinExitsError(t *testing.T) {
+	env, _, stderr := initEnv(t)
+	env.Stdin = bytes.NewReader([]byte("{not valid json"))
+	if code := Run([]string{"init", "--step"}, env); code != ExitError {
+		t.Fatalf("exit = %d, want %d", code, ExitError)
+	}
+	if stderr.String() == "" {
+		t.Error("stderr is empty, want a decode error")
+	}
+}
+
+func TestInitStepUnknownAnswerExitsErrorWithMessage(t *testing.T) {
+	env, _, stderr := initEnv(t)
+	req := question.AnswerSet{SchemaVersion: question.SchemaVersion, Answers: map[string]string{"bogus.key": "x"}}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env.Stdin = bytes.NewReader(data)
+	if code := Run([]string{"init", "--step"}, env); code != ExitError {
+		t.Fatalf("exit = %d, want %d", code, ExitError)
+	}
+	if !strings.Contains(stderr.String(), "answer does not match a currently applicable question") {
+		t.Errorf("stderr = %q, want ErrUnknownAnswer's message", stderr.String())
+	}
+}
+
+func TestInitStepAlreadyInitializedExitsError(t *testing.T) {
+	env, _, stderr := initEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	req := question.AnswerSet{SchemaVersion: question.SchemaVersion, Answers: map[string]string{}}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env.Stdin = bytes.NewReader(data)
+	if code := Run([]string{"init", "--step"}, env); code != ExitError {
+		t.Fatalf("exit = %d, want %d", code, ExitError)
+	}
+	if !strings.Contains(stderr.String(), "already initialized") || !strings.Contains(stderr.String(), "orch configure") {
+		t.Errorf("stderr = %q, want the already-initialized message naming orch configure", stderr.String())
+	}
+}
+
+// stepOnce sends req to `orch init --step` and decodes the resulting
+// Document, failing the test on any non-zero exit.
+func stepOnce(t *testing.T, env Env, req question.AnswerSet) question.Document {
+	t.Helper()
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	env.Stdin = bytes.NewReader(data)
+	env.Stdout = &stdout
+	env.Stderr = &stderr
+	if code := Run([]string{"init", "--step"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d; stderr = %s", code, ExitOK, stderr.String())
+	}
+	var doc question.Document
+	if err := json.Unmarshal(stdout.Bytes(), &doc); err != nil {
+		t.Fatalf("decode step document: %v\n%s", err, stdout.String())
+	}
+	return doc
+}
+
+// TestInitStepEndToEndReachesComplete walks `orch init --step` from an
+// empty answer set to the terminal complete document over the CLI's
+// own stdin/stdout boundary, answering every question with its
+// default and approving the summary — the CLI-level analogue of
+// internal/interview's own golden-transcript walk
+// (TestGoldenTranscriptBothHosts), proving the decode-stdin ->
+// Detect -> Next -> encode-stdout wiring round-trips correctly.
+//
+// It does not byte-compare against internal/interview's own golden
+// transcript files: those pin Facts.GitRoot to the literal placeholder
+// "/repo", decoupled from the real repoRoot the interview package's
+// own tests pass to Next directly. cli/init.go, per spec, threads
+// facts.GitRoot itself into Next (falling back to Env.RepoRoot only
+// when git is absent), so a real, on-disk root is load-bearing here —
+// buildSummary reads CLAUDE.md/AGENTS.md/.gitignore from it. A CLI
+// test cannot reuse "/repo" without breaking that file I/O, so this
+// walk instead proves the same live behavior end to end.
+func TestInitStepEndToEndReachesComplete(t *testing.T) {
+	env, _, _ := initEnv(t)
+	req := question.AnswerSet{SchemaVersion: question.SchemaVersion, Answers: map[string]string{}}
+
+	const maxSteps = 20
+	for step := 1; step <= maxSteps; step++ {
+		doc := stepOnce(t, env, req)
+		if doc.SchemaVersion != question.SchemaVersion {
+			t.Fatalf("step %d: schema_version = %d, want %d", step, doc.SchemaVersion, question.SchemaVersion)
+		}
+		switch doc.Kind {
+		case question.DocQuestions:
+			for _, q := range doc.Questions {
+				if q.Default == "" {
+					t.Fatalf("step %d: question %s has no default", step, q.ID)
+				}
+				req.Answers[q.ID] = q.Default
+			}
+		case question.DocSummary:
+			if len(doc.Summary.Blockers) != 0 {
+				t.Fatalf("step %d: unexpected blockers: %v", step, doc.Summary.Blockers)
+			}
+			req.Answers["approval"] = "approve"
+		case question.DocComplete:
+			if !doc.Complete.BootstrapReady {
+				t.Fatalf("step %d: BootstrapReady = false, want true (git and gh were both detected): %+v", step, doc.Complete)
+			}
+			if len(doc.Complete.Summary.Files) != 2 {
+				t.Errorf("step %d: Summary.Files = %v, want CLAUDE.md and AGENTS.md (both hosts enabled)", step, doc.Complete.Summary.Files)
+			}
+			return
+		default:
+			t.Fatalf("step %d: unexpected document kind %q", step, doc.Kind)
+		}
+	}
+	t.Fatalf("did not reach a complete document within %d steps", maxSteps)
+}
+
+// TestInitBootstrapAlreadyInitializedExitsError proves --bootstrap
+// wiring: a fully-walked, valid answer set re-derives to a ready
+// Complete document, but a committed configuration already on disk
+// makes internal/bootstrap.Execute fail closed before any mutation —
+// exercised here through the CLI boundary (decode stdin, call
+// Execute, exit 1 with its message on stderr).
+func TestInitBootstrapAlreadyInitializedExitsError(t *testing.T) {
+	env, _, _ := initEnv(t)
+	req := question.AnswerSet{SchemaVersion: question.SchemaVersion, Answers: map[string]string{}}
+	for step := 1; step <= 20; step++ {
+		doc := stepOnce(t, env, req)
+		switch doc.Kind {
+		case question.DocQuestions:
+			for _, q := range doc.Questions {
+				req.Answers[q.ID] = q.Default
+			}
+		case question.DocSummary:
+			req.Answers["approval"] = "approve"
+		case question.DocComplete:
+			step = 999 // done walking
+		default:
+			t.Fatalf("unexpected document kind %q", doc.Kind)
+		}
+		if step == 999 {
+			break
+		}
+	}
+
+	writeConfig(t, env.RepoRoot, validTOML)
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env.Stdin = bytes.NewReader(data)
+	var stdout, stderr bytes.Buffer
+	env.Stdout = &stdout
+	env.Stderr = &stderr
+	if code := Run([]string{"init", "--bootstrap"}, env); code != ExitError {
+		t.Fatalf("exit = %d, want %d; stdout = %s stderr = %s", code, ExitError, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "already initialized") {
+		t.Errorf("stderr = %q, want the already-initialized message", stderr.String())
+	}
+}
+
+// checkGolden compares got against the golden file at path, rewriting
+// it first when -update is passed (internal/interview's convention).
+func checkGolden(t *testing.T, path string, got []byte) {
+	t.Helper()
+	if *update {
+		if err := os.WriteFile(path, got, 0o644); err != nil {
+			t.Fatalf("write golden: %v", err)
+		}
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden (run `go test ./internal/cli -update`): %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("does not match %s\n--- got ---\n%s\n--- want ---\n%s", path, got, want)
+	}
+}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -8,10 +8,11 @@ import (
 
 // TestNoArgCommandsRejectTrailingArgs proves noArgs still rejects a
 // trailing argument for every PRD §22 command except the ones that parse
-// their own argv: the adapter-plumbing `run` verb and `resume` (which
-// takes flags).
+// their own argv: the adapter-plumbing `run` verb, `resume` (which
+// takes flags), and `init` (which takes --step/--bootstrap; see
+// init_test.go for its own trailing-argument coverage).
 func TestNoArgCommandsRejectTrailingArgs(t *testing.T) {
-	for _, name := range []string{"init", "status", "doctor", "configure", "configure-local", "abort", "metrics"} {
+	for _, name := range []string{"status", "doctor", "configure", "configure-local", "abort", "metrics"} {
 		t.Run(name, func(t *testing.T) {
 			env, _, stderr := testEnv(t)
 			if code := Run([]string{name, "extra"}, env); code != ExitUsage {

--- a/internal/cli/testdata/init_report.golden.txt
+++ b/internal/cli/testdata/init_report.golden.txt
@@ -1,0 +1,9 @@
+orch init: detection report
+  claude CLI:  yes
+  codex CLI:   yes
+  git:         yes
+  git root:    <ROOT>
+  gh:          yes
+  memhub CLI:  no
+
+this is a report only; an adapter drives the interactive interview through `orch init --step`.

--- a/internal/gitops/commit.go
+++ b/internal/gitops/commit.go
@@ -1,0 +1,35 @@
+package gitops
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// CommitAll stages every change in dir (`git add -A`) and commits it
+// with message. It is the mechanical-commit primitive `orch init
+// --bootstrap` (internal/bootstrap) uses to capture its generated
+// files in the disposable worktree it just populated: a caller that
+// reaches CommitAll always expects a real change, so an empty commit
+// — nothing staged after `git add -A` — is a bug, not a benign no-op,
+// and CommitAll fails closed with ErrNothingToCommit rather than
+// create one (`git commit --allow-empty` is never used here).
+func (g *Git) CommitAll(ctx context.Context, dir, message string) error {
+	if _, err := g.git(ctx, dir, "add", "-A"); err != nil {
+		return err
+	}
+	res, err := g.run(ctx, dir, "diff", "--cached", "--quiet")
+	if err != nil {
+		return err
+	}
+	switch res.ExitCode {
+	case 0:
+		return fmt.Errorf("%w in %s", ErrNothingToCommit, dir)
+	case 1:
+		// Staged changes exist; proceed to commit.
+	default:
+		return fmt.Errorf("git diff --cached --quiet in %s exited %d: %s", dir, res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	_, err = g.git(ctx, dir, "commit", "-m", message)
+	return err
+}

--- a/internal/gitops/commit_test.go
+++ b/internal/gitops/commit_test.go
@@ -1,0 +1,74 @@
+package gitops
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+)
+
+func TestCommitAll(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root,
+		execxtest.Call{Name: "git", Args: []string{"add", "-A"}, Dir: root},
+		execxtest.Call{Name: "git", Args: []string{"diff", "--cached", "--quiet"}, Dir: root, Exit: 1},
+		execxtest.Call{Name: "git", Args: []string{"commit", "-m", "Bootstrap orch configuration"}, Dir: root},
+	)
+	if err := g.CommitAll(context.Background(), root, "Bootstrap orch configuration"); err != nil {
+		t.Fatalf("CommitAll: %v", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestCommitAllNothingStaged(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root,
+		execxtest.Call{Name: "git", Args: []string{"add", "-A"}, Dir: root},
+		execxtest.Call{Name: "git", Args: []string{"diff", "--cached", "--quiet"}, Dir: root, Exit: 0},
+	)
+	err := g.CommitAll(context.Background(), root, "message")
+	script.AssertExhausted()
+	if !errors.Is(err, ErrNothingToCommit) {
+		t.Fatalf("err = %v, want ErrNothingToCommit", err)
+	}
+}
+
+func TestCommitAllAddFails(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root,
+		execxtest.Call{Name: "git", Args: []string{"add", "-A"}, Dir: root, Exit: 1, Stderr: "fatal: bad object"},
+	)
+	err := g.CommitAll(context.Background(), root, "message")
+	script.AssertExhausted()
+	if err == nil {
+		t.Fatal("CommitAll succeeded, want error")
+	}
+}
+
+func TestCommitAllDiffCheckUnexpectedExit(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root,
+		execxtest.Call{Name: "git", Args: []string{"add", "-A"}, Dir: root},
+		execxtest.Call{Name: "git", Args: []string{"diff", "--cached", "--quiet"}, Dir: root, Exit: 128, Stderr: "fatal: ambiguous argument"},
+	)
+	err := g.CommitAll(context.Background(), root, "message")
+	script.AssertExhausted()
+	if err == nil {
+		t.Fatal("CommitAll succeeded, want error")
+	}
+}
+
+func TestCommitAllCommitFails(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root,
+		execxtest.Call{Name: "git", Args: []string{"add", "-A"}, Dir: root},
+		execxtest.Call{Name: "git", Args: []string{"diff", "--cached", "--quiet"}, Dir: root, Exit: 1},
+		execxtest.Call{Name: "git", Args: []string{"commit", "-m", "message"}, Dir: root, Exit: 1, Stderr: "fatal: unable to write commit"},
+	)
+	err := g.CommitAll(context.Background(), root, "message")
+	script.AssertExhausted()
+	if err == nil {
+		t.Fatal("CommitAll succeeded, want error")
+	}
+}

--- a/internal/gitops/errors.go
+++ b/internal/gitops/errors.go
@@ -38,4 +38,8 @@ var (
 	// safe from RequireClean and isolation guarantees when git itself
 	// will never report it in `status --porcelain`).
 	ErrNotIgnored = errors.New("path is not git-ignored")
+	// ErrNothingToCommit reports that CommitAll staged nothing: the
+	// caller expected a change and an empty commit would silently hide
+	// that bug rather than fail closed.
+	ErrNothingToCommit = errors.New("nothing to commit")
 )


### PR DESCRIPTION
## What

Task 15 PR B — the second half of `orch init` (PR A landed the question contract + interview engine as #16). This PR makes init reachable:

- **`internal/bootstrap`** (new): the mechanical in-binary bootstrap executor (PRD §18 steps 10–15, decision "no model subagent"). Stage 0 re-derives the terminal `question.Complete` document itself from the raw answers via `interview.Detect` + `Next` — there is no Complete parameter, so an adapter cannot forge approval or inject file content — then runs zero-mutation preflights (not-already-initialized, `RequireClean`, gh auth+repo, orphan checks on the fixed `orch/bootstrap` branch). Stage 1 mutates in fixed order: label taxonomy → bootstrap issue → disposable temp-dir worktree (resolves the `.gitignore` chicken-and-egg: the path is outside the repo, so inside-iff-ignored never applies) → write config/instruction files/gitignore lines → §18.13 mechanical validation → commit → push → PR → awaiting-review → cleanup. Every post-issue failure names the artifacts it left and their exact cleanup commands; cleanup runs under `context.WithoutCancel`.
- **`internal/cli/init.go`** (new): bare `orch init` = human detection report (never reads stdin, exit 0); `--step` = the AnswerSet-stdin → Document-stdout step loop committed in PR A's package doc; `--bootstrap` = AnswerSet-stdin → `bootstrap.Execute` → schema-versioned JSON report.
- **`gitops.CommitAll`** (new primitive): `add -A` + commit in a named worktree; an empty commit fails closed (`ErrNothingToCommit`).

## Why

Resolves the last init gap: the interview engine existed but was CLI-unreachable. Contract calls from the spec pass (memhub decision, spec at `.memhub/docs/task15-pr-b-spec.md`): no Delivery lock (fail-closed artifact preflights on a fixed branch name are the mutual exclusion; the primary checkout is never written, per §23); the flow ends at PR open (merge stays an explicit human act on GitHub); crashed re-runs fail closed with named remediation; the issue/PR body renders the Complete document (markdown + fenced canonical JSON) rather than bending manifest's closed five-role schema around a non-model actor.

## Review notes

Implemented by a delegated subagent (tenth cycle); main-thread review verified the nine flagged judgment calls sound and fixed one fail-closed inconsistency: `--step`'s already-initialized check treated an indeterminate `os.Stat` as "not initialized" — it now fails closed like `--bootstrap`'s stage 0 (`requireNotInitialized`).

## Testing

`gofmt` clean, `go build`, `go vet`, `go test ./...` all green locally (Windows). New coverage: 11 bootstrap Execute tests over a real git sandbox with scripted gh (happy path, every preflight, pre-commit cleanup, push-failure artifact reporting), 6 validation unit tests, 5 CommitAll transcript tests, 10 CLI init tests including a stdin-never-read probe and a full `--step` walk to the complete document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7LU4KkTJuD91bLy64C3Bm
