### PR TITLE
Add internal/memhub and absorb the duplicated status probers

### DIFF
--- a/internal/interview/detect.go
+++ b/internal/interview/detect.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/memhub"
 )
 
 // Deps carries Detect's injectable surface: LookPath and Runner are
@@ -52,10 +53,9 @@ type Facts struct {
 // Git is probed with a raw `git rev-parse --show-toplevel` through
 // Runner rather than gitops.Open, which asserts .orchestrator/ sits at
 // the git root and so cannot hold before initialization exists.
-// memhub is probed the same way internal/run's unexported execProber
-// does — `memhub status` with the repo root as an explicit working
-// directory (PRD §20) — duplicated here in miniature rather than
-// exported from internal/run, which stays a Delivery-only package.
+// memhub is probed through internal/memhub's Client, the shared PRD
+// §20 client that runs `memhub status` with the repo root as an
+// explicit working directory.
 func Detect(ctx context.Context, deps Deps) Facts {
 	var f Facts
 	f.ClaudeCLI = lookPathOK(deps.LookPath, "claude")
@@ -98,17 +98,12 @@ func detectGitRoot(ctx context.Context, deps Deps) (string, bool) {
 	return strings.TrimSpace(res.Stdout), true
 }
 
-// probeMemhub runs `memhub status` in deps.RepoRoot (PRD §20: the main
-// checkout as an explicit process working directory) and reports
-// whether it exited zero, plus a detail string for the failure case —
-// the spawn error's text, or trimmed stderr for a non-zero exit.
+// probeMemhub runs internal/memhub's Client.Probe against deps.RepoRoot
+// and reports whether it succeeded, plus a detail string for the
+// failure case — Probe's error text verbatim.
 func probeMemhub(ctx context.Context, deps Deps) (healthy bool, detail string) {
-	res, err := deps.Runner.Run(ctx, execx.Cmd{Name: "memhub", Args: []string{"status"}, Dir: deps.RepoRoot})
-	if err != nil {
+	if err := memhub.New(deps.Runner, deps.RepoRoot).Probe(ctx); err != nil {
 		return false, err.Error()
-	}
-	if res.ExitCode != 0 {
-		return false, strings.TrimSpace(res.Stderr)
 	}
 	return true, ""
 }

--- a/internal/interview/detect_test.go
+++ b/internal/interview/detect_test.go
@@ -63,8 +63,9 @@ func TestDetectMemhubUnhealthy(t *testing.T) {
 	if facts.MemhubHealthy {
 		t.Error("MemhubHealthy = true, want false on a non-zero exit")
 	}
-	if facts.MemhubDetail != "db locked" {
-		t.Errorf("MemhubDetail = %q, want %q", facts.MemhubDetail, "db locked")
+	const wantDetail = "memhub status exited 1: db locked"
+	if facts.MemhubDetail != wantDetail {
+		t.Errorf("MemhubDetail = %q, want %q", facts.MemhubDetail, wantDetail)
 	}
 }
 

--- a/internal/memhub/memhub.go
+++ b/internal/memhub/memhub.go
@@ -1,0 +1,46 @@
+// Package memhub is the mechanical PRD §20 client for the external
+// memhub CLI. It observes two disciplines: every command runs with
+// the primary checkout as its explicit working directory — never a
+// worktree, since worktrees never get a memhub DB copy — and the
+// package is policy-free. Mode gating (required/best-effort/off)
+// stays with callers (internal/run's memhubGate); memhub only reads
+// memhub state here and never writes, renders, reindexes, or syncs.
+package memhub
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kninetimmy/orch/internal/execx"
+)
+
+// Client runs read-only memhub CLI commands against one repository
+// through an injected execx.Runner.
+type Client struct {
+	runner execx.Runner
+	// dir is the primary checkout root. It must never be a worktree —
+	// worktrees never get a memhub DB copy (PRD §20).
+	dir string
+}
+
+// New binds a Client to the repository whose primary checkout root is
+// dir.
+func New(runner execx.Runner, dir string) Client {
+	return Client{runner: runner, dir: dir}
+}
+
+// Probe runs `memhub status` in the primary checkout and reports
+// whether memhub is reachable and healthy. A spawn error is returned
+// unwrapped; a non-zero exit becomes an error naming the exit code
+// and memhub's trimmed stderr.
+func (c Client) Probe(ctx context.Context) error {
+	res, err := c.runner.Run(ctx, execx.Cmd{Name: "memhub", Args: []string{"status"}, Dir: c.dir})
+	if err != nil {
+		return err
+	}
+	if res.ExitCode != 0 {
+		return fmt.Errorf("memhub status exited %d: %s", res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	return nil
+}

--- a/internal/memhub/memhub_test.go
+++ b/internal/memhub/memhub_test.go
@@ -1,0 +1,49 @@
+package memhub
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+)
+
+func TestClientProbeHealthy(t *testing.T) {
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name: "memhub", Args: []string{"status"}, Dir: "/repo",
+	}}}
+	c := New(script, "/repo")
+	if err := c.Probe(context.Background()); err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestClientProbeNonZeroExit(t *testing.T) {
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name: "memhub", Args: []string{"status"}, Dir: "/repo", Exit: 1, Stderr: "unreachable",
+	}}}
+	c := New(script, "/repo")
+	err := c.Probe(context.Background())
+	if err == nil {
+		t.Fatal("Probe succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "unreachable") {
+		t.Errorf("err = %v, want it to mention memhub's stderr", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestClientProbeSpawnErrorPassthrough(t *testing.T) {
+	sentinel := errors.New("exec: \"memhub\": executable file not found in $PATH")
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name: "memhub", Args: []string{"status"}, Dir: "/repo", Err: sentinel,
+	}}}
+	c := New(script, "/repo")
+	err := c.Probe(context.Background())
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want sentinel returned unwrapped", err)
+	}
+	script.AssertExhausted()
+}

--- a/internal/run/activate.go
+++ b/internal/run/activate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/gitops"
 	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/memhub"
 	"github.com/kninetimmy/orch/internal/routing"
 	"github.com/kninetimmy/orch/internal/state"
 )
@@ -206,7 +207,7 @@ func Activate(ctx context.Context, env Env, reqJSON []byte) (*ActivationResult, 
 			return nil, fmt.Errorf("%w: %s; create them in the repository (gh label create <name>) or remove them from the plan, then resubmit for approval", ErrAreaLabelMissing, strings.Join(missing, ", "))
 		}
 	}
-	if _, err := memhubGate(ctx, cfg.Memhub.Mode, execProber{runner: env.Runner, dir: env.RepoRoot}); err != nil {
+	if _, err := memhubGate(ctx, cfg.Memhub.Mode, memhub.New(env.Runner, env.RepoRoot)); err != nil {
 		return nil, err
 	}
 	containerAbs := filepath.Join(env.RepoRoot, filepath.FromSlash(WorktreeContainer))

--- a/internal/run/gate.go
+++ b/internal/run/gate.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kninetimmy/orch/internal/config"
 	"github.com/kninetimmy/orch/internal/lockfile"
 	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/memhub"
 	"github.com/kninetimmy/orch/internal/state"
 )
 
@@ -87,7 +88,7 @@ func Plan(ctx context.Context, env Env, planJSON []byte) (*GateDoc, error) {
 		return nil, err
 	}
 
-	mh, err := memhubGate(ctx, cfg.Memhub.Mode, execProber{runner: env.Runner, dir: env.RepoRoot})
+	mh, err := memhubGate(ctx, cfg.Memhub.Mode, memhub.New(env.Runner, env.RepoRoot))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/run/memhub.go
+++ b/internal/run/memhub.go
@@ -3,35 +3,13 @@ package run
 import (
 	"context"
 	"fmt"
-	"strings"
-
-	"github.com/kninetimmy/orch/internal/execx"
 )
 
-// Prober checks memhub reachability. execProber is the production
-// implementation; tests inject a fake so they never spawn a real
-// memhub process. The interface is shaped so a future internal/memhub
-// package can absorb it without changing this package's call sites.
+// Prober checks memhub reachability. internal/memhub's Client is the
+// production implementation; tests inject a fake so they never spawn
+// a real memhub process.
 type Prober interface {
 	Probe(ctx context.Context) error
-}
-
-// execProber runs `memhub status` via the injected Runner with the
-// primary checkout as its explicit working directory (PRD §20).
-type execProber struct {
-	runner execx.Runner
-	dir    string
-}
-
-func (p execProber) Probe(ctx context.Context) error {
-	res, err := p.runner.Run(ctx, execx.Cmd{Name: "memhub", Args: []string{"status"}, Dir: p.dir})
-	if err != nil {
-		return err
-	}
-	if res.ExitCode != 0 {
-		return fmt.Errorf("memhub status exited %d: %s", res.ExitCode, strings.TrimSpace(res.Stderr))
-	}
-	return nil
 }
 
 // MemhubReport records a plan/gate document's memhub probe outcome.

--- a/internal/run/memhub_test.go
+++ b/internal/run/memhub_test.go
@@ -8,33 +8,12 @@ import (
 
 	"github.com/kninetimmy/orch/internal/execx"
 	"github.com/kninetimmy/orch/internal/execx/execxtest"
+	"github.com/kninetimmy/orch/internal/memhub"
 )
-
-func TestExecProberProbe(t *testing.T) {
-	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
-		Name: "memhub", Args: []string{"status"}, Dir: "/repo",
-	}}}
-	p := execProber{runner: script, dir: "/repo"}
-	if err := p.Probe(context.Background()); err != nil {
-		t.Fatalf("Probe: %v", err)
-	}
-	script.AssertExhausted()
-}
-
-func TestExecProberNonZeroExit(t *testing.T) {
-	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
-		Name: "memhub", Args: []string{"status"}, Dir: "/repo", Exit: 1, Stderr: "unreachable",
-	}}}
-	p := execProber{runner: script, dir: "/repo"}
-	if err := p.Probe(context.Background()); err == nil {
-		t.Fatal("Probe succeeded, want error")
-	}
-	script.AssertExhausted()
-}
 
 func TestMemhubGateRequiredHealthy(t *testing.T) {
 	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{Name: "memhub", Args: []string{"status"}, Dir: "/repo"}}}
-	rep, err := memhubGate(context.Background(), "required", execProber{runner: script, dir: "/repo"})
+	rep, err := memhubGate(context.Background(), "required", memhub.New(script, "/repo"))
 	if err != nil {
 		t.Fatalf("memhubGate: %v", err)
 	}
@@ -48,7 +27,7 @@ func TestMemhubGateRequiredExitOneFailsClosed(t *testing.T) {
 	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
 		Name: "memhub", Args: []string{"status"}, Dir: "/repo", Exit: 1,
 	}}}
-	_, err := memhubGate(context.Background(), "required", execProber{runner: script, dir: "/repo"})
+	_, err := memhubGate(context.Background(), "required", memhub.New(script, "/repo"))
 	if !errors.Is(err, ErrMemhubRequired) {
 		t.Fatalf("err = %v, want ErrMemhubRequired", err)
 	}
@@ -60,7 +39,7 @@ func TestMemhubGateRequiredSpawnErrorFailsClosed(t *testing.T) {
 	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
 		Name: "memhub", Args: []string{"status"}, Dir: "/repo", Err: sentinel,
 	}}}
-	_, err := memhubGate(context.Background(), "required", execProber{runner: script, dir: "/repo"})
+	_, err := memhubGate(context.Background(), "required", memhub.New(script, "/repo"))
 	if !errors.Is(err, ErrMemhubRequired) {
 		t.Fatalf("err = %v, want ErrMemhubRequired", err)
 	}
@@ -74,7 +53,7 @@ func TestMemhubGateBestEffortRecordsNotFatal(t *testing.T) {
 	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
 		Name: "memhub", Args: []string{"status"}, Dir: "/repo", Exit: 1, Stderr: "down",
 	}}}
-	rep, err := memhubGate(context.Background(), "best-effort", execProber{runner: script, dir: "/repo"})
+	rep, err := memhubGate(context.Background(), "best-effort", memhub.New(script, "/repo"))
 	if err != nil {
 		t.Fatalf("memhubGate: %v", err)
 	}
@@ -86,7 +65,7 @@ func TestMemhubGateBestEffortRecordsNotFatal(t *testing.T) {
 
 func TestMemhubGateOffSkipsProbe(t *testing.T) {
 	script := &execxtest.Script{T: t} // no calls scripted
-	rep, err := memhubGate(context.Background(), "off", execProber{runner: script, dir: "/repo"})
+	rep, err := memhubGate(context.Background(), "off", memhub.New(script, "/repo"))
 	if err != nil {
 		t.Fatalf("memhubGate: %v", err)
 	}


### PR DESCRIPTION
## What

Task 19 PR A — the pure-refactor half of the memhub integration (PRD §20):

- New package `internal/memhub`: a thin, policy-free client for the external memhub CLI. `Client.Probe` runs `memhub status` with the **primary checkout** as its explicit working directory (never a worktree — PRD §20's cwd discipline, now documented and drift-pinned in one place). Mode gating (`required`/`best-effort`/`off`) deliberately stays with callers.
- `internal/run`: deletes the unexported `execProber` — the seam its own doc comment anticipated ("shaped so a future internal/memhub package can absorb it"). `Prober`, `MemhubReport`, and `memhubGate` keep their exact shapes; `Plan` and `Activate` now construct `memhub.New(env.Runner, env.RepoRoot)`.
- `internal/interview`: `probeMemhub`'s hand-duplicated body (self-documented as "duplicated here in miniature") delegates to the same client.
- Probe tests move to `internal/memhub` on the existing `execxtest` scripted-fake idiom, including a pin on the exact command and Dir; every `memhubGate` policy test is retained unchanged in behavior.

## Why

Two hand-duplicated probers with subtly divergent post-processing were the standing cost of not having `internal/memhub`. Task 19 PR B (the recall canary probe joining the plan/activate gate, plus the `orch doctor` memhub check) lands on top of this package; splitting refactor from behavior keeps each reviewable in isolation.

## One deliberate behavior delta

`Facts.MemhubDetail` on an unhealthy probe now carries the shared client's full error text (`memhub status exited 1: db locked`) instead of bare trimmed stderr (`db locked`) — surfaced only in `orch init`'s human-readable detection report. Reconstructing the old string would have required a parsing shim reintroducing exactly the duplication this PR removes. No golden pins the old text; the one direct test assertion was updated.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l .` all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)