### PR TITLE
Add memhub recall probe to the Delivery gate and orch doctor

### DIFF
--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -71,7 +71,7 @@ closed at a read-only preflight if any is missing (create it with
 Call `orch run plan` with the `PlanDoc` on stdin. The result is a
 `GateDoc` (`schema_version: 1`): `plan_digest`, `plan_title`, `host`,
 `config_revision`, `config_overrides`, `merge_strategy`, `memhub`
-(`{mode, probe, detail}`), `ci` (`{workflows_present, statement}`), and
+(`{mode, probe, recall, detail}`), `ci` (`{workflows_present, statement}`), and
 `issues[]` — each with `id`, `title`, `objective`,
 `acceptance_criteria`, `role`, `executor` (`{model, effort}`),
 `reviewer` (`{model, effort}`), `reviewer_downgraded`,
@@ -153,6 +153,11 @@ in flight at once. For each issue:
    recorded server-side regardless; this cue only shapes in-session
    behavior.) Include the worktree path, branch, objective, acceptance
    criteria, and required tests in the prompt.
+
+   Before spawning, you (the Architect) perform whatever memhub recall
+   is relevant to the issue, with the main checkout as cwd — never a
+   worktree. Embed the relevant recall results directly in the dispatch
+   prompt; the executor subagent never invokes memhub itself.
 
 3. **PR-open** — once the executor reports verification evidence, call
    `orch run pr-open`:

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -71,7 +71,7 @@ closed at a read-only preflight if any is missing (create it with
 Call `orch run plan` with the `PlanDoc` on stdin. The result is a
 `GateDoc` (`schema_version: 1`): `plan_digest`, `plan_title`, `host`,
 `config_revision`, `config_overrides`, `merge_strategy`, `memhub`
-(`{mode, probe, detail}`), `ci` (`{workflows_present, statement}`), and
+(`{mode, probe, recall, detail}`), `ci` (`{workflows_present, statement}`), and
 `issues[]` — each with `id`, `title`, `objective`,
 `acceptance_criteria`, `role`, `executor` (`{model, effort}`),
 `reviewer` (`{model, effort}`), `reviewer_downgraded`,
@@ -159,6 +159,11 @@ in flight at once. For each issue:
    opening line is a statement of fact, not a behavioral nudge. Include
    the worktree path, branch, objective, acceptance criteria, and
    required tests in the prompt.
+
+   Before dispatching, you (the Architect) perform whatever memhub
+   recall is relevant to the issue, with the main checkout as cwd —
+   never a worktree. Embed the relevant recall results directly in the
+   dispatch prompt; the executor agent never invokes memhub itself.
 
 3. **PR-open** — once the executor reports verification evidence, call
    `orch run pr-open`:

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -88,6 +88,13 @@ type fakeRunner struct {
 	// checkIgnoreExit scripts `git check-ignore`: 0 ignored, 1 not
 	// ignored, anything else an error (the guard ignore probe).
 	checkIgnoreExit int
+	// memhubStatusExit/memhubRecallExit script the memhub doctor check
+	// (zero values report healthy; recall answers with valid empty-
+	// results JSON by default).
+	memhubStatusExit   int
+	memhubStatusStderr string
+	memhubRecallExit   int
+	memhubRecallStderr string
 }
 
 func (f fakeRunner) Run(_ context.Context, c execx.Cmd) (execx.Result, error) {
@@ -113,6 +120,16 @@ func (f fakeRunner) Run(_ context.Context, c execx.Cmd) (execx.Result, error) {
 				j = `{"nameWithOwner":"o/r","defaultBranchRef":{"name":"main"},"url":"https://github.com/o/r"}`
 			}
 			return execx.Result{Stdout: j}, nil
+		}
+	case "memhub":
+		switch c.Args[0] {
+		case "status":
+			return execx.Result{Stderr: f.memhubStatusStderr, ExitCode: f.memhubStatusExit}, nil
+		case "recall":
+			if f.memhubRecallExit != 0 {
+				return execx.Result{Stderr: f.memhubRecallStderr, ExitCode: f.memhubRecallExit}, nil
+			}
+			return execx.Result{Stdout: `{"results":[]}`}, nil
 		}
 	}
 	return execx.Result{}, fmt.Errorf("fakeRunner: unexpected command %s %v", c.Name, c.Args)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/gitops"
 	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/memhub"
 	"github.com/kninetimmy/orch/internal/state"
 )
 
@@ -66,6 +67,30 @@ func runDoctor(env Env) error {
 			fmt.Fprintf(env.Stdout, "note  %s applied; overrides: %s\n", config.LocalOverridePath, strings.Join(cfg.Overrides, ", "))
 		} else {
 			fmt.Fprintf(env.Stdout, "note  %s present; no overrides set\n", config.LocalOverridePath)
+		}
+	}
+
+	if cfgErr == nil {
+		switch cfg.Memhub.Mode {
+		case "off":
+			fmt.Fprintf(env.Stdout, "note  memhub: skipped (mode off)\n")
+		default:
+			mh := memhub.New(env.Runner, env.RepoRoot)
+			mhErr := mh.Probe(context.Background())
+			if mhErr == nil {
+				// Health succeeded; only now does recall run, mirroring
+				// the plan/activate gate's skip-recall-on-health-failure
+				// rule (PRD §20): recall against a memhub whose status
+				// already failed tells us nothing new.
+				mhErr = mh.Recall(context.Background())
+			}
+			if cfg.Memhub.Mode == "required" {
+				check("memhub", mhErr)
+			} else if mhErr != nil {
+				fmt.Fprintf(env.Stdout, "note  memhub: %v\n", mhErr)
+			} else {
+				fmt.Fprintf(env.Stdout, "ok    memhub\n")
+			}
 		}
 	}
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -123,6 +123,75 @@ func TestDoctorMissingConfig(t *testing.T) {
 	}
 }
 
+func TestDoctorMemhubModeOffNeverProbes(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML) // memhub mode = "off"
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "note  memhub: skipped (mode off)") {
+		t.Errorf("stdout missing memhub skip note:\n%s", stdout.String())
+	}
+}
+
+func TestDoctorMemhubBestEffortHealthy(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, strings.Replace(validTOML, `mode = "off"`, `mode = "best-effort"`, 1))
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "ok    memhub") {
+		t.Errorf("stdout missing healthy memhub:\n%s", stdout.String())
+	}
+}
+
+func TestDoctorMemhubBestEffortUnhealthyNonFatal(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, strings.Replace(validTOML, `mode = "off"`, `mode = "best-effort"`, 1))
+	env.Runner = fakeRunner{toplevel: env.RepoRoot, memhubStatusExit: 1, memhubStatusStderr: "down"}
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (best-effort must never fail doctor)\n%s", code, ExitOK, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "note  memhub:") {
+		t.Errorf("stdout missing memhub note:\n%s", stdout.String())
+	}
+}
+
+func TestDoctorMemhubRequiredHealthy(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, strings.Replace(validTOML, `mode = "off"`, `mode = "required"`, 1))
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "ok    memhub") {
+		t.Errorf("stdout missing healthy memhub:\n%s", stdout.String())
+	}
+}
+
+func TestDoctorMemhubRequiredHealthFailureFailsDoctor(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, strings.Replace(validTOML, `mode = "off"`, `mode = "required"`, 1))
+	env.Runner = fakeRunner{toplevel: env.RepoRoot, memhubStatusExit: 1, memhubStatusStderr: "unreachable"}
+	if code := Run([]string{"doctor"}, env); code != ExitError {
+		t.Errorf("exit = %d, want %d", code, ExitError)
+	}
+	if !strings.Contains(stdout.String(), "FAIL  memhub") {
+		t.Errorf("stdout missing memhub failure:\n%s", stdout.String())
+	}
+}
+
+func TestDoctorMemhubRequiredRecallFailureFailsDoctor(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, strings.Replace(validTOML, `mode = "off"`, `mode = "required"`, 1))
+	env.Runner = fakeRunner{toplevel: env.RepoRoot, memhubRecallExit: 1, memhubRecallStderr: "wedged"}
+	if code := Run([]string{"doctor"}, env); code != ExitError {
+		t.Errorf("exit = %d, want %d", code, ExitError)
+	}
+	if !strings.Contains(stdout.String(), "FAIL  memhub") {
+		t.Errorf("stdout missing memhub failure:\n%s", stdout.String())
+	}
+}
+
 func TestDoctorConsistentDeliveryPasses(t *testing.T) {
 	env, stdout, _ := testEnv(t)
 	writeConfig(t, env.RepoRoot, validTOML)

--- a/internal/memhub/memhub.go
+++ b/internal/memhub/memhub.go
@@ -9,11 +9,17 @@ package memhub
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/kninetimmy/orch/internal/execx"
 )
+
+// RecallProbeQuery is a fixed canary literal Recall searches for. Its
+// content is irrelevant — Recall exercises the retrieval path, not any
+// particular result.
+const RecallProbeQuery = "orch memhub recall probe"
 
 // Client runs read-only memhub CLI commands against one repository
 // through an injected execx.Runner.
@@ -41,6 +47,33 @@ func (c Client) Probe(ctx context.Context) error {
 	}
 	if res.ExitCode != 0 {
 		return fmt.Errorf("memhub status exited %d: %s", res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	return nil
+}
+
+// Recall runs `memhub recall` with a fixed canary query in the primary
+// checkout and reports whether the live retrieval path (DB, FTS,
+// embeddings) is actually working end to end — the capability Delivery
+// planning depends on, and one `memhub status` alone does not exercise
+// (decision: a real canary recall over `memhub doctor --strict`). A
+// spawn error is returned unwrapped; a non-zero exit becomes an error
+// naming the exit code and memhub's trimmed stderr; an exit 0 with
+// stdout that is not valid JSON becomes an error too, since that
+// pattern means a wedged retrieval path that still exits 0.
+func (c Client) Recall(ctx context.Context) error {
+	res, err := c.runner.Run(ctx, execx.Cmd{
+		Name: "memhub",
+		Args: []string{"recall", RecallProbeQuery, "--json", "--max-results", "1"},
+		Dir:  c.dir,
+	})
+	if err != nil {
+		return err
+	}
+	if res.ExitCode != 0 {
+		return fmt.Errorf("memhub recall exited %d: %s", res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	if !json.Valid([]byte(strings.TrimSpace(res.Stdout))) {
+		return fmt.Errorf("memhub recall exited 0 but stdout is not valid JSON: %q", strings.TrimSpace(res.Stdout))
 	}
 	return nil
 }

--- a/internal/memhub/memhub_test.go
+++ b/internal/memhub/memhub_test.go
@@ -47,3 +47,63 @@ func TestClientProbeSpawnErrorPassthrough(t *testing.T) {
 	}
 	script.AssertExhausted()
 }
+
+// recallArgs is the exact argument vector Recall must send, pinning
+// the canary query and flags every Recall test checks against.
+var recallArgs = []string{"recall", RecallProbeQuery, "--json", "--max-results", "1"}
+
+func TestClientRecallHealthyWithZeroResults(t *testing.T) {
+	// Valid JSON with zero results MUST pass: the probe checks the
+	// path works, not that results exist.
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name: "memhub", Args: recallArgs, Dir: "/repo", Stdout: `{"results":[]}`,
+	}}}
+	c := New(script, "/repo")
+	if err := c.Recall(context.Background()); err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestClientRecallNonZeroExit(t *testing.T) {
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name: "memhub", Args: recallArgs, Dir: "/repo", Exit: 1, Stderr: "unreachable",
+	}}}
+	c := New(script, "/repo")
+	err := c.Recall(context.Background())
+	if err == nil {
+		t.Fatal("Recall succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "unreachable") {
+		t.Errorf("err = %v, want it to mention memhub's stderr", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestClientRecallInvalidJSONStdout(t *testing.T) {
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name: "memhub", Args: recallArgs, Dir: "/repo", Stdout: "not json",
+	}}}
+	c := New(script, "/repo")
+	err := c.Recall(context.Background())
+	if err == nil {
+		t.Fatal("Recall succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), "not valid JSON") {
+		t.Errorf("err = %v, want it to mention invalid JSON", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestClientRecallSpawnErrorPassthrough(t *testing.T) {
+	sentinel := errors.New("exec: \"memhub\": executable file not found in $PATH")
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name: "memhub", Args: recallArgs, Dir: "/repo", Err: sentinel,
+	}}}
+	c := New(script, "/repo")
+	err := c.Recall(context.Background())
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want sentinel returned unwrapped", err)
+	}
+	script.AssertExhausted()
+}

--- a/internal/run/gate_test.go
+++ b/internal/run/gate_test.go
@@ -84,8 +84,8 @@ func TestPlanGoldenTwoIssue(t *testing.T) {
 	if len(doc.ConfigOverrides) != 0 {
 		t.Errorf("ConfigOverrides = %v, want none", doc.ConfigOverrides)
 	}
-	if doc.Memhub.Mode != "off" || doc.Memhub.Probe != "skipped" {
-		t.Errorf("Memhub = %+v, want off/skipped", doc.Memhub)
+	if doc.Memhub.Mode != "off" || doc.Memhub.Probe != "skipped" || doc.Memhub.Recall != "skipped" {
+		t.Errorf("Memhub = %+v, want off/skipped/skipped", doc.Memhub)
 	}
 	if doc.CI.WorkflowsPresent {
 		t.Error("CI.WorkflowsPresent = true, want false (no workflow fixture)")

--- a/internal/run/memhub.go
+++ b/internal/run/memhub.go
@@ -5,35 +5,45 @@ import (
 	"fmt"
 )
 
-// Prober checks memhub reachability. internal/memhub's Client is the
-// production implementation; tests inject a fake so they never spawn
-// a real memhub process.
+// Prober checks memhub reachability and the live recall path.
+// internal/memhub's Client is the production implementation; tests
+// inject a fake so they never spawn a real memhub process.
 type Prober interface {
 	Probe(ctx context.Context) error
+	Recall(ctx context.Context) error
 }
 
 // MemhubReport records a plan/gate document's memhub probe outcome.
 type MemhubReport struct {
 	Mode   string `json:"mode"`
-	Probe  string `json:"probe"` // "healthy" | "unhealthy" | "skipped"
+	Probe  string `json:"probe"`  // "healthy" | "unhealthy" | "skipped"
+	Recall string `json:"recall"` // "healthy" | "unhealthy" | "skipped"
 	Detail string `json:"detail,omitempty"`
 }
 
-// memhubGate applies config.Memhub.Mode's policy to a probe (PRD §20):
-// "off" never calls the prober; "required" fails closed with
-// ErrMemhubRequired on any probe failure (exit non-zero or a spawn
-// error, both mean the same thing here — memhub cannot be reached);
-// "best-effort" records the failure without stopping the caller.
+// memhubGate applies config.Memhub.Mode's policy to health and recall
+// probes (PRD §20): "off" never calls the prober; "required" fails
+// closed with ErrMemhubRequired on any probe failure (exit non-zero or
+// a spawn error, both mean the same thing here — memhub cannot be
+// reached, or cannot actually serve recall); "best-effort" records the
+// failure without stopping the caller. Health runs first; recall only
+// runs once health has succeeded, since attempting recall against a
+// memhub whose status already failed tells us nothing new.
 func memhubGate(ctx context.Context, mode string, p Prober) (MemhubReport, error) {
 	if mode == "off" {
-		return MemhubReport{Mode: mode, Probe: "skipped"}, nil
+		return MemhubReport{Mode: mode, Probe: "skipped", Recall: "skipped"}, nil
 	}
-	err := p.Probe(ctx)
-	if err == nil {
-		return MemhubReport{Mode: mode, Probe: "healthy"}, nil
+	if err := p.Probe(ctx); err != nil {
+		if mode == "required" {
+			return MemhubReport{}, fmt.Errorf("%w: %v", ErrMemhubRequired, err)
+		}
+		return MemhubReport{Mode: mode, Probe: "unhealthy", Recall: "skipped", Detail: err.Error()}, nil
 	}
-	if mode == "required" {
-		return MemhubReport{}, fmt.Errorf("%w: %v", ErrMemhubRequired, err)
+	if err := p.Recall(ctx); err != nil {
+		if mode == "required" {
+			return MemhubReport{}, fmt.Errorf("%w: %v", ErrMemhubRequired, err)
+		}
+		return MemhubReport{Mode: mode, Probe: "healthy", Recall: "unhealthy", Detail: err.Error()}, nil
 	}
-	return MemhubReport{Mode: mode, Probe: "unhealthy", Detail: err.Error()}, nil
+	return MemhubReport{Mode: mode, Probe: "healthy", Recall: "healthy"}, nil
 }

--- a/internal/run/memhub_test.go
+++ b/internal/run/memhub_test.go
@@ -11,14 +11,34 @@ import (
 	"github.com/kninetimmy/orch/internal/memhub"
 )
 
+// recallArgs is the exact argument vector Client.Recall sends, pinning
+// the canary query and flags every gate test scripts against.
+var recallArgs = []string{"recall", memhub.RecallProbeQuery, "--json", "--max-results", "1"}
+
 func TestMemhubGateRequiredHealthy(t *testing.T) {
-	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{Name: "memhub", Args: []string{"status"}, Dir: "/repo"}}}
+	// Scripted in order: health first, then recall — pins the ordering.
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		{Name: "memhub", Args: []string{"status"}, Dir: "/repo"},
+		{Name: "memhub", Args: recallArgs, Dir: "/repo", Stdout: `{"results":[]}`},
+	}}
 	rep, err := memhubGate(context.Background(), "required", memhub.New(script, "/repo"))
 	if err != nil {
 		t.Fatalf("memhubGate: %v", err)
 	}
-	if rep.Probe != "healthy" || rep.Mode != "required" {
+	if rep.Probe != "healthy" || rep.Recall != "healthy" || rep.Mode != "required" {
 		t.Errorf("report = %+v", rep)
+	}
+	script.AssertExhausted()
+}
+
+func TestMemhubGateRequiredRecallFailureFailsClosed(t *testing.T) {
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		{Name: "memhub", Args: []string{"status"}, Dir: "/repo"},
+		{Name: "memhub", Args: recallArgs, Dir: "/repo", Exit: 1, Stderr: "wedged"},
+	}}
+	_, err := memhubGate(context.Background(), "required", memhub.New(script, "/repo"))
+	if !errors.Is(err, ErrMemhubRequired) {
+		t.Fatalf("err = %v, want ErrMemhubRequired", err)
 	}
 	script.AssertExhausted()
 }
@@ -49,7 +69,9 @@ func TestMemhubGateRequiredSpawnErrorFailsClosed(t *testing.T) {
 	script.AssertExhausted()
 }
 
-func TestMemhubGateBestEffortRecordsNotFatal(t *testing.T) {
+func TestMemhubGateBestEffortHealthFailureSkipsRecall(t *testing.T) {
+	// Exactly one call scripted — pins that recall is never attempted
+	// against a memhub whose status already failed.
 	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
 		Name: "memhub", Args: []string{"status"}, Dir: "/repo", Exit: 1, Stderr: "down",
 	}}}
@@ -57,8 +79,23 @@ func TestMemhubGateBestEffortRecordsNotFatal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("memhubGate: %v", err)
 	}
-	if rep.Probe != "unhealthy" || rep.Detail == "" {
-		t.Errorf("report = %+v, want unhealthy with detail", rep)
+	if rep.Probe != "unhealthy" || rep.Recall != "skipped" || rep.Detail == "" {
+		t.Errorf("report = %+v, want unhealthy/skipped with detail", rep)
+	}
+	script.AssertExhausted()
+}
+
+func TestMemhubGateBestEffortRecallFailureRecordsNotFatal(t *testing.T) {
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		{Name: "memhub", Args: []string{"status"}, Dir: "/repo"},
+		{Name: "memhub", Args: recallArgs, Dir: "/repo", Exit: 1, Stderr: "wedged"},
+	}}
+	rep, err := memhubGate(context.Background(), "best-effort", memhub.New(script, "/repo"))
+	if err != nil {
+		t.Fatalf("memhubGate: %v", err)
+	}
+	if rep.Probe != "healthy" || rep.Recall != "unhealthy" || rep.Detail == "" {
+		t.Errorf("report = %+v, want healthy/unhealthy with detail", rep)
 	}
 	script.AssertExhausted()
 }
@@ -69,16 +106,20 @@ func TestMemhubGateOffSkipsProbe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("memhubGate: %v", err)
 	}
-	if rep.Probe != "skipped" {
-		t.Errorf("report = %+v, want skipped", rep)
+	if rep.Probe != "skipped" || rep.Recall != "skipped" {
+		t.Errorf("report = %+v, want skipped/skipped", rep)
 	}
 	script.AssertExhausted() // proves no call was made
 }
 
 // fakeProber lets memhubGate tests avoid execx entirely where useful.
-type fakeProber struct{ err error }
+type fakeProber struct {
+	err       error
+	recallErr error
+}
 
-func (f fakeProber) Probe(context.Context) error { return f.err }
+func (f fakeProber) Probe(context.Context) error  { return f.err }
+func (f fakeProber) Recall(context.Context) error { return f.recallErr }
 
 var _ Prober = fakeProber{}
 var _ execx.Runner = (*execxtest.Script)(nil)


### PR DESCRIPTION
## What

Task 19 PR B — the behavior half of the memhub integration, on top of #32:

- **`internal/memhub.Recall`**: a fixed-canary `memhub recall "orch memhub recall probe" --json --max-results 1` that must exit 0 **and** produce valid-JSON stdout. Zero results pass — the probe checks that the retrieval path (DB, FTS, embeddings) works, not that results exist. Invalid JSON at exit 0 fails: a wedged retrieval path that still exits 0 must not pass.
- **The plan/activate gate probes health then recall** (PRD §20: "Delivery planning blocks if memhub health or recall fails" — the "or recall" clause was previously unimplemented). Ordering is pinned by test; recall is skipped when health already failed (one-call script pins the skip). `required` fails closed with `ErrMemhubRequired` on either; `best-effort` records both. `MemhubReport` gains an additive `recall` field ("healthy"|"unhealthy"|"skipped") at the existing schema version, per the emit-side-additive precedent.
- **`orch doctor` gains the memhub check** both adapter READMEs already claimed (previously untrue): `off` → skipped note, never probes; `best-effort` → reported, never fails doctor; `required` → any probe failure fails doctor. Mirrors the gate's skip-recall-on-health-failure rule; uses the file's existing check/note idiom and `context.Background()` convention.
- **Both adapters' orch-delivery skills**: GateDoc `memhub` field list updated to `{mode, probe, recall, detail}`, and a new dispatch-step paragraph codifies Architect-mediated recall — the Architect recalls with the main checkout as cwd and embeds results in dispatch prompts; subagents never invoke memhub themselves (Claude-host scout/reviewer cannot anyway: no Bash, no MCP tools).

## Why

Closes the three PRD §20 gaps found in the task-19 survey: the unimplemented recall clause, the doctor/README contradiction, and the unwired subagent-recall allowance. Design calls recorded as staged memhub decisions: real recall canary over `memhub doctor --strict`; doctor check over README correction; Architect-mediated recall over a new plumbing verb; two-PR split.

## Verification

`go build ./...`, `go vet ./...`, `go test ./... -count=1`, `gofmt -l .` all clean locally, including both adapters' drift-pin suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)