### PR TITLE
Correct marketplace listing claims in adapter READMEs

### DIFF
--- a/adapters/claude/README.md
+++ b/adapters/claude/README.md
@@ -77,8 +77,10 @@ claude plugin install orch-claude@orch
 ```
 
 The manifest at the repository root (`.claude-plugin/marketplace.json`)
-lists both hosts' adapters; Claude Code filters the Codex entry
-automatically, so only `orch-claude` appears in its plugin list.
+lists both hosts' adapters — install this host's by its exact name,
+`orch-claude`. The Codex entry (`orch`, source `adapters/codex`) may
+also appear in listings; it bundles Codex-format components and is not
+this adapter.
 
 This ordering matters mechanically, not just procedurally. Both hooks
 above are bare commands (`orch guard claude`, `orch hook claude

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -89,8 +89,11 @@ decision, not an oversight).
    ```
 
    The manifest at the repository root
-   (`.claude-plugin/marketplace.json`) serves both hosts — Codex CLI
-   reads the same file and filters the Claude entry automatically.
+   (`.claude-plugin/marketplace.json`) serves both hosts — install this
+   host's entry by its exact name, `orch`. The Claude entry
+   (`orch-claude`, source `adapters/claude`) also shows up in
+   `codex plugin list` as installable (verified on codex-cli 0.144.1);
+   it bundles Claude-format components and is not this adapter.
 3. **Approve the plugin-bundled hooks' one-time trust prompt.** Codex
    CLI requires the user to review and trust plugin-bundled hooks before
    they run at all. Until that approval happens, `orch guard codex` and


### PR DESCRIPTION
## What

Rewords one paragraph in each adapter README's install section: instead of claiming each host "filters" the other host's marketplace entry automatically, say the verified thing — install your host's entry by its exact name (`orch-claude` on Claude Code, `orch` on Codex CLI); the other host's entry may appear in listings but bundles the wrong host's components.

## Why

The post-merge smoke of PR #29's GitHub marketplace path (this machine, codex-cli 0.144.1) showed `codex plugin list` presents `orch-claude@orch` as installable — the Claude entry is not filtered from Codex's listing, contradicting the sentence merged in #29 (which followed the task-32 notes). Cross-host coexistence itself works exactly as designed: both two-command installs succeeded from the GitHub source and each host installed the right adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)