### PR TITLE
Add Claude adapter scaffold: session-start verb, plugin manifest, guard hook

### DIFF
--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "orch",
+  "description": "Claude Code host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
+  "version": "0.1.0",
+  "author": { "name": "kninetimmy" }
+}

--- a/adapters/claude/README.md
+++ b/adapters/claude/README.md
@@ -1,8 +1,107 @@
 # Claude Code adapter
 
-This directory will hold the Claude Code host adapter: the non-Go
-artifacts (skills, hooks, Architect instruction templates, and managed
-instruction-block content per PRD §19) that integrate Claude Code with
-the shared core by invoking the `orch` binary.
+## What this is
 
-Nothing is implemented yet.
+This directory is the Claude Code host adapter for Orch: a Claude Code
+plugin that connects a Claude Code session to the shared `orch` binary.
+It is deliberately thin (PRD §6) — "the detailed state machine must not
+be independently reimplemented in Markdown skills or platform-specific
+shell scripts." Every policy decision (what is writable, what routing
+applies, what a Delivery run's state is) is made by the `orch` binary.
+This adapter only translates Claude Code host events into calls against
+that binary, presents native dialogs, and spawns role subagents. It
+never re-derives a decision the engine already made.
+
+## Artifact map (this PR)
+
+After this PR, the plugin carries only enforcement and session-context
+scaffolding:
+
+- `.claude-plugin/plugin.json` — the plugin manifest (name, description,
+  version, author). Component directories (`commands/`, `agents/`,
+  `skills/`, `hooks/`) are auto-discovered by Claude Code; there is
+  nothing else to declare here yet.
+- `hooks/hooks.json` — two hooks:
+  - `PreToolUse` on `Write|Edit|MultiEdit|NotebookEdit` runs
+    `orch guard claude`, which reads the tool-call event on stdin and
+    denies the write when Orch's policy (Assist read-only, Delivery
+    worktree containment) says so. An allow is silence: guard
+    never bypasses Claude Code's own permission prompts.
+  - `SessionStart` on `startup|resume|clear|compact` runs
+    `orch hook claude session-start`, which injects a short context block
+    at session start when the current directory is inside an Orch
+    repository with a readable configuration and state: the operating
+    mode, the memhub mode, a reminder to load the `orch-architect` skill
+    before planning or making a change, and the three setup interviews
+    (`/orch:init`, `/orch:configure`, `/orch:configure-local`). Outside an
+    Orch repository, or if the repository is unreadable, it injects
+    nothing and never blocks the session.
+
+Skills (`orch-architect`, `orch-delivery`, `orch-setup`), the three
+`/orch:*` slash commands, and the four `orch-*` subagents are **not**
+part of this PR — they land in the next PR (PR 2), which is what turns
+this scaffolding into a usable end-to-end workflow.
+
+## Install order
+
+Install the `orch` binary on `PATH` **before** installing this plugin.
+PRD §18 states this ordering directly: "Global host plugins are
+installed before repository initialization," and the binary is what
+every hook in this plugin shells out to.
+
+This ordering matters mechanically, not just procedurally. Both hooks
+above are bare commands (`orch guard claude`, `orch hook claude
+session-start`) with no shell interposed. If `orch` is not resolvable on
+`PATH`, invoking either command fails with a shell "command not found"
+exit. Claude Code's PreToolUse hook protocol treats a hook's non-zero,
+non-JSON exit as **non-blocking** — i.e. fail-open. A missing binary does
+not produce a denial or an error dialog; it silently stops enforcing and
+stops injecting session context. Installing the binary first, and
+running `orch doctor` to confirm the environment is healthy, closes that
+gap before it can matter. `orch doctor` is the health check for the
+locally installed environment (Git, GitHub, memhub, and configuration);
+run it after installing the binary and again after `orch init`.
+
+## Known limitations
+
+These are accepted for this PR and the adapter as a whole, not open
+bugs:
+
+- **Bash-mediated writes are not guarded.** The `PreToolUse` hook only
+  covers the four file-editing tools (`Write`, `Edit`, `MultiEdit`,
+  `NotebookEdit`). A file write made through `Bash` (for example `echo >
+  file` or a script) does not go through `orch guard claude`. Claude
+  Code's own permission prompts on `Bash` are the backstop here. This
+  limitation is shared with the future Codex adapter and is a candidate
+  for a core feature later, not something this adapter alone can close.
+- **A missing `orch` binary fails open, not closed.** As described under
+  Install order: a hook command that cannot be found exits non-blocking
+  by the hook protocol's own rules, so both the write guard and the
+  session-start context silently stop working rather than erroring
+  loudly. Install order, `orch doctor`, and the visible absence of
+  session-start context are the mitigations; there is no way to make a
+  missing binary fail closed from inside the hook itself.
+- **Reasoning effort has no per-subagent parameter on this host.** Claude
+  Code subagent spawns do not accept an effort knob, so the routed effort
+  (low/high/xhigh) is approximated by a prompt cue in the subagent's
+  instructions rather than an actual host parameter. The exact routed
+  effort is still recorded in the engine's audit trail; only the
+  in-session behavior is an approximation. Parity tests (task 21) assert
+  the prompt cue is present, not that it changed model behavior.
+- **`orch guard`'s `--role` narrowing is unused by this adapter.** Hooks
+  in Claude Code are plugin-global, not scoped per subagent, so the
+  adapter never passes `--role` when invoking guard. Read-only role
+  enforcement (scout and reviewer must never write) instead comes from
+  each subagent's own tool whitelist in its agent definition (PR 2), not
+  from guard's role-narrowing flag.
+
+## Host version
+
+This design assumes a Claude Code version with plugin support
+(component auto-discovery for `commands/`, `agents/`, `skills/`, and
+`hooks/hooks.json`), `SessionStart` hooks, and the `AskUserQuestion` tool.
+A formally pinned minimum supported Claude Code version is deliberately
+deferred (PRD §24) to the sandbox-e2e and parity milestones (task 21),
+where it will be recorded alongside the manual smoke test this PR's plan
+calls for. Until then, treat the Claude Code version this adapter is
+manually smoke-tested against during development as the de-facto floor.

--- a/adapters/claude/doc.go
+++ b/adapters/claude/doc.go
@@ -1,0 +1,7 @@
+// Package claude anchors the adapters/claude directory as a Go package
+// so its validation tests (plugin_test.go) build and run under the
+// module's ordinary `go test ./...`. The Claude Code plugin itself is
+// non-Go: the manifest, hooks, skills, commands, and agents under this
+// directory are read directly by Claude Code, never compiled. This file
+// carries no runtime code.
+package claude

--- a/adapters/claude/hooks/hooks.json
+++ b/adapters/claude/hooks/hooks.json
@@ -1,0 +1,27 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "orch guard claude",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "orch hook claude session-start"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -1,0 +1,175 @@
+// Package claude_test validates the non-Go Claude Code plugin artifacts
+// under this directory: the manifest, the hooks manifest, and their
+// consistency with the internal/guard PreToolUse contract they mirror.
+// These are ordinary Go tests so `go test ./...` catches drift without a
+// separate host-specific test runner.
+package claude_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/guard"
+)
+
+// pluginManifest is the strict shape of .claude-plugin/plugin.json.
+type pluginManifest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Version     string `json:"version"`
+	Author      struct {
+		Name string `json:"name"`
+	} `json:"author"`
+}
+
+// hookEntry is one `hooks` array element under a matcher.
+type hookEntry struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+	Timeout int    `json:"timeout,omitempty"`
+}
+
+// hookMatcher is one PreToolUse/SessionStart array element.
+type hookMatcher struct {
+	Matcher string      `json:"matcher"`
+	Hooks   []hookEntry `json:"hooks"`
+}
+
+// hooksManifest is the strict shape of hooks/hooks.json.
+type hooksManifest struct {
+	Hooks struct {
+		PreToolUse   []hookMatcher `json:"PreToolUse"`
+		SessionStart []hookMatcher `json:"SessionStart"`
+	} `json:"hooks"`
+}
+
+// decodeStrict parses path into v with DisallowUnknownFields, so an
+// unexpected key in either manifest fails the test instead of silently
+// passing through.
+func decodeStrict(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+}
+
+func TestPluginManifestStrict(t *testing.T) {
+	var m pluginManifest
+	decodeStrict(t, ".claude-plugin/plugin.json", &m)
+	if m.Name != "orch" {
+		t.Errorf("name = %q, want orch", m.Name)
+	}
+	if m.Description == "" {
+		t.Error("description is empty")
+	}
+	if m.Version != "0.1.0" {
+		t.Errorf("version = %q, want 0.1.0", m.Version)
+	}
+	if m.Author.Name == "" {
+		t.Error("author.name is empty")
+	}
+}
+
+func loadHooksManifest(t *testing.T) hooksManifest {
+	t.Helper()
+	var m hooksManifest
+	decodeStrict(t, "hooks/hooks.json", &m)
+	return m
+}
+
+func TestHooksManifestStrict(t *testing.T) {
+	m := loadHooksManifest(t)
+	if len(m.Hooks.PreToolUse) == 0 {
+		t.Fatal("hooks.json has no PreToolUse entries")
+	}
+	if len(m.Hooks.SessionStart) == 0 {
+		t.Fatal("hooks.json has no SessionStart entries")
+	}
+	for _, event := range [][]hookMatcher{m.Hooks.PreToolUse, m.Hooks.SessionStart} {
+		for _, matcher := range event {
+			if len(matcher.Hooks) == 0 {
+				t.Errorf("matcher %q has no hooks", matcher.Matcher)
+			}
+			for _, h := range matcher.Hooks {
+				if h.Type != "command" {
+					t.Errorf("matcher %q: hook type = %q, want command", matcher.Matcher, h.Type)
+				}
+				if strings.TrimSpace(h.Command) == "" {
+					t.Errorf("matcher %q: empty command", matcher.Matcher)
+				}
+			}
+		}
+	}
+}
+
+// TestMatcherGuardParity pins the PreToolUse matcher's tool_name set
+// against the exact set internal/guard's Claude PreToolUse handling
+// accepts, in both directions: the matcher must name every guard-handled
+// tool, and name nothing else (guard denies any other tool_name, so
+// broadening the matcher would hard-deny it at the hook, never reaching
+// guard's own decision).
+func TestMatcherGuardParity(t *testing.T) {
+	m := loadHooksManifest(t)
+	if len(m.Hooks.PreToolUse) != 1 {
+		t.Fatalf("PreToolUse has %d entries, want exactly 1", len(m.Hooks.PreToolUse))
+	}
+	matcher := m.Hooks.PreToolUse[0].Matcher
+	got := strings.Split(matcher, "|")
+	sort.Strings(got)
+
+	want := guard.ClaudeTools()
+	sort.Strings(want)
+
+	if len(got) != len(want) {
+		t.Fatalf("matcher tools = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("matcher tools = %v, want %v", got, want)
+			break
+		}
+	}
+}
+
+// portabilityForbidden are shell metacharacters a bare-argv hook command
+// must never contain: hook commands run directly as argv on every OS, no
+// shell interposed, so a shell-syntax command would work nowhere.
+const portabilityForbidden = "|><&;$%\"'`()"
+
+func TestHookCommandsPortable(t *testing.T) {
+	m := loadHooksManifest(t)
+	check := func(matchers []hookMatcher) {
+		for _, matcher := range matchers {
+			for _, h := range matcher.Hooks {
+				if strings.ContainsAny(h.Command, portabilityForbidden) {
+					t.Errorf("command %q contains a shell metacharacter", h.Command)
+				}
+			}
+		}
+	}
+	check(m.Hooks.PreToolUse)
+	check(m.Hooks.SessionStart)
+}
+
+// TestHookCommandsPinnedToBinaryVerbs drift-pins the hook commands to the
+// exact orch verbs they invoke, so a rename of either verb breaks this
+// test instead of silently divorcing the plugin from the binary.
+func TestHookCommandsPinnedToBinaryVerbs(t *testing.T) {
+	m := loadHooksManifest(t)
+	if got := m.Hooks.PreToolUse[0].Hooks[0].Command; got != "orch guard claude" {
+		t.Errorf("PreToolUse command = %q, want %q", got, "orch guard claude")
+	}
+	if got := m.Hooks.SessionStart[0].Hooks[0].Command; got != "orch hook claude session-start" {
+		t.Errorf("SessionStart command = %q, want %q", got, "orch hook claude session-start")
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -76,6 +76,7 @@ func commands() []command {
 		{"metrics", "Show local metrics (not implemented)", noArgs("metrics", notImplemented("metrics"))},
 		{"run", "Adapter plumbing: Delivery run verbs (JSON stdin/stdout; not a human command)", runRunVerb},
 		{"guard", "Adapter plumbing: pre-write enforcement for host hooks (not a human command)", runGuard},
+		{"hook", "Adapter plumbing: host lifecycle-event verbs (not a human command)", runHook},
 	}
 }
 

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/paths"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// hookUsage is the one-line usage for the adapter plumbing surface,
+// mirroring guardUsage. `orch hook claude session-start` is the only
+// valid form.
+const hookUsage = "orch hook: usage: orch hook claude session-start"
+
+// runHook dispatches the host lifecycle-event verbs (PRD §23 adapter
+// plumbing). Host adapters call it from their own lifecycle hooks; it is
+// never invoked by a human directly.
+func runHook(env Env, args []string) error {
+	if len(args) != 2 || args[0] != "claude" || args[1] != "session-start" {
+		return usageError(hookUsage)
+	}
+	return hookClaudeSessionStart(env)
+}
+
+// hookClaudeSessionStart answers a Claude Code SessionStart event. Its
+// stdout becomes injected session context, so unlike every other verb in
+// this package it is deliberately fail-OPEN, not fail-closed: a broken or
+// non-orch repository must never break a Claude Code session from
+// starting. It never reads stdin (the same console-hang concern as `run
+// status --json`) and always exits 0 once its arguments are valid — any
+// discovery, config, or state failure degrades to silent output, not an
+// error. The architect skill's own `orch run status --json` call surfaces
+// a broken repo loudly later, once a session is actually underway.
+func hookClaudeSessionStart(env Env) error {
+	root, err := paths.FindOutermostRoot(env.RepoRoot)
+	if err != nil {
+		return nil // no .orchestrator ancestor (or an unwalkable one): silent
+	}
+	cfg, err := config.Load(root)
+	if err != nil {
+		return nil // unreadable/invalid config: silent
+	}
+	st, err := state.Load(root)
+	if err != nil {
+		return nil // unreadable/invalid state: silent
+	}
+	fmt.Fprint(env.Stdout, sessionStartContext(cfg, st))
+	return nil
+}
+
+// deliveryPhaseOrder lists state.Phase in the lifecycle order state.go
+// declares them, so the run summary line's phase counts render in a
+// stable, human-legible sequence rather than map iteration order.
+var deliveryPhaseOrder = []state.Phase{
+	state.PhasePlanned, state.PhaseIssueCreated, state.PhaseWorktreeReady,
+	state.PhaseDispatched, state.PhasePROpen, state.PhaseInReview,
+	state.PhaseAwaitingMerge, state.PhaseMerged, state.PhaseCleaned,
+	state.PhaseAbandoned, state.PhaseBlocked,
+}
+
+// sessionStartContext renders the compact plain-text context block the
+// SessionStart hook injects: Claude Code takes a hook's raw stdout as
+// context text, not a JSON envelope, so this is deliberately prose, not a
+// document.
+func sessionStartContext(cfg *config.Config, st *state.State) string {
+	var b strings.Builder
+	if st.Mode == state.ModeDelivery {
+		fmt.Fprintln(&b, "This repository is managed by Orch (mode: delivery).")
+		fmt.Fprintln(&b, deliveryRunSummary(st.Run))
+	} else {
+		fmt.Fprintln(&b, "This repository is managed by Orch (mode: assist).")
+	}
+	fmt.Fprintf(&b, "Memhub mode: %s.\n", cfg.Memhub.Mode)
+	fmt.Fprintln(&b, "Before planning or acting on any request that would change tracked files, load and follow the `orch-architect` skill. Setup interviews: /orch:init, /orch:configure, /orch:configure-local.")
+	return b.String()
+}
+
+// deliveryRunSummary renders the one-line Delivery run summary: run id,
+// host, and per-phase issue counts in deliveryPhaseOrder, skipping any
+// phase with zero issues.
+func deliveryRunSummary(run *state.Run) string {
+	counts := make(map[state.Phase]int, len(deliveryPhaseOrder))
+	for _, iss := range run.Issues {
+		counts[iss.Phase]++
+	}
+	var parts []string
+	for _, phase := range deliveryPhaseOrder {
+		if n := counts[phase]; n > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", n, phase))
+		}
+	}
+	return fmt.Sprintf("Delivery run %s (host %s): %s.", run.ID, run.Host, strings.Join(parts, ", "))
+}

--- a/internal/cli/hook_test.go
+++ b/internal/cli/hook_test.go
@@ -1,0 +1,156 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/paths"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+func TestHookSessionStartNoOrchAncestorSilent(t *testing.T) {
+	env, stdout, stderr := testEnv(t)
+	if code := Run([]string{"hook", "claude", "session-start"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr %q)", code, ExitOK, stderr.String())
+	}
+	if stdout.String() != "" {
+		t.Errorf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestHookSessionStartAssistRepo(t *testing.T) {
+	env, stdout, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	if code := Run([]string{"hook", "claude", "session-start"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr %q)", code, ExitOK, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"mode: assist", "off", "orch-architect"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestHookSessionStartNestedCwdWalksUp(t *testing.T) {
+	env, stdout, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	nested := filepath.Join(env.RepoRoot, "a", "b", "c")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	env.RepoRoot = nested
+	if code := Run([]string{"hook", "claude", "session-start"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr %q)", code, ExitOK, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "orch-architect") {
+		t.Errorf("stdout missing context from the discovered root:\n%s", stdout.String())
+	}
+}
+
+func TestHookSessionStartCorruptStateSilent(t *testing.T) {
+	env, stdout, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	if err := os.WriteFile(filepath.Join(env.RepoRoot, filepath.FromSlash(state.Path)), []byte("{ not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if code := Run([]string{"hook", "claude", "session-start"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr %q)", code, ExitOK, stderr.String())
+	}
+	if stdout.String() != "" {
+		t.Errorf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestHookSessionStartInvalidConfigSilent(t *testing.T) {
+	env, stdout, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML+"\nbogus_key = true\n")
+	if code := Run([]string{"hook", "claude", "session-start"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr %q)", code, ExitOK, stderr.String())
+	}
+	if stdout.String() != "" {
+		t.Errorf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+func TestHookSessionStartDeliveryRun(t *testing.T) {
+	env, stdout, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	planned := []state.Issue{{PlanID: "a", Title: "A", Phase: state.PhasePlanned}}
+	plan := state.PlanRef{Title: "t", Digest: "sha256:x", ConfigRevision: "r1"}
+	st, err := state.EnterDelivery(env.RepoRoot, "claude", plan, planned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision := &state.Decision{
+		Role:      manifest.RoleImplementer,
+		Executor:  manifest.Selection{Model: "m", Effort: "e"},
+		Reviewer:  manifest.Selection{Model: "m", Effort: "e"},
+		Rationale: "r",
+	}
+	st.Run.Issues = []state.Issue{
+		{PlanID: "a", Title: "A", Phase: state.PhaseDispatched, Number: 1, Branch: "b1", Worktree: "wt1", Decision: decision},
+		{PlanID: "b", Title: "B", Phase: state.PhaseDispatched, Number: 2, Branch: "b2", Worktree: "wt2", Decision: decision},
+		{PlanID: "c", Title: "C", Phase: state.PhaseInReview, Number: 3, Branch: "b3", Worktree: "wt3", Decision: decision, PRNumber: 3},
+		{PlanID: "d", Title: "D", Phase: state.PhasePlanned},
+	}
+	if err := state.Save(env.RepoRoot, st); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := Run([]string{"hook", "claude", "session-start"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr %q)", code, ExitOK, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "mode: delivery") {
+		t.Errorf("stdout missing delivery mode:\n%s", out)
+	}
+	want := "Delivery run " + st.Run.ID + " (host claude): 1 planned, 2 dispatched, 1 in-review."
+	if !strings.Contains(out, want) {
+		t.Errorf("stdout missing run summary %q:\n%s", want, out)
+	}
+}
+
+func TestHookBadArgsUsage(t *testing.T) {
+	cases := map[string][]string{
+		"no args":       {"hook"},
+		"unknown host":  {"hook", "codex", "session-start"},
+		"unknown verb":  {"hook", "claude", "session-end"},
+		"missing verb":  {"hook", "claude"},
+		"trailing args": {"hook", "claude", "session-start", "extra"},
+	}
+	for name, args := range cases {
+		t.Run(name, func(t *testing.T) {
+			env, _, stderr := testEnv(t)
+			if code := Run(args, env); code != ExitUsage {
+				t.Fatalf("exit = %d, want %d", code, ExitUsage)
+			}
+			if !strings.Contains(stderr.String(), "orch hook: usage") {
+				t.Errorf("stderr missing hookUsage: %q", stderr.String())
+			}
+		})
+	}
+}
+
+// TestHookSessionStartFindsOutermostRoot confirms the walk uses
+// FindOutermostRoot (matching guard), not FindRoot: a nested
+// .orchestrator ancestor (as a Delivery worktree would carry) must not
+// shadow the outermost one.
+func TestHookSessionStartFindsOutermostRoot(t *testing.T) {
+	env, stdout, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	inner := filepath.Join(env.RepoRoot, "nested")
+	if err := os.MkdirAll(filepath.Join(inner, paths.OrchestratorDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	env.RepoRoot = inner
+	if code := Run([]string{"hook", "claude", "session-start"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr %q)", code, ExitOK, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "orch-architect") {
+		t.Errorf("stdout missing context from the outermost root:\n%s", stdout.String())
+	}
+}

--- a/internal/guard/claude.go
+++ b/internal/guard/claude.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"sort"
 )
 
 // ErrUnknownTool reports a PreToolUse event whose tool_name guard does
@@ -22,6 +23,31 @@ type claudeEvent struct {
 	ToolName  string          `json:"tool_name"`
 	ToolInput json.RawMessage `json:"tool_input"`
 	CWD       string          `json:"cwd"`
+}
+
+// claudeToolPathField maps each Claude Code write tool_name guard
+// understands to the tool_input field carrying its write target. It is
+// the single source for both toolTargets dispatch and ClaudeTools, so
+// the two cannot drift apart.
+var claudeToolPathField = map[string]string{
+	"Write":        "file_path",
+	"Edit":         "file_path",
+	"MultiEdit":    "file_path",
+	"NotebookEdit": "notebook_path",
+}
+
+// ClaudeTools returns, sorted, the Claude Code tool_name values guard
+// extracts a write target from. Any other tool_name is ErrUnknownTool
+// (deny by default). It exists so the Claude adapter's plugin_test.go
+// can pin the hooks.json PreToolUse matcher against the exact dispatch
+// set by import instead of duplicating the tool list.
+func ClaudeTools() []string {
+	names := make([]string, 0, len(claudeToolPathField))
+	for name := range claudeToolPathField {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // PathsFromClaudeEvent decodes a raw PreToolUse event and returns the
@@ -58,26 +84,24 @@ func PathsFromClaudeEvent(payload []byte) ([]string, error) {
 	return out, nil
 }
 
-// toolTargets extracts the raw path field(s) each write tool carries.
+// toolTargets extracts the raw path field(s) each write tool carries,
+// dispatching on claudeToolPathField. A tool_name absent from the table
+// is ErrUnknownTool; a missing path field decodes to "" and is rejected
+// as an empty write path by the caller.
 func toolTargets(ev claudeEvent) ([]string, error) {
-	switch ev.ToolName {
-	case "Write", "Edit", "MultiEdit":
-		var in struct {
-			FilePath string `json:"file_path"`
-		}
-		if err := json.Unmarshal(ev.ToolInput, &in); err != nil {
-			return nil, fmt.Errorf("parse %s tool_input: %w", ev.ToolName, err)
-		}
-		return []string{in.FilePath}, nil
-	case "NotebookEdit":
-		var in struct {
-			NotebookPath string `json:"notebook_path"`
-		}
-		if err := json.Unmarshal(ev.ToolInput, &in); err != nil {
-			return nil, fmt.Errorf("parse %s tool_input: %w", ev.ToolName, err)
-		}
-		return []string{in.NotebookPath}, nil
-	default:
+	field, ok := claudeToolPathField[ev.ToolName]
+	if !ok {
 		return nil, fmt.Errorf("%w %q; guard denies by default", ErrUnknownTool, ev.ToolName)
 	}
+	var in map[string]json.RawMessage
+	if err := json.Unmarshal(ev.ToolInput, &in); err != nil {
+		return nil, fmt.Errorf("parse %s tool_input: %w", ev.ToolName, err)
+	}
+	var path string
+	if raw, ok := in[field]; ok {
+		if err := json.Unmarshal(raw, &path); err != nil {
+			return nil, fmt.Errorf("parse %s tool_input: %w", ev.ToolName, err)
+		}
+	}
+	return []string{path}, nil
 }


### PR DESCRIPTION
## What

PR 1 of 2 for task 17 (Claude Code adapter), per the approved plan: the enforcement + scaffold half that makes Orch guard enforcement live in real Claude Code sessions.

**Core addition — `orch hook claude session-start`** (`internal/cli/hook.go`):
- New adapter-plumbing command, registered alongside `run`/`guard`. Deliberately **fail-open** (the inverse of the repo rule, documented in-code): a broken or non-orch repository must never break a Claude Code session from starting. Never reads stdin; always exits 0 once args are valid.
- Walks up from cwd via `paths.FindOutermostRoot` (same discovery as guard). Outside an orch repo, or when config/state fail to load: silent. Otherwise injects a compact context block: mode line, one-line Delivery run summary (run ID, host, per-phase counts) when applicable, memhub mode, and the directive to load the `orch-architect` skill + the three `/orch:*` setup commands.

**Plugin scaffold** (`adapters/claude/`):
- `.claude-plugin/plugin.json` — minimal manifest (name `orch`, component dirs auto-discovered).
- `hooks/hooks.json` — `PreToolUse` on `Write|Edit|MultiEdit|NotebookEdit` → `orch guard claude`; `SessionStart` on `startup|resume|clear|compact` → `orch hook claude session-start`. Bare argv only — no shell syntax, portable across all three OSes.
- `plugin_test.go` (+ `doc.go` anchor) — strict-JSON manifest validation, **matcher↔guard parity** pinned via `guard.ClaudeTools()`, shell-metacharacter portability lint, and command strings drift-pinned to the binary verbs. Runs under the ordinary `go test ./...`.
- `README.md` — rewritten: install order (binary on PATH **before** plugin; a missing binary fails open under the hook protocol, so ordering is mechanical, not cosmetic), artifact map, four known limitations, host-version note (formal minimum stays a PRD §24 deferral).

**Guard refactor**: `toolTargets` now dispatches on a `claudeToolPathField` table and `ClaudeTools()` derives from the same table — the exported set the adapter test pins against cannot drift from real dispatch (main-thread review caught the implementer's hand-written list as a drift risk).

## Why

First slice of Phase 4. This PR alone delivers the acceptance-critical property (PRD §23) "Assist reliably blocks tracked-file changes / Delivery cannot write outside registered worktrees" inside real Claude Code sessions. PR 2 adds the instruction artifacts (3 skills, 3 slash commands, 4 role agents) that make the full workflow drivable.

## Verification

- `gofmt` clean, `go build`, `go vet`, `go test ./...` all green (new `internal/cli` hook suite + `adapters/claude` plugin suite included).
- Manual smoke on Windows against the built binary: session-start injects the context block inside an orch-initialized scratch repo and stays silent outside one; `orch guard claude` answers an Assist-mode Edit with the exact `permissionDecision: deny` JSON and denies unknown tool names by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)