### PR TITLE
Close cross-host parity: shared drift pins and protocol-level tests

### DIFF
--- a/adapters/claude/README.md
+++ b/adapters/claude/README.md
@@ -117,11 +117,13 @@ bugs:
 
 ## Host version
 
-This design assumes a Claude Code version with plugin support
-(component auto-discovery for `commands/`, `agents/`, `skills/`, and
-`hooks/hooks.json`), `SessionStart` hooks, and the `AskUserQuestion` tool.
-A formally pinned minimum supported Claude Code version is deliberately
-deferred (PRD §24) to the sandbox-e2e and parity milestones (task 21),
-where it will be recorded alongside the manual smoke test this PR's plan
-calls for. Until then, treat the Claude Code version this adapter is
-manually smoke-tested against during development as the de-facto floor.
+Formal minimum: Claude Code >= 2.1.207 (the version the task-18
+end-to-end smoke validated: plugin component auto-discovery for
+`commands/`, `agents/`, `skills/`, and `hooks/hooks.json`, `SessionStart`
+hooks, the `AskUserQuestion` tool, and the `PreToolUse`
+`permissionDecision` protocol), formalized at task 21 alongside the
+Codex CLI floor.
+
+The Codex CLI adapter lives at `adapters/codex/` and passes the same
+shared parity suite (`internal/adaptertest`) this adapter's plugin tests
+do.

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -1,9 +1,12 @@
 // Package claude_test validates the non-Go Claude Code plugin artifacts
 // under this directory: the manifest, the hooks manifest, the agent and
 // skill markdown, and their consistency with the internal/guard
-// PreToolUse contract and internal/run wire contracts they mirror.
-// These are ordinary Go tests so `go test ./...` catches drift without a
-// separate host-specific test runner.
+// PreToolUse contract and internal/run wire contracts they mirror. These
+// are ordinary Go tests so `go test ./...` catches drift without a
+// separate host-specific test runner. Cross-host invariants shared with
+// the Codex adapter live in internal/adaptertest (PRD §23's shared
+// parity layer); this file only holds Claude-specific fixtures and
+// checks.
 package claude_test
 
 import (
@@ -11,13 +14,12 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"testing"
 
+	"github.com/kninetimmy/orch/internal/adaptertest"
 	"github.com/kninetimmy/orch/internal/guard"
-	"github.com/kninetimmy/orch/internal/run"
 )
 
 // pluginManifest is the strict shape of .claude-plugin/plugin.json.
@@ -127,42 +129,23 @@ func TestMatcherGuardParity(t *testing.T) {
 	if len(m.Hooks.PreToolUse) != 1 {
 		t.Fatalf("PreToolUse has %d entries, want exactly 1", len(m.Hooks.PreToolUse))
 	}
-	matcher := m.Hooks.PreToolUse[0].Matcher
-	got := strings.Split(matcher, "|")
-	sort.Strings(got)
-
-	want := guard.ClaudeTools()
-	sort.Strings(want)
-
-	if len(got) != len(want) {
-		t.Fatalf("matcher tools = %v, want %v", got, want)
-	}
-	for i := range got {
-		if got[i] != want[i] {
-			t.Errorf("matcher tools = %v, want %v", got, want)
-			break
-		}
-	}
+	adaptertest.CheckMatcherEqualsGuardTools(t, m.Hooks.PreToolUse[0].Matcher, guard.ClaudeTools())
 }
-
-// portabilityForbidden are shell metacharacters a bare-argv hook command
-// must never contain: hook commands run directly as argv on every OS, no
-// shell interposed, so a shell-syntax command would work nowhere.
-const portabilityForbidden = "|><&;$%\"'`()"
 
 func TestHookCommandsPortable(t *testing.T) {
 	m := loadHooksManifest(t)
-	check := func(matchers []hookMatcher) {
-		for _, matcher := range matchers {
-			for _, h := range matcher.Hooks {
-				if strings.ContainsAny(h.Command, portabilityForbidden) {
-					t.Errorf("command %q contains a shell metacharacter", h.Command)
-				}
-			}
+	var commands []string
+	for _, matcher := range m.Hooks.PreToolUse {
+		for _, h := range matcher.Hooks {
+			commands = append(commands, h.Command)
 		}
 	}
-	check(m.Hooks.PreToolUse)
-	check(m.Hooks.SessionStart)
+	for _, matcher := range m.Hooks.SessionStart {
+		for _, h := range matcher.Hooks {
+			commands = append(commands, h.Command)
+		}
+	}
+	adaptertest.CheckHookCommandPortability(t, commands)
 }
 
 // TestHookCommandsPinnedToBinaryVerbs drift-pins the hook commands to the
@@ -222,18 +205,23 @@ func splitCSV(s string) []string {
 }
 
 // agentSpec is the committed §10 Claude profile for one agents/*.md
-// role (task 17 plan item 10): its exact model and exact tool set.
+// role's Claude-specific fields not already covered by
+// adaptertest.Profile: its exact tool set. Profile("claude") pins the
+// model directly; Claude frontmatter has no effort field to assert.
 type agentSpec struct {
-	model string
 	tools []string
 }
 
 // agentRoster is the full four-agent Claude profile this plugin ships.
+// Profile("claude") also carries a "reviewer-safe" entry with no Claude
+// agent file — Claude Code has a per-spawn model override, so it needs
+// no safe-downgrade agent of its own, and this roster deliberately does
+// not require a fifth agent to exist.
 var agentRoster = map[string]agentSpec{
-	"orch-scout":       {model: "claude-sonnet-5", tools: []string{"Read", "Grep", "Glob", "WebFetch", "WebSearch"}},
-	"orch-implementer": {model: "claude-sonnet-5", tools: []string{"Read", "Grep", "Glob", "Edit", "Write", "NotebookEdit", "Bash"}},
-	"orch-specialist":  {model: "claude-opus-4-8", tools: []string{"Read", "Grep", "Glob", "Edit", "Write", "NotebookEdit", "Bash"}},
-	"orch-reviewer":    {model: "claude-opus-4-8", tools: []string{"Read", "Grep", "Glob", "Bash"}},
+	"orch-scout":       {tools: []string{"Read", "Grep", "Glob", "WebFetch", "WebSearch"}},
+	"orch-implementer": {tools: []string{"Read", "Grep", "Glob", "Edit", "Write", "NotebookEdit", "Bash"}},
+	"orch-specialist":  {tools: []string{"Read", "Grep", "Glob", "Edit", "Write", "NotebookEdit", "Bash"}},
+	"orch-reviewer":    {tools: []string{"Read", "Grep", "Glob", "Bash"}},
 }
 
 // writeExcludedAgents are the roles that must never carry a write tool
@@ -250,8 +238,9 @@ var writeTools = []string{"Write", "Edit", "MultiEdit", "NotebookEdit"}
 // committed §10 Claude profile: all four agents exist with a complete
 // frontmatter, scout and reviewer exclude every write tool, no agent
 // lists Task or an mcp__ tool (subagents have no memhub write surface),
-// and models match their role exactly.
+// and models match adaptertest.Profile("claude") for their role exactly.
 func TestAgentFrontmatter(t *testing.T) {
+	profile := adaptertest.Profile("claude")
 	for name, want := range agentRoster {
 		t.Run(name, func(t *testing.T) {
 			path := filepath.Join("agents", name+".md")
@@ -266,11 +255,14 @@ func TestAgentFrontmatter(t *testing.T) {
 			if fm["tools"] == "" {
 				t.Fatal("tools is empty")
 			}
-			if fm["model"] != want.model {
-				t.Errorf("model = %q, want %q", fm["model"], want.model)
+
+			role := strings.TrimPrefix(name, "orch-")
+			roleSpec, ok := profile[role]
+			if !ok {
+				t.Fatalf("no adaptertest.Profile(\"claude\") entry for role %q", role)
 			}
-			if fm["model"] != "claude-sonnet-5" && fm["model"] != "claude-opus-4-8" {
-				t.Errorf("model %q is not one of the two committed Claude profile models", fm["model"])
+			if fm["model"] != roleSpec.Model {
+				t.Errorf("model = %q, want %q", fm["model"], roleSpec.Model)
 			}
 
 			tools := splitCSV(fm["tools"])
@@ -310,141 +302,29 @@ func TestAgentFrontmatter(t *testing.T) {
 	}
 }
 
-// skillFiles returns every skills/*/SKILL.md path.
-func skillFiles(t *testing.T) []string {
-	t.Helper()
-	matches, err := filepath.Glob(filepath.Join("skills", "*", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("glob skills/*/SKILL.md: %v", err)
-	}
-	if len(matches) == 0 {
-		t.Fatal("no skills/*/SKILL.md files found")
-	}
-	return matches
-}
+// skillGlob is the pattern every shared skill-drift check in this
+// package scans.
+const skillGlob = "skills/*/SKILL.md"
 
-// runVerbTokens is the closed set every `orch run <word>` token found in
-// a skill must belong to: the 13 document-taking verbs internal/cli/run.go
-// dispatches, plus "status" (orch run status --json, dispatched
-// separately but still spelled "orch run status").
-var runVerbTokens = map[string]bool{
-	"plan": true, "activate": true, "dispatch": true, "pr-open": true,
-	"review": true, "escalate": true, "ci": true, "merge-report": true,
-	"merge": true, "block": true, "abandon": true, "cleanup": true,
-	"complete": true, "status": true,
-}
+const deliverySkillPath = "skills/orch-delivery/SKILL.md"
+const setupSkillPath = "skills/orch-setup/SKILL.md"
 
-var orchRunTokenPattern = regexp.MustCompile(`orch run ([a-z-]+)`)
-
-// TestSkillOrchRunVerbsAreReal drift-pins every `orch run <verb>` token
-// mentioned in a skill against the real verb set: a renamed or removed
-// verb that a skill still mentions fails this test instead of silently
-// documenting a dead command.
 func TestSkillOrchRunVerbsAreReal(t *testing.T) {
-	for _, path := range skillFiles(t) {
-		data, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("read %s: %v", path, err)
-		}
-		for _, m := range orchRunTokenPattern.FindAllStringSubmatch(string(data), -1) {
-			verb := m[1]
-			if !runVerbTokens[verb] {
-				t.Errorf("%s: mentions `orch run %s`, which is not one of the 13 verbs or status", path, verb)
-			}
-		}
-	}
+	adaptertest.CheckRunVerbTokens(t, skillGlob)
 }
 
-// statementConstants maps every internal/run approval/statement literal
-// this plugin's skills may quote to the exported constant it must equal.
-// Importing internal/run here means a rename of any of these constants
-// breaks the build, and a value change makes the map key (read live from
-// the constant, not hardcoded) no longer match the skill's hardcoded
-// prose — either way, drift breaks this test instead of silently
-// documenting a wrong statement.
-var statementConstants = map[string]string{
-	run.ApprovalStatement:      "run.ApprovalStatement",
-	run.MergeApprovalStatement: "run.MergeApprovalStatement",
-	run.AbandonStatement:       "run.AbandonStatement",
-	run.CleanupStatement:       "run.CleanupStatement",
-}
-
-var statementLiteralPattern = regexp.MustCompile(`"statement":\s*"([a-z-]+)"`)
-
-// TestSkillStatementLiteralsPinnedToRunConstants asserts every
-// `"statement": "..."` literal quoted in a skill equals one of the
-// internal/run approval/statement constants, and that every constant
-// appears at least once (so a skill can never silently drop or misquote
-// one of the anti-forgery statements the engine requires verbatim).
 func TestSkillStatementLiteralsPinnedToRunConstants(t *testing.T) {
-	seen := map[string]bool{}
-	for _, path := range skillFiles(t) {
-		data, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("read %s: %v", path, err)
-		}
-		for _, m := range statementLiteralPattern.FindAllStringSubmatch(string(data), -1) {
-			literal := m[1]
-			constName, ok := statementConstants[literal]
-			if !ok {
-				t.Errorf("%s: statement literal %q does not equal any internal/run approval/statement constant", path, literal)
-				continue
-			}
-			seen[constName] = true
-		}
-	}
-	for _, constName := range statementConstants {
-		if !seen[constName] {
-			t.Errorf("no skill quotes the statement literal for %s", constName)
-		}
-	}
+	adaptertest.CheckStatementLiterals(t, skillGlob)
 }
 
-// planGateOptions are the exact §8 four options the orch-delivery skill
-// must present at the plan gate, in order.
-var planGateOptions = []string{
-	"Approve and enter Delivery",
-	"Adjust agent routing",
-	"Revise scope",
-	"Cancel and remain read-only",
-}
-
-// TestDeliverySkillHasPlanGateOptions pins the orch-delivery skill's
-// documented plan-gate AskUserQuestion options against the exact PRD §8
-// four-option set.
 func TestDeliverySkillHasPlanGateOptions(t *testing.T) {
-	data, err := os.ReadFile(filepath.Join("skills", "orch-delivery", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("read orch-delivery/SKILL.md: %v", err)
-	}
-	content := string(data)
-	for _, opt := range planGateOptions {
-		if !strings.Contains(content, opt) {
-			t.Errorf("orch-delivery/SKILL.md does not contain plan-gate option %q", opt)
-		}
-	}
+	adaptertest.CheckPlanGateOptions(t, deliverySkillPath)
 }
 
-// setupTerminalForms are the exact three terminal-form command strings
-// the orch-setup skill must document, one per interview.
-var setupTerminalForms = []string{
-	"orch init --bootstrap",
-	"orch configure --deliver",
-	"orch configure-local --apply",
+func TestDeliverySkillHasMergeGateOptions(t *testing.T) {
+	adaptertest.CheckMergeGateOptions(t, deliverySkillPath)
 }
 
-// TestSetupSkillHasTerminalForms pins the orch-setup skill's documented
-// terminal forms against the exact three commands each interview ends
-// with.
 func TestSetupSkillHasTerminalForms(t *testing.T) {
-	data, err := os.ReadFile(filepath.Join("skills", "orch-setup", "SKILL.md"))
-	if err != nil {
-		t.Fatalf("read orch-setup/SKILL.md: %v", err)
-	}
-	content := string(data)
-	for _, form := range setupTerminalForms {
-		if !strings.Contains(content, form) {
-			t.Errorf("orch-setup/SKILL.md does not contain terminal form %q", form)
-		}
-	}
+	adaptertest.CheckSetupTerminalForms(t, setupSkillPath)
 }

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -12,6 +12,10 @@ This adapter only translates Codex CLI host events into calls against
 that binary, presents native dialogs, and dispatches role agents. It
 never re-derives a decision the engine already made.
 
+The Claude Code adapter lives at `adapters/claude/` and passes the same
+shared parity suite (`internal/adaptertest`) this adapter's plugin tests
+do.
+
 ## Artifact map
 
 - `.codex-plugin/plugin.json` — the plugin manifest (name, description,

--- a/internal/cli/guard_parity_test.go
+++ b/internal/cli/guard_parity_test.go
@@ -1,0 +1,242 @@
+// guard_parity_test.go pins the PRD §23 cross-host invariant directly:
+// the Claude Code and Codex CLI adapters answer the exact same
+// PreToolUse/SessionStart questions the exact same way, modulo each
+// host's own event envelope and (for session-start) its one host-varying
+// closing sentence. internal/adaptertest pins the plugin artifacts;
+// these tests pin the protocol-level behavior behind them, at the
+// internal/guard and internal/cli layer both hosts' hooks actually call.
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/guard"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// equalPathSets reports whether a and b contain the same paths, ignoring
+// order: PathsFromClaudeEvent and PathsFromCodexEvent extract targets in
+// each host's own envelope order, which need not match between hosts for
+// an equivalent event.
+func equalPathSets(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	sortedA := append([]string(nil), a...)
+	sortedB := append([]string(nil), b...)
+	sort.Strings(sortedA)
+	sort.Strings(sortedB)
+	for i := range sortedA {
+		if sortedA[i] != sortedB[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestGuardEventPathExtractionParity asserts guard.PathsFromClaudeEvent
+// and guard.PathsFromCodexEvent extract the identical absolute write
+// target(s) from equivalent host events: a file create, an edit, a
+// notebook edit, and a relative path resolved against cwd. It also
+// confirms an unrecognized tool_name is ErrUnknownTool on both hosts.
+func TestGuardEventPathExtractionParity(t *testing.T) {
+	root := t.TempDir()
+	createTarget := filepath.Join(root, "new.go")
+	editTarget := filepath.Join(root, "existing.go")
+	notebookTarget := filepath.Join(root, "notebook.ipynb")
+
+	cases := []struct {
+		name        string
+		claudeEvent []byte
+		codexEvent  []byte
+	}{
+		{
+			name:        "create",
+			claudeEvent: []byte(claudePayload(t, "Write", "file_path", createTarget, "")),
+			codexEvent:  []byte(codexPayload(t, "apply_patch", "*** Begin Patch\n*** Add File: "+createTarget+"\n+contents\n*** End Patch", "")),
+		},
+		{
+			name:        "edit",
+			claudeEvent: []byte(claudePayload(t, "Edit", "file_path", editTarget, "")),
+			codexEvent:  []byte(codexPayload(t, "apply_patch", "*** Begin Patch\n*** Update File: "+editTarget+"\n@@ hunk header\n-old\n+new\n*** End Patch", "")),
+		},
+		{
+			name:        "notebook",
+			claudeEvent: []byte(claudePayload(t, "NotebookEdit", "notebook_path", notebookTarget, "")),
+			codexEvent:  []byte(codexPayload(t, "apply_patch", "*** Begin Patch\n*** Update File: "+notebookTarget+"\n@@ hunk header\n-old\n+new\n*** End Patch", "")),
+		},
+		{
+			name:        "relative path resolved against cwd",
+			claudeEvent: []byte(claudePayload(t, "Write", "file_path", "sub/new.go", root)),
+			codexEvent:  []byte(codexPayload(t, "apply_patch", "*** Begin Patch\n*** Add File: sub/new.go\n+x\n*** End Patch", root)),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			claudePaths, err := guard.PathsFromClaudeEvent(tc.claudeEvent)
+			if err != nil {
+				t.Fatalf("PathsFromClaudeEvent err = %v", err)
+			}
+			codexPaths, err := guard.PathsFromCodexEvent(tc.codexEvent)
+			if err != nil {
+				t.Fatalf("PathsFromCodexEvent err = %v", err)
+			}
+			if !equalPathSets(claudePaths, codexPaths) {
+				t.Errorf("path sets differ: claude = %v, codex = %v", claudePaths, codexPaths)
+			}
+		})
+	}
+
+	t.Run("unknown tool", func(t *testing.T) {
+		bashEvent := []byte(`{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}`)
+		_, claudeErr := guard.PathsFromClaudeEvent(bashEvent)
+		if !errors.Is(claudeErr, guard.ErrUnknownTool) {
+			t.Errorf("claude err = %v, want ErrUnknownTool", claudeErr)
+		}
+		_, codexErr := guard.PathsFromCodexEvent(bashEvent)
+		if !errors.Is(codexErr, guard.ErrUnknownTool) {
+			t.Errorf("codex err = %v, want ErrUnknownTool", codexErr)
+		}
+	})
+}
+
+// TestGuardVerdictParityAcrossHosts asserts `orch guard claude` and
+// `orch guard codex` reach the identical verdict for the equivalent
+// scenario: an Assist-mode write to a tracked file (both deny), a
+// Delivery write inside the registered worktree (both allow, silently),
+// and a Delivery write outside every registered worktree (both deny).
+// Each host gets its own fresh fixture (guard state lives on disk), built
+// by the same closure so both fixtures place the write at the same
+// scenario-relative location; the deny document text carries only the
+// verdict's Reason, never its Path, so identical wording is the only bar
+// to clear even though each fixture's temp-dir root differs.
+func TestGuardVerdictParityAcrossHosts(t *testing.T) {
+	cases := []struct {
+		name  string
+		build func(t *testing.T) (env Env, target string)
+	}{
+		{
+			name: "assist tracked file denies",
+			build: func(t *testing.T) (Env, string) {
+				env, _, _, root := guardRepo(t, 1) // not ignored → deny
+				return env, filepath.Join(root, "src", "x.go")
+			},
+		},
+		{
+			name: "delivery write inside registered worktree allows",
+			build: func(t *testing.T) (Env, string) {
+				env, _, _, worktreeAbs := deliveryGuardEnv(t)
+				return env, filepath.Join(worktreeAbs, "src", "x.go")
+			},
+		},
+		{
+			name: "delivery write outside registered worktree denies",
+			build: func(t *testing.T) (Env, string) {
+				env, _, _, worktreeAbs := deliveryGuardEnv(t)
+				return env, filepath.Join(filepath.Dir(worktreeAbs), "outside.go")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			claudeEnv, claudeTarget := tc.build(t)
+			var claudeStdout bytes.Buffer
+			claudeEnv.Stdout = &claudeStdout
+			claudeEnv.Stdin = strings.NewReader(claudePayload(t, "Write", "file_path", claudeTarget, ""))
+			claudeCode := Run([]string{"guard", "claude"}, claudeEnv)
+
+			codexEnv, codexTarget := tc.build(t)
+			var codexStdout bytes.Buffer
+			codexEnv.Stdout = &codexStdout
+			envelope := "*** Begin Patch\n*** Update File: " + codexTarget + "\n@@ hunk header\n-old\n+new\n*** End Patch"
+			codexEnv.Stdin = strings.NewReader(codexPayload(t, "apply_patch", envelope, ""))
+			codexCode := Run([]string{"guard", "codex"}, codexEnv)
+
+			if claudeCode != codexCode {
+				t.Fatalf("exit codes differ: claude = %d, codex = %d", claudeCode, codexCode)
+			}
+			claudeOut := strings.TrimSpace(claudeStdout.String())
+			codexOut := strings.TrimSpace(codexStdout.String())
+			if claudeOut != codexOut {
+				t.Errorf("deny documents differ:\nclaude: %q\ncodex:  %q", claudeOut, codexOut)
+			}
+		})
+	}
+}
+
+// TestGuardInternalFailureParityExitsTwo asserts malformed JSON on stdin
+// is the identical internal failure on both hosts: exit 2 (the hook
+// protocol's blocking code), silent stdout — never the deny document, and
+// never exit 1.
+func TestGuardInternalFailureParityExitsTwo(t *testing.T) {
+	claudeEnv, claudeStdout, _, _ := guardRepo(t, 1)
+	claudeEnv.Stdin = strings.NewReader(`{ not json`)
+	claudeCode := Run([]string{"guard", "claude"}, claudeEnv)
+
+	codexEnv, codexStdout, _, _ := guardRepo(t, 1)
+	codexEnv.Stdin = strings.NewReader(`{ not json`)
+	codexCode := Run([]string{"guard", "codex"}, codexEnv)
+
+	if claudeCode != ExitUsage || codexCode != ExitUsage {
+		t.Fatalf("exit codes = claude %d, codex %d, want both %d", claudeCode, codexCode, ExitUsage)
+	}
+	if claudeStdout.String() != "" || codexStdout.String() != "" {
+		t.Errorf("internal failure emitted output: claude %q, codex %q", claudeStdout.String(), codexStdout.String())
+	}
+}
+
+// TestSessionStartParity extends TestHookSessionStartSharedLinesAcrossHosts
+// (which already pins shared-lines parity for an Assist-mode repo) one
+// notch further: a Delivery-mode repo with dispatched and in-review
+// issues, mirroring TestHookCodexSessionStartDeliveryRun's fixture, must
+// also render identical output across hosts apart from the closing
+// sentence — in particular this exercises deliveryRunSummary's rendering,
+// which the Assist-mode fixture never reaches.
+func TestSessionStartParity(t *testing.T) {
+	env, stdoutClaude, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	planned := []state.Issue{{PlanID: "a", Title: "A", Phase: state.PhasePlanned}}
+	plan := state.PlanRef{Title: "t", Digest: "sha256:x", ConfigRevision: "r1"}
+	st, err := state.EnterDelivery(env.RepoRoot, "claude", plan, planned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision := &state.Decision{
+		Role:      manifest.RoleImplementer,
+		Executor:  manifest.Selection{Model: "m", Effort: "e"},
+		Reviewer:  manifest.Selection{Model: "m", Effort: "e"},
+		Rationale: "r",
+	}
+	st.Run.Issues = []state.Issue{
+		{PlanID: "a", Title: "A", Phase: state.PhaseDispatched, Number: 1, Branch: "b1", Worktree: "wt1", Decision: decision},
+		{PlanID: "b", Title: "B", Phase: state.PhaseInReview, Number: 2, Branch: "b2", Worktree: "wt2", Decision: decision, PRNumber: 2},
+	}
+	if err := state.Save(env.RepoRoot, st); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := Run([]string{"hook", "claude", "session-start"}, env); code != ExitOK {
+		t.Fatalf("claude exit = %d, want %d (stderr %q)", code, ExitOK, stderr.String())
+	}
+
+	var stdoutCodex bytes.Buffer
+	envCodex := env
+	envCodex.Stdout = &stdoutCodex
+	if code := Run([]string{"hook", "codex", "session-start"}, envCodex); code != ExitOK {
+		t.Fatalf("codex exit = %d, want %d", code, ExitOK)
+	}
+
+	claudeShared := strings.TrimSuffix(stdoutClaude.String(), sessionStartClosing["claude"]+"\n")
+	codexShared := strings.TrimSuffix(stdoutCodex.String(), sessionStartClosing["codex"]+"\n")
+	if claudeShared != codexShared {
+		t.Errorf("delivery-state shared lines differ:\nclaude: %q\ncodex:  %q", claudeShared, codexShared)
+	}
+}


### PR DESCRIPTION
## What

PR 3 of 3 for task 21, completing the PRD SS23 acceptance criterion **"Codex and Claude adapters pass shared parity tests."** Builds on #24 (core plumbing) and #25 (adapter artifacts + `internal/adaptertest`).

- **Claude plugin tests migrate onto the shared layer** — the run-verb allowlist, statement-literal pins (read live from `internal/run`), plan-gate options, terminal forms, hook portability, and matcher/guard parity now run from `internal/adaptertest`, the single source both adapters consume; the local Claude copies are deleted (net -177 lines). Host-specific checks stay local: strict manifest decodes, the frontmatter parser, per-agent tool whitelists, and the pinned `orch guard claude` / `orch hook claude session-start` command strings. `agentRoster` models now assert against `adaptertest.Profile("claude")` instead of a second hardcoded table, and the new `TestDeliverySkillHasMergeGateOptions` brings Claude up to the merge-gate pin Codex shipped with. Zero test-name loss (10 originals all kept, 1 added).
- **Protocol-level parity tests** (`internal/cli/guard_parity_test.go`) — beyond artifact pins, the behavior itself is now pinned cross-host: equivalent Claude/Codex events extract identical absolute path sets (create / edit / notebook / relative-vs-cwd, plus unknown-tool -> `ErrUnknownTool` on both decoders); `orch guard claude` and `orch guard codex` reach identical exit codes **and byte-equal deny documents** across Assist-deny, Delivery-allow-inside-worktree, and Delivery-deny-outside scenarios; malformed stdin is exit 2 and silent on both; and a Delivery-state session-start renders identical output across hosts apart from the one host-keyed closing sentence — exercising `deliveryRunSummary`, which the existing Assist-mode parity test never reached.
- **READMEs** — the Claude adapter''s host-version section replaces its "deferred to task 21" framing with the formal floor (Claude Code >= 2.1.207, the task-18 smoke-validated surface); both adapter READMEs now cross-link each other and name the shared parity suite.

## Why

Decision 6 built the Claude adapter first precisely so the Codex adapter would land together with a parity suite proving the two hosts answer the same questions the same way. This PR is that closure: cross-host invariants have exactly one source, and a change that breaks parity now fails `go test ./...` on the spot instead of drifting silently.

Verified: `gofmt` clean, `go build ./...`, `go vet ./...`, `go test ./...` green (adapters/claude, adapters/codex, internal/cli re-run uncached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDJjTSwBQ5YrnnWfE4Fjrv