### PR TITLE
Bump adapter plugin versions to 0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "kninetimmy" },
   "metadata": {
     "description": "Host adapters for the Orch development orchestrator",
-    "version": "0.1.0"
+    "version": "0.2.0"
   },
   "plugins": [
     {

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Claude Code host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -78,8 +78,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.1.0" {
-		t.Errorf("version = %q, want 0.1.0", m.Version)
+	if m.Version != "0.2.0" {
+		t.Errorf("version = %q, want 0.2.0", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Codex CLI host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -79,8 +79,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.1.0" {
-		t.Errorf("version = %q, want 0.1.0", m.Version)
+	if m.Version != "0.2.0" {
+		t.Errorf("version = %q, want 0.2.0", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")


### PR DESCRIPTION
## What

Bumps both adapter `plugin.json` versions and the marketplace `metadata.version` from 0.1.0 to 0.2.0, in lockstep (the root `marketplace_test.go` pins their equality), and updates the exact-version drift pins in both adapters' `plugin_test.go`.

## Why

PR #33 changed skill content in both adapters (`orch-delivery` GateDoc field + Architect-mediated recall prose) without a version bump, so hosts with the plugin already installed keep serving the stale pre-#33 skills from their plugin caches. Bumping the version lets plugin refresh pick up the current skill content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)