### PR TITLE
Add Codex guard and session-start core plumbing

### DIFF
--- a/internal/cli/guard.go
+++ b/internal/cli/guard.go
@@ -14,10 +14,11 @@ import (
 
 // guardUsage is the one-line usage for the adapter plumbing surface,
 // mirroring runUsage.
-const guardUsage = "orch guard: usage: orch guard check [--role <role>] [--issue <n>] [--] <path>... | orch guard claude [--role <role>] [--issue <n>] (PreToolUse JSON on stdin)"
+const guardUsage = "orch guard: usage: orch guard check [--role <role>] [--issue <n>] [--] <path>... | orch guard claude [--role <role>] [--issue <n>] (PreToolUse JSON on stdin) | orch guard codex [--role <role>] [--issue <n>] (PreToolUse JSON on stdin)"
 
 // runGuard dispatches the pre-write enforcement verbs (PRD §23): `orch
-// guard check` (host-neutral argv) and `orch guard claude` (Claude Code
+// guard check` (host-neutral argv), `orch guard claude` (Claude Code
+// PreToolUse JSON on stdin), and `orch guard codex` (Codex CLI
 // PreToolUse JSON on stdin). Host adapters call it from their own
 // PreToolUse hooks before every agent write; it is never invoked by a
 // human directly.
@@ -30,6 +31,8 @@ func runGuard(env Env, args []string) error {
 		return guardCheck(env, args[1:])
 	case "claude":
 		return guardClaude(env, args[1:])
+	case "codex":
+		return guardCodex(env, args[1:])
 	default:
 		return usageError(guardUsage)
 	}
@@ -62,12 +65,14 @@ func guardCheck(env Env, args []string) error {
 	return fmt.Errorf("%s: %s", v.Path, v.Reason) // exit 1, names path + reason
 }
 
-// guardClaude answers a Claude Code PreToolUse event read from stdin. It
-// never emits a permissionDecision of "allow" — an allow is silence, so
-// guard never bypasses the user's own permission prompts. A denial exits
-// 0 with the hook's deny document on stdout. Any internal failure exits
-// 2 (the hook protocol's blocking code); the verb never exits 1.
-func guardClaude(env Env, args []string) error {
+// guardHostHook answers a PreToolUse event read from stdin, decoded into
+// absolute write targets by decode (guard.PathsFromClaudeEvent or
+// guard.PathsFromCodexEvent). It never emits a permissionDecision of
+// "allow" — an allow is silence, so guard never bypasses the user's own
+// permission prompts. A denial exits 0 with the hook's deny document on
+// stdout. Any internal failure exits 2 (the hook protocol's blocking
+// code); the verb never exits 1.
+func guardHostHook(env Env, args []string, decode func([]byte) ([]string, error)) error {
 	role, issue, rest, err := parseGuardFlags(args)
 	if err != nil {
 		return err
@@ -81,10 +86,10 @@ func guardClaude(env Env, args []string) error {
 		return exitCodeError{code: ExitUsage, err: fmt.Errorf("read stdin: %w", err)}
 	}
 
-	targets, err := guard.PathsFromClaudeEvent(payload)
+	targets, err := decode(payload)
 	if err != nil {
-		if errors.Is(err, guard.ErrUnknownTool) {
-			return emitClaudeDeny(env.Stdout, err.Error())
+		if errors.Is(err, guard.ErrUnknownTool) || errors.Is(err, guard.ErrPatchEnvelope) {
+			return emitPreToolUseDeny(env.Stdout, err.Error())
 		}
 		return exitCodeError{code: ExitUsage, err: err}
 	}
@@ -100,11 +105,22 @@ func guardClaude(env Env, args []string) error {
 	if v.Allow {
 		return nil // exit 0, no output, no opinion
 	}
-	return emitClaudeDeny(env.Stdout, v.Reason)
+	return emitPreToolUseDeny(env.Stdout, v.Reason)
+}
+
+// guardClaude answers a Claude Code PreToolUse event read from stdin.
+func guardClaude(env Env, args []string) error {
+	return guardHostHook(env, args, guard.PathsFromClaudeEvent)
+}
+
+// guardCodex answers a Codex CLI PreToolUse event read from stdin.
+func guardCodex(env Env, args []string) error {
+	return guardHostHook(env, args, guard.PathsFromCodexEvent)
 }
 
 // hookOutput is the PreToolUse response guard writes on a denial. Its
-// shape is fixed by the Claude Code hook protocol.
+// shape is fixed by the PreToolUse hook protocol, which Codex CLI mirrors
+// from Claude Code.
 type hookOutput struct {
 	HookSpecificOutput hookSpecificOutput `json:"hookSpecificOutput"`
 }
@@ -115,10 +131,11 @@ type hookSpecificOutput struct {
 	PermissionDecisionReason string `json:"permissionDecisionReason"`
 }
 
-// emitClaudeDeny writes the deny document to stdout and returns nil so
-// the verb exits 0 (the denial is carried by the document, not the exit
-// code). A stdout write failure is an internal failure → blocking exit 2.
-func emitClaudeDeny(w io.Writer, reason string) error {
+// emitPreToolUseDeny writes the deny document to stdout and returns nil
+// so the verb exits 0 (the denial is carried by the document, not the
+// exit code). A stdout write failure is an internal failure → blocking
+// exit 2.
+func emitPreToolUseDeny(w io.Writer, reason string) error {
 	data, err := json.Marshal(hookOutput{HookSpecificOutput: hookSpecificOutput{
 		HookEventName:            "PreToolUse",
 		PermissionDecision:       "deny",

--- a/internal/cli/guard_test.go
+++ b/internal/cli/guard_test.go
@@ -44,6 +44,50 @@ func claudePayload(t *testing.T, tool, pathKey, pathVal, cwd string) string {
 	return string(b)
 }
 
+// codexPayload marshals a minimal Codex CLI PreToolUse event whose
+// tool_input carries envelope as its apply_patch command.
+func codexPayload(t *testing.T, toolName, envelope, cwd string) string {
+	t.Helper()
+	m := map[string]any{
+		"tool_name":  toolName,
+		"tool_input": map[string]string{"command": envelope},
+	}
+	if cwd != "" {
+		m["cwd"] = cwd
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// deliveryGuardEnv builds a Delivery repo with one dispatched issue
+// (deliveryIssue) and its registered worktree checked out on the
+// matching branch — the shared fixture for every guard test that needs
+// an active run, so check and the host hook verbs exercise the same
+// containment rules.
+func deliveryGuardEnv(t *testing.T) (env Env, stdout, stderr *bytes.Buffer, worktreeAbs string) {
+	t.Helper()
+	env, stdout, stderr, root := guardRepo(t, 1)
+	planned := []state.Issue{{PlanID: "a", Title: "A", Phase: state.PhasePlanned}}
+	plan := state.PlanRef{Title: "t", Digest: "sha256:x", ConfigRevision: "r1"}
+	if _, err := state.EnterDelivery(root, "claude", plan, planned); err != nil {
+		t.Fatal(err)
+	}
+	st, err := state.Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Run.Issues = []state.Issue{deliveryIssue()}
+	if err := state.Save(root, st); err != nil {
+		t.Fatal(err)
+	}
+	worktreeAbs = filepath.Join(root, "wt")
+	writeGitPointer(t, worktreeAbs, "ref: refs/heads/feature-3\n")
+	return env, stdout, stderr, worktreeAbs
+}
+
 func TestGuardCheckAllowIgnored(t *testing.T) {
 	env, stdout, stderr, root := guardRepo(t, 0) // 0 = ignored
 	target := filepath.Join(root, "build", "out.o")
@@ -202,28 +246,123 @@ func TestGuardClaudeNeverExitsOne(t *testing.T) {
 }
 
 func TestGuardCheckDeliveryAllows(t *testing.T) {
-	env, _, stderr, root := guardRepo(t, 1)
-	// Enter Delivery with one dispatched issue and a matching worktree.
-	planned := []state.Issue{{PlanID: "a", Title: "A", Phase: state.PhasePlanned}}
-	plan := state.PlanRef{Title: "t", Digest: "sha256:x", ConfigRevision: "r1"}
-	if _, err := state.EnterDelivery(root, "claude", plan, planned); err != nil {
-		t.Fatal(err)
-	}
-	st, err := state.Load(root)
-	if err != nil {
-		t.Fatal(err)
-	}
-	st.Run.Issues = []state.Issue{deliveryIssue()}
-	if err := state.Save(root, st); err != nil {
-		t.Fatal(err)
-	}
-
-	worktreeAbs := filepath.Join(root, "wt")
-	writeGitPointer(t, worktreeAbs, "ref: refs/heads/feature-3\n")
+	env, _, stderr, worktreeAbs := deliveryGuardEnv(t)
 	target := filepath.Join(worktreeAbs, "src", "x.go")
 
 	if code := Run([]string{"guard", "check", "--role", "implementer", "--issue", "3", target}, env); code != ExitOK {
 		t.Fatalf("exit = %d, want %d (stderr %q)", code, ExitOK, stderr.String())
+	}
+}
+
+func TestGuardCodexAllowSilent(t *testing.T) {
+	env, stdout, _, worktreeAbs := deliveryGuardEnv(t)
+	envelope := "*** Begin Patch\n*** Update File: src/x.go\n@@ hunk header\n-old\n+new\n*** End Patch"
+	env.Stdin = strings.NewReader(codexPayload(t, "apply_patch", envelope, worktreeAbs))
+	if code := Run([]string{"guard", "codex", "--role", "implementer", "--issue", "3"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stdout %q)", code, ExitOK, stdout.String())
+	}
+	if stdout.String() != "" {
+		t.Errorf("allow emitted output: %q", stdout.String())
+	}
+}
+
+func TestGuardCodexDenyJSON(t *testing.T) {
+	env, stdout, _, root := guardRepo(t, 1) // not ignored → deny
+	envelope := "*** Begin Patch\n*** Update File: src/x.go\n@@ hunk header\n-old\n+new\n*** End Patch"
+	env.Stdin = strings.NewReader(codexPayload(t, "apply_patch", envelope, root))
+	const wantReason = "assist is read-only for repository files; ask for a Delivery plan"
+	want := `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"` + wantReason + `"}}`
+	if code := Run([]string{"guard", "codex"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d", code, ExitOK)
+	}
+	if strings.TrimSpace(stdout.String()) != want {
+		t.Errorf("stdout = %q, want %q", stdout.String(), want)
+	}
+}
+
+func TestGuardCodexUnknownToolDenies(t *testing.T) {
+	env, stdout, _, _ := guardRepo(t, 1)
+	env.Stdin = strings.NewReader(`{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}`)
+	if code := Run([]string{"guard", "codex"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d", code, ExitOK)
+	}
+	var out struct {
+		HookSpecificOutput struct {
+			PermissionDecision       string `json:"permissionDecision"`
+			PermissionDecisionReason string `json:"permissionDecisionReason"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("stdout is not the deny document: %q (%v)", stdout.String(), err)
+	}
+	if out.HookSpecificOutput.PermissionDecision != "deny" {
+		t.Errorf("permissionDecision = %q, want deny", out.HookSpecificOutput.PermissionDecision)
+	}
+	if !strings.Contains(out.HookSpecificOutput.PermissionDecisionReason, "unrecognized tool_name") {
+		t.Errorf("reason = %q, want unrecognized tool_name", out.HookSpecificOutput.PermissionDecisionReason)
+	}
+}
+
+// TestGuardCodexMalformedEnvelopeDeniesWithJSON confirms a garbage
+// apply_patch envelope is a deny document at exit 0, not the blocking
+// exit 2: ErrPatchEnvelope is guard's other deny-by-default sentinel,
+// same status as ErrUnknownTool.
+func TestGuardCodexMalformedEnvelopeDeniesWithJSON(t *testing.T) {
+	env, stdout, _, root := guardRepo(t, 1)
+	env.Stdin = strings.NewReader(codexPayload(t, "apply_patch", "not a patch envelope at all", root))
+	if code := Run([]string{"guard", "codex"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (garbage envelope must deny, not block)", code, ExitOK)
+	}
+	var out struct {
+		HookSpecificOutput struct {
+			PermissionDecision       string `json:"permissionDecision"`
+			PermissionDecisionReason string `json:"permissionDecisionReason"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("stdout is not the deny document: %q (%v)", stdout.String(), err)
+	}
+	if out.HookSpecificOutput.PermissionDecision != "deny" {
+		t.Errorf("permissionDecision = %q, want deny", out.HookSpecificOutput.PermissionDecision)
+	}
+}
+
+func TestGuardCodexMalformedJSONExits2(t *testing.T) {
+	env, stdout, _, _ := guardRepo(t, 1)
+	env.Stdin = strings.NewReader(`{ not json`)
+	if code := Run([]string{"guard", "codex"}, env); code != ExitUsage {
+		t.Fatalf("exit = %d, want %d", code, ExitUsage)
+	}
+	if stdout.String() != "" {
+		t.Errorf("internal failure emitted a decision: %q", stdout.String())
+	}
+}
+
+// TestGuardCodexMoveDeniesWhenDestinationOutsideWorktree confirms a Move
+// to destination is checked as its own write target: an Update inside
+// the registered worktree paired with a Move that escapes it must deny,
+// naming the escaping path.
+func TestGuardCodexMoveDeniesWhenDestinationOutsideWorktree(t *testing.T) {
+	env, stdout, _, worktreeAbs := deliveryGuardEnv(t)
+	envelope := "*** Begin Patch\n*** Update File: src/x.go\n@@ hunk header\n-old\n+new\n*** Move to: ../escaped.go\n*** End Patch"
+	env.Stdin = strings.NewReader(codexPayload(t, "apply_patch", envelope, worktreeAbs))
+	if code := Run([]string{"guard", "codex"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d", code, ExitOK)
+	}
+	var out struct {
+		HookSpecificOutput struct {
+			PermissionDecision       string `json:"permissionDecision"`
+			PermissionDecisionReason string `json:"permissionDecisionReason"`
+		} `json:"hookSpecificOutput"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("stdout is not the deny document: %q (%v)", stdout.String(), err)
+	}
+	if out.HookSpecificOutput.PermissionDecision != "deny" {
+		t.Errorf("permissionDecision = %q, want deny", out.HookSpecificOutput.PermissionDecision)
+	}
+	if !strings.Contains(out.HookSpecificOutput.PermissionDecisionReason, "outside every registered worktree") {
+		t.Errorf("reason = %q, want outside every registered worktree", out.HookSpecificOutput.PermissionDecisionReason)
 	}
 }
 

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -10,30 +10,35 @@ import (
 )
 
 // hookUsage is the one-line usage for the adapter plumbing surface,
-// mirroring guardUsage. `orch hook claude session-start` is the only
-// valid form.
-const hookUsage = "orch hook: usage: orch hook claude session-start"
+// mirroring guardUsage. `orch hook <claude|codex> session-start` is the
+// only valid form.
+const hookUsage = "orch hook: usage: orch hook <claude|codex> session-start"
 
 // runHook dispatches the host lifecycle-event verbs (PRD §23 adapter
 // plumbing). Host adapters call it from their own lifecycle hooks; it is
 // never invoked by a human directly.
 func runHook(env Env, args []string) error {
-	if len(args) != 2 || args[0] != "claude" || args[1] != "session-start" {
+	if len(args) != 2 || args[1] != "session-start" {
 		return usageError(hookUsage)
 	}
-	return hookClaudeSessionStart(env)
+	switch args[0] {
+	case "claude", "codex":
+		return hookSessionStart(env, args[0])
+	default:
+		return usageError(hookUsage)
+	}
 }
 
-// hookClaudeSessionStart answers a Claude Code SessionStart event. Its
-// stdout becomes injected session context, so unlike every other verb in
-// this package it is deliberately fail-OPEN, not fail-closed: a broken or
-// non-orch repository must never break a Claude Code session from
-// starting. It never reads stdin (the same console-hang concern as `run
-// status --json`) and always exits 0 once its arguments are valid — any
+// hookSessionStart answers a host's SessionStart event. Its stdout
+// becomes injected session context, so unlike every other verb in this
+// package it is deliberately fail-OPEN, not fail-closed: a broken or
+// non-orch repository must never break a session from starting. It
+// never reads stdin (the same console-hang concern as `run status
+// --json`) and always exits 0 once its arguments are valid — any
 // discovery, config, or state failure degrades to silent output, not an
 // error. The architect skill's own `orch run status --json` call surfaces
 // a broken repo loudly later, once a session is actually underway.
-func hookClaudeSessionStart(env Env) error {
+func hookSessionStart(env Env, host string) error {
 	root, err := paths.FindOutermostRoot(env.RepoRoot)
 	if err != nil {
 		return nil // no .orchestrator ancestor (or an unwalkable one): silent
@@ -46,7 +51,7 @@ func hookClaudeSessionStart(env Env) error {
 	if err != nil {
 		return nil // unreadable/invalid state: silent
 	}
-	fmt.Fprint(env.Stdout, sessionStartContext(cfg, st))
+	fmt.Fprint(env.Stdout, sessionStartContext(cfg, st, host))
 	return nil
 }
 
@@ -60,11 +65,22 @@ var deliveryPhaseOrder = []state.Phase{
 	state.PhaseAbandoned, state.PhaseBlocked,
 }
 
+// sessionStartClosing is the one host-varying line sessionStartContext
+// appends, keyed by host. Every other line is shared and byte-identical
+// between hosts (the parity test pins this). claude's value is the
+// existing sentence, unchanged, since it is what the installed Claude
+// plugin injects today; codex's points at the Codex adapter's own
+// skill-invocation surface instead of Claude's slash commands.
+var sessionStartClosing = map[string]string{
+	"claude": "Before planning or acting on any request that would change tracked files, load and follow the `orch-architect` skill. Setup interviews: /orch:init, /orch:configure, /orch:configure-local.",
+	"codex":  "Before planning or acting on any request that would change tracked files, load and follow the `orch-architect` skill. Setup interviews: invoke the `orch-setup` skill for init, configure, or configure-local.",
+}
+
 // sessionStartContext renders the compact plain-text context block the
-// SessionStart hook injects: Claude Code takes a hook's raw stdout as
+// SessionStart hook injects: both hosts take a hook's raw stdout as
 // context text, not a JSON envelope, so this is deliberately prose, not a
 // document.
-func sessionStartContext(cfg *config.Config, st *state.State) string {
+func sessionStartContext(cfg *config.Config, st *state.State, host string) string {
 	var b strings.Builder
 	if st.Mode == state.ModeDelivery {
 		fmt.Fprintln(&b, "This repository is managed by Orch (mode: delivery).")
@@ -73,7 +89,7 @@ func sessionStartContext(cfg *config.Config, st *state.State) string {
 		fmt.Fprintln(&b, "This repository is managed by Orch (mode: assist).")
 	}
 	fmt.Fprintf(&b, "Memhub mode: %s.\n", cfg.Memhub.Mode)
-	fmt.Fprintln(&b, "Before planning or acting on any request that would change tracked files, load and follow the `orch-architect` skill. Setup interviews: /orch:init, /orch:configure, /orch:configure-local.")
+	fmt.Fprintln(&b, sessionStartClosing[host])
 	return b.String()
 }
 

--- a/internal/cli/hook_test.go
+++ b/internal/cli/hook_test.go
@@ -117,7 +117,6 @@ func TestHookSessionStartDeliveryRun(t *testing.T) {
 func TestHookBadArgsUsage(t *testing.T) {
 	cases := map[string][]string{
 		"no args":       {"hook"},
-		"unknown host":  {"hook", "codex", "session-start"},
 		"unknown verb":  {"hook", "claude", "session-end"},
 		"missing verb":  {"hook", "claude"},
 		"trailing args": {"hook", "claude", "session-start", "extra"},
@@ -152,5 +151,104 @@ func TestHookSessionStartFindsOutermostRoot(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "orch-architect") {
 		t.Errorf("stdout missing context from the outermost root:\n%s", stdout.String())
+	}
+}
+
+func TestHookCodexSessionStartAssist(t *testing.T) {
+	env, stdout, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	if code := Run([]string{"hook", "codex", "session-start"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr %q)", code, ExitOK, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"mode: assist", "off", "orch-architect", "orch-setup"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestHookCodexSessionStartDeliveryRun(t *testing.T) {
+	env, stdout, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	planned := []state.Issue{{PlanID: "a", Title: "A", Phase: state.PhasePlanned}}
+	plan := state.PlanRef{Title: "t", Digest: "sha256:x", ConfigRevision: "r1"}
+	st, err := state.EnterDelivery(env.RepoRoot, "codex", plan, planned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision := &state.Decision{
+		Role:      manifest.RoleImplementer,
+		Executor:  manifest.Selection{Model: "m", Effort: "e"},
+		Reviewer:  manifest.Selection{Model: "m", Effort: "e"},
+		Rationale: "r",
+	}
+	st.Run.Issues = []state.Issue{
+		{PlanID: "a", Title: "A", Phase: state.PhaseDispatched, Number: 1, Branch: "b1", Worktree: "wt1", Decision: decision},
+		{PlanID: "b", Title: "B", Phase: state.PhaseInReview, Number: 2, Branch: "b2", Worktree: "wt2", Decision: decision, PRNumber: 2},
+	}
+	if err := state.Save(env.RepoRoot, st); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := Run([]string{"hook", "codex", "session-start"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr %q)", code, ExitOK, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "mode: delivery") {
+		t.Errorf("stdout missing delivery mode:\n%s", out)
+	}
+	want := "Delivery run " + st.Run.ID + " (host codex): 1 dispatched, 1 in-review."
+	if !strings.Contains(out, want) {
+		t.Errorf("stdout missing run summary %q:\n%s", want, out)
+	}
+	if !strings.Contains(out, "orch-setup") {
+		t.Errorf("stdout missing codex closing sentence:\n%s", out)
+	}
+}
+
+func TestHookCodexSessionStartNoRootSilent(t *testing.T) {
+	env, stdout, stderr := testEnv(t)
+	if code := Run([]string{"hook", "codex", "session-start"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr %q)", code, ExitOK, stderr.String())
+	}
+	if stdout.String() != "" {
+		t.Errorf("stdout = %q, want empty", stdout.String())
+	}
+}
+
+// TestHookUnknownHostUsage confirms a host neither claude nor codex is a
+// usage error (exit 2), not a silent no-op — runHook validates the host
+// argument itself before ever dispatching to hookSessionStart.
+func TestHookUnknownHostUsage(t *testing.T) {
+	env, _, stderr := testEnv(t)
+	if code := Run([]string{"hook", "gemini", "session-start"}, env); code != ExitUsage {
+		t.Fatalf("exit = %d, want %d", code, ExitUsage)
+	}
+	if !strings.Contains(stderr.String(), "orch hook: usage") {
+		t.Errorf("stderr missing hookUsage: %q", stderr.String())
+	}
+}
+
+// TestHookSessionStartSharedLinesAcrossHosts pins sessionStartContext's
+// shared lines identical between hosts: only the closing sentence
+// (sessionStartClosing) may differ.
+func TestHookSessionStartSharedLinesAcrossHosts(t *testing.T) {
+	envClaude, stdoutClaude, stderr := testEnv(t)
+	writeConfig(t, envClaude.RepoRoot, validTOML)
+	if code := Run([]string{"hook", "claude", "session-start"}, envClaude); code != ExitOK {
+		t.Fatalf("claude exit = %d, want %d (stderr %q)", code, ExitOK, stderr.String())
+	}
+
+	envCodex, stdoutCodex, stderr2 := testEnv(t)
+	writeConfig(t, envCodex.RepoRoot, validTOML)
+	if code := Run([]string{"hook", "codex", "session-start"}, envCodex); code != ExitOK {
+		t.Fatalf("codex exit = %d, want %d (stderr %q)", code, ExitOK, stderr2.String())
+	}
+
+	claudeShared := strings.TrimSuffix(stdoutClaude.String(), sessionStartClosing["claude"]+"\n")
+	codexShared := strings.TrimSuffix(stdoutCodex.String(), sessionStartClosing["codex"]+"\n")
+	if claudeShared != codexShared {
+		t.Errorf("shared lines differ:\nclaude: %q\ncodex:  %q", claudeShared, codexShared)
 	}
 }

--- a/internal/guard/claude.go
+++ b/internal/guard/claude.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"path/filepath"
 	"sort"
 )
 
@@ -68,20 +67,7 @@ func PathsFromClaudeEvent(payload []byte) ([]string, error) {
 		return nil, err
 	}
 
-	out := make([]string, 0, len(raw))
-	for _, p := range raw {
-		if p == "" {
-			return nil, fmt.Errorf("PreToolUse %s: empty write path", ev.ToolName)
-		}
-		if !filepath.IsAbs(p) {
-			if ev.CWD == "" {
-				return nil, fmt.Errorf("PreToolUse %s: relative path %q with no cwd in payload", ev.ToolName, p)
-			}
-			p = filepath.Join(ev.CWD, p)
-		}
-		out = append(out, p)
-	}
-	return out, nil
+	return absTargets(ev.ToolName, ev.CWD, raw)
 }
 
 // toolTargets extracts the raw path field(s) each write tool carries,

--- a/internal/guard/codex.go
+++ b/internal/guard/codex.go
@@ -1,0 +1,177 @@
+package guard
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ErrPatchEnvelope reports an apply_patch tool_input whose command
+// envelope guard cannot parse into at least one write target: missing
+// "*** Begin Patch"/"*** End Patch" framing, a directive line guard does
+// not recognize, or a directive with an empty path. Like ErrUnknownTool,
+// it is a deny (fail closed), not an internal failure: an upstream
+// envelope format guard's parser does not yet understand must degrade to
+// a denial the agent can report, never a silent allow.
+var ErrPatchEnvelope = errors.New("malformed apply_patch envelope")
+
+// codexEvent is the subset of a Codex CLI PreToolUse hook payload guard
+// reads. It is decoded WITHOUT DisallowUnknownFields, for the same
+// reason as claudeEvent: host payloads carry many fields guard does not
+// consume, unlike orch's own schema-versioned documents that reject
+// unknown fields on principle.
+type codexEvent struct {
+	ToolName  string          `json:"tool_name"`
+	ToolInput json.RawMessage `json:"tool_input"`
+	CWD       string          `json:"cwd"`
+}
+
+// codexInterceptedTools is the single source of truth for the Codex CLI
+// tool_name values guard extracts a write target from. Codex CLI routes
+// every file mutation — create, update, delete, rename — through
+// "apply_patch"; "Bash" and "mcp__<server>__<tool>" carry no parsed path
+// list and are ErrUnknownTool.
+var codexInterceptedTools = map[string]bool{
+	"apply_patch": true,
+}
+
+// CodexTools returns, sorted, the Codex CLI tool_name values guard
+// extracts a write target from. It exists so the Codex adapter's
+// hooks.json PreToolUse matcher can be pinned against the exact dispatch
+// set by import instead of duplicating the tool list — the same purpose
+// ClaudeTools serves for the Claude adapter.
+func CodexTools() []string {
+	names := make([]string, 0, len(codexInterceptedTools))
+	for name := range codexInterceptedTools {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// PathsFromCodexEvent decodes a raw PreToolUse event and returns the
+// absolute write targets it declares. Only tool_name "apply_patch"
+// carries a write target: its tool_input.command is the raw patch
+// envelope string, parsed by parseApplyPatchPaths. A relative target is
+// resolved against the payload's cwd; a relative target with no cwd is
+// an internal failure. An unrecognized tool_name — including "Bash" and
+// any "mcp__*" tool — returns an error wrapping ErrUnknownTool so the
+// caller can deny by default; inspecting Bash commands for write targets
+// is deliberately out of scope here (task 27).
+func PathsFromCodexEvent(payload []byte) ([]string, error) {
+	var ev codexEvent
+	if err := json.Unmarshal(payload, &ev); err != nil {
+		return nil, fmt.Errorf("parse PreToolUse event: %w", err)
+	}
+
+	if !codexInterceptedTools[ev.ToolName] {
+		return nil, fmt.Errorf("%w %q; guard denies by default", ErrUnknownTool, ev.ToolName)
+	}
+
+	var in struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(ev.ToolInput, &in); err != nil {
+		return nil, fmt.Errorf("parse %s tool_input: %w", ev.ToolName, err)
+	}
+
+	raw, err := parseApplyPatchPaths(in.Command)
+	if err != nil {
+		return nil, err
+	}
+
+	return absTargets(ev.ToolName, ev.CWD, raw)
+}
+
+// applyPatchDirectives lists the envelope directive prefixes
+// parseApplyPatchPaths treats as write-target lines, keeping the
+// recognized-directive set in one place alongside the loop that reads
+// it. Any other "*** "-prefixed line (bar the Begin/End framing) is an
+// unrecognized directive and fails closed.
+var applyPatchDirectives = []string{
+	"*** Add File: ",
+	"*** Update File: ",
+	"*** Delete File: ",
+	"*** Move to: ",
+}
+
+// parseApplyPatchPaths line-scans a raw apply_patch envelope string and
+// returns every write-target path it declares, in envelope order.
+// Duplicates (e.g. an Update File immediately followed by its own Move
+// to) are returned as-is — Checker evaluates each path independently, so
+// there is nothing to dedupe.
+//
+// The envelope must open with "*** Begin Patch" (the first non-empty
+// line) and contain "*** End Patch"; either missing is ErrPatchEnvelope.
+// Recognized directive lines are "*** Add File: <p>", "*** Update File:
+// <p>", "*** Delete File: <p>", and "*** Move to: <p>" — Move collects
+// its destination in addition to the Update path it renames, since both
+// are write targets. Hunk body lines (@@ headers, +/-/context lines) do
+// not start with "*** " and are skipped, never parsed as paths. Any
+// other line starting with "*** " (other than Begin/End Patch) is an
+// unrecognized directive: an upstream format addition must degrade to a
+// deny, never a silent allow, so it is ErrPatchEnvelope. An empty path
+// after a directive's colon is likewise ErrPatchEnvelope, as is an
+// envelope that yields zero paths. Each line has at most one trailing
+// "\r" trimmed before matching, tolerating a CRLF envelope; path text
+// itself is not trimmed beyond the single space the directive syntax
+// specifies after the colon.
+func parseApplyPatchPaths(envelope string) ([]string, error) {
+	lines := strings.Split(envelope, "\n")
+	var paths []string
+	sawFirstNonEmpty := false
+	sawEnd := false
+
+	for _, raw := range lines {
+		line := strings.TrimSuffix(raw, "\r")
+
+		if !sawFirstNonEmpty {
+			if line == "" {
+				continue
+			}
+			sawFirstNonEmpty = true
+			if line != "*** Begin Patch" {
+				return nil, fmt.Errorf("%w: envelope must open with \"*** Begin Patch\", got %q", ErrPatchEnvelope, line)
+			}
+			continue
+		}
+
+		if !strings.HasPrefix(line, "*** ") {
+			continue // hunk body: @@ header, +/-/context line, or blank
+		}
+		if line == "*** End Patch" {
+			sawEnd = true
+			continue
+		}
+
+		matched := false
+		for _, prefix := range applyPatchDirectives {
+			if !strings.HasPrefix(line, prefix) {
+				continue
+			}
+			matched = true
+			p := strings.TrimPrefix(line, prefix)
+			if p == "" {
+				return nil, fmt.Errorf("%w: empty path after %q", ErrPatchEnvelope, strings.TrimSuffix(prefix, ": "))
+			}
+			paths = append(paths, p)
+			break
+		}
+		if !matched {
+			return nil, fmt.Errorf("%w: unrecognized directive %q", ErrPatchEnvelope, line)
+		}
+	}
+
+	if !sawFirstNonEmpty {
+		return nil, fmt.Errorf("%w: empty envelope", ErrPatchEnvelope)
+	}
+	if !sawEnd {
+		return nil, fmt.Errorf("%w: missing \"*** End Patch\"", ErrPatchEnvelope)
+	}
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("%w: no write targets found", ErrPatchEnvelope)
+	}
+	return paths, nil
+}

--- a/internal/guard/codex_test.go
+++ b/internal/guard/codex_test.go
@@ -1,0 +1,233 @@
+package guard
+
+import (
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// codexPayload marshals a minimal Codex CLI PreToolUse event whose
+// tool_input carries the given apply_patch envelope as its command.
+func codexPayload(t *testing.T, toolName, envelope, cwd string) []byte {
+	t.Helper()
+	m := map[string]any{
+		"tool_name":  toolName,
+		"tool_input": map[string]string{"command": envelope},
+	}
+	if cwd != "" {
+		m["cwd"] = cwd
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func TestCodexTools(t *testing.T) {
+	got := CodexTools()
+	want := []string{"apply_patch"}
+	if len(got) != len(want) {
+		t.Fatalf("CodexTools() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("CodexTools() = %v, want %v", got, want)
+		}
+	}
+}
+
+const addUpdateDeleteEnvelope = `*** Begin Patch
+*** Add File: new.txt
++contents
+*** Update File: existing.txt
+@@ hunk header
+-old
++new
+*** Delete File: gone.txt
+*** End Patch`
+
+func TestPathsFromCodexEventAddUpdateDelete(t *testing.T) {
+	root := t.TempDir()
+	got, err := PathsFromCodexEvent(codexPayload(t, "apply_patch", addUpdateDeleteEnvelope, root))
+	if err != nil {
+		t.Fatalf("PathsFromCodexEvent err = %v", err)
+	}
+	want := []string{
+		filepath.Join(root, "new.txt"),
+		filepath.Join(root, "existing.txt"),
+		filepath.Join(root, "gone.txt"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("paths = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("paths[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+const moveEnvelope = `*** Begin Patch
+*** Update File: old/name.txt
+@@ hunk header
+-old
++new
+*** Move to: new/name.txt
+*** End Patch`
+
+func TestPathsFromCodexEventMoveExtractsBothPaths(t *testing.T) {
+	root := t.TempDir()
+	got, err := PathsFromCodexEvent(codexPayload(t, "apply_patch", moveEnvelope, root))
+	if err != nil {
+		t.Fatalf("PathsFromCodexEvent err = %v", err)
+	}
+	want := []string{
+		filepath.Join(root, "old", "name.txt"),
+		filepath.Join(root, "new", "name.txt"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("paths = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("paths[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestPathsFromCodexEventRelativeResolvedAgainstCWD(t *testing.T) {
+	root := t.TempDir()
+	envelope := "*** Begin Patch\n*** Add File: sub/new.txt\n+x\n*** End Patch"
+	got, err := PathsFromCodexEvent(codexPayload(t, "apply_patch", envelope, root))
+	if err != nil {
+		t.Fatalf("PathsFromCodexEvent err = %v", err)
+	}
+	want := filepath.Join(root, "sub", "new.txt")
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("paths = %v, want [%q]", got, want)
+	}
+}
+
+func TestPathsFromCodexEventRelativeNoCWDErrors(t *testing.T) {
+	envelope := "*** Begin Patch\n*** Add File: sub/new.txt\n+x\n*** End Patch"
+	_, err := PathsFromCodexEvent(codexPayload(t, "apply_patch", envelope, ""))
+	if err == nil {
+		t.Fatal("PathsFromCodexEvent err = nil, want relative-path-no-cwd error")
+	}
+}
+
+func TestPathsFromCodexEventAbsolutePathsPassThrough(t *testing.T) {
+	root := t.TempDir()
+	abs := filepath.Join(root, "already", "absolute.txt")
+	envelope := "*** Begin Patch\n*** Add File: " + abs + "\n+x\n*** End Patch"
+	got, err := PathsFromCodexEvent(codexPayload(t, "apply_patch", envelope, ""))
+	if err != nil {
+		t.Fatalf("PathsFromCodexEvent err = %v", err)
+	}
+	if len(got) != 1 || got[0] != abs {
+		t.Fatalf("paths = %v, want [%q]", got, abs)
+	}
+}
+
+func TestPathsFromCodexEventBashErrorsUnknownTool(t *testing.T) {
+	payload, err := json.Marshal(map[string]any{
+		"tool_name":  "Bash",
+		"tool_input": map[string]string{"command": "rm -rf /"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = PathsFromCodexEvent(payload)
+	if !errors.Is(err, ErrUnknownTool) {
+		t.Fatalf("err = %v, want ErrUnknownTool", err)
+	}
+}
+
+func TestPathsFromCodexEventMCPToolErrorsUnknownTool(t *testing.T) {
+	payload, err := json.Marshal(map[string]any{
+		"tool_name":  "mcp__memhub__recall",
+		"tool_input": map[string]string{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = PathsFromCodexEvent(payload)
+	if !errors.Is(err, ErrUnknownTool) {
+		t.Fatalf("err = %v, want ErrUnknownTool", err)
+	}
+}
+
+func TestPathsFromCodexEventMalformedJSON(t *testing.T) {
+	_, err := PathsFromCodexEvent([]byte(`{ not json`))
+	if err == nil {
+		t.Fatal("PathsFromCodexEvent err = nil, want parse error")
+	}
+	if errors.Is(err, ErrUnknownTool) || errors.Is(err, ErrPatchEnvelope) {
+		t.Fatalf("err = %v, want a plain decode error, not a deny sentinel", err)
+	}
+}
+
+func TestPathsFromCodexEventMissingBeginPatch(t *testing.T) {
+	envelope := "*** Add File: new.txt\n+x\n*** End Patch"
+	_, err := PathsFromCodexEvent(codexPayload(t, "apply_patch", envelope, "/repo"))
+	if !errors.Is(err, ErrPatchEnvelope) {
+		t.Fatalf("err = %v, want ErrPatchEnvelope", err)
+	}
+}
+
+func TestPathsFromCodexEventMissingEndPatch(t *testing.T) {
+	envelope := "*** Begin Patch\n*** Add File: new.txt\n+x"
+	_, err := PathsFromCodexEvent(codexPayload(t, "apply_patch", envelope, "/repo"))
+	if !errors.Is(err, ErrPatchEnvelope) {
+		t.Fatalf("err = %v, want ErrPatchEnvelope", err)
+	}
+}
+
+func TestPathsFromCodexEventUnrecognizedDirective(t *testing.T) {
+	envelope := "*** Begin Patch\n*** Frobnicate: new.txt\n*** End Patch"
+	_, err := PathsFromCodexEvent(codexPayload(t, "apply_patch", envelope, "/repo"))
+	if !errors.Is(err, ErrPatchEnvelope) {
+		t.Fatalf("err = %v, want ErrPatchEnvelope", err)
+	}
+}
+
+func TestPathsFromCodexEventZeroPaths(t *testing.T) {
+	envelope := "*** Begin Patch\n*** End Patch"
+	_, err := PathsFromCodexEvent(codexPayload(t, "apply_patch", envelope, "/repo"))
+	if !errors.Is(err, ErrPatchEnvelope) {
+		t.Fatalf("err = %v, want ErrPatchEnvelope", err)
+	}
+}
+
+func TestPathsFromCodexEventEmptyPathAfterDirective(t *testing.T) {
+	envelope := "*** Begin Patch\n*** Add File: \n*** End Patch"
+	_, err := PathsFromCodexEvent(codexPayload(t, "apply_patch", envelope, "/repo"))
+	if !errors.Is(err, ErrPatchEnvelope) {
+		t.Fatalf("err = %v, want ErrPatchEnvelope", err)
+	}
+}
+
+func TestPathsFromCodexEventCRLFMatchesLF(t *testing.T) {
+	root := t.TempDir()
+	crlf := strings.ReplaceAll(addUpdateDeleteEnvelope, "\n", "\r\n")
+
+	lfPaths, err := PathsFromCodexEvent(codexPayload(t, "apply_patch", addUpdateDeleteEnvelope, root))
+	if err != nil {
+		t.Fatalf("LF envelope err = %v", err)
+	}
+	crlfPaths, err := PathsFromCodexEvent(codexPayload(t, "apply_patch", crlf, root))
+	if err != nil {
+		t.Fatalf("CRLF envelope err = %v", err)
+	}
+	if len(lfPaths) != len(crlfPaths) {
+		t.Fatalf("CRLF paths = %v, want %v", crlfPaths, lfPaths)
+	}
+	for i := range lfPaths {
+		if lfPaths[i] != crlfPaths[i] {
+			t.Errorf("CRLF paths[%d] = %q, want %q", i, crlfPaths[i], lfPaths[i])
+		}
+	}
+}

--- a/internal/guard/event.go
+++ b/internal/guard/event.go
@@ -1,0 +1,31 @@
+package guard
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// absTargets resolves each raw write-target path a decoder extracted
+// from a PreToolUse event into an absolute path, shared by every host
+// decoder (PathsFromClaudeEvent, PathsFromCodexEvent) so the
+// resolution rule cannot drift between hosts. A relative path is joined
+// against cwd; a relative path with no cwd in the payload, or an empty
+// path, is an internal failure — the decoder cannot verify the target,
+// so it must not be silently allowed through, and it maps to the hook
+// protocol's blocking exit rather than a deny.
+func absTargets(toolName, cwd string, raw []string) ([]string, error) {
+	out := make([]string, 0, len(raw))
+	for _, p := range raw {
+		if p == "" {
+			return nil, fmt.Errorf("PreToolUse %s: empty write path", toolName)
+		}
+		if !filepath.IsAbs(p) {
+			if cwd == "" {
+				return nil, fmt.Errorf("PreToolUse %s: relative path %q with no cwd in payload", toolName, p)
+			}
+			p = filepath.Join(cwd, p)
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}


### PR DESCRIPTION
## What

PR 1 of 3 for task 21 (Codex CLI adapter + shared parity tests): the core Go plumbing the Codex adapter will hook into. No adapter artifacts yet; `adapters/codex/` is untouched.

- **`orch guard codex`** — new host hook verb. `internal/guard/codex.go` decodes a Codex CLI PreToolUse payload: Codex routes *all* file mutations (create/update/delete/rename) through the single `apply_patch` tool whose `tool_input.command` is a raw patch envelope with **no parsed path list**, so `PathsFromCodexEvent` line-scans the `*** Add/Update/Delete File:` / `*** Move to:` directives itself, collecting both sides of a Move. A new `ErrPatchEnvelope` sentinel makes any envelope the parser does not understand (missing framing, unrecognized `*** ` directive, zero paths, empty path) a deny-with-reason, never a silent allow and never a blocking failure. `Bash` and `mcp__*` remain `ErrUnknownTool` denials — shell-command inspection is deliberately task 27. `CodexTools()` mirrors `ClaudeTools()` so PR 2's hooks.json matcher can be drift-pinned by import.
- **Shared `guardHostHook`** — `guardClaude`'s body, parameterized on the decoder; `claude`/`codex` are now two-line wrappers with identical hook semantics (allow = silent exit 0; deny = `permissionDecision` JSON at exit 0; internal failure = exit 2, never the fail-open exit 1). `absTargets` (new `internal/guard/event.go`) is the extracted path-resolution tail shared by both decoders so cwd-resolution semantics cannot drift; Claude behavior is byte-identical and its existing tests pass unchanged.
- **`orch hook codex session-start`** — `hookSessionStart` is host-parameterized (fail-open contract unchanged); only the closing sentence varies per host via `sessionStartClosing` (Claude's byte-for-byte untouched, Codex's points at skill invocation since Codex custom prompts are deprecated), and `TestHookSessionStartSharedLinesAcrossHosts` pins every other line identical.

## Why

Codex CLI hooks (GA 2026-05-14) mirror Claude Code's PreToolUse/SessionStart protocol, so the proven adapter contract ports — but the payload shape differs enough (envelope parsing vs per-tool path fields) to need its own fail-closed decoder in the core rather than adapter-side logic (PRD SS6: adapters stay thin, the state machine is never reimplemented in shell/Markdown). Landing the plumbing first keeps this PR pure Go and lets PR 2 (adapter artifacts + parity layer) pin its hooks against these symbols.

Verified: `gofmt` clean, `go build ./...`, `go vet ./...`, `go test ./...` all green locally (guard/cli/adapters suites re-run uncached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDJjTSwBQ5YrnnWfE4Fjrv