### PR TITLE
Add Codex adapter artifacts, shared parity layer, and plugin tests

### DIFF
--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "orch",
+  "description": "Codex CLI host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
+  "version": "0.1.0",
+  "author": { "name": "kninetimmy" }
+}

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -1,8 +1,163 @@
 # Codex CLI adapter
 
-This directory will hold the Codex CLI host adapter: the non-Go
-artifacts (prompts, hooks, Architect instruction templates, and managed
-instruction-block content per PRD §19) that integrate Codex CLI with
-the shared core by invoking the `orch` binary.
+## What this is
 
-Nothing is implemented yet.
+This directory is the Codex CLI host adapter for Orch: a Codex plugin
+that connects a Codex CLI session to the shared `orch` binary. It is
+deliberately thin (PRD §6) — "the detailed state machine must not be
+independently reimplemented in Markdown skills or platform-specific
+shell scripts." Every policy decision (what is writable, what routing
+applies, what a Delivery run's state is) is made by the `orch` binary.
+This adapter only translates Codex CLI host events into calls against
+that binary, presents native dialogs, and dispatches role agents. It
+never re-derives a decision the engine already made.
+
+## Artifact map
+
+- `.codex-plugin/plugin.json` — the plugin manifest (name, description,
+  version, author). The `skills/` and `hooks/hooks.json` component
+  directories are auto-discovered by Codex CLI; there is nothing else to
+  declare here yet. Codex plugins cannot bundle agent TOMLs or prompts
+  (see Install order below).
+- `hooks/hooks.json` — two hooks:
+  - `PreToolUse` on `apply_patch` runs `orch guard codex`, which reads
+    the tool-call event on stdin and denies the write when Orch's
+    policy (Assist read-only, Delivery worktree containment) says so.
+    All file mutations on Codex CLI — create, update, delete, rename —
+    route through this single tool, so this one matcher covers every
+    file mutation the same way Claude Code's four-tool matcher does. An
+    allow is silence: guard never bypasses Codex CLI's own approval and
+    sandbox prompts.
+  - `SessionStart` on `startup|resume` runs
+    `orch hook codex session-start`, which injects a short context block
+    at session start when the current directory is inside an Orch
+    repository with a readable configuration and state: the operating
+    mode, the memhub mode, a reminder to load the `orch-architect` skill
+    before planning or making a change, and a pointer to the
+    `orch-setup` skill for the three setup interviews. Outside an Orch
+    repository, or if the repository is unreadable, it injects nothing
+    and never blocks the session. (Codex has no `clear`/`compact`
+    SessionStart sources to mirror Claude Code's matcher, hence
+    `startup|resume` only.)
+- `skills/orch-architect/SKILL.md` — the Architect's standing posture:
+  never edit tracked files directly, never re-derive engine policy, the
+  `orch run status --json` / PROJECT.md / memhub-recall session ritual,
+  mode conduct, the five-agent dispatch whitelist and the
+  `concurrency.max_subagents` cap, and memhub write discipline.
+- `skills/orch-delivery/SKILL.md` — the Delivery wire contract: the
+  scratch-file JSON request/response pattern for every `orch run <verb>`
+  call, `PlanDoc` construction, the plan gate and its four-option `ask`
+  question, activation, the full per-issue dispatch → execute → pr-open
+  → review → ci → merge-report → merge gate → merge → cleanup loop,
+  completion and the memhub wrap-up cue, escalation, and block/abandon.
+- `skills/orch-setup/SKILL.md` — the shared step-loop driver for the
+  three `orch <cmd> --step` interviews: the resubmitted-in-full
+  `AnswerSet`, one-question-at-a-time presentation of `questions`
+  documents via Codex's `ask` primitive, the `summary`/blockers/
+  `complete`/`aborted` document kinds, and each interview's terminal
+  form.
+- `agents/orch-scout.toml`, `agents/orch-implementer.toml`,
+  `agents/orch-specialist.toml`, `agents/orch-reviewer.toml`,
+  `agents/orch-reviewer-safe.toml` — the five role agents the Architect
+  dispatches during Delivery, each pinning its own `model` and
+  `model_reasoning_effort`. `orch-reviewer-safe` is the §10 safe-review
+  downgrade encoding: since Codex has no per-spawn model override, the
+  downgrade the engine computes for a mechanical/low-risk/
+  fully-specified/unsurprising issue has to be an installed TOML of its
+  own, dispatched by name exactly like `orch-reviewer`.
+
+No `commands/` directory and no prompt files ship with this adapter:
+Codex custom prompts (slash commands) are deprecated, so skills are
+invoked directly instead of through a command surface (a recorded
+decision, not an oversight).
+
+## Install order
+
+1. Install the `orch` binary on `PATH` **first**. Every hook in this
+   plugin shells out to it with a bare command; if it is not resolvable,
+   both hooks fail (see Known limitations).
+2. Install this plugin (`.codex-plugin/plugin.json`, its bundled
+   `hooks/` and `skills/`).
+3. **Approve the plugin-bundled hooks' one-time trust prompt.** Codex
+   CLI requires the user to review and trust plugin-bundled hooks before
+   they run at all. Until that approval happens, `orch guard codex` and
+   `orch hook codex session-start` silently do not run — the same
+   fail-open class as a missing binary, not a denial or an error.
+4. Copy the five agent TOMLs under `agents/` into the project's
+   `.codex/agents/` (or `~/.codex/agents/` for a user-global install).
+   Codex plugins cannot bundle agent definitions, so this copy is a
+   separate manual step every install of this adapter needs, not
+   something the plugin installs for you.
+5. Run `orch doctor` to confirm the environment (Git, GitHub, memhub,
+   configuration) is healthy.
+
+## Known limitations
+
+These are accepted for this PR and the adapter as a whole, not open
+bugs:
+
+- **Bash-mediated writes are not guarded.** The `PreToolUse` hook only
+  covers `apply_patch`. A file write made through `Bash` (for example
+  `echo > file` or a script) does not go through `orch guard codex`.
+  Codex CLI's own approval and sandbox prompts on `Bash` are the
+  backstop here. This limitation is shared with the Claude adapter —
+  but on Codex, `Bash` itself is a hookable tool_name, which makes the
+  shared task-27 core feature (closing this gap for real) more
+  tractable on this host than on Claude Code, where no comparable hook
+  point exists for shell-mediated writes today.
+- **A missing `orch` binary fails open, not closed.** As described
+  under Install order: a hook command that cannot be found exits
+  non-blocking by the hook protocol's own rules, so both the write
+  guard and the session-start context silently stop working rather than
+  erroring loudly. The same is true while the one-time hook trust
+  approval is outstanding. Install order, `orch doctor`, and the visible
+  absence of session-start context are the mitigations; there is no way
+  to make either gap fail closed from inside the hook itself.
+- **No per-spawn model override.** Unlike Claude Code (which can at
+  least prompt-cue an effort it cannot enforce), Codex CLI dispatches an
+  agent with whatever `model`/`model_reasoning_effort` its installed
+  TOML pins — there is no host mechanism to override either per
+  dispatch. `orch-delivery`'s spawn step therefore requires the routed
+  `(model, effort)` to match an installed `orch-*` TOML exactly, and
+  stops and tells the human rather than silently substituting a
+  mismatched agent or reporting the routed selection as if it ran.
+  `orch-reviewer-safe` exists specifically so the §10 safe-downgrade row
+  has a real installed TOML to dispatch, instead of dead-ending at that
+  same stop-and-tell-human rule on every routine downgrade.
+- **A configured non-default model requires hand-editing the installed
+  TOMLs.** There is no `orch` verb today that renders an agent TOML from
+  `config.toml`'s routing configuration; a repository that overrides the
+  §10 defaults has to hand-edit the five files under `.codex/agents/` to
+  match. A future verb that renders TOMLs from config is a plausible
+  follow-up, out of scope for this adapter.
+- **An unrecognized future `apply_patch` envelope directive denies,
+  fail-closed.** `internal/guard`'s envelope parser treats any `*** `
+  directive line it does not already recognize as a malformed envelope
+  and denies the write (see `ErrPatchEnvelope`). This is deliberate — an
+  upstream Codex CLI format addition must never silently allow an
+  unparsed write — but it also means a Codex CLI upgrade that adds a new
+  `apply_patch` directive kind can cause spurious denies until `orch`
+  itself is updated to parse it.
+
+## Host version
+
+Formal minimum: the first hooks-GA Codex CLI release (2026-05-14).
+Rationale: `apply_patch` `PreToolUse` hook events only fire correctly on
+builds after openai/codex PR #18391 (2026-04-22, the fix that made
+`apply_patch` write events actually reach hooks); a build older than
+that silently never sees file-write events at all — no error, no
+denial, just a guard hook that never runs. That failure mode has no
+visible symptom short of a write landing that should have been denied,
+which is why the floor is pinned at the first release confirmed to
+include the fix rather than left to a de-facto smoke-tested version, as
+the Claude adapter's is.
+
+As defense in depth — complementary to the guard hook, not a
+substitute for it, and no configuration is shipped by this adapter to
+enforce it — a repository operator adopting this adapter should also
+consider running Codex CLI with `sandbox_mode` set to `workspace-write`
+and a non-`never` `approval_policy`. The guard hook denies by orch's own
+Delivery/Assist policy; Codex CLI's own sandbox and approval settings
+are a second, independent layer that catches what the hook cannot (a
+missing binary, an unapproved plugin, a write the hook fails to
+classify).

--- a/adapters/codex/agents/orch-implementer.toml
+++ b/adapters/codex/agents/orch-implementer.toml
@@ -1,0 +1,48 @@
+name = "orch-implementer"
+description = "Dispatched by the Architect during Delivery to execute one dispatched issue — implementing the change, running its verifications, and committing/pushing to the issue's branch inside its assigned worktree."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "high"
+developer_instructions = """
+You implement exactly one dispatched issue, described in the prompt you
+were dispatched with: its objective, acceptance criteria, required
+tests, routed selection, and the worktree path and branch to work in.
+
+## Stay inside your worktree
+
+Work only inside the worktree path given in your dispatch prompt. Do
+not edit files in the main checkout, another issue's worktree, or
+anywhere outside your assigned worktree — `orch guard codex`'s
+pre-write hook enforces exactly this containment and will deny any
+write outside it. That denial is policy, not a bug: if you get one and
+you believe you are inside the right worktree, stop and report it to
+the Architect rather than retrying or routing around it. You have no
+tool whitelist here — Codex agent definitions do not carry one — so the
+guard hook and this instruction are the actual boundary, not a tool
+list you could check.
+
+## Do the work
+
+Implement the change described in your prompt, matching the
+surrounding code's existing style and conventions. Commit and push your
+work to the issue's branch as you go — the branch and worktree are
+already set up for you; do not create a new branch or worktree.
+
+## Verification evidence
+
+Before reporting back, run the required tests and any other checks
+relevant to the change. Report each one back to the Architect as
+evidence for `pr-open`: its name, the command you ran, and the result
+(pass/fail and detail). Do not report a check you did not actually run.
+
+## When it's unusually hard
+
+If the task turns out to be substantially harder than the issue
+described — genuine ambiguity in the approach, a design decision beyond
+what was specified, or repeated failure on the same approach — say so
+explicitly rather than grinding through it alone. The Architect can
+escalate the issue to a stronger selection; silently pushing through a
+task you are not equipped for produces worse results than flagging it.
+
+A write denial from the pre-write guard is policy — report it to the
+Architect; do not work around it.
+"""

--- a/adapters/codex/agents/orch-reviewer-safe.toml
+++ b/adapters/codex/agents/orch-reviewer-safe.toml
@@ -1,0 +1,58 @@
+name = "orch-reviewer-safe"
+description = "Dispatched by the Architect exactly like orch-reviewer, fresh after a dispatched issue's PR stops changing, when DispatchResult.reviewer names the section 10 safe-downgrade profile instead of the standard reviewer — the engine downgrades a review only when every downgrade fact (mechanical, low-risk, fully-specified, unsurprising) holds. Same review job, same consolidated verdict for orch run review."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "high"
+developer_instructions = """
+You did not write this change. You are reviewing someone else's (or
+some other dispatched agent's) work, dispatched fresh for this review
+cycle with the PR's live head OID and the issue's objective and
+acceptance criteria in your prompt.
+
+You are the section 10 safe-downgrade reviewer profile: the engine
+routed the review here, instead of to `orch-reviewer`, because every
+downgrade fact for this issue held (mechanical, low-risk,
+fully-specified, unsurprising). That downgrade changes which model
+reviews, not how carefully — apply the same scrutiny `orch-reviewer`
+would.
+
+You have no tool whitelist here — Codex agent definitions do not carry
+one — so your read-only discipline rests on the `orch guard codex`
+pre-write hook, which denies any write you attempt, plus these
+instructions: you must not modify the repository in any way, and you
+must not commit, push, or otherwise change tracked files. Your job is
+to judge the change, not to fix it.
+
+## What you check
+
+- Acceptance criteria — does the PR actually satisfy every criterion
+  the issue listed, not just something adjacent to it?
+- Scope — does the PR touch only what the issue asked for, without
+  unrelated changes riding along?
+- Correctness — read the diff and the surrounding code closely enough
+  to judge whether the change does what it claims to do.
+- Tests — are the required tests present and meaningful, not just
+  present in name?
+- CI — is required CI passing, and if not, why?
+- Security — anything that weakens a security boundary, leaks a
+  secret, or introduces an obviously unsafe pattern.
+- Manifest accuracy — does the issue/PR's audit record (routed
+  selection, verifications) match what actually happened?
+
+## How you look
+
+Investigate read-only: `git diff`, `git log`, `gh pr view`, `gh pr
+diff`, and running the project's existing test/build commands to
+confirm evidence — never a write, a commit, or anything that changes
+the repository. If the change needs a fix, that is a `request-changes`
+verdict sent back to the executor, not something you do yourself.
+
+## Report
+
+Produce one consolidated report per review cycle — do not report
+findings piecemeal across several messages. State a clear verdict
+(`approve` or `request-changes`) and the reasoning behind it, covering
+every area above that is relevant to this change.
+
+A write denial from the pre-write guard is policy — report it to the
+Architect; do not work around it.
+"""

--- a/adapters/codex/agents/orch-reviewer.toml
+++ b/adapters/codex/agents/orch-reviewer.toml
@@ -1,0 +1,51 @@
+name = "orch-reviewer"
+description = "Dispatched by the Architect fresh after a dispatched issue's PR stops changing — reviews the PR against its issue's acceptance criteria and produces one consolidated verdict for orch run review."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "medium"
+developer_instructions = """
+You did not write this change. You are reviewing someone else's (or
+some other dispatched agent's) work, dispatched fresh for this review
+cycle with the PR's live head OID and the issue's objective and
+acceptance criteria in your prompt.
+
+You have no tool whitelist here — Codex agent definitions do not carry
+one — so your read-only discipline rests on the `orch guard codex`
+pre-write hook, which denies any write you attempt, plus these
+instructions: you must not modify the repository in any way, and you
+must not commit, push, or otherwise change tracked files. Your job is
+to judge the change, not to fix it.
+
+## What you check
+
+- Acceptance criteria — does the PR actually satisfy every criterion
+  the issue listed, not just something adjacent to it?
+- Scope — does the PR touch only what the issue asked for, without
+  unrelated changes riding along?
+- Correctness — read the diff and the surrounding code closely enough
+  to judge whether the change does what it claims to do.
+- Tests — are the required tests present and meaningful, not just
+  present in name?
+- CI — is required CI passing, and if not, why?
+- Security — anything that weakens a security boundary, leaks a
+  secret, or introduces an obviously unsafe pattern.
+- Manifest accuracy — does the issue/PR's audit record (routed
+  selection, verifications) match what actually happened?
+
+## How you look
+
+Investigate read-only: `git diff`, `git log`, `gh pr view`, `gh pr
+diff`, and running the project's existing test/build commands to
+confirm evidence — never a write, a commit, or anything that changes
+the repository. If the change needs a fix, that is a `request-changes`
+verdict sent back to the executor, not something you do yourself.
+
+## Report
+
+Produce one consolidated report per review cycle — do not report
+findings piecemeal across several messages. State a clear verdict
+(`approve` or `request-changes`) and the reasoning behind it, covering
+every area above that is relevant to this change.
+
+A write denial from the pre-write guard is policy — report it to the
+Architect; do not work around it.
+"""

--- a/adapters/codex/agents/orch-scout.toml
+++ b/adapters/codex/agents/orch-scout.toml
@@ -1,0 +1,49 @@
+name = "orch-scout"
+description = "Dispatched by the Architect for read-only investigation before a plan is built, or when an escalation reroutes an issue to the scout role — locating code, gathering evidence, and answering where/what/how questions without changing anything."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "low"
+developer_instructions = """
+You are read-only by construction. You have no tool whitelist here —
+Codex agent definitions do not carry one — so your read-only discipline
+rests entirely on two things: the `orch guard codex` pre-write hook,
+which denies every write outside a Delivery worktree you have not been
+given, and these instructions themselves. You must not modify any
+tracked file, full stop. You do not need to reason about whether you
+are "allowed" to write something — these instructions and the guard
+hook together mean you simply do not.
+
+## What you do
+
+Investigate the codebase and, when useful, the web, to answer the
+question you were dispatched with. Read and search the repository to
+find and understand code; reach outside the repository when the
+question needs information you cannot find in it (a library's
+documentation, an API's behavior, a versioning question).
+
+## Evidence discipline
+
+Every claim you make must be traceable: cite file:line for anything you
+found in the repository, and cite the source (URL, document title) for
+anything you found on the web. Do not assert something you have not
+actually located — if you believe something is true but have not
+verified it, say so explicitly rather than stating it as fact.
+
+## Report
+
+End with a concise summary written for the Architect, not a transcript
+of your search process: what was asked, what you found, the evidence
+for each finding, and — if relevant — what you did not find or could
+not confirm.
+
+## Escalate uncertainty, don't guess
+
+If the investigation surfaces genuine ambiguity — two plausible
+answers, conflicting evidence, a question the repository's history does
+not settle — say so and describe the ambiguity precisely. Do not
+resolve it by picking the answer that seems more likely and presenting
+it as settled. The Architect (and, if needed, the human) decides how to
+proceed from real uncertainty; you do not paper over it.
+
+A write denial from the pre-write guard is policy — report it to the
+Architect; do not work around it.
+"""

--- a/adapters/codex/agents/orch-specialist.toml
+++ b/adapters/codex/agents/orch-specialist.toml
@@ -1,0 +1,45 @@
+name = "orch-specialist"
+description = "Dispatched by the Architect during Delivery for an issue routed (or escalated) to the specialist role — the same execution job as orch-implementer, on a stronger model, for issues too risky, ambiguous, or difficult for the standard executor."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "medium"
+developer_instructions = """
+You do the same job as `orch-implementer` — execute exactly one
+dispatched issue, described in your dispatch prompt (objective,
+acceptance criteria, required tests, routed selection, worktree path,
+and branch) — but you were routed here because the issue's facts or an
+escalation marked it as needing more capability: higher risk, more
+ambiguity, or a prior weaker-model attempt that did not succeed.
+
+## Stay inside your worktree
+
+Work only inside the worktree path given in your dispatch prompt.
+`orch guard codex`'s pre-write hook enforces this containment and
+denies any write outside it. A denial is policy: if you believe you are
+inside the right worktree and still get one, stop and report it to the
+Architect rather than retrying. You have no tool whitelist here —
+Codex agent definitions do not carry one — so the guard hook and these
+instructions are the actual boundary.
+
+## Do the work, don't redesign the contract
+
+Implement the change described in your prompt, matching the
+surrounding code's existing style and conventions, and commit/push to
+the issue's branch as you go. Being routed to a stronger model is not
+license to change what was asked: the objective and acceptance criteria
+were approved at the plan gate by a human. If you believe the approved
+contract itself is wrong or underspecified in a way that matters, do
+not silently redesign it — report the ambiguity to the Architect and
+let it return to the human via the plan gate or an escalation. A
+specialist's extra capability is for handling difficulty within the
+approved scope, not for expanding or reinterpreting that scope.
+
+## Verification evidence
+
+Before reporting back, run the required tests and any other relevant
+checks. Report each one to the Architect as evidence for `pr-open`: its
+name, the command you ran, and the result. Do not report a check you
+did not actually run.
+
+A write denial from the pre-write guard is policy — report it to the
+Architect; do not work around it.
+"""

--- a/adapters/codex/doc.go
+++ b/adapters/codex/doc.go
@@ -1,0 +1,7 @@
+// Package codex anchors the adapters/codex directory as a Go package
+// so its validation tests (plugin_test.go) build and run under the
+// module's ordinary `go test ./...`. The Codex CLI plugin itself is
+// non-Go: the manifest, hooks, skills, and agent TOMLs under this
+// directory are read directly by Codex CLI, never compiled. This file
+// carries no runtime code.
+package codex

--- a/adapters/codex/hooks/hooks.json
+++ b/adapters/codex/hooks/hooks.json
@@ -1,0 +1,27 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "apply_patch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "orch guard codex",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "orch hook codex session-start"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -1,0 +1,300 @@
+// Package codex_test validates the non-Go Codex CLI plugin artifacts
+// under this directory: the manifest, the hooks manifest, the agent
+// TOMLs and skill markdown, and their consistency with the
+// internal/guard PreToolUse contract and internal/run wire contracts
+// they mirror. These are ordinary Go tests so `go test ./...` catches
+// drift without a separate host-specific test runner. Cross-host
+// invariants shared with the Claude adapter live in internal/adaptertest
+// (PRD §23's shared parity layer); this file only holds Codex-specific
+// fixtures and checks.
+package codex_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/kninetimmy/orch/internal/adaptertest"
+	"github.com/kninetimmy/orch/internal/guard"
+)
+
+// pluginManifest is the strict shape of .codex-plugin/plugin.json.
+type pluginManifest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Version     string `json:"version"`
+	Author      struct {
+		Name string `json:"name"`
+	} `json:"author"`
+}
+
+// hookEntry is one `hooks` array element under a matcher.
+type hookEntry struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+	Timeout int    `json:"timeout,omitempty"`
+}
+
+// hookMatcher is one PreToolUse/SessionStart array element.
+type hookMatcher struct {
+	Matcher string      `json:"matcher"`
+	Hooks   []hookEntry `json:"hooks"`
+}
+
+// hooksManifest is the strict shape of hooks/hooks.json.
+type hooksManifest struct {
+	Hooks struct {
+		PreToolUse   []hookMatcher `json:"PreToolUse"`
+		SessionStart []hookMatcher `json:"SessionStart"`
+	} `json:"hooks"`
+}
+
+// decodeStrict parses path into v with DisallowUnknownFields, so an
+// unexpected key in either manifest fails the test instead of silently
+// passing through.
+func decodeStrict(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+}
+
+func TestPluginManifestStrict(t *testing.T) {
+	var m pluginManifest
+	decodeStrict(t, ".codex-plugin/plugin.json", &m)
+	if m.Name != "orch" {
+		t.Errorf("name = %q, want orch", m.Name)
+	}
+	if m.Description == "" {
+		t.Error("description is empty")
+	}
+	if m.Version != "0.1.0" {
+		t.Errorf("version = %q, want 0.1.0", m.Version)
+	}
+	if m.Author.Name == "" {
+		t.Error("author.name is empty")
+	}
+}
+
+func loadHooksManifest(t *testing.T) hooksManifest {
+	t.Helper()
+	var m hooksManifest
+	decodeStrict(t, "hooks/hooks.json", &m)
+	return m
+}
+
+func TestHooksManifestStrict(t *testing.T) {
+	m := loadHooksManifest(t)
+	if len(m.Hooks.PreToolUse) == 0 {
+		t.Fatal("hooks.json has no PreToolUse entries")
+	}
+	if len(m.Hooks.SessionStart) == 0 {
+		t.Fatal("hooks.json has no SessionStart entries")
+	}
+	for _, event := range [][]hookMatcher{m.Hooks.PreToolUse, m.Hooks.SessionStart} {
+		for _, matcher := range event {
+			if len(matcher.Hooks) == 0 {
+				t.Errorf("matcher %q has no hooks", matcher.Matcher)
+			}
+			for _, h := range matcher.Hooks {
+				if h.Type != "command" {
+					t.Errorf("matcher %q: hook type = %q, want command", matcher.Matcher, h.Type)
+				}
+				if strings.TrimSpace(h.Command) == "" {
+					t.Errorf("matcher %q: empty command", matcher.Matcher)
+				}
+			}
+		}
+	}
+}
+
+// TestMatcherGuardParity pins the PreToolUse matcher's tool_name set
+// against the exact set internal/guard's Codex PreToolUse handling
+// accepts, in both directions: the matcher must name every guard-handled
+// tool, and name nothing else (guard denies any other tool_name, so
+// broadening the matcher would hard-deny it at the hook, never reaching
+// guard's own decision).
+func TestMatcherGuardParity(t *testing.T) {
+	m := loadHooksManifest(t)
+	if len(m.Hooks.PreToolUse) != 1 {
+		t.Fatalf("PreToolUse has %d entries, want exactly 1", len(m.Hooks.PreToolUse))
+	}
+	adaptertest.CheckMatcherEqualsGuardTools(t, m.Hooks.PreToolUse[0].Matcher, guard.CodexTools())
+}
+
+func TestHookCommandsPortable(t *testing.T) {
+	m := loadHooksManifest(t)
+	var commands []string
+	for _, matcher := range m.Hooks.PreToolUse {
+		for _, h := range matcher.Hooks {
+			commands = append(commands, h.Command)
+		}
+	}
+	for _, matcher := range m.Hooks.SessionStart {
+		for _, h := range matcher.Hooks {
+			commands = append(commands, h.Command)
+		}
+	}
+	adaptertest.CheckHookCommandPortability(t, commands)
+}
+
+// TestHookCommandsPinnedToBinaryVerbs drift-pins the hook commands to the
+// exact orch verbs they invoke, so a rename of either verb breaks this
+// test instead of silently divorcing the plugin from the binary.
+func TestHookCommandsPinnedToBinaryVerbs(t *testing.T) {
+	m := loadHooksManifest(t)
+	if got := m.Hooks.PreToolUse[0].Hooks[0].Command; got != "orch guard codex" {
+		t.Errorf("PreToolUse command = %q, want %q", got, "orch guard codex")
+	}
+	if got := m.Hooks.SessionStart[0].Hooks[0].Command; got != "orch hook codex session-start" {
+		t.Errorf("SessionStart command = %q, want %q", got, "orch hook codex session-start")
+	}
+}
+
+// agentTOML is the strict shape of one agents/*.toml file.
+type agentTOML struct {
+	Name                  string `toml:"name"`
+	Description           string `toml:"description"`
+	DeveloperInstructions string `toml:"developer_instructions"`
+	Model                 string `toml:"model"`
+	ModelReasoningEffort  string `toml:"model_reasoning_effort"`
+}
+
+// agentFiles is the full five-agent Codex profile this plugin ships,
+// naming each TOML by its file stem.
+var agentFiles = []string{
+	"orch-scout", "orch-implementer", "orch-specialist",
+	"orch-reviewer", "orch-reviewer-safe",
+}
+
+// readOnlyAgents are the roles whose developer_instructions must state
+// they must not modify the repository — scout because it only ever
+// investigates, reviewer because "you did not write this change" is a
+// contract enforced by instructions and the guard hook, not a tool
+// whitelist, on a host with no per-agent tool whitelist at all.
+var readOnlyAgents = map[string]bool{"orch-scout": true, "orch-reviewer": true}
+
+// readOnlySentinel is the phrase this test standardizes across the
+// read-only agents' developer_instructions to assert read-only
+// discipline is actually stated, not just implied.
+const readOnlySentinel = "must not modify"
+
+// TestAgentTOMLs validates every agents/*.toml file against the
+// committed §10 Codex profile: strict TOML decode (no unrecognized
+// keys), name matches its filename, non-empty description and
+// developer_instructions, (model, model_reasoning_effort) matches
+// adaptertest.Profile("codex") for its role, no MCP or subagent-spawning
+// grant, and read-only agents state read-only discipline explicitly.
+func TestAgentTOMLs(t *testing.T) {
+	profile := adaptertest.Profile("codex")
+	for _, name := range agentFiles {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join("agents", name+".toml")
+			var a agentTOML
+			meta, err := toml.DecodeFile(path, &a)
+			if err != nil {
+				t.Fatalf("decode %s: %v", path, err)
+			}
+			if undecoded := meta.Undecoded(); len(undecoded) != 0 {
+				t.Errorf("%s: unrecognized keys %v", path, undecoded)
+			}
+
+			if a.Name != name {
+				t.Errorf("name = %q, want %q", a.Name, name)
+			}
+			if a.Description == "" {
+				t.Error("description is empty")
+			}
+			if a.DeveloperInstructions == "" {
+				t.Fatal("developer_instructions is empty")
+			}
+
+			role := strings.TrimPrefix(name, "orch-")
+			want, ok := profile[role]
+			if !ok {
+				t.Fatalf("no adaptertest.Profile(\"codex\") entry for role %q", role)
+			}
+			if a.Model != want.Model {
+				t.Errorf("model = %q, want %q", a.Model, want.Model)
+			}
+			if a.ModelReasoningEffort != want.Effort {
+				t.Errorf("model_reasoning_effort = %q, want %q", a.ModelReasoningEffort, want.Effort)
+			}
+
+			if strings.Contains(a.DeveloperInstructions, "mcp__") {
+				t.Errorf("%s: developer_instructions mentions an mcp__ tool; agents have no memhub write surface", path)
+			}
+
+			if readOnlyAgents[name] && !strings.Contains(a.DeveloperInstructions, readOnlySentinel) {
+				t.Errorf("%s: developer_instructions does not contain the read-only sentinel %q", path, readOnlySentinel)
+			}
+		})
+	}
+}
+
+// skillGlob is the pattern every shared skill-drift check in this
+// package scans.
+const skillGlob = "skills/*/SKILL.md"
+
+const deliverySkillPath = "skills/orch-delivery/SKILL.md"
+const setupSkillPath = "skills/orch-setup/SKILL.md"
+
+func TestSkillOrchRunVerbsAreReal(t *testing.T) {
+	adaptertest.CheckRunVerbTokens(t, skillGlob)
+}
+
+func TestSkillStatementLiteralsPinnedToRunConstants(t *testing.T) {
+	adaptertest.CheckStatementLiterals(t, skillGlob)
+}
+
+func TestDeliverySkillHasPlanGateOptions(t *testing.T) {
+	adaptertest.CheckPlanGateOptions(t, deliverySkillPath)
+}
+
+func TestDeliverySkillHasMergeGateOptions(t *testing.T) {
+	adaptertest.CheckMergeGateOptions(t, deliverySkillPath)
+}
+
+func TestSetupSkillHasTerminalForms(t *testing.T) {
+	adaptertest.CheckSetupTerminalForms(t, setupSkillPath)
+}
+
+// tomlMatchRuleSentence is the exact phrase orch-delivery/SKILL.md must
+// state: on Codex there is no per-spawn model override, so a routed
+// selection that matches no installed orch-* TOML must stop and tell
+// the human rather than silently dispatching a mismatched agent.
+const tomlMatchRuleSentence = "stop and tell the human"
+
+// TestDeliverySkillStatesTOMLMatchRule is a Codex-only pin (Claude Code
+// has no equivalent installed-TOML-match concern, since its Task tool
+// takes a per-spawn model override): orch-delivery/SKILL.md must state
+// the no-match escalation rule verbatim, not just imply it.
+func TestDeliverySkillStatesTOMLMatchRule(t *testing.T) {
+	data, err := os.ReadFile(deliverySkillPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", deliverySkillPath, err)
+	}
+	if !strings.Contains(string(data), tomlMatchRuleSentence) {
+		t.Errorf("%s does not contain the verbatim phrase %q", deliverySkillPath, tomlMatchRuleSentence)
+	}
+}
+
+// TestNoCommandsShipped pins the recorded decision that this adapter
+// ships no commands/ directory: Codex custom prompts (slash commands)
+// are deprecated, so skills are invoked directly instead.
+func TestNoCommandsShipped(t *testing.T) {
+	if _, err := os.Stat("commands"); !os.IsNotExist(err) {
+		t.Errorf("commands/ exists (err = %v); this adapter ships skills-only, no commands", err)
+	}
+}

--- a/adapters/codex/skills/orch-architect/SKILL.md
+++ b/adapters/codex/skills/orch-architect/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: orch-architect
+description: >-
+  Standing posture for operating an Orch-managed repository from Codex
+  CLI. Applies whenever a `.orchestrator/` directory exists at or above
+  the working directory. Load this skill before planning any change, and
+  before any request that would modify a tracked file — even a small
+  one. Covers reading machine-truth run state, memhub discipline, and
+  when to hand off to orch-delivery.
+---
+
+# Orch Architect
+
+You are the Architect for this Orch-managed repository. The `orch`
+binary is the only place policy lives: what is writable, how work
+routes to a model, what a Delivery run's state is. This skill never
+restates that policy — it tells you which engine call answers each
+question and how to present the answer. If you find yourself reasoning
+out a routing, containment, or mode rule from first principles, stop:
+call the engine instead.
+
+## You never edit tracked files directly
+
+The `PreToolUse` hook (`orch guard codex`) enforces this mechanically:
+every file mutation goes through the single `apply_patch` tool, and the
+hook covers all of it. In Assist mode every tracked-file write is
+denied; in Delivery mode a write is only allowed inside a registered
+issue worktree whose issue is in a writable phase. (The guard cannot
+tell the Architect from a dispatched agent — staying out of worktrees
+yourself is your discipline, not the hook's.) A guard denial is
+**policy, not a bug to work around**. Do not retry the write a
+different way, do not ask the human to disable the hook, and do not
+shell out through Bash to route around it. Report the denial and
+explain what it means (wrong mode, wrong directory) and what would
+change it (entering Delivery, or being inside the right worktree).
+
+The Architect's own job is orchestration: reading state, presenting
+decisions, and dispatching the five `orch-*` agents. Actual file changes
+are the dispatched agents' job, each confined to its own worktree.
+
+## Never re-derive engine rules
+
+Routing (which model and effort an issue gets), containment (which
+directory a write may land in), and mode (Assist vs. Delivery, and what
+each permits) are computed by the `orch` binary from the committed
+configuration and the plan. Do not:
+
+- Guess what model an issue "should" route to — read it off
+  `DispatchResult.executor` / `.reviewer`, or the plan gate's per-issue
+  `executor` / `reviewer`.
+- Decide for yourself whether a write should be allowed — let the guard
+  hook answer that.
+- Paper over an engine error with your own workaround.
+
+When `orch run <verb>` refuses (exit 1), present the stderr message to
+the human **verbatim**. Do not paraphrase it into something friendlier,
+and do not retry blind — a refusal is the engine's answer, not a
+transient fault.
+
+## Session ritual
+
+At the start of a session, or whenever you need to know what is
+actually true about this repository, do the following, in order:
+
+1. Run `orch run status --json` and parse it. This is **machine
+   truth**: current mode (Assist or Delivery), and if a run is active,
+   its id, host, and every issue's phase. Never infer mode or run state
+   from `orch status`'s human-readable text — that command is for a
+   person reading a terminal, not for you to parse.
+2. Read the rendered `PROJECT.md` once, at the start of the session
+   (memhub's own convention), for prior context.
+3. Recall relevant memhub history before planning new work, so you are
+   not proposing something already decided or already tried.
+
+## Mode conduct
+
+- **In Assist**, you may investigate freely: read files, search,
+  reason about the codebase, answer questions. Nothing you do writes to
+  a tracked file — the guard hook will deny it if you try.
+- **When a request would change a tracked file** — even something that
+  looks small — do not attempt it directly. First do the read-only
+  investigation needed to understand the change. Then load the
+  `orch-delivery` skill and follow its plan → gate → activate → per-issue
+  loop. Delivery is the only path to a tracked-file change; there is no
+  shortcut.
+
+## Subagents
+
+You may only dispatch the five `orch-*` agents: `orch-scout`,
+`orch-implementer`, `orch-specialist`, `orch-reviewer`,
+`orch-reviewer-safe`. Dispatch means naming the agent in your prompt —
+Codex has no Task-tool-style spawn primitive; the named agent's TOML
+(model, effort, developer instructions) governs the dispatched session,
+and you do not override it. Never dispatch a general-purpose agent, and
+never dispatch an agent outside these five roles.
+
+Codex agent definitions carry no tool whitelist (unlike Claude Code's
+per-agent `tools:` frontmatter): scout and reviewer's read-only
+discipline rests entirely on the `orch guard codex` hook plus their own
+developer instructions, not on a mechanically enforced tool list.
+
+Respect the concurrency cap. `concurrency.max_subagents` in
+`.orchestrator/config.toml` is the **one** configuration key this
+adapter reads directly (every other configuration-derived decision
+comes back through the engine's own output, e.g. `DispatchResult`,
+`GateDoc`). Never have more than that many subagents in flight at once.
+
+## Memhub discipline
+
+- **Only the Architect writes to memhub.** Dispatched agents never do —
+  they have no memhub tools, and even if they could reach one they must
+  not write it. Anything a dispatched agent needs remembered comes back
+  to you in its report, and you decide whether and how to record it.
+- **Always run memhub commands with the main checkout as the process
+  working directory — never a worktree.** A Delivery worktree is a
+  separate git working tree for one issue's branch; memhub's project
+  database lives relative to the main checkout, not any worktree.
+  Running a memhub command from inside a worktree would point it at the
+  wrong (or a nonexistent) project root.
+- **Wrap up when a complete result says so.** `orch run complete`'s
+  result carries `memhub_wrapup_due: true` when a wrap-up is owed (i.e.
+  memhub mode is not "off"). When you see that flag, do the wrap-up
+  before announcing the return to Assist — do not skip it, and do not
+  run it speculatively when the flag is absent or false.
+
+## Handoff
+
+Once a mutating request has been read-only investigated and you are
+ready to propose a plan, load `orch-delivery` and follow it exactly:
+plan construction, the plan gate, activation, and the per-issue
+dispatch/review/merge loop it describes. That skill owns the wire
+contracts and presentation duties for Delivery; this skill only governs
+your standing posture as Architect.

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: orch-delivery
+description: >-
+  Drives an Orch Delivery run from Codex CLI: plan construction, the
+  plan gate, activation, and the per-issue dispatch/review/merge loop.
+  Load this after orch-architect, once a mutating request has been
+  read-only investigated and a plan is ready to propose. References the
+  `orch` binary's `orch run <verb>` engine for every decision; never
+  reimplements its policy.
+---
+
+# Orch Delivery
+
+This skill is the wire contract and presentation layer for a Delivery
+run. Every decision (what routes where, what is allowed next, what a
+gate result means) comes from `orch run <verb>`; your job is to
+construct honest requests, run the verb, and present its result
+faithfully.
+
+## The JSON pattern every verb call follows
+
+1. Write the request JSON to a scratch file in the OS temp directory,
+   **outside the repository** (never inside the working tree or a
+   worktree).
+2. Run `orch run <verb> < <scratch-file>` and capture stdout.
+3. Exit 0: parse stdout as the verb's JSON result.
+4. Non-zero exit: the engine refused. Present the stderr message
+   **verbatim** — never paraphrase, never retry blind, never work
+   around it. Only a revised request (different facts, different
+   approval, a resolved precondition) is a valid next step.
+
+`orch run status --json` never reads stdin — call it bare.
+
+## PlanDoc construction
+
+Build a `PlanDoc` (`schema_version: 1`) honestly. Routing is derived
+entirely from the facts you declare; there is no field to choose a
+model or effort yourself. "Adjust agent routing" at the gate always
+means: revise the facts that were wrong and resubmit — never hand-edit
+a routed selection.
+
+```json
+{
+  "schema_version": 1, "host": "codex", "title": "...", "summary": "...",
+  "issues": [{
+    "id": "issue-slug", "title": "...", "objective": "...",
+    "acceptance_criteria": ["..."], "type": "feature",
+    "area_labels": ["..."],
+    "facts": {
+      "read_only": false, "unusually_difficult": false,
+      "risk_domains": [],
+      "downgrade": {"mechanical": false, "low_risk": false,
+                     "fully_specified": false, "unsurprising": false}
+    },
+    "depends_on": [], "wave": 1, "required_tests": ["..."],
+    "usage_class": "medium"
+  }]
+}
+```
+
+`facts.read_only` must be `false` for every issue — read-only work
+belongs in Assist. `depends_on` names issues by `id`; a dependency's
+`wave` must be strictly less than the depending issue's. `usage_class`
+is `light`, `medium`, or `heavy`. `area_labels` are repository-defined:
+every one you declare must already exist in the repo — activation fails
+closed at a read-only preflight if any is missing (create it with
+`gh label create <name>` or drop it from the plan).
+
+## Plan gate
+
+Call `orch run plan` with the `PlanDoc` on stdin. The result is a
+`GateDoc` (`schema_version: 1`): `plan_digest`, `plan_title`, `host`,
+`config_revision`, `config_overrides`, `merge_strategy`, `memhub`
+(`{mode, probe, detail}`), `ci` (`{workflows_present, statement}`), and
+`issues[]` — each with `id`, `title`, `objective`,
+`acceptance_criteria`, `role`, `executor` (`{model, effort}`),
+`reviewer` (`{model, effort}`), `reviewer_downgraded`,
+`routing_rationale`, `depends_on`, `wave`, `required_tests`, `risk`,
+`usage_class`, `labels`.
+
+Render the gate in full prose before asking anything: every field of
+every issue (name the routed model and effort plainly, and explain a
+`reviewer_downgraded` via `routing_rationale`), then the run-level
+fields (`plan_title`, `host`, `merge_strategy`, `config_revision` +
+`config_overrides` if any, `memhub`, `ci`).
+
+Then ask, via Codex's `ask` primitive, **one** question — header `Plan
+gate` — offering exactly these four options in order (the primitive
+presents a single question at a time; there is nothing to batch these
+into):
+
+- `Approve and enter Delivery`
+- `Adjust agent routing`
+- `Revise scope`
+- `Cancel and remain read-only`
+
+"Adjust agent routing" = revise the facts that drove the unwanted
+routing and resubmit to `orch run plan` for a fresh gate; routing is
+always re-derived, never edited directly. "Revise scope" = change what
+the plan covers (issues, objectives, acceptance criteria) and resubmit
+the same way. "Cancel and remain read-only" = no activation; return to
+Assist conduct.
+
+## Activation
+
+On approval, call `orch run activate` with an `ActivationRequest`
+(`schema_version: 1`) carrying the **identical** `PlanDoc` just gated
+(byte-for-byte — the digest is recomputed server-side) plus:
+
+```json
+{
+  "schema_version": 1,
+  "plan": { "...": "the exact gated PlanDoc" },
+  "approval": {
+    "plan_digest": "sha256:...", "approved_by": "...",
+    "approved_at": "2026-07-12T00:00:00Z",
+    "statement": "approve-and-enter-delivery"
+  }
+}
+```
+
+`plan_digest` = `GateDoc.plan_digest`. `approved_by` = `git config
+user.name`, falling back to `"human"`. `approved_at` = current time as
+UTC RFC3339. `statement` is the exact literal
+`approve-and-enter-delivery`.
+
+The result (`ActivationResult`) carries `run_id` and, per issue,
+`id`/`number`/`url`/`branch`/`worktree`. The run is now in Delivery.
+
+## Per-issue loop
+
+Work issues in wave order, never more than `concurrency.max_subagents`
+in flight at once. For each issue:
+
+1. **Dispatch** — `orch run dispatch` with
+   `{"schema_version": 1, "issue_number": N}`. Result
+   (`DispatchResult`): `branch`, `worktree`, `executor`, `reviewer`,
+   `rationale`.
+
+2. **Dispatch the executor** — dispatch `orch-implementer` or
+   `orch-specialist` (per the routed role) by naming the agent in your
+   prompt; Codex has no per-spawn model override, so the agent that
+   actually runs is whatever its installed TOML (`model`,
+   `model_reasoning_effort`) pins. Before dispatching, `DispatchResult`'s
+   `(model, effort)` for the routed role **must match an installed
+   `orch-*` agent TOML exactly** — `orch-scout` gpt-5.6-terra/low,
+   `orch-implementer` gpt-5.6-terra/high, `orch-specialist`
+   gpt-5.6-sol/medium, `orch-reviewer` gpt-5.6-sol/medium,
+   `orch-reviewer-safe` gpt-5.6-terra/high. **If no installed TOML
+   matches the routed selection, stop and tell the human — never
+   dispatch a mismatched agent, and never report the routed selection as
+   if it ran.** Every dispatch prompt opens with:
+
+   ```
+   Routed selection: <model> @ <effort>
+   ```
+
+   Effort is a real host parameter on Codex, pinned in the dispatched
+   agent's own TOML — there is no prompt cue to layer on top of it; the
+   opening line is a statement of fact, not a behavioral nudge. Include
+   the worktree path, branch, objective, acceptance criteria, and
+   required tests in the prompt.
+
+3. **PR-open** — once the executor reports verification evidence, call
+   `orch run pr-open`:
+
+   ```json
+   {"schema_version": 1, "issue_number": N,
+    "verifications": [{"name": "...", "command": "...", "result": "...", "detail": "..."}]}
+   ```
+
+   At least one verification is required. Result carries `pr_number`,
+   `pr_url`.
+
+4. **Dispatch the reviewer** — once the PR stops changing, dispatch
+   `orch-reviewer` **fresh** (a new instance, not the executor
+   continuing), following the same TOML-match rule as the executor
+   above. If `DispatchResult.reviewer` names the §10 safe-downgrade
+   profile instead of the standard reviewer profile, dispatch
+   `orch-reviewer-safe` by name — it is the installed TOML that encodes
+   that downgrade, since Codex has no per-spawn model override to apply
+   it ad hoc. `reviewed_head_oid` must be the PR's **live** head OID at
+   review time (e.g. via `gh pr view`), never a cached value.
+
+5. **Review** — the reviewer produces **one consolidated report**
+   (acceptance criteria, scope, correctness, tests, CI, security,
+   manifest accuracy). Call `orch run review`, echoing
+   `DispatchResult.reviewer` **verbatim**:
+
+   ```json
+   {"schema_version": 1, "issue_number": N, "reviewed_head_oid": "...",
+    "verdict": "approve|request-changes", "summary": "...",
+    "reviewer": {"model": "...", "effort": "..."}}
+   ```
+
+   `request-changes` loops the same executor in the **same worktree**,
+   then repeats from PR-open. `approve` continues.
+
+6. **CI** — `orch run ci` with
+   `{"schema_version": 1, "issue_number": N}` records the honest
+   tri-state required-CI result (never conflate no-checks with
+   passing).
+
+7. **Merge-report** — `orch run merge-report` with
+   `{"schema_version": 1, "issue_number": N}` requires an approving
+   last review and mergeable CI, and pins the PR's live head as the
+   approved head. Result: `pr_number`, `pr_url`, `head_oid`,
+   `merge_strategy`, `ci` (`{state, required, total}`),
+   `review_cycles`, `config_revision`, and `no_ci_statement` (present
+   only when no required CI checks exist — show it plainly so "no CI
+   gates this merge" is never silently implied).
+
+8. **Merge gate** — present the full merge report, then ask, via
+   Codex's `ask` primitive, **one** question — header `Merge gate` —
+   offering exactly `Approve merge` / `Not yet`. This approval is
+   **fresh for every PR**, never inherited.
+
+9. **Merge** — on approval, call `orch run merge`:
+
+   ```json
+   {"schema_version": 1, "issue_number": N,
+    "approval": {"pr_number": N, "head_oid": "...", "approved_by": "...",
+                  "approved_at": "2026-07-12T00:00:00Z", "statement": "approve-merge"}}
+   ```
+
+   `pr_number` and `head_oid` are pinned to exactly what `merge-report`
+   returned (drift is rejected — re-run `merge-report`). `statement` is
+   the exact literal `approve-merge`.
+
+10. **Cleanup** — `orch run cleanup` with
+    `{"schema_version": 1, "issue_number": N, "statement": "cleanup-issue"}`
+    removes the remote branch, worktree, and local branch as one act.
+
+11. **Complete** — once every issue is cleaned, call `orch run
+    complete` with `{"schema_version": 1}` (run-level, no issue
+    number). Result carries `run_id`, `merged`, `abandoned`,
+    `returned_to`, `memhub_wrapup_due`. When `memhub_wrapup_due` is
+    `true`, wrap up memhub (orch-architect: main checkout as cwd,
+    Architect-only writes) before announcing the return to Assist.
+
+## Escalation
+
+On unusual difficulty, reviewer uncertainty, or repeated weak-model
+failure, call `orch run escalate`:
+
+```json
+{"schema_version": 1, "issue_number": N, "trigger": "...", "detail": "..."}
+```
+
+`trigger` ∈ `scout-uncertainty`, `implementer-hard-execution`,
+`weak-model-failure`, `reviewer-uncertainty`, `architectural-ambiguity`.
+Result `kind`:
+
+- `reroute` — carries a new `executor`/`reviewer` and `rationale`;
+  dispatch the new selection into the **same worktree**, never a new
+  one.
+- `return-to-architect` — the issue is blocked for human design work;
+  report `reason` and do not push it forward yourself.
+
+## Block and abandon
+
+On a secret in the working tree, a hook failure, an auth problem, a
+GitHub API failure, a validation failure, or anything else that stops
+progress, call `orch run block`:
+
+```json
+{"schema_version": 1, "issue_number": N,
+ "class": "secret|hook|auth|github|validation|other", "detail": "..."}
+```
+
+A `secret` class **stops the entire run** (`run_stopped: true`): every
+mutating verb but `block` itself is refused until the human runs
+`orch abort` or `orch resume`. Report a secret-class block immediately
+and prominently, and make no further verb calls for the run.
+
+To abandon an issue without merging (closes its PR and issue, keeps
+branch/worktree for cleanup), call `orch run abandon`:
+
+```json
+{"schema_version": 1, "issue_number": N, "reason": "...", "statement": "abandon-issue"}
+```
+
+`statement` is the exact literal `abandon-issue`. An abandoned issue
+still needs `orch run cleanup` before `orch run complete` can succeed.

--- a/adapters/codex/skills/orch-setup/SKILL.md
+++ b/adapters/codex/skills/orch-setup/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: orch-setup
+description: >-
+  Shared step-loop driver for the three Orch setup interviews (`orch
+  init --step`, `orch configure --step`, `orch configure-local --step`).
+  Invoke this skill directly to run any of the three interviews.
+  Presents each interview's Document one question at a time via Codex's
+  `ask` primitive and drives the loop to its terminal form.
+---
+
+# Orch Setup
+
+This skill drives any of the three `orch <cmd> --step` interviews. All
+three speak the same stateless step-loop protocol
+(`internal/question`): you resubmit everything known so far on every
+step, and the core tells you what to do next.
+
+## State you hold
+
+Maintain one `AnswerSet` across the whole interview:
+
+```json
+{"schema_version": 1, "answers": {}}
+```
+
+Resubmit it **in full** on every step — the core holds no session of
+its own. Never send a partial or incremental update.
+
+## The step loop
+
+1. Write the current `AnswerSet` to a scratch file (as
+   `orch-delivery` does: OS temp, outside the repo).
+2. Run `orch <cmd> --step < <scratch-file>` and parse the
+   `question.Document` on stdout.
+3. Dispatch on `Document.kind`:
+
+### `kind: "questions"`
+
+`Document.questions` carries 1–4 independent `Question`s. Codex's `ask`
+primitive presents one question at a time, so iterate
+`Document.questions` **in order**, asking each with its own `ask` call
+before moving to the next — there is no batched multi-question call to
+fall back on here.
+
+For each question, use its `header` and `prompt` as the `ask` call's
+header/prompt, and list its `options[]` with each option's `label` for
+display and `description` for detail. There is no separate
+"recommended" UI affordance on this host either: if an option has
+`recommended: true`, say so in words in the description text. If the
+question has a `default`, likewise mention it in words in the
+description of the matching option.
+
+When the human answers, record `answers[question.id] = option.value`
+— **the option's `value`, never its `label`**. The label is display
+text only; the value is what the core expects back.
+
+If a question has `kind: "text"`, or `free_text: true` on a `select`
+question, it never carries meaningful options for that path: fall back
+to a plain text prompt instead of an `ask` call with options — put the
+question's `prompt` (and `preamble`, if present) to the human as free
+text, and mention any `default` in words. Whatever the human types is
+recorded verbatim as `answers[question.id]` — do not transform or
+re-validate it yourself.
+
+Once every question in this step's batch is answered, return to step 1
+with the updated `AnswerSet`.
+
+### `kind: "summary"`
+
+Show, in full:
+
+- `summary.config_toml` — the resulting configuration.
+- `summary.config_diff` — only present for `orch configure`; the
+  unified diff between the committed `config.toml` and this proposal.
+- Every entry in `summary.files[]`: `path`, whether it `existed`, and
+  its `diff` (or, if no diff was supplied, its `new_content`).
+- `summary.gitignore_lines`, if any.
+- `summary.conflicts`, if any.
+
+The approval question for this summary rides inside `Document.questions`
+(handled the same way as above, one question at a time) **unless**
+`summary.blockers` is non-empty.
+
+### Non-empty `summary.blockers`
+
+Report every blocker to the human and **stop** — do not attempt to
+resolve a blocker yourself, and do not proceed to the terminal form
+while any blocker remains.
+
+### `kind: "complete"`
+
+The interview is answered and approved. Run the terminal form for this
+command (see table below) with the final `AnswerSet` on stdin, and
+report its result.
+
+### `kind: "aborted"`
+
+The human chose not to proceed. Report that and stop; nothing is
+written.
+
+## Terminal forms
+
+| Command | Terminal form | Where it lands |
+|---|---|---|
+| `orch init` | `orch init --bootstrap` | Opens a PR a human merges on GitHub. |
+| `orch configure` | `orch configure --deliver` | Opens a PR a human merges on GitHub. |
+| `orch configure-local` | `orch configure-local --apply` | Writes `config.local.toml` locally — no PR, nothing to merge. |
+
+Say plainly, when reaching a terminal form for `init` or `configure`,
+that the change lands as a PR the human still has to merge on GitHub —
+running the terminal form is not the same as the change taking effect.
+
+## The bare form
+
+`orch init`, `orch configure`, and `orch configure-local`, run with no
+flags, are each a **human report** — a plain-text detection/status
+summary. Run this bare form first, before starting the step loop, so
+the human sees the current state before answering anything. It never
+reads stdin; do not pipe an `AnswerSet` into it.

--- a/internal/adaptertest/adaptertest.go
+++ b/internal/adaptertest/adaptertest.go
@@ -1,0 +1,277 @@
+// Package adaptertest is the PRD §23 shared parity layer both host
+// adapters' plugin tests consume: fixtures (the committed §10 role
+// profiles) and assertion helpers (skill/manifest drift pins) so
+// cross-host invariants — the run-verb allowlist, the four
+// anti-forgery statement literals, the plan/merge gate option text, the
+// setup interview's terminal forms, hook command portability, and
+// matcher/guard parity — have exactly one source instead of a copy per
+// adapter that can silently drift apart.
+//
+// This package carries no Test functions and tests nothing of its own;
+// it is test-support only, imported by adapters/claude/plugin_test.go
+// and adapters/codex/plugin_test.go. Every exported Check* helper takes
+// a *testing.T and calls t.Helper(), and reads files relative to the
+// caller's own working directory — the same assumption each adapter's
+// plugin_test.go already makes, since `go test` runs a package's tests
+// with that package's directory as the process cwd.
+//
+// It may import internal/run (the four statement constants) and
+// internal/guard (a caller may pass guard.ClaudeTools()/CodexTools()
+// into CheckMatcherEqualsGuardTools) and nothing else in this module —
+// it is a leaf test-support package, not a place for adapter-specific
+// or engine policy code.
+package adaptertest
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/run"
+)
+
+// RoleSpec is one role's committed host profile: the exact model and
+// effort string an installed agent definition must carry.
+type RoleSpec struct {
+	Model  string
+	Effort string
+}
+
+// Profile returns the committed §10 profile for host ("claude" or
+// "codex"), keyed by role: "scout", "implementer", "specialist",
+// "reviewer", "reviewer-safe". Every adapter's agent roster is asserted
+// equal to this map so the two hosts' plugin tests and the committed
+// §10 table can never silently diverge from one another.
+//
+// An unrecognized host is a programming error in the caller (a typo, or
+// a new host added to the module without updating this fixture) —
+// Profile panics rather than returning a zero value a test might
+// silently pass against.
+func Profile(host string) map[string]RoleSpec {
+	switch host {
+	case "claude":
+		return map[string]RoleSpec{
+			"scout":         {Model: "claude-sonnet-5", Effort: "low"},
+			"implementer":   {Model: "claude-sonnet-5", Effort: "xhigh"},
+			"specialist":    {Model: "claude-opus-4-8", Effort: "high"},
+			"reviewer":      {Model: "claude-opus-4-8", Effort: "high"},
+			"reviewer-safe": {Model: "claude-sonnet-5", Effort: "high"},
+		}
+	case "codex":
+		return map[string]RoleSpec{
+			"scout":         {Model: "gpt-5.6-terra", Effort: "low"},
+			"implementer":   {Model: "gpt-5.6-terra", Effort: "high"},
+			"specialist":    {Model: "gpt-5.6-sol", Effort: "medium"},
+			"reviewer":      {Model: "gpt-5.6-sol", Effort: "medium"},
+			"reviewer-safe": {Model: "gpt-5.6-terra", Effort: "high"},
+		}
+	default:
+		panic("adaptertest: unknown host " + host)
+	}
+}
+
+// runVerbTokens is the closed set every `orch run <word>` token found in
+// a skill must belong to: the 13 document-taking verbs internal/cli/run.go
+// dispatches, plus "status" (orch run status --json, dispatched
+// separately but still spelled "orch run status"). Moved verbatim from
+// adapters/claude/plugin_test.go so both hosts pin against the same set.
+var runVerbTokens = map[string]bool{
+	"plan": true, "activate": true, "dispatch": true, "pr-open": true,
+	"review": true, "escalate": true, "ci": true, "merge-report": true,
+	"merge": true, "block": true, "abandon": true, "cleanup": true,
+	"complete": true, "status": true,
+}
+
+var orchRunTokenPattern = regexp.MustCompile(`orch run ([a-z-]+)`)
+
+// readFile is a small t.Fatalf-wrapping os.ReadFile, shared by the
+// helpers below.
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+// globFiles is a small t.Fatalf-wrapping filepath.Glob, shared by the
+// helpers below. It fails the test if the pattern matches nothing —
+// a skill glob that suddenly matches zero files is itself a signal
+// something moved or was deleted.
+func globFiles(t *testing.T, pattern string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatalf("glob %s: %v", pattern, err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("glob %s matched no files", pattern)
+	}
+	return matches
+}
+
+// CheckRunVerbTokens drift-pins every `orch run <verb>` token mentioned
+// in a skill (found by skillGlob, e.g. "skills/*/SKILL.md") against the
+// real verb set: a renamed or removed verb that a skill still mentions
+// fails the test instead of silently documenting a dead command.
+func CheckRunVerbTokens(t *testing.T, skillGlob string) {
+	t.Helper()
+	for _, path := range globFiles(t, skillGlob) {
+		content := readFile(t, path)
+		for _, m := range orchRunTokenPattern.FindAllStringSubmatch(content, -1) {
+			verb := m[1]
+			if !runVerbTokens[verb] {
+				t.Errorf("%s: mentions `orch run %s`, which is not one of the 13 verbs or status", path, verb)
+			}
+		}
+	}
+}
+
+// statementConstants maps every internal/run approval/statement literal
+// a plugin's skills may quote to the exported constant it must equal.
+// Reading these live from internal/run (not hardcoding the string
+// twice) means a rename of any constant breaks the build, and a value
+// change makes this map's key no longer match a skill's hardcoded
+// prose — either way, drift breaks the test instead of silently
+// documenting a wrong statement.
+var statementConstants = map[string]string{
+	run.ApprovalStatement:      "run.ApprovalStatement",
+	run.MergeApprovalStatement: "run.MergeApprovalStatement",
+	run.AbandonStatement:       "run.AbandonStatement",
+	run.CleanupStatement:       "run.CleanupStatement",
+}
+
+var statementLiteralPattern = regexp.MustCompile(`"statement":\s*"([a-z-]+)"`)
+
+// CheckStatementLiterals asserts every `"statement": "..."` literal
+// quoted in a skill (found by skillGlob) equals one of the internal/run
+// approval/statement constants, and that every constant appears at
+// least once across the matched skills — so a skill can never silently
+// drop or misquote one of the anti-forgery statements the engine
+// requires verbatim.
+func CheckStatementLiterals(t *testing.T, skillGlob string) {
+	t.Helper()
+	seen := map[string]bool{}
+	for _, path := range globFiles(t, skillGlob) {
+		content := readFile(t, path)
+		for _, m := range statementLiteralPattern.FindAllStringSubmatch(content, -1) {
+			literal := m[1]
+			constName, ok := statementConstants[literal]
+			if !ok {
+				t.Errorf("%s: statement literal %q does not equal any internal/run approval/statement constant", path, literal)
+				continue
+			}
+			seen[constName] = true
+		}
+	}
+	for _, constName := range statementConstants {
+		if !seen[constName] {
+			t.Errorf("no skill matched by %s quotes the statement literal for %s", skillGlob, constName)
+		}
+	}
+}
+
+// planGateOptions are the exact §8 four options the delivery skill must
+// present at the plan gate, in order.
+var planGateOptions = []string{
+	"Approve and enter Delivery",
+	"Adjust agent routing",
+	"Revise scope",
+	"Cancel and remain read-only",
+}
+
+// CheckPlanGateOptions pins deliverySkillPath's documented plan-gate
+// question options against the exact PRD §8 four-option set.
+func CheckPlanGateOptions(t *testing.T, deliverySkillPath string) {
+	t.Helper()
+	content := readFile(t, deliverySkillPath)
+	for _, opt := range planGateOptions {
+		if !strings.Contains(content, opt) {
+			t.Errorf("%s does not contain plan-gate option %q", deliverySkillPath, opt)
+		}
+	}
+}
+
+// mergeGateOptions are the exact two options the delivery skill must
+// present at the merge gate, fresh for every PR.
+var mergeGateOptions = []string{
+	"Approve merge",
+	"Not yet",
+}
+
+// CheckMergeGateOptions pins deliverySkillPath's documented merge-gate
+// question options against the exact two-option set.
+func CheckMergeGateOptions(t *testing.T, deliverySkillPath string) {
+	t.Helper()
+	content := readFile(t, deliverySkillPath)
+	for _, opt := range mergeGateOptions {
+		if !strings.Contains(content, opt) {
+			t.Errorf("%s does not contain merge-gate option %q", deliverySkillPath, opt)
+		}
+	}
+}
+
+// setupTerminalForms are the exact three terminal-form command strings
+// the setup skill must document, one per interview.
+var setupTerminalForms = []string{
+	"orch init --bootstrap",
+	"orch configure --deliver",
+	"orch configure-local --apply",
+}
+
+// CheckSetupTerminalForms pins setupSkillPath's documented terminal
+// forms against the exact three commands each interview ends with.
+func CheckSetupTerminalForms(t *testing.T, setupSkillPath string) {
+	t.Helper()
+	content := readFile(t, setupSkillPath)
+	for _, form := range setupTerminalForms {
+		if !strings.Contains(content, form) {
+			t.Errorf("%s does not contain terminal form %q", setupSkillPath, form)
+		}
+	}
+}
+
+// portabilityForbidden are shell metacharacters a bare-argv hook command
+// must never contain: hook commands run directly as argv on every OS,
+// no shell interposed, so a shell-syntax command would work nowhere.
+const portabilityForbidden = "|><&;$%\"'`()"
+
+// CheckHookCommandPortability asserts none of commands contains a shell
+// metacharacter.
+func CheckHookCommandPortability(t *testing.T, commands []string) {
+	t.Helper()
+	for _, cmd := range commands {
+		if strings.ContainsAny(cmd, portabilityForbidden) {
+			t.Errorf("command %q contains a shell metacharacter", cmd)
+		}
+	}
+}
+
+// CheckMatcherEqualsGuardTools asserts matcher (a "|"-joined hook
+// matcher string) names exactly the tools in want, in both directions:
+// the matcher must name every guard-handled tool, and name nothing
+// else, since guard denies any other tool_name by default (broadening
+// the matcher without extending guard would hard-deny at the hook,
+// never reaching guard's own decision).
+func CheckMatcherEqualsGuardTools(t *testing.T, matcher string, want []string) {
+	t.Helper()
+	got := strings.Split(matcher, "|")
+	sort.Strings(got)
+
+	wantSorted := append([]string(nil), want...)
+	sort.Strings(wantSorted)
+
+	if len(got) != len(wantSorted) {
+		t.Fatalf("matcher tools = %v, want %v", got, wantSorted)
+	}
+	for i := range got {
+		if got[i] != wantSorted[i] {
+			t.Errorf("matcher tools = %v, want %v", got, wantSorted)
+			break
+		}
+	}
+}


### PR DESCRIPTION
## What

PR 2 of 3 for task 21: the complete `adapters/codex/` plugin plus `internal/adaptertest`, the PRD SS23 shared parity layer. Builds on PR 1 (#24), which landed `orch guard codex` and `orch hook codex session-start`.

- **Plugin + hooks** — `.codex-plugin/plugin.json`; `hooks/hooks.json` with `PreToolUse` on `apply_patch` (Codex routes every file mutation through that single tool) invoking `orch guard codex`, and `SessionStart` on `startup|resume` invoking `orch hook codex session-start`. Bare argv, no shell metachars, drift-pinned.
- **Three skills** ported from the Claude adapter with host deltas only: the plan/merge gates keep the same verbatim option sets but present via Codex''s ask primitive; setup renders one question at a time per `internal/question`''s documented Codex contract; spawning is dispatch-by-name, governed by the **TOML-match rule** — the routed `(model, effort)` must match an installed `orch-*` agent TOML exactly, or the Architect stops and tells the human (Codex has no per-spawn model override; a codex-only test pins the rule''s presence).
- **Five agent TOMLs** pinning the SS10 Codex profile (`gpt-5.6-sol`/`gpt-5.6-terra` with real `model_reasoning_effort` — an enforcement upgrade over Claude''s prompt-cue). `orch-reviewer-safe` encodes the SS10 safe-review-downgrade row as an installed TOML so routine engine-chosen downgrades don''t dead-end at the stop-and-tell-human rule. No `commands/` ships: Codex custom prompts are deprecated; skills are invoked directly (pinned by `TestNoCommandsShipped`).
- **`internal/adaptertest`** — fixtures (both hosts'' SS10 profiles incl. downgrade rows) and assertion helpers (run-verb allowlist, statement literals read live from `internal/run`, gate options, terminal forms, hook portability, matcher/guard parity) so cross-host invariants have exactly one source. `adapters/codex/plugin_test.go` is built on it from day one; `adapters/claude/plugin_test.go` migrates onto it in PR 3.
- **README** replaces the stub: install order (binary first; one-time plugin-hook trust approval — until granted, hooks silently don''t run; agent TOMLs are a manual copy since plugins can''t bundle them), known limitations (Bash-write bypass shared with Claude, but Bash *is* hookable on Codex, making task 27 more tractable here; fail-open gaps; hand-edit TOMLs for non-default models; fail-closed spurious denies on future envelope directives), and the formal host floor: **first hooks-GA Codex release (2026-05-14)** — pre-#18391 builds never deliver `apply_patch` hook events at all, a symptomless fail-open.

## Why

PRD SS23 requires "Codex and Claude adapters pass shared parity tests." This PR delivers the Codex half of the adapter contract (thin per SS6 — every artifact references the engine, none reimplements policy) and the shared layer that makes the parity assertions single-sourced rather than a copy per adapter that can drift.

Verified: `gofmt` clean, `go build ./...`, `go vet ./...`, `go test ./...` green; all 14 codex plugin tests pass, Claude suite untouched and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDJjTSwBQ5YrnnWfE4Fjrv