### PR TITLE
Add checksum-verified install scripts and install docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,5 @@
 *.diff text eol=lf
 *.json text eol=lf
 *.txt text eol=lf
+*.sh text eol=lf
+*.ps1 text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,25 @@ jobs:
       - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12.2
+
+  scripts:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Lint install.sh
+        if: runner.os == 'Linux'
+        run: |
+          sh -n install.sh
+          shellcheck --shell=sh install.sh
+      - name: Lint install.ps1
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          if (-not (Get-Module -ListAvailable PSScriptAnalyzer)) {
+            Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
+          }
+          Invoke-ScriptAnalyzer -Path install.ps1 -Severity Error, Warning -EnableExit

--- a/README.md
+++ b/README.md
@@ -61,6 +61,86 @@ escalating back to the Architect if everything else is exhausted.
 
 ## Install
 
+### Quick install (script)
+
+Both scripts download the release binary for your OS and architecture,
+verify its SHA-256 against the release's `SHA256SUMS` **before**
+installing, and fail closed on any mismatch.
+
+Linux / macOS — installs to `~/.local/bin` (override with
+`ORCH_INSTALL_DIR`); pin a version with `ORCH_VERSION=v0.1.0`:
+
+```sh
+curl -fsSLO https://raw.githubusercontent.com/kninetimmy/orch/main/install.sh
+# inspect it, then:
+sh install.sh
+```
+
+Windows (PowerShell) — installs to `%LOCALAPPDATA%\Programs\orch` and
+adds that directory to your user `PATH` (skip the PATH change with
+`-NoPathUpdate`; pin a version with `-Version v0.1.0`):
+
+```powershell
+iwr https://raw.githubusercontent.com/kninetimmy/orch/main/install.ps1 -OutFile install.ps1
+# inspect it, then:
+powershell -ExecutionPolicy Bypass -File .\install.ps1
+```
+
+### Plugin install (two commands per host)
+
+With the binary on `PATH`, each host installs its adapter straight from
+this repository's marketplace manifest:
+
+```sh
+# Claude Code
+claude plugin marketplace add kninetimmy/orch
+claude plugin install orch-claude@orch
+
+# Codex CLI
+codex plugin marketplace add kninetimmy/orch
+codex plugin add orch@orch
+```
+
+Then follow the host-specific steps in the adapter READMEs
+([Claude Code](adapters/claude/README.md#install-order),
+[Codex CLI](adapters/codex/README.md#install-order)) — Codex CLI
+additionally needs the one-time hook trust approval, the five agent
+TOMLs copied, and the `request_user_input` feature enabled.
+
+### Bootstrap with your agent
+
+Paste this into a Claude Code or Codex CLI session to have the agent
+run the install end to end:
+
+```text
+Install the Orch orchestrator from https://github.com/kninetimmy/orch:
+1. Detect my OS and run the matching install script from the repository
+   root (install.sh on Linux/macOS; install.ps1 on Windows — download
+   it, then run: powershell -ExecutionPolicy Bypass -File .\install.ps1).
+   The script verifies the binary's SHA-256 against the release's
+   SHA256SUMS. If that verification fails, STOP and report the failure —
+   never bypass it or install an unverified binary.
+2. Confirm `orch` resolves on PATH and `orch status` prints a release
+   version on its first line. On Windows a new terminal may be needed
+   for the PATH change — ask me instead of guessing.
+3. Install your host's adapter plugin:
+   - Claude Code: claude plugin marketplace add kninetimmy/orch
+     then: claude plugin install orch-claude@orch
+   - Codex CLI: codex plugin marketplace add kninetimmy/orch
+     then: codex plugin add orch@orch
+4. Codex CLI only: copy the five agent TOMLs (orch-scout,
+   orch-implementer, orch-specialist, orch-reviewer, orch-reviewer-safe)
+   from the plugin's agents/ directory into ./.codex/agents/ or
+   ~/.codex/agents/, add the two request_user_input stanzas from
+   adapters/codex/README.md to ~/.codex/config.toml, and tell me that
+   the plugin hook trust prompt is a one-time approval only I can
+   confirm — do not proceed as if hooks are active until I do.
+5. Run `orch doctor`, report what it says, and point me at `orch init`
+   for the repository I want orchestrated.
+```
+
+### Manual download
+
 Download the static binary for your OS and architecture from
 [GitHub Releases](https://github.com/kninetimmy/orch/releases)
 (`orch_<os>_<arch>`, Windows binaries end in `.exe`), then verify its
@@ -79,8 +159,9 @@ Rename it to `orch` (or `orch.exe`) and place it on your PATH.
 `orch status` and `orch doctor` print the binary's release version on
 their first line; adapters and docs pin a release version.
 
-Alternatively, build from source with Go 1.26+ (source builds report
-version `dev`):
+### Build from source
+
+Build with Go 1.26+ (source builds report version `dev`):
 
 ```sh
 git clone https://github.com/kninetimmy/orch.git

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,145 @@
+<#
+.SYNOPSIS
+Download the released orch binary for Windows, verify its SHA-256
+against the release's published SHA256SUMS, and install it. Fails
+closed: nothing is installed unless the checksum matches.
+
+.PARAMETER Version
+Release tag to install (default: latest), e.g. v0.1.0.
+
+.PARAMETER InstallDir
+Install directory (default: %LOCALAPPDATA%\Programs\orch).
+
+.PARAMETER NoPathUpdate
+By default the install directory is appended to the user PATH (never
+the machine PATH) when missing. This switch prints the command to do it
+yourself instead.
+
+.NOTES
+Exit codes mirror install.sh: 0 ok, 2 unsupported platform or bad
+-Version, 3 download failure, 4 checksum failure, 5 install failure.
+#>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'user-facing installer output')]
+[CmdletBinding()]
+param(
+    [string]$Version = 'latest',
+    [string]$InstallDir = "$env:LOCALAPPDATA\Programs\orch",
+    [switch]$NoPathUpdate
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repo = 'kninetimmy/orch'
+$exitClass = 2
+$tmp = $null
+
+try {
+    try {
+        # Validate the version before it reaches a URL; fail closed on
+        # anything outside the tag charset.
+        if ($Version -ne 'latest' -and $Version -notmatch '^v[0-9][0-9A-Za-z.+-]*$') {
+            throw "Version must be a release tag like v0.1.0 (got: $Version)"
+        }
+
+        switch ($env:PROCESSOR_ARCHITECTURE) {
+            'AMD64' { $arch = 'amd64' }
+            'ARM64' { $arch = 'arm64' }
+            default { throw "unsupported architecture: $env:PROCESSOR_ARCHITECTURE (releases cover amd64 and arm64)" }
+        }
+        $asset = "orch_windows_$arch.exe"
+
+        if ($Version -eq 'latest') {
+            $base = "https://github.com/$repo/releases/latest/download"
+        }
+        else {
+            $base = "https://github.com/$repo/releases/download/$Version"
+        }
+
+        $exitClass = 3
+        # TLS 1.2 for Windows PowerShell 5.1 (harmless on PowerShell 7+).
+        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+        $tmp = Join-Path $env:TEMP ("orch-install-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $tmp | Out-Null
+        $binaryPath = Join-Path $tmp $asset
+        $sumsPath = Join-Path $tmp 'SHA256SUMS'
+        Invoke-WebRequest -UseBasicParsing -Uri "$base/$asset" -OutFile $binaryPath
+        Invoke-WebRequest -UseBasicParsing -Uri "$base/SHA256SUMS" -OutFile $sumsPath
+
+        $exitClass = 4
+        # Verify before anything touches the install dir: exact-filename
+        # match against the checksum list; a missing line is a failure,
+        # never a skip.
+        $expected = $null
+        foreach ($line in Get-Content $sumsPath) {
+            if ($line -match '^([0-9a-fA-F]{64})\s+\*?(.+)$' -and $Matches[2] -eq $asset) {
+                $expected = $Matches[1]
+                break
+            }
+        }
+        if (-not $expected) {
+            throw "SHA256SUMS has no entry for $asset"
+        }
+        $actual = (Get-FileHash -Path $binaryPath -Algorithm SHA256).Hash
+        if ($actual -ne $expected) {
+            throw "checksum mismatch for ${asset}: expected $expected, got $actual - refusing to install"
+        }
+
+        $exitClass = 5
+        New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+        $dest = Join-Path $InstallDir 'orch.exe'
+        Copy-Item -Path $binaryPath -Destination $dest -Force
+
+        Write-Host "installed: $dest"
+        # Best-effort version echo; status prints it on its first stdout
+        # line. Stderr is dropped (a non-orch cwd is normal here), and
+        # under Windows PowerShell 5.1 that redirect needs a non-Stop
+        # preference or the stderr write itself becomes terminating.
+        $statusLine = $null
+        $prevPreference = $ErrorActionPreference
+        $ErrorActionPreference = 'SilentlyContinue'
+        try {
+            $statusLine = & $dest status 2>$null | Select-Object -First 1
+        }
+        finally {
+            $ErrorActionPreference = $prevPreference
+        }
+        if ($statusLine) { Write-Host $statusLine }
+
+        # User PATH only, never machine PATH, never silent.
+        $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+        if ($null -eq $userPath) { $userPath = '' }
+        $onPath = $false
+        foreach ($segment in ($userPath -split ';')) {
+            if ($segment -and $segment.TrimEnd('\') -ieq $InstallDir.TrimEnd('\')) {
+                $onPath = $true
+                break
+            }
+        }
+        if (-not $onPath) {
+            if ($NoPathUpdate) {
+                Write-Host "$InstallDir is not on your user PATH; add it with:"
+                Write-Host "  [Environment]::SetEnvironmentVariable('Path', '$InstallDir;' + [Environment]::GetEnvironmentVariable('Path', 'User'), 'User')"
+            }
+            else {
+                $newPath = ($userPath.TrimEnd(';') + ';' + $InstallDir).TrimStart(';')
+                [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+                Write-Host "added $InstallDir to your user PATH - restart your terminal to pick it up"
+            }
+        }
+
+        Write-Host "next: run 'orch doctor'"
+        $exitClass = 0
+    }
+    finally {
+        if ($tmp -and (Test-Path $tmp)) {
+            Remove-Item -Recurse -Force -Path $tmp
+        }
+    }
+}
+catch {
+    [Console]::Error.WriteLine("install.ps1: $($_.Exception.Message)")
+    exit $exitClass
+}
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+# install.sh — download the released orch binary for this OS and
+# architecture from GitHub Releases, verify its SHA-256 against the
+# release's published SHA256SUMS, and install it. Fails closed: nothing
+# lands on PATH unless the checksum matches.
+#
+# Environment:
+#   ORCH_VERSION      release tag to install (default: latest), e.g. v0.1.0
+#   ORCH_INSTALL_DIR  install directory (default: $HOME/.local/bin)
+#
+# Exit codes: 0 ok, 2 unsupported platform or bad ORCH_VERSION,
+# 3 download/tooling failure, 4 checksum failure, 5 install failure.
+
+set -eu
+
+repo="kninetimmy/orch"
+
+fail() {
+  code="$1"
+  shift
+  echo "install.sh: $*" >&2
+  exit "$code"
+}
+
+version="${ORCH_VERSION:-latest}"
+install_dir="${ORCH_INSTALL_DIR:-$HOME/.local/bin}"
+
+# Validate the version before it reaches a URL: a leading v, then only
+# tag charset. Anything else fails closed.
+if [ "$version" != "latest" ]; then
+  case "$version" in
+    v[0-9]*) ;;
+    *) fail 2 "ORCH_VERSION must be a release tag like v0.1.0 (got: $version)" ;;
+  esac
+  case "$version" in
+    *[!0-9A-Za-z.+-]*) fail 2 "ORCH_VERSION contains characters outside the tag charset (got: $version)" ;;
+  esac
+fi
+
+# OS/arch resolve through closed tables to fixed literals only; raw
+# uname output is never interpolated into a URL or path.
+case "$(uname -s)" in
+  Linux) os=linux ;;
+  Darwin) os=darwin ;;
+  MINGW* | MSYS* | CYGWIN*) fail 2 "this is Windows: use install.ps1 instead" ;;
+  *) fail 2 "unsupported OS: $(uname -s) (releases cover linux and darwin; on Windows use install.ps1)" ;;
+esac
+
+case "$(uname -m)" in
+  x86_64 | amd64) arch=amd64 ;;
+  aarch64 | arm64) arch=arm64 ;;
+  *) fail 2 "unsupported architecture: $(uname -m) (releases cover amd64 and arm64)" ;;
+esac
+
+asset="orch_${os}_${arch}"
+if [ "$version" = "latest" ]; then
+  base="https://github.com/$repo/releases/latest/download"
+else
+  base="https://github.com/$repo/releases/download/$version"
+fi
+
+tmp="$(mktemp -d)" || fail 3 "mktemp failed"
+trap 'rm -rf "$tmp"' EXIT
+
+if command -v curl >/dev/null 2>&1; then
+  fetch() { curl -fsSL --proto '=https' --tlsv1.2 -o "$2" "$1"; }
+elif command -v wget >/dev/null 2>&1; then
+  fetch() { wget -q -O "$2" "$1"; }
+else
+  fail 3 "neither curl nor wget found; install one and re-run"
+fi
+
+fetch "$base/$asset" "$tmp/$asset" || fail 3 "download failed: $base/$asset"
+fetch "$base/SHA256SUMS" "$tmp/SHA256SUMS" || fail 3 "download failed: $base/SHA256SUMS"
+
+# Verify before anything touches the install dir. No checksum tool is a
+# failure, never a skip.
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$tmp/$asset" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  actual="$(shasum -a 256 "$tmp/$asset" | awk '{print $1}')"
+else
+  fail 4 "neither sha256sum nor shasum found; refusing to install an unverified binary"
+fi
+
+expected="$(awk -v name="$asset" '$2 == name { print $1 }' "$tmp/SHA256SUMS")"
+[ -n "$expected" ] || fail 4 "SHA256SUMS has no entry for $asset"
+if [ "$actual" != "$expected" ]; then
+  fail 4 "checksum mismatch for $asset: expected $expected, got $actual — refusing to install"
+fi
+
+mkdir -p "$install_dir" || fail 5 "cannot create $install_dir (set ORCH_INSTALL_DIR to a writable directory)"
+chmod 0755 "$tmp/$asset"
+mv -f "$tmp/$asset" "$install_dir/orch" || fail 5 "cannot write $install_dir/orch"
+
+echo "installed: $install_dir/orch"
+"$install_dir/orch" status 2>/dev/null | head -n 1 || true
+
+case ":$PATH:" in
+  *":$install_dir:"*) ;;
+  *)
+    echo ""
+    echo "$install_dir is not on your PATH; add it, e.g.:"
+    echo "  export PATH=\"$install_dir:\$PATH\""
+    ;;
+esac
+
+echo "next: run 'orch doctor'"


### PR DESCRIPTION
## What

- **`install.sh`** (strict POSIX) and **`install.ps1`** (Windows PowerShell 5.1-compatible): download the release binary for the current OS/arch plus `SHA256SUMS`, verify the SHA-256 with an exact-filename match, and only then install. Fail closed on every path: checksum mismatch, missing SUMS entry, or no checksum tool installs nothing (exit 4); version tags are charset-validated before reaching a URL; OS/arch resolve through closed tables so raw `uname`/`PROCESSOR_ARCHITECTURE` output is never interpolated. Exit codes: 0 ok / 2 unsupported platform / 3 download / 4 checksum / 5 install.
- PATH policy: `install.ps1` appends the install dir (`%LOCALAPPDATA%\Programs\orch`) to the **user** PATH by default, `-NoPathUpdate` to opt out; `install.sh` targets `~/.local/bin` and only prints the `export PATH` line — it never edits shell profiles.
- Root README `## Install` rework: quick-install scripts first (download-inspect-run posture, not `iwr | iex`), then the two-command per-host plugin install from the marketplace manifest (PR #29), then a paste-into-agent bootstrap prompt that explicitly forbids bypassing a failed checksum, with manual download and source builds kept as fallbacks.
- CI: new `scripts` lint job — `sh -n` + shellcheck (ubuntu), PSScriptAnalyzer at Error/Warning (windows). `.gitattributes` pins `*.sh`/`*.ps1` to LF (a CRLF checkout would break `sh install.sh`).

## Why

Task 26: nothing owned "new user goes from zero to orch binary + adapter installed" — the README documented a manual download/verify flow only, and the PRD's "global host plugins are installed before repository initialization" assumed a mechanism it never defined. The scripts are that mechanism, and they make the repo's standing rule (verify SHA-256 on any downloaded binary, fail closed) the default path instead of a documented ask.

## Verification (live, against the real v0.1.0 release)

- `install.ps1` end to end on Windows: checksum verified, installed to `%LOCALAPPDATA%\Programs\orch`, user PATH appended (idempotent on re-run), binary self-reports `orch: v0.1.0`. PSScriptAnalyzer clean at Error/Warning.
- `install.sh` full download→verify→install path exercised under a shadowed `uname` (Git Bash), installing the real `orch_linux_amd64` after a genuine SHA256SUMS match.
- Fail-closed negatives, each with the right exit code and nothing installed: malformed version (2), URL-unsafe `ORCH_VERSION='v1;curl evil'` (2), Git Bash without the shim → "use install.ps1" (2), nonexistent release (3), forced checksum mismatch (4).

Textually references PR #29's marketplace commands; no file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
