### PR TITLE
Fix Codex adapter findings from the task-30 parity smoke

### DIFF
--- a/adapters/claude/agents/orch-implementer.md
+++ b/adapters/claude/agents/orch-implementer.md
@@ -28,6 +28,11 @@ surrounding code's existing style and conventions. Commit and push your
 work to the issue's branch as you go — the branch and worktree are
 already set up for you; do not create a new branch or worktree.
 
+Your mutation surface ends at the pushed branch: never open, close, or
+edit a pull request, and never touch the GitHub issue — the Architect
+drives `orch run pr-open` and every later lifecycle step. A PR opened
+by hand carries no audit record, and the run blocks on it.
+
 ## Verification evidence
 
 Before reporting back, run the required tests and any other checks

--- a/adapters/claude/agents/orch-specialist.md
+++ b/adapters/claude/agents/orch-specialist.md
@@ -35,6 +35,11 @@ let it return to the human via the plan gate or an escalation. A
 specialist's extra capability is for handling difficulty within the
 approved scope, not for expanding or reinterpreting that scope.
 
+Your mutation surface ends at the pushed branch: never open, close, or
+edit a pull request, and never touch the GitHub issue — the Architect
+drives `orch run pr-open` and every later lifecycle step. A PR opened
+by hand carries no audit record, and the run blocks on it.
+
 ## Verification evidence
 
 Before reporting back, run the required tests and any other relevant

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -50,16 +50,16 @@ do.
   `concurrency.max_subagents` cap, and memhub write discipline.
 - `skills/orch-delivery/SKILL.md` — the Delivery wire contract: the
   scratch-file JSON request/response pattern for every `orch run <verb>`
-  call, `PlanDoc` construction, the plan gate and its four-option `ask`
-  question, activation, the full per-issue dispatch → execute → pr-open
+  call, `PlanDoc` construction, the plan gate and its four-option
+  `request_user_input` question, activation, the full per-issue dispatch → execute → pr-open
   → review → ci → merge-report → merge gate → merge → cleanup loop,
   completion and the memhub wrap-up cue, escalation, and block/abandon.
 - `skills/orch-setup/SKILL.md` — the shared step-loop driver for the
   three `orch <cmd> --step` interviews: the resubmitted-in-full
   `AnswerSet`, one-question-at-a-time presentation of `questions`
-  documents via Codex's `ask` primitive, the `summary`/blockers/
-  `complete`/`aborted` document kinds, and each interview's terminal
-  form.
+  documents via Codex's `request_user_input` primitive, the
+  `summary`/blockers/`complete`/`aborted` document kinds, and each
+  interview's terminal form.
 - `agents/orch-scout.toml`, `agents/orch-implementer.toml`,
   `agents/orch-specialist.toml`, `agents/orch-reviewer.toml`,
   `agents/orch-reviewer-safe.toml` — the five role agents the Architect
@@ -92,7 +92,22 @@ decision, not an oversight).
    Codex plugins cannot bundle agent definitions, so this copy is a
    separate manual step every install of this adapter needs, not
    something the plugin installs for you.
-5. Run `orch doctor` to confirm the environment (Git, GitHub, memhub,
+5. Enable the `request_user_input` question primitive — verified on
+   codex-cli 0.144.1, both of these in `~/.codex/config.toml`:
+
+   ```toml
+   [tools.experimental_request_user_input]
+
+   [features]
+   default_mode_request_user_input = true
+   ```
+
+   (The `[tools]` entry is a struct, not a boolean — the bare table
+   enables it with defaults.) The setup interviews and the plan/merge
+   gates present their questions through `request_user_input`, which
+   is otherwise gated to plan mode; without these the skills degrade
+   to plain-text questions the human answers by typing.
+6. Run `orch doctor` to confirm the environment (Git, GitHub, memhub,
    configuration) is healthy.
 
 ## Known limitations
@@ -156,6 +171,14 @@ which is why the floor is pinned at the first release confirmed to
 include the fix rather than left to a de-facto smoke-tested version, as
 the Claude adapter's is.
 
+Two behaviors verified live in the task-30 parity smoke (codex-cli
+0.144.1, 2026-07-12): PreToolUse hooks **do** fire on dispatched-agent
+(subagent) `apply_patch` calls — load-bearing here, since Codex agent
+definitions carry no tool whitelist, so scout/reviewer read-only
+discipline is mechanically enforced by the guard, not just by
+`developer_instructions` — and `request_user_input` is root-thread
+only, so a dispatched agent can never raise a native question.
+
 As defense in depth — complementary to the guard hook, not a
 substitute for it, and no configuration is shipped by this adapter to
 enforce it — a repository operator adopting this adapter should also
@@ -164,4 +187,9 @@ and a non-`never` `approval_policy`. The guard hook denies by orch's own
 Delivery/Assist policy; Codex CLI's own sandbox and approval settings
 are a second, independent layer that catches what the hook cannot (a
 missing binary, an unapproved plugin, a write the hook fails to
-classify).
+classify). One Windows caveat, observed live: `workspace-write`
+requires Codex's sandbox helper infrastructure to be installed and
+healthy — where it is absent, every agent `apply_patch` fails before
+any mutation (`orchestrator_helper_launch_failed`), which stops
+Delivery execution cold. Verify the sandbox works before adopting that
+mode on Windows.

--- a/adapters/codex/agents/orch-implementer.toml
+++ b/adapters/codex/agents/orch-implementer.toml
@@ -27,6 +27,11 @@ surrounding code's existing style and conventions. Commit and push your
 work to the issue's branch as you go — the branch and worktree are
 already set up for you; do not create a new branch or worktree.
 
+Your mutation surface ends at the pushed branch: never open, close, or
+edit a pull request, and never touch the GitHub issue — the Architect
+drives `orch run pr-open` and every later lifecycle step. A PR opened
+by hand carries no audit record, and the run blocks on it.
+
 ## Verification evidence
 
 Before reporting back, run the required tests and any other checks

--- a/adapters/codex/agents/orch-specialist.toml
+++ b/adapters/codex/agents/orch-specialist.toml
@@ -33,6 +33,11 @@ let it return to the human via the plan gate or an escalation. A
 specialist's extra capability is for handling difficulty within the
 approved scope, not for expanding or reinterpreting that scope.
 
+Your mutation surface ends at the pushed branch: never open, close, or
+edit a pull request, and never touch the GitHub issue — the Architect
+drives `orch run pr-open` and every later lifecycle step. A PR opened
+by hand carries no audit record, and the run blocks on it.
+
 ## Verification evidence
 
 Before reporting back, run the required tests and any other relevant

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -84,10 +84,9 @@ every issue (name the routed model and effort plainly, and explain a
 fields (`plan_title`, `host`, `merge_strategy`, `config_revision` +
 `config_overrides` if any, `memhub`, `ci`).
 
-Then ask, via Codex's `ask` primitive, **one** question — header `Plan
-gate` — offering exactly these four options in order (the primitive
-presents a single question at a time; there is nothing to batch these
-into):
+Then ask, via Codex's `request_user_input` primitive, **one** question
+— header `Plan gate` — offering exactly these four options in order
+(one question, nothing to batch):
 
 - `Approve and enter Delivery`
 - `Adjust agent routing`
@@ -211,9 +210,9 @@ in flight at once. For each issue:
    gates this merge" is never silently implied).
 
 8. **Merge gate** — present the full merge report, then ask, via
-   Codex's `ask` primitive, **one** question — header `Merge gate` —
-   offering exactly `Approve merge` / `Not yet`. This approval is
-   **fresh for every PR**, never inherited.
+   Codex's `request_user_input` primitive, **one** question — header
+   `Merge gate` — offering exactly `Approve merge` / `Not yet`. This
+   approval is **fresh for every PR**, never inherited.
 
 9. **Merge** — on approval, call `orch run merge`:
 

--- a/adapters/codex/skills/orch-setup/SKILL.md
+++ b/adapters/codex/skills/orch-setup/SKILL.md
@@ -5,7 +5,8 @@ description: >-
   init --step`, `orch configure --step`, `orch configure-local --step`).
   Invoke this skill directly to run any of the three interviews.
   Presents each interview's Document one question at a time via Codex's
-  `ask` primitive and drives the loop to its terminal form.
+  `request_user_input` primitive and drives the loop to its terminal
+  form.
 ---
 
 # Orch Setup
@@ -36,14 +37,16 @@ its own. Never send a partial or incremental update.
 
 ### `kind: "questions"`
 
-`Document.questions` carries 1–4 independent `Question`s. Codex's `ask`
-primitive presents one question at a time, so iterate
-`Document.questions` **in order**, asking each with its own `ask` call
-before moving to the next — there is no batched multi-question call to
-fall back on here.
+`Document.questions` carries 1–4 independent `Question`s. Present them
+via Codex's `request_user_input` primitive: iterate
+`Document.questions` **in order**, asking each with its own
+`request_user_input` call before moving to the next. (If the primitive
+is unavailable in this session — it is gated off outside plan mode
+unless the `default_mode_request_user_input` feature is enabled — say
+so once, then fall back to asking the same questions as plain text.)
 
-For each question, use its `header` and `prompt` as the `ask` call's
-header/prompt, and list its `options[]` with each option's `label` for
+For each question, use its `header` and `prompt` as the
+`request_user_input` call's header/prompt, and list its `options[]` with each option's `label` for
 display and `description` for detail. There is no separate
 "recommended" UI affordance on this host either: if an option has
 `recommended: true`, say so in words in the description text. If the
@@ -54,9 +57,19 @@ When the human answers, record `answers[question.id] = option.value`
 — **the option's `value`, never its `label`**. The label is display
 text only; the value is what the core expects back.
 
-If a question has `kind: "text"`, or `free_text: true` on a `select`
-question, it never carries meaningful options for that path: fall back
-to a plain text prompt instead of an `ask` call with options — put the
+If a `select` question has `free_text: true`, it still carries real
+options — present them through `request_user_input` exactly as above,
+and append one extra option, label `Other — enter a custom value`, as
+the free-text path (`request_user_input` options are selection-only;
+this extra option stands in for the built-in "Other" entry Claude
+Code's question tool has). A listed option records its `value` as
+usual. Only if the human picks Other, ask a plain-text follow-up and
+record what they type verbatim as `answers[question.id]` — do not
+transform or re-validate it yourself; if the core rejects it, its
+re-ask message says why.
+
+If a question has `kind: "text"`, it carries no options at all: fall
+back to a plain text prompt — put the
 question's `prompt` (and `preamble`, if present) to the human as free
 text, and mention any `default` in words. Whatever the human types is
 recorded verbatim as `answers[question.id]` — do not transform or


### PR DESCRIPTION
## What

Three fixes from the manual Codex parity smoke (task 30, codex-cli 0.144.1):

1. **Question primitive** - the Codex skills referenced an `ask` primitive that does not exist; the real tool is `request_user_input` (plan-mode-gated; enabled via `[tools.experimental_request_user_input]` + the `default_mode_request_user_input` feature). The setup skill also dropped the engine's select options on `free_text` questions, forcing humans to type exact model IDs; options now render natively with an appended "Other" entry.
2. **Executor scope** - the implementer opened a PR itself via `gh` (the documented Bash gap, observed live); resume's orphan-PR discriminator caught it as designed. All four executor instruction files (implementer/specialist, both hosts) now explicitly end the mutation surface at the pushed branch.
3. **README** - the verified `request_user_input` enablement, the resolved subagent-coverage unknown (PreToolUse hooks DO fire on dispatched-agent apply_patch calls - verified live), `request_user_input` being root-thread-only, and a Windows `workspace-write` caveat (absent sandbox helper infrastructure fails all agent writes).

## Why

The smoke exists to validate the adapter against a real host; these are the deltas between what the ported artifacts assumed and what codex-cli 0.144.1 actually does. The subagent-coverage resolution is the important one: Codex agent TOMLs carry no tool whitelist, so the guard firing on dispatched agents is what makes scout/reviewer read-only discipline mechanical rather than advisory.

Smoke summary: full init-from-Codex bootstrap, two complete Delivery cycles (issues 13/16, PRs 15/17, pinned squash merges, delivered status), live block->resume recovery from a host-level apply_patch failure, orphan-PR rejection and recovery, kill-at-pr-open resume convergence, orch-reviewer-safe dispatched by name on a routed downgrade, and the subagent guard probe denied with the exact worktree-containment reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDJjTSwBQ5YrnnWfE4Fjrv