### PR TITLE
Fail activation closed on plan area labels missing from the repo

### DIFF
--- a/ORCH-PRD.md
+++ b/ORCH-PRD.md
@@ -309,7 +309,7 @@ One issue maps to one branch/worktree and one PR.
 
 Every issue carries:
 
-- One status: `ready`, `in-progress`, `blocked`, `needs-human`, or `awaiting-review`.
+- One status: `ready`, `in-progress`, `blocked`, `needs-human`, `awaiting-review`, or `delivered` (terminal; set by merge just before the issue closes).
 - One type: `feature`, `bug`, `chore`, `infra`, `docs`, or `research`.
 - One role: `implementer` or `specialist`.
 - One risk: `standard` or `critical`.

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -61,7 +61,10 @@ a routed selection.
 `facts.read_only` must be `false` for every issue — read-only work
 belongs in Assist. `depends_on` names issues by `id`; a dependency's
 `wave` must be strictly less than the depending issue's. `usage_class`
-is `light`, `medium`, or `heavy`.
+is `light`, `medium`, or `heavy`. `area_labels` are repository-defined:
+every one you declare must already exist in the repo — activation fails
+closed at a read-only preflight if any is missing (create it with
+`gh label create <name>` or drop it from the plan).
 
 ## Plan gate
 

--- a/internal/bootstrap/helpers_test.go
+++ b/internal/bootstrap/helpers_test.go
@@ -251,6 +251,7 @@ var taxonomyLabels = []struct{ name, color, desc string }{
 	{"blocked", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
 	{"needs-human", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
 	{"awaiting-review", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
+	{"delivered", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
 	{"feature", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
 	{"bug", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
 	{"chore", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
@@ -288,7 +289,7 @@ func ghCreatePRCall(number int) execxtest.Call {
 }
 
 func ghSetStatusCall(number int, to ghops.Status) execxtest.Call {
-	all := []ghops.Status{ghops.StatusReady, ghops.StatusInProgress, ghops.StatusBlocked, ghops.StatusNeedsHuman, ghops.StatusAwaitingReview}
+	all := []ghops.Status{ghops.StatusReady, ghops.StatusInProgress, ghops.StatusBlocked, ghops.StatusNeedsHuman, ghops.StatusAwaitingReview, ghops.StatusDelivered}
 	args := []string{"issue", "edit", strconv.Itoa(number)}
 	for _, s := range all {
 		if s != to {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -20,7 +20,7 @@ const Path = ".orchestrator/config.toml"
 const LocalOverridePath = ".orchestrator/config.local.toml"
 
 // ErrNotInitialized reports a missing committed configuration file.
-var ErrNotInitialized = errors.New("not initialized: " + Path + " not found (orch init is not yet implemented)")
+var ErrNotInitialized = errors.New("not initialized: " + Path + " not found (run `orch init` to set up this repository)")
 
 // Load reads, parses, and validates the committed configuration under
 // repoRoot, then merges in any machine-local overlay from

--- a/internal/ghops/checks.go
+++ b/internal/ghops/checks.go
@@ -69,7 +69,10 @@ func (g *GH) RequiredCI(ctx context.Context, number int) (CISummary, error) {
 	}
 	switch res.ExitCode {
 	case 0, 1, 8:
-		// Data: 0 all passing, 1 something failed, 8 checks pending.
+		// Data. gh documents 1 (something failed) and 8 (pending) for
+		// the human-output mode; with --json, gh 2.87.3 exits 0 in
+		// every state (verified live, fact 17). All three are accepted
+		// so the state derivation below owns the signal either way.
 	default:
 		return CISummary{}, fmt.Errorf("gh pr checks in %s exited %d: %s", g.root, res.ExitCode, strings.TrimSpace(res.Stderr))
 	}

--- a/internal/ghops/issue_test.go
+++ b/internal/ghops/issue_test.go
@@ -180,6 +180,7 @@ func TestSetStatus(t *testing.T) {
 			"issue", "edit", "42",
 			"--remove-label", "ready", "--remove-label", "in-progress",
 			"--remove-label", "needs-human", "--remove-label", "awaiting-review",
+			"--remove-label", "delivered",
 			"--add-label", "blocked",
 		},
 		Dir: root,

--- a/internal/ghops/labels.go
+++ b/internal/ghops/labels.go
@@ -15,13 +15,16 @@ import (
 // Status is the exactly-one workflow-status label (PRD §13).
 type Status string
 
-// The five status labels.
+// The six status labels. Delivered is terminal: merge sets it just
+// before closing the issue, so a closed delivered issue does not keep
+// wearing the needs-human set at merge-report.
 const (
 	StatusReady          Status = "ready"
 	StatusInProgress     Status = "in-progress"
 	StatusBlocked        Status = "blocked"
 	StatusNeedsHuman     Status = "needs-human"
 	StatusAwaitingReview Status = "awaiting-review"
+	StatusDelivered      Status = "delivered"
 )
 
 // Type is the exactly-one change-type label (PRD §13).
@@ -58,7 +61,7 @@ const (
 
 // statuses lists all status labels in canonical order; SetStatus and
 // the taxonomy table depend on this order being stable.
-var statuses = []Status{StatusReady, StatusInProgress, StatusBlocked, StatusNeedsHuman, StatusAwaitingReview}
+var statuses = []Status{StatusReady, StatusInProgress, StatusBlocked, StatusNeedsHuman, StatusAwaitingReview, StatusDelivered}
 
 // roleLabels lists all role labels in canonical order; SetRole depends
 // on this order being stable.
@@ -81,6 +84,7 @@ var taxonomy = []labelDef{
 	{"blocked", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
 	{"needs-human", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
 	{"awaiting-review", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
+	{"delivered", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
 	{"feature", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
 	{"bug", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
 	{"chore", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},

--- a/internal/ghops/labels.go
+++ b/internal/ghops/labels.go
@@ -202,13 +202,9 @@ func matchesAny(folded string, forbidden []string) bool {
 	return false
 }
 
-// EnsureLabelTaxonomy lists the repository's labels and creates any
-// missing taxonomy label with its pinned color and description;
-// existing labels are never modified (no --force: repository
-// customizations survive). Idempotent; returns the names it created,
-// in taxonomy order, for the audit trail. The list-then-create gap is
-// not atomic; the run engine serializes conflicting writes (PRD §14).
-func (g *GH) EnsureLabelTaxonomy(ctx context.Context) ([]string, error) {
+// existingLabelNames lists the repository's labels as a set keyed by
+// lowercase name (GitHub label names are case-insensitive).
+func (g *GH) existingLabelNames(ctx context.Context) (map[string]bool, error) {
 	var existing []struct {
 		Name string `json:"name"`
 	}
@@ -216,9 +212,43 @@ func (g *GH) EnsureLabelTaxonomy(ctx context.Context) ([]string, error) {
 	if err := g.ghJSON(ctx, &existing, "label", "list", "--json", "name", "--limit", "1000"); err != nil {
 		return nil, err
 	}
-	present := map[string]bool{}
+	present := make(map[string]bool, len(existing))
 	for _, l := range existing {
 		present[strings.ToLower(l.Name)] = true
+	}
+	return present, nil
+}
+
+// MissingLabels reports which of names do not exist in the repository,
+// in the order given (case-insensitive, matching GitHub's label-name
+// semantics). Read-only; what a missing label means is the caller's
+// policy — the run engine fails activation closed on absent
+// plan-declared area labels, because area labels are
+// repository-defined (PRD §13) and orch never invents them.
+func (g *GH) MissingLabels(ctx context.Context, names []string) ([]string, error) {
+	present, err := g.existingLabelNames(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var missing []string
+	for _, n := range names {
+		if !present[strings.ToLower(n)] {
+			missing = append(missing, n)
+		}
+	}
+	return missing, nil
+}
+
+// EnsureLabelTaxonomy lists the repository's labels and creates any
+// missing taxonomy label with its pinned color and description;
+// existing labels are never modified (no --force: repository
+// customizations survive). Idempotent; returns the names it created,
+// in taxonomy order, for the audit trail. The list-then-create gap is
+// not atomic; the run engine serializes conflicting writes (PRD §14).
+func (g *GH) EnsureLabelTaxonomy(ctx context.Context) ([]string, error) {
+	present, err := g.existingLabelNames(ctx)
+	if err != nil {
+		return nil, err
 	}
 	var created []string
 	for _, def := range taxonomy {

--- a/internal/ghops/labels_test.go
+++ b/internal/ghops/labels_test.go
@@ -103,6 +103,61 @@ func allTaxonomyNames() []string {
 	return names
 }
 
+func TestMissingLabels(t *testing.T) {
+	root := tempRoot(t)
+	list := labelListCall
+	list.Dir = root
+	list.Env = ghTestEnv
+	list.Stdout = labelJSON("Core", "docs-site")
+	g, script := openScripted(t, root, list)
+	missing, err := g.MissingLabels(context.Background(), []string{"core", "CLI", "docs-site", "greet"})
+	if err != nil {
+		t.Fatalf("MissingLabels: %v", err)
+	}
+	script.AssertExhausted()
+	// Present names match case-insensitively; missing names come back
+	// in the order given, original casing preserved.
+	want := []string{"CLI", "greet"}
+	if len(missing) != len(want) || missing[0] != want[0] || missing[1] != want[1] {
+		t.Errorf("missing = %v, want %v", missing, want)
+	}
+}
+
+func TestMissingLabelsAllPresent(t *testing.T) {
+	root := tempRoot(t)
+	list := labelListCall
+	list.Dir = root
+	list.Env = ghTestEnv
+	list.Stdout = labelJSON("core", "cli")
+	g, script := openScripted(t, root, list)
+	missing, err := g.MissingLabels(context.Background(), []string{"Core", "cli"})
+	if err != nil {
+		t.Fatalf("MissingLabels: %v", err)
+	}
+	script.AssertExhausted()
+	if len(missing) != 0 {
+		t.Errorf("missing = %v, want none", missing)
+	}
+}
+
+func TestMissingLabelsListFails(t *testing.T) {
+	root := tempRoot(t)
+	list := labelListCall
+	list.Dir = root
+	list.Env = ghTestEnv
+	list.Stderr = "HTTP 403: forbidden"
+	list.Exit = 1
+	g, script := openScripted(t, root, list)
+	missing, err := g.MissingLabels(context.Background(), []string{"core"})
+	script.AssertExhausted()
+	if err == nil || !strings.Contains(err.Error(), "exited 1") {
+		t.Fatalf("err = %v, want list failure", err)
+	}
+	if missing != nil {
+		t.Errorf("missing = %v, want nil on error", missing)
+	}
+}
+
 func TestEnsureLabelTaxonomyAllPresent(t *testing.T) {
 	root := tempRoot(t)
 	list := labelListCall

--- a/internal/run/activate.go
+++ b/internal/run/activate.go
@@ -114,8 +114,10 @@ func wrapAfterEnter(err error) error {
 //     approval, derive routing and labels for every issue.
 //   - Phase 2 (read-only preflights): Assist+no-lock, clean primary
 //     checkout, authenticated GitHub remote, primary on the default
-//     branch (F4), the memhub gate, and the worktree container
-//     git-ignored (F1).
+//     branch (F4), every plan-declared area label existing in the
+//     repository (area labels are repository-defined per PRD §13, so
+//     activation never creates them), the memhub gate, and the
+//     worktree container git-ignored (F1).
 //   - Phase 3 (idempotent GitHub prep): EnsureLabelTaxonomy — the only
 //     mutation before the lock is held (F6).
 //   - Phase 4: state.EnterDelivery acquires the lock and records the
@@ -194,6 +196,15 @@ func Activate(ctx context.Context, env Env, reqJSON []byte) (*ActivationResult, 
 	}
 	if branch != repo.DefaultBranch {
 		return nil, fmt.Errorf("primary checkout is on %s, not the default branch %s; activation requires the primary checkout on the default branch", branch, repo.DefaultBranch)
+	}
+	if areas := planAreaLabels(plan); len(areas) > 0 {
+		missing, err := gh.MissingLabels(ctx, areas)
+		if err != nil {
+			return nil, err
+		}
+		if len(missing) > 0 {
+			return nil, fmt.Errorf("%w: %s; create them in the repository (gh label create <name>) or remove them from the plan, then resubmit for approval", ErrAreaLabelMissing, strings.Join(missing, ", "))
+		}
 	}
 	if _, err := memhubGate(ctx, cfg.Memhub.Mode, execProber{runner: env.Runner, dir: env.RepoRoot}); err != nil {
 		return nil, err
@@ -289,6 +300,25 @@ func Activate(ctx context.Context, env Env, reqJSON []byte) (*ActivationResult, 
 		return nil, wrapAfterEnter(err)
 	}
 	return result, nil
+}
+
+// planAreaLabels collects the plan's area labels across issues in
+// document order, deduplicated case-insensitively (GitHub label names
+// are), for the activation preflight.
+func planAreaLabels(p *PlanDoc) []string {
+	seen := map[string]bool{}
+	var areas []string
+	for _, pi := range p.Issues {
+		for _, a := range pi.AreaLabels {
+			folded := strings.ToLower(a)
+			if seen[folded] {
+				continue
+			}
+			seen[folded] = true
+			areas = append(areas, a)
+		}
+	}
+	return areas
 }
 
 // issueBody renders the human-prose portion of a created issue's body

--- a/internal/run/activate_test.go
+++ b/internal/run/activate_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kninetimmy/orch/internal/execx"
@@ -113,8 +114,12 @@ func ghRepoViewCall(defaultBranch string) execxtest.Call {
 	}
 }
 
+func ghLabelListCall(stdout string) execxtest.Call {
+	return execxtest.Call{Name: "gh", Args: []string{"label", "list", "--json", "name", "--limit", "1000"}, Stdout: stdout}
+}
+
 func ghLabelListEmptyCall() execxtest.Call {
-	return execxtest.Call{Name: "gh", Args: []string{"label", "list", "--json", "name", "--limit", "1000"}, Stdout: "[]"}
+	return ghLabelListCall("[]")
 }
 
 // taxonomyLabels mirrors ghops's private label taxonomy table
@@ -275,6 +280,74 @@ func TestActivateHappyPathTwoIssuesTwoWaves(t *testing.T) {
 			t.Errorf("Issues[%d] = %+v, want %+v", i, got, want)
 		}
 	}
+}
+
+// areaPlanJSON is a single-issue plan declaring two area labels,
+// passing Validate against testConfig().
+func areaPlanJSON() string {
+	return `{
+  "schema_version": 1,
+  "host": "claude",
+  "title": "Area label plan",
+  "issues": [
+    {
+      "id": "a",
+      "title": "Issue A",
+      "objective": "Do A",
+      "acceptance_criteria": ["A works"],
+      "type": "feature",
+      "facts": {"read_only": false},
+      "wave": 1,
+      "required_tests": ["go test ./..."],
+      "usage_class": "light",
+      "area_labels": ["core", "cli"]
+    }
+  ]
+}`
+}
+
+func TestActivateAreaLabelsPresentProceeds(t *testing.T) {
+	root := newActivateRepo(t)
+	// Preflight matches area labels case-insensitively (GitHub label
+	// names are); the taxonomy step then lists again and creates the
+	// full §13 set.
+	repoLabels := `[{"name":"Core"},{"name":"cli"}]`
+	calls := []execxtest.Call{ghOpenCall(), ghRepoViewCall("main"), ghLabelListCall(repoLabels), ghLabelListCall(repoLabels)}
+	calls = append(calls, ghLabelCreateCalls()...)
+	calls = append(calls,
+		ghIssueCreateCall("Issue A", []string{"ready", "feature", "implementer", "standard", "core", "cli"}, 1),
+	)
+	script := &execxtest.Script{T: t, Calls: calls}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	result, err := Activate(context.Background(), env, activationJSON(t, areaPlanJSON()))
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	script.AssertExhausted()
+	if len(result.Issues) != 1 || result.Issues[0].Number != 1 {
+		t.Errorf("Issues = %+v, want one issue #1", result.Issues)
+	}
+}
+
+func TestActivateMissingAreaLabelLeavesNothing(t *testing.T) {
+	root := newActivateRepo(t)
+	// The repo has "core" but not "cli": activation must fail closed at
+	// the read-only preflight, before the taxonomy step or any issue.
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghOpenCall(), ghRepoViewCall("main"), ghLabelListCall(`[{"name":"core"}]`),
+	}}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	_, err := Activate(context.Background(), env, activationJSON(t, areaPlanJSON()))
+	if !errors.Is(err, ErrAreaLabelMissing) {
+		t.Fatalf("err = %v, want ErrAreaLabelMissing", err)
+	}
+	if !strings.Contains(err.Error(), "cli") || strings.Contains(err.Error(), "core,") {
+		t.Errorf("err = %v, want the missing label named and the present one not", err)
+	}
+	script.AssertExhausted()
+	assertNoDeliveryState(t, root)
 }
 
 func TestActivateFailureAtSecondIssueCreateIsResumable(t *testing.T) {

--- a/internal/run/activate_test.go
+++ b/internal/run/activate_test.go
@@ -130,6 +130,7 @@ var taxonomyLabels = []struct{ name, color, desc string }{
 	{"blocked", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
 	{"needs-human", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
 	{"awaiting-review", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
+	{"delivered", "1D76DB", "orch status label — exactly one per issue (PRD §13)"},
 	{"feature", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
 	{"bug", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},
 	{"chore", "0E8A16", "orch type label — exactly one per issue (PRD §13)"},

--- a/internal/run/errors.go
+++ b/internal/run/errors.go
@@ -19,6 +19,11 @@ var (
 	// other than ApprovalStatement, or a plan_digest that does not
 	// equal the recomputed digest (the "adjust = resubmit" loop).
 	ErrBadApproval = errors.New("activation approval is invalid")
+	// ErrAreaLabelMissing reports plan-declared area labels absent from
+	// the repository at activation preflight: area labels are
+	// repository-defined (PRD §13), so activation never creates them —
+	// it fails closed before any mutation instead.
+	ErrAreaLabelMissing = errors.New("plan-declared area labels do not exist in the repository")
 	// ErrMemhubRequired reports that config.Memhub.Mode is "required"
 	// and the memhub probe failed or could not run (PRD §20: fail
 	// closed rather than proceed without memory).

--- a/internal/run/lifecycle_test.go
+++ b/internal/run/lifecycle_test.go
@@ -98,7 +98,7 @@ func ghCloseIssueCall(number int) execxtest.Call {
 
 func ghSetStatusCall(number int, to ghops.Status) execxtest.Call {
 	args := []string{"issue", "edit", strconv.Itoa(number)}
-	for _, s := range []ghops.Status{ghops.StatusReady, ghops.StatusInProgress, ghops.StatusBlocked, ghops.StatusNeedsHuman, ghops.StatusAwaitingReview} {
+	for _, s := range []ghops.Status{ghops.StatusReady, ghops.StatusInProgress, ghops.StatusBlocked, ghops.StatusNeedsHuman, ghops.StatusAwaitingReview, ghops.StatusDelivered} {
 		if s != to {
 			args = append(args, "--remove-label", string(s))
 		}
@@ -240,6 +240,7 @@ func TestLifecycleWalk(t *testing.T) {
 	runVerb(t, root, Merge, `{"schema_version":1,"issue_number":1,"approval":{"pr_number":10,"head_oid":"head-oid-2","approved_by":"alice","approved_at":"2026-07-11T12:00:00Z","statement":"approve-merge"}}`,
 		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-2"), ghRollupEmptyCall(10),
 		ghMergePRCall(10, "head-oid-2"), ghPRViewCall(10, "MERGED", "head-oid-2"),
+		ghSetStatusCall(1, ghops.StatusDelivered),
 		ghIssueViewCall(t, 1, "OPEN", body), ghCloseIssueCall(1), ghSetIssueBodyCall(1))
 	wantPhase(t, root, 1, state.PhaseMerged)
 

--- a/internal/run/merge.go
+++ b/internal/run/merge.go
@@ -108,6 +108,12 @@ func Merge(ctx context.Context, env Env, reqJSON []byte) (*MergeResult, error) {
 		pr = merged
 	}
 
+	// Terminal status (PRD §13): the issue reads delivered from here
+	// on, not the needs-human set at merge-report.
+	if err := gh.SetStatus(ctx, issue.Number, ghops.StatusDelivered); err != nil {
+		return nil, wrapAfterMutation(err)
+	}
+
 	// Confirm issue closure (PRD §12 step 17): the Closes link usually
 	// fires on merge, but the human merge approval covers closing it if
 	// it did not.


### PR DESCRIPTION
## What

Activation now verifies, in its Phase 2 read-only preflights, that every plan-declared area label already exists in the repository, and fails closed with a new `ErrAreaLabelMissing` sentinel — naming the missing labels and the remediation (`gh label create <name>` or drop them from the plan) — before the Delivery lock, state, or any GitHub mutation. Plans that declare no area labels skip the extra `gh label list` call entirely, so existing flows are unchanged.

Supporting changes:

- `internal/ghops`: new read-only `MissingLabels(ctx, names)` (case-insensitive, matching GitHub's label-name semantics; missing names return in the order given, casing preserved). The label-list read is extracted into `existingLabelNames`, shared with `EnsureLabelTaxonomy` — no behavior change there.
- `internal/run/activate.go`: `planAreaLabels` collects the plan's areas in document order, deduplicated case-insensitively; the preflight sits with the other gh reads, after the default-branch check.
- `adapters/claude/skills/orch-delivery/SKILL.md`: the PlanDoc-construction section now tells the Architect that `area_labels` must already exist in the repo.
- Tests: ghops unit tests for `MissingLabels` (present/missing/case-insensitive/list-failure), plus activation tests for the happy path with areas present (case-insensitive match, issue created with area labels) and the fail-closed path (`ErrAreaLabelMissing`, no state/lock left behind, transcript ends at the preflight).

## Why

Found live in the task-18 sandbox smoke (memhub task 28): the plan declared area label `greet`, activation's idempotent taxonomy step creates only the closed PRD §13 labels, so `gh issue create --label greet` failed **mid-activation** — after the lock and state were taken. The failure semantics held (state preserved, resume honestly refused, abort + re-activate recovered), but the failure belongs before any mutation.

Design call (user decision): fail closed at preflight rather than auto-create. Area labels are repository-defined per PRD §13 — orch never invents them; a typo'd area label should surface as an error, not become a permanent repo label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDJjTSwBQ5YrnnWfE4Fjrv


## Also: task 29 post-smoke cleanups (second commit)

- `config.ErrNotInitialized` now points at `orch init` instead of claiming it is not yet implemented (stale since task 15).
- `ghops/checks.go` exit-code comment corrected to the live-verified gh 2.87.3 behavior (fact 17): with `--json`, `pr checks` exits 0 in every state; 1/8 are human-output-mode codes and stay accepted. Behavior unchanged.
- **New terminal `delivered` status label** (user decision): the PRD §13 taxonomy gains `delivered`, set by the merge verb just before confirming issue closure, so delivered issues no longer close wearing `needs-human`. PRD §13 amended. Bootstrap issues still close wearing `awaiting-review` — orch is not running when the human merges the bootstrap PR, so there is no mechanical moment to update them (documented, unchanged).
