### PR TITLE
Add release pipeline: tag-driven GitHub Releases with SHA-256 checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: release
+
+# Tag-driven releases (decision 8): pushing a v* tag cross-compiles the
+# single static orch binary for every supported OS/arch, publishes a
+# SHA256SUMS file alongside, and creates the GitHub Release with
+# generated notes. Installs verify the checksum before use.
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      # A tag is not gated by the PR workflow, so prove the tagged
+      # commit builds and passes tests before anything is published.
+      - run: go build ./...
+      - run: go vet ./...
+      - run: go test ./...
+
+      - name: Cross-compile
+        run: |
+          set -euo pipefail
+          mkdir dist
+          for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do
+            goos=${target%/*}
+            goarch=${target#*/}
+            ext=""
+            [ "$goos" = "windows" ] && ext=".exe"
+            CGO_ENABLED=0 GOOS=$goos GOARCH=$goarch go build -trimpath \
+              -ldflags "-s -w -X github.com/kninetimmy/orch/internal/cli.Version=${GITHUB_REF_NAME}" \
+              -o "dist/orch_${goos}_${goarch}${ext}" ./cmd/orch
+          done
+
+      - name: Checksums
+        run: cd dist && sha256sum * > SHA256SUMS
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" dist/* \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+            --verify-tag

--- a/README.md
+++ b/README.md
@@ -61,8 +61,26 @@ escalating back to the Architect if everything else is exhausted.
 
 ## Install
 
-There are no binary releases yet (that pipeline is planned). Build
-from source with Go 1.26+:
+Download the static binary for your OS and architecture from
+[GitHub Releases](https://github.com/kninetimmy/orch/releases)
+(`orch_<os>_<arch>`, Windows binaries end in `.exe`), then verify its
+SHA-256 against the `SHA256SUMS` file published with the release
+**before running it** — don't skip this:
+
+```sh
+# Linux / macOS
+sha256sum --check --ignore-missing SHA256SUMS
+
+# Windows (PowerShell): compare against the matching SHA256SUMS line
+(Get-FileHash orch_windows_amd64.exe -Algorithm SHA256).Hash
+```
+
+Rename it to `orch` (or `orch.exe`) and place it on your PATH.
+`orch status` and `orch doctor` print the binary's release version on
+their first line; adapters and docs pin a release version.
+
+Alternatively, build from source with Go 1.26+ (source builds report
+version `dev`):
 
 ```sh
 git clone https://github.com/kninetimmy/orch.git

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -15,6 +15,8 @@ import (
 )
 
 func runDoctor(env Env) error {
+	fmt.Fprintf(env.Stdout, "note  orch version: %s\n", Version)
+
 	failed := false
 	check := func(name string, err error) {
 		if err != nil {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -19,7 +19,7 @@ func TestDoctorAllChecksPass(t *testing.T) {
 		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
 	}
 	out := stdout.String()
-	for _, want := range []string{"ok    git on PATH", "ok    git repository", "ok    gh on PATH", "ok    gh authentication", "ok    gh repository: o/r", "ok    configuration"} {
+	for _, want := range []string{"note  orch version: dev", "ok    git on PATH", "ok    git repository", "ok    gh on PATH", "ok    gh authentication", "ok    gh repository: o/r", "ok    configuration"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q:\n%s", want, out)
 		}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -11,6 +11,8 @@ import (
 )
 
 func runStatus(env Env) error {
+	fmt.Fprintf(env.Stdout, "orch:   %s\n", Version)
+
 	cfg, err := config.Load(env.RepoRoot)
 	if err != nil {
 		return err

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -12,12 +12,17 @@ import (
 )
 
 func TestStatusNotInitialized(t *testing.T) {
-	env, _, stderr := testEnv(t)
+	env, stdout, stderr := testEnv(t)
 	if code := Run([]string{"status"}, env); code != ExitError {
 		t.Errorf("exit = %d, want %d", code, ExitError)
 	}
 	if !strings.Contains(stderr.String(), "not initialized") {
 		t.Errorf("stderr = %q", stderr.String())
+	}
+	// The version line prints before any repository check, so even an
+	// uninitialized repository identifies the binary on PATH.
+	if !strings.Contains(stdout.String(), "orch:   dev") {
+		t.Errorf("stdout missing version line:\n%s", stdout.String())
 	}
 }
 
@@ -28,7 +33,7 @@ func TestStatusValidConfig(t *testing.T) {
 		t.Fatalf("exit = %d, want %d", code, ExitOK)
 	}
 	out := stdout.String()
-	for _, want := range []string{"mode:   assist", `revision "r1"`, "hosts:  claude"} {
+	for _, want := range []string{"orch:   dev", "mode:   assist", `revision "r1"`, "hosts:  claude"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q:\n%s", want, out)
 		}

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,0 +1,12 @@
+package cli
+
+// Version is the release version of this binary, stamped by the
+// release workflow via
+//
+//	-ldflags "-X github.com/kninetimmy/orch/internal/cli.Version=v1.2.3"
+//
+// Builds without the stamp (go build, go install, go test) report
+// "dev". status and doctor print it before any repository checks, so
+// an uninitialized or broken repository can still identify the binary
+// on PATH.
+var Version = "dev"


### PR DESCRIPTION
## What

Closes out task 22 (Phase 5 packaging, decision 8 — resolves the PRD §24 packaging/update deferral).

- **`internal/cli/version.go`** — new `Version` var (default `"dev"`), stamped at release time via `-ldflags -X`. `orch status` (`orch:   v1.2.3`) and `orch doctor` (`note  orch version: v1.2.3`) print it as their first line, *before* any repository check, so an uninitialized or broken repo can still identify the binary on PATH. No new command — PRD §22's eight-command surface stays closed (user call, 2026-07-13).
- **`.github/workflows/release.yml`** — on a `v*` tag push: re-runs build/vet/test on the tagged commit (tags aren't gated by the PR workflow), cross-compiles static binaries (`CGO_ENABLED=0`, `-trimpath -s -w`) for linux/darwin/windows × amd64/arm64, writes `SHA256SUMS`, and creates the GitHub Release with `--generate-notes --verify-tag`.
- **README** — Install section now leads with the release download and **mandatory SHA-256 verification before use** (standing security rule); build-from-source stays documented and reports version `dev`.

## Why

Both adapters are now smoke-validated end-to-end (tasks 18/30), so distribution is the bottleneck: task 26 (install.sh/ps1) and task 32 (two-command plugin install) both need release binaries + a checksums file to verify against. Asset names are stable (`orch_<os>_<arch>[.exe]`) so install scripts can construct URLs from a pinned tag; the tag itself carries the version, and the stamped binary self-reports it for `orch doctor`.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` all green; `gofmt -l` clean.
- Stamped build verified end-to-end: `-ldflags -X ...Version=v9.9.9-test` → `orch status` prints `orch:   v9.9.9-test`, `orch doctor` prints `note  orch version: v9.9.9-test`, both in an uninitialized repo.
- Workflow itself only runs on a `v*` tag; first real exercise will be the v0.1.0 tag after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)