### PR TITLE
Add internal/metrics and implement orch metrics

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "kninetimmy" },
   "metadata": {
     "description": "Host adapters for the Orch development orchestrator",
-    "version": "0.2.0"
+    "version": "0.3.0"
   },
   "plugins": [
     {

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ orch configure        Change committed settings (delivered as a PR)
 orch configure-local  Change machine-local overrides (applied directly)
 orch resume           Reconcile an interrupted Delivery run and continue
 orch abort            Stop a Delivery run and return to Assist
-orch metrics          Local usage metrics (not implemented yet)
+orch metrics          Local usage metrics
 ```
 
 `orch run` and `orch guard` also exist but are plumbing — the host

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Claude Code host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -78,8 +78,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.2.0" {
-		t.Errorf("version = %q, want 0.2.0", m.Version)
+	if m.Version != "0.3.0" {
+		t.Errorf("version = %q, want 0.3.0", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -193,9 +193,9 @@ in flight at once. For each issue:
    ```
 
    `usage` is optional (PRD §21), same rule as PR-open: only report
-   what the reviewer subagent's Task result actually carries. `request-
-   changes` loops the same executor in the **same worktree**, then
-   repeats from PR-open. `approve` continues.
+   what the reviewer subagent's Task result actually carries.
+   `request-changes` loops the same executor in the **same worktree**,
+   then repeats from PR-open. `approve` continues.
 
 6. **CI** — `orch run ci` with
    `{"schema_version": 1, "issue_number": N}` records the honest

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -164,11 +164,15 @@ in flight at once. For each issue:
 
    ```json
    {"schema_version": 1, "issue_number": N,
-    "verifications": [{"name": "...", "command": "...", "result": "...", "detail": "..."}]}
+    "verifications": [{"name": "...", "command": "...", "result": "...", "detail": "..."}],
+    "usage": {"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0,
+               "cache_creation_tokens": 0, "duration_ms": 0}}
    ```
 
-   At least one verification is required. Result carries `pr_number`,
-   `pr_url`.
+   At least one verification is required. `usage` is optional (PRD
+   §21): supply only the fields the executor's Task result actually
+   reports (token totals and duration), never an estimate. Result
+   carries `pr_number`, `pr_url`.
 
 4. **Spawn the reviewer** — once the PR stops changing, spawn
    `orch-reviewer` **fresh** (a new instance, not the executor
@@ -183,11 +187,15 @@ in flight at once. For each issue:
    ```json
    {"schema_version": 1, "issue_number": N, "reviewed_head_oid": "...",
     "verdict": "approve|request-changes", "summary": "...",
-    "reviewer": {"model": "...", "effort": "..."}}
+    "reviewer": {"model": "...", "effort": "..."},
+    "usage": {"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0,
+               "cache_creation_tokens": 0, "duration_ms": 0}}
    ```
 
-   `request-changes` loops the same executor in the **same worktree**,
-   then repeats from PR-open. `approve` continues.
+   `usage` is optional (PRD §21), same rule as PR-open: only report
+   what the reviewer subagent's Task result actually carries. `request-
+   changes` loops the same executor in the **same worktree**, then
+   repeats from PR-open. `approve` continues.
 
 6. **CI** — `orch run ci` with
    `{"schema_version": 1, "issue_number": N}` records the honest

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Codex CLI host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -79,8 +79,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.2.0" {
-		t.Errorf("version = %q, want 0.2.0", m.Version)
+	if m.Version != "0.3.0" {
+		t.Errorf("version = %q, want 0.3.0", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -170,11 +170,14 @@ in flight at once. For each issue:
 
    ```json
    {"schema_version": 1, "issue_number": N,
-    "verifications": [{"name": "...", "command": "...", "result": "...", "detail": "..."}]}
+    "verifications": [{"name": "...", "command": "...", "result": "...", "detail": "..."}],
+    "usage": {"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0,
+               "cache_creation_tokens": 0, "duration_ms": 0}}
    ```
 
-   At least one verification is required. Result carries `pr_number`,
-   `pr_url`.
+   At least one verification is required. `usage` is optional (PRD
+   §21): supply only the fields the executor's own reporting actually
+   gives you, never an estimate. Result carries `pr_number`, `pr_url`.
 
 4. **Dispatch the reviewer** — once the PR stops changing, dispatch
    `orch-reviewer` **fresh** (a new instance, not the executor
@@ -194,9 +197,13 @@ in flight at once. For each issue:
    ```json
    {"schema_version": 1, "issue_number": N, "reviewed_head_oid": "...",
     "verdict": "approve|request-changes", "summary": "...",
-    "reviewer": {"model": "...", "effort": "..."}}
+    "reviewer": {"model": "...", "effort": "..."},
+    "usage": {"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0,
+               "cache_creation_tokens": 0, "duration_ms": 0}}
    ```
 
+   `usage` is optional (PRD §21), same rule as PR-open: only report
+   what the reviewer agent's own reporting actually gives you.
    `request-changes` loops the same executor in the **same worktree**,
    then repeats from PR-open. `approve` continues.
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -73,16 +73,10 @@ func commands() []command {
 		{"configure-local", "Interview and apply machine-local overrides", runConfigureLocal},
 		{"resume", "Reconcile an interrupted Delivery run against GitHub and continue", runResume},
 		{"abort", "Stop dispatch and return to Assist", noArgs("abort", runAbort)},
-		{"metrics", "Show local metrics (not implemented)", noArgs("metrics", notImplemented("metrics"))},
+		{"metrics", "Show local metrics", noArgs("metrics", cmdMetrics)},
 		{"run", "Adapter plumbing: Delivery run verbs (JSON stdin/stdout; not a human command)", runRunVerb},
 		{"guard", "Adapter plumbing: pre-write enforcement for host hooks (not a human command)", runGuard},
 		{"hook", "Adapter plumbing: host lifecycle-event verbs (not a human command)", runHook},
-	}
-}
-
-func notImplemented(name string) func(Env) error {
-	return func(Env) error {
-		return fmt.Errorf("%s is not implemented yet", name)
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -190,20 +190,6 @@ func TestRunUnexpectedArgument(t *testing.T) {
 	}
 }
 
-func TestNotImplementedCommandsFailClosed(t *testing.T) {
-	for _, name := range []string{"metrics"} {
-		t.Run(name, func(t *testing.T) {
-			env, _, stderr := testEnv(t)
-			if code := Run([]string{name}, env); code != ExitError {
-				t.Errorf("exit = %d, want %d", code, ExitError)
-			}
-			if !strings.Contains(stderr.String(), "not implemented") {
-				t.Errorf("stderr = %q", stderr.String())
-			}
-		})
-	}
-}
-
 func TestRunDefaultsLookPath(t *testing.T) {
 	// Run must not panic when LookPath is nil (main.go passes none).
 	var stdout, stderr bytes.Buffer

--- a/internal/cli/metrics.go
+++ b/internal/cli/metrics.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 
 	"github.com/kninetimmy/orch/internal/config"
 	"github.com/kninetimmy/orch/internal/metrics"
@@ -80,10 +81,9 @@ type runSummary struct {
 	ciByState map[string]int
 
 	// usage sums every event that carries a usage payload; usageEvents
-	// counts how many of totalEvents did.
+	// counts how many of eventCount did.
 	usage       metrics.Usage
 	usageEvents int
-	totalEvents int
 }
 
 // summarizeRun computes runSummary from doc in one pass, trusting the
@@ -95,7 +95,6 @@ func summarizeRun(doc metrics.Document) runSummary {
 		eventCount:   len(doc.Events),
 		blockClasses: map[string]int{},
 		ciByState:    map[string]int{},
-		totalEvents:  len(doc.Events),
 	}
 	if len(doc.Events) > 0 {
 		s.firstAt = doc.Events[0].At
@@ -167,14 +166,7 @@ func sortedCounts(m map[string]int) string {
 	for i, k := range keys {
 		parts[i] = fmt.Sprintf("%s: %d", k, m[k])
 	}
-	out := ""
-	for i, p := range parts {
-		if i > 0 {
-			out += ", "
-		}
-		out += p
-	}
-	return out
+	return strings.Join(parts, ", ")
 }
 
 // printRunSummary writes s in status.go's aligned label style.
@@ -199,6 +191,6 @@ func printRunSummary(w io.Writer, s runSummary) {
 	if s.usageEvents > 0 {
 		fmt.Fprintf(w, "usage:       input %d, output %d, cache read %d, cache creation %d, duration %dms\n",
 			s.usage.InputTokens, s.usage.OutputTokens, s.usage.CacheReadTokens, s.usage.CacheCreationTokens, s.usage.DurationMS)
-		fmt.Fprintf(w, "             usage reported on %d of %d events\n", s.usageEvents, s.totalEvents)
+		fmt.Fprintf(w, "             usage reported on %d of %d events\n", s.usageEvents, s.eventCount)
 	}
 }

--- a/internal/cli/metrics.go
+++ b/internal/cli/metrics.go
@@ -1,0 +1,204 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/metrics"
+)
+
+// cmdMetrics prints a read-only summary of every recorded metrics
+// document (PRD §21, §22): whether metrics are currently enabled, then
+// one block per Delivery run metrics.LoadAll finds. It never mutates
+// anything and, critically, never creates .orchestrator/metrics —
+// LoadAll guarantees that (PRD §23: disabled metrics create no
+// storage), so running this command on a repository that has never
+// enabled metrics leaves it exactly as it found it.
+func cmdMetrics(env Env) error {
+	fmt.Fprintf(env.Stdout, "orch:   %s\n", Version)
+
+	cfg, err := config.Load(env.RepoRoot)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(env.Stdout, "metrics enabled: %t\n", cfg.Metrics.Enabled)
+
+	docs, err := metrics.LoadAll(env.RepoRoot)
+	if err != nil {
+		return err
+	}
+	if len(docs) == 0 {
+		// Metrics may be disabled right now with no history at all, or
+		// disabled after an earlier enabled period left nothing behind
+		// (LoadAll only ever reports what is actually on disk); either
+		// way an empty history is not an error.
+		fmt.Fprintln(env.Stdout, "no metrics recorded.")
+		return nil
+	}
+
+	for i, doc := range docs {
+		if i > 0 {
+			fmt.Fprintln(env.Stdout)
+		}
+		printRunSummary(env.Stdout, summarizeRun(doc))
+	}
+	return nil
+}
+
+// runSummary is the printable digest of one metrics.Document, computed
+// once so printRunSummary stays pure formatting.
+type runSummary struct {
+	runID      string
+	eventCount int
+	firstAt    string
+	lastAt     string
+
+	issuesSeen int
+	merged     int
+	abandoned  int
+	blocked    int
+	// blockClasses counts block events by class (a re-block on the same
+	// issue counts again — it is a fresh event, not a fresh issue).
+	blockClasses map[string]int
+
+	escalations int
+
+	// reviewCycles is the total number of review events recorded (each
+	// review call is one cycle by construction). reviewedIssues is the
+	// number of distinct issues with at least one review event.
+	// firstPassApprove counts issues whose first recorded review event
+	// approved.
+	reviewCycles     int
+	reviewedIssues   int
+	firstPassApprove int
+
+	// ciByState counts issues by their last recorded ci event's state
+	// (polling only ever overwrites, so "last" is "most recent
+	// observation", not a first-vs-final judgement).
+	ciByState map[string]int
+
+	// usage sums every event that carries a usage payload; usageEvents
+	// counts how many of totalEvents did.
+	usage       metrics.Usage
+	usageEvents int
+	totalEvents int
+}
+
+// summarizeRun computes runSummary from doc in one pass, trusting the
+// document's event order (Append only ever appends, so it is
+// insertion — and therefore chronological — order).
+func summarizeRun(doc metrics.Document) runSummary {
+	s := runSummary{
+		runID:        doc.RunID,
+		eventCount:   len(doc.Events),
+		blockClasses: map[string]int{},
+		ciByState:    map[string]int{},
+		totalEvents:  len(doc.Events),
+	}
+	if len(doc.Events) > 0 {
+		s.firstAt = doc.Events[0].At
+		s.lastAt = doc.Events[len(doc.Events)-1].At
+	}
+
+	issuesSeen := map[int]bool{}
+	mergedIssues := map[int]bool{}
+	abandonedIssues := map[int]bool{}
+	firstReviewVerdict := map[int]string{}
+	ciLastState := map[int]string{}
+
+	for _, ev := range doc.Events {
+		if ev.IssueNumber != 0 {
+			issuesSeen[ev.IssueNumber] = true
+		}
+		switch ev.Verb {
+		case "merge":
+			mergedIssues[ev.IssueNumber] = true
+		case "abandon":
+			abandonedIssues[ev.IssueNumber] = true
+		case "block":
+			s.blocked++
+			s.blockClasses[ev.BlockClass]++
+		case "escalate":
+			s.escalations++
+		case "review":
+			s.reviewCycles++
+			if _, ok := firstReviewVerdict[ev.IssueNumber]; !ok {
+				firstReviewVerdict[ev.IssueNumber] = ev.Verdict
+			}
+		case "ci":
+			ciLastState[ev.IssueNumber] = ev.CIState
+		}
+		if ev.Usage != nil {
+			s.usageEvents++
+			s.usage.InputTokens += ev.Usage.InputTokens
+			s.usage.OutputTokens += ev.Usage.OutputTokens
+			s.usage.CacheReadTokens += ev.Usage.CacheReadTokens
+			s.usage.CacheCreationTokens += ev.Usage.CacheCreationTokens
+			s.usage.DurationMS += ev.Usage.DurationMS
+		}
+	}
+
+	s.issuesSeen = len(issuesSeen)
+	s.merged = len(mergedIssues)
+	s.abandoned = len(abandonedIssues)
+	s.reviewedIssues = len(firstReviewVerdict)
+	for _, verdict := range firstReviewVerdict {
+		if verdict == "approve" {
+			s.firstPassApprove++
+		}
+	}
+	for _, state := range ciLastState {
+		s.ciByState[state]++
+	}
+	return s
+}
+
+// sortedCounts renders m as "key: value" pairs sorted by key, for
+// deterministic output over map iteration.
+func sortedCounts(m map[string]int) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		parts[i] = fmt.Sprintf("%s: %d", k, m[k])
+	}
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += ", "
+		}
+		out += p
+	}
+	return out
+}
+
+// printRunSummary writes s in status.go's aligned label style.
+func printRunSummary(w io.Writer, s runSummary) {
+	fmt.Fprintf(w, "run:         %s\n", s.runID)
+	fmt.Fprintf(w, "events:      %d (first %s, last %s)\n", s.eventCount, s.firstAt, s.lastAt)
+
+	blockedDetail := ""
+	if len(s.blockClasses) > 0 {
+		blockedDetail = fmt.Sprintf(" (%s)", sortedCounts(s.blockClasses))
+	}
+	fmt.Fprintf(w, "issues:      %d seen; merged %d, abandoned %d, blocked %d%s\n", s.issuesSeen, s.merged, s.abandoned, s.blocked, blockedDetail)
+	fmt.Fprintf(w, "escalations: %d\n", s.escalations)
+	fmt.Fprintf(w, "reviews:     %d cycles; first-pass approve: %d of %d reviewed issues\n", s.reviewCycles, s.firstPassApprove, s.reviewedIssues)
+
+	if len(s.ciByState) > 0 {
+		fmt.Fprintf(w, "ci:          %s\n", sortedCounts(s.ciByState))
+	} else {
+		fmt.Fprintln(w, "ci:          none observed")
+	}
+
+	if s.usageEvents > 0 {
+		fmt.Fprintf(w, "usage:       input %d, output %d, cache read %d, cache creation %d, duration %dms\n",
+			s.usage.InputTokens, s.usage.OutputTokens, s.usage.CacheReadTokens, s.usage.CacheCreationTokens, s.usage.DurationMS)
+		fmt.Fprintf(w, "             usage reported on %d of %d events\n", s.usageEvents, s.totalEvents)
+	}
+}

--- a/internal/cli/metrics_test.go
+++ b/internal/cli/metrics_test.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/metrics"
+)
+
+func TestMetricsNotInitialized(t *testing.T) {
+	env, stdout, stderr := testEnv(t)
+	if code := Run([]string{"metrics"}, env); code != ExitError {
+		t.Errorf("exit = %d, want %d", code, ExitError)
+	}
+	if !strings.Contains(stderr.String(), "not initialized") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+	// The version line prints before any repository check, matching
+	// status's convention (status_test.go's TestStatusNotInitialized).
+	if !strings.Contains(stdout.String(), "orch:   dev") {
+		t.Errorf("stdout missing version line:\n%s", stdout.String())
+	}
+}
+
+func TestMetricsNoHistoryCreatesNoStorage(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	if code := Run([]string{"metrics"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d", code, ExitOK)
+	}
+	out := stdout.String()
+	for _, want := range []string{"orch:   dev", "metrics enabled: false", "no metrics recorded."} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(env.RepoRoot, filepath.FromSlash(metrics.Dir))); !os.IsNotExist(err) {
+		t.Errorf("metrics dir exists after `orch metrics` (stat err = %v), want absent", err)
+	}
+}
+
+// writeMetricsFixture writes a hand-built metrics document directly to
+// disk (bypassing metrics.Append), so the test controls exact event
+// shapes without spinning up a Delivery run.
+func writeMetricsFixture(t *testing.T, root, runID string, doc metrics.Document) {
+	t.Helper()
+	dir := filepath.Join(root, filepath.FromSlash(metrics.Dir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Document's fields are exported and json-tagged, so marshaling it
+	// directly is exactly the shape metrics.Append itself would have
+	// written.
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, runID+".json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMetricsSummarizesFixtureRun(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+
+	usage := &metrics.Usage{InputTokens: 100, OutputTokens: 40, CacheReadTokens: 5, CacheCreationTokens: 2, DurationMS: 300}
+	doc := metrics.Document{
+		SchemaVersion: metrics.SchemaVersion,
+		RunID:         "run-20260713T000000Z-aaaaaaaa",
+		Events: []metrics.Event{
+			{At: "2026-07-13T00:00:00Z", Verb: "dispatch", IssueNumber: 1, Role: "implementer"},
+			{At: "2026-07-13T00:01:00Z", Verb: "pr-open", IssueNumber: 1, Usage: usage},
+			{At: "2026-07-13T00:02:00Z", Verb: "review", IssueNumber: 1, Verdict: "approve", ReviewCycles: 1},
+			{At: "2026-07-13T00:03:00Z", Verb: "ci", IssueNumber: 1, CIState: "passing"},
+			{At: "2026-07-13T00:04:00Z", Verb: "merge", IssueNumber: 1},
+			{At: "2026-07-13T00:05:00Z", Verb: "block", IssueNumber: 2, BlockClass: "hook"},
+			{At: "2026-07-13T00:06:00Z", Verb: "complete", Merged: 1, Abandoned: 0},
+		},
+	}
+	writeMetricsFixture(t, env.RepoRoot, doc.RunID, doc)
+
+	if code := Run([]string{"metrics"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"orch:   dev",
+		"metrics enabled: false",
+		"run:         run-20260713T000000Z-aaaaaaaa",
+		"events:      7 (first 2026-07-13T00:00:00Z, last 2026-07-13T00:06:00Z)",
+		"issues:      2 seen; merged 1, abandoned 0, blocked 1 (hook: 1)",
+		"escalations: 0",
+		"reviews:     1 cycles; first-pass approve: 1 of 1 reviewed issues",
+		"ci:          passing: 1",
+		"usage:       input 100, output 40, cache read 5, cache creation 2, duration 300ms",
+		"usage reported on 1 of 7 events",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestMetricsOmitsUsageLinesWhenNoEventCarriesUsage(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	doc := metrics.Document{
+		SchemaVersion: metrics.SchemaVersion,
+		RunID:         "run-20260713T000000Z-bbbbbbbb",
+		Events:        []metrics.Event{{At: "2026-07-13T00:00:00Z", Verb: "dispatch", IssueNumber: 1}},
+	}
+	writeMetricsFixture(t, env.RepoRoot, doc.RunID, doc)
+
+	if code := Run([]string{"metrics"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	if strings.Contains(stdout.String(), "usage:") {
+		t.Errorf("output has a usage: line though no event carried usage:\n%s", stdout.String())
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,273 @@
+// Package metrics is the mechanical PRD §21 recorder: one
+// schema-versioned JSON document per Delivery run at
+// .orchestrator/metrics/<run-id>.json, local-only and never
+// transmitted. Like gitops, ghops, and memhub it is policy-free — the
+// Metrics.Enabled gate, event timestamps, and event content all belong
+// to callers (internal/run, internal/cli); this package only knows how
+// to validate, append to, and load documents. Disabled metrics means
+// callers simply never call Append; LoadAll never creates the
+// directory itself, so a repository that has never enabled metrics
+// gains no storage from merely reading (PRD §23: disabled metrics
+// create no storage).
+//
+// Exactly one Delivery run owns a repository at a time (the Delivery
+// lock, internal/lockfile), so writes to any one run's document are
+// serialized by construction — this package needs no locking of its
+// own.
+//
+// PRD §21 mapping: first-pass review outcome is the first "review"
+// event recorded for an issue; retries show up as ReviewCycles and
+// repeated review events; model fallback is an "escalate" event;
+// durations between lifecycle events fall out of consecutive Event.At
+// stamps.
+package metrics
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+
+	"github.com/kninetimmy/orch/internal/manifest"
+)
+
+// SchemaVersion is the metrics document schema this build reads and
+// writes.
+const SchemaVersion = 1
+
+// Dir is the repo-relative, slash-form location of the metrics
+// directory: one file per Delivery run.
+const Dir = ".orchestrator/metrics"
+
+// runIDPattern is the closed run-id shape Append accepts. Run ids are
+// already filename-safe by construction (state/transition.go's
+// newRunID: "run-<UTC stamp>-<hex>"), but Append never joins
+// unvalidated input into a path regardless of who calls it.
+var runIDPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// Usage is adapter-reported model usage (PRD §21 "where available");
+// every field is optional and omitted when zero. It is otherwise
+// opaque adapter-reported data — the only content check this package
+// performs is that no field is negative.
+type Usage struct {
+	InputTokens         int64 `json:"input_tokens,omitempty"`
+	OutputTokens        int64 `json:"output_tokens,omitempty"`
+	CacheReadTokens     int64 `json:"cache_read_tokens,omitempty"`
+	CacheCreationTokens int64 `json:"cache_creation_tokens,omitempty"`
+	DurationMS          int64 `json:"duration_ms,omitempty"`
+}
+
+// Validate reports the first negative field in u. A nil u is valid —
+// usage is optional everywhere it appears, so the nil receiver must
+// not panic.
+func (u *Usage) Validate() error {
+	if u == nil {
+		return nil
+	}
+	switch {
+	case u.InputTokens < 0:
+		return fmt.Errorf("usage.input_tokens is negative (%d)", u.InputTokens)
+	case u.OutputTokens < 0:
+		return fmt.Errorf("usage.output_tokens is negative (%d)", u.OutputTokens)
+	case u.CacheReadTokens < 0:
+		return fmt.Errorf("usage.cache_read_tokens is negative (%d)", u.CacheReadTokens)
+	case u.CacheCreationTokens < 0:
+		return fmt.Errorf("usage.cache_creation_tokens is negative (%d)", u.CacheCreationTokens)
+	case u.DurationMS < 0:
+		return fmt.Errorf("usage.duration_ms is negative (%d)", u.DurationMS)
+	default:
+		return nil
+	}
+}
+
+// Event is one lifecycle observation. At and Verb are required;
+// everything else is verb-specific and left zero/empty when the verb
+// does not carry it — see internal/run/metrics.go for the per-verb
+// field mapping.
+type Event struct {
+	At                 string              `json:"at"`
+	Verb               string              `json:"verb"`
+	IssueNumber        int                 `json:"issue_number,omitempty"`
+	Role               string              `json:"role,omitempty"`
+	Executor           *manifest.Selection `json:"executor,omitempty"`
+	Reviewer           *manifest.Selection `json:"reviewer,omitempty"`
+	ReviewerDowngraded bool                `json:"reviewer_downgraded,omitempty"`
+	Rationale          string              `json:"rationale,omitempty"`
+	Verdict            string              `json:"verdict,omitempty"`
+	ReviewCycles       int                 `json:"review_cycles,omitempty"`
+	CIState            string              `json:"ci_state,omitempty"`
+	BlockClass         string              `json:"block_class,omitempty"`
+	RunStopped         bool                `json:"run_stopped,omitempty"`
+	EscalateKind       string              `json:"escalate_kind,omitempty"`
+	Reason             string              `json:"reason,omitempty"`
+	Merged             int                 `json:"merged,omitempty"`
+	Abandoned          int                 `json:"abandoned,omitempty"`
+	Usage              *Usage              `json:"usage,omitempty"`
+}
+
+// validate reports the first violation in ev: At and Verb are
+// required, and any usage it carries must be non-negative.
+func (ev Event) validate() error {
+	if ev.At == "" {
+		return errors.New("event.at is empty")
+	}
+	if ev.Verb == "" {
+		return errors.New("event.verb is empty")
+	}
+	return ev.Usage.Validate()
+}
+
+// Document is one Delivery run's metrics history, schema-versioned
+// like internal/state and internal/manifest.
+type Document struct {
+	SchemaVersion int     `json:"schema_version"`
+	RunID         string  `json:"run_id"`
+	Events        []Event `json:"events"`
+}
+
+func dirPath(repoRoot string) string {
+	return filepath.Join(repoRoot, filepath.FromSlash(Dir))
+}
+
+func docPath(repoRoot, runID string) string {
+	return filepath.Join(dirPath(repoRoot), runID+".json")
+}
+
+// validateRunID fails closed on anything that is not a plain
+// filename-safe token: Append never joins unvalidated input into a
+// path.
+func validateRunID(runID string) error {
+	if !runIDPattern.MatchString(runID) {
+		return fmt.Errorf("invalid run id %q", runID)
+	}
+	return nil
+}
+
+// strictDecode decodes data into v, rejecting unknown fields and
+// trailing data, mirroring internal/run's decodeRequest and
+// internal/state's Load discipline for schema-versioned documents.
+func strictDecode(data []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
+		return err
+	}
+	if dec.More() {
+		return errors.New("trailing data after document")
+	}
+	return nil
+}
+
+// Append records ev under repoRoot's run-scoped metrics document
+// (.orchestrator/metrics/<runID>.json): it validates runID and ev,
+// loads and validates the existing document if one is present (a
+// missing file starts a fresh one at the current SchemaVersion),
+// appends ev, creates the metrics directory if needed, and writes the
+// document back atomically.
+func Append(repoRoot, runID string, ev Event) error {
+	if err := validateRunID(runID); err != nil {
+		return err
+	}
+	if err := ev.validate(); err != nil {
+		return err
+	}
+
+	path := docPath(repoRoot, runID)
+	doc := Document{SchemaVersion: SchemaVersion, RunID: runID}
+	data, err := os.ReadFile(path)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		// A fresh document: doc already holds the right schema/run id.
+	case err != nil:
+		return fmt.Errorf("read %s: %w", path, err)
+	default:
+		if decErr := strictDecode(data, &doc); decErr != nil {
+			return fmt.Errorf("parse %s: %v", path, decErr)
+		}
+		if doc.SchemaVersion != SchemaVersion {
+			return fmt.Errorf("%s: unsupported schema_version %d (this build understands %d)", path, doc.SchemaVersion, SchemaVersion)
+		}
+		if doc.RunID != runID {
+			return fmt.Errorf("%s: run_id %q does not match %q", path, doc.RunID, runID)
+		}
+	}
+
+	doc.Events = append(doc.Events, ev)
+
+	dir := dirPath(repoRoot)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", dir, err)
+	}
+	return write(path, dir, doc)
+}
+
+// write atomically replaces path with doc's JSON encoding: temp file
+// in dir (path's directory), sync, then rename — state.go's write
+// shape exactly (state.go:315-341), so a crash mid-write never
+// corrupts a document an earlier Append already committed, and the
+// rename replaces on Windows too.
+func write(path, dir string, doc Document) error {
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode %s: %w", path, err)
+	}
+	f, err := os.CreateTemp(dir, "metrics-*.tmp")
+	if err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	tmp := f.Name()
+	_, err = f.Write(append(data, '\n'))
+	if err == nil {
+		err = f.Sync()
+	}
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	if err == nil {
+		err = os.Rename(tmp, path)
+	}
+	if err != nil {
+		_ = os.Remove(tmp) // best effort; the prior document is untouched
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// LoadAll reads every run-*.json file in repoRoot's metrics directory,
+// sorted by filename (run ids are UTC-stamp-prefixed and sort
+// chronologically, state/transition.go:168-176's newRunID). A missing
+// directory is not an error — it reports (nil, nil) and, critically,
+// never creates the directory itself: `orch metrics` is a read path,
+// and disabled metrics must never gain storage merely from running it
+// (PRD §23). Every file is strict-decoded and fails closed on a
+// corrupt file or an unsupported schema_version, naming the file.
+func LoadAll(repoRoot string) ([]Document, error) {
+	pattern := filepath.Join(dirPath(repoRoot), "run-*.json")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("list %s: %w", pattern, err)
+	}
+	sort.Strings(matches)
+
+	var docs []Document
+	for _, path := range matches {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		var doc Document
+		if err := strictDecode(data, &doc); err != nil {
+			return nil, fmt.Errorf("parse %s: %v", path, err)
+		}
+		if doc.SchemaVersion != SchemaVersion {
+			return nil, fmt.Errorf("%s: unsupported schema_version %d (this build understands %d)", path, doc.SchemaVersion, SchemaVersion)
+		}
+		docs = append(docs, doc)
+	}
+	return docs, nil
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,211 @@
+package metrics
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/manifest"
+)
+
+func writeDoc(t *testing.T, root, runID, content string) {
+	t.Helper()
+	dir := filepath.Join(root, filepath.FromSlash(Dir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, runID+".json"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAppendCreatesDirAndFile(t *testing.T) {
+	root := t.TempDir()
+	if err := Append(root, "run-1", Event{At: "2026-07-13T00:00:00Z", Verb: "dispatch"}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	path := filepath.Join(root, filepath.FromSlash(Dir), "run-1.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+}
+
+func TestAppendThenLoadAllRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	executor := manifest.Selection{Model: "claude-sonnet-5", Effort: "xhigh"}
+	reviewer := manifest.Selection{Model: "claude-opus-4-8", Effort: "high"}
+	ev := Event{
+		At:                 "2026-07-13T00:00:00Z",
+		Verb:               "dispatch",
+		IssueNumber:        1,
+		Role:               "implementer",
+		Executor:           &executor,
+		Reviewer:           &reviewer,
+		ReviewerDowngraded: false,
+		Rationale:          "impl",
+	}
+	if err := Append(root, "run-1", ev); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	docs, err := LoadAll(root)
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("docs = %+v, want 1", docs)
+	}
+	doc := docs[0]
+	if doc.SchemaVersion != SchemaVersion || doc.RunID != "run-1" {
+		t.Errorf("doc = %+v", doc)
+	}
+	if len(doc.Events) != 1 {
+		t.Fatalf("events = %+v, want 1", doc.Events)
+	}
+	got := doc.Events[0]
+	if got.At != ev.At || got.Verb != ev.Verb || got.IssueNumber != ev.IssueNumber || got.Role != ev.Role || got.Rationale != ev.Rationale {
+		t.Errorf("event = %+v, want %+v", got, ev)
+	}
+	if got.Executor == nil || *got.Executor != *ev.Executor {
+		t.Errorf("executor = %+v, want %+v", got.Executor, ev.Executor)
+	}
+	if got.Reviewer == nil || *got.Reviewer != *ev.Reviewer {
+		t.Errorf("reviewer = %+v, want %+v", got.Reviewer, ev.Reviewer)
+	}
+}
+
+func TestAppendTwiceAppendsToOneDocument(t *testing.T) {
+	root := t.TempDir()
+	if err := Append(root, "run-1", Event{At: "t1", Verb: "dispatch"}); err != nil {
+		t.Fatalf("Append 1: %v", err)
+	}
+	if err := Append(root, "run-1", Event{At: "t2", Verb: "pr-open"}); err != nil {
+		t.Fatalf("Append 2: %v", err)
+	}
+
+	docs, err := LoadAll(root)
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("docs = %+v, want 1 document (one file, two events)", docs)
+	}
+	if len(docs[0].Events) != 2 {
+		t.Fatalf("events = %+v, want 2", docs[0].Events)
+	}
+	if docs[0].Events[0].Verb != "dispatch" || docs[0].Events[1].Verb != "pr-open" {
+		t.Errorf("events out of order: %+v", docs[0].Events)
+	}
+}
+
+func TestAppendFailClosed(t *testing.T) {
+	cases := []struct {
+		name    string
+		setup   func(t *testing.T, root string)
+		runID   string
+		ev      Event
+		wantMsg string
+	}{
+		{
+			name:    "corrupt json",
+			setup:   func(t *testing.T, root string) { writeDoc(t, root, "run-1", "{broken") },
+			runID:   "run-1",
+			ev:      Event{At: "t", Verb: "dispatch"},
+			wantMsg: "run-1.json",
+		},
+		{
+			name: "wrong schema version",
+			setup: func(t *testing.T, root string) {
+				writeDoc(t, root, "run-1", `{"schema_version":99,"run_id":"run-1","events":[]}`)
+			},
+			runID:   "run-1",
+			ev:      Event{At: "t", Verb: "dispatch"},
+			wantMsg: "schema_version 99",
+		},
+		{
+			name: "mismatched run id",
+			setup: func(t *testing.T, root string) {
+				writeDoc(t, root, "run-1", `{"schema_version":1,"run_id":"run-other","events":[]}`)
+			},
+			runID:   "run-1",
+			ev:      Event{At: "t", Verb: "dispatch"},
+			wantMsg: "run_id",
+		},
+		{
+			name:    "invalid run id argument",
+			setup:   func(t *testing.T, root string) {},
+			runID:   "../escape",
+			ev:      Event{At: "t", Verb: "dispatch"},
+			wantMsg: "invalid run id",
+		},
+		{
+			name:    "negative usage",
+			setup:   func(t *testing.T, root string) {},
+			runID:   "run-1",
+			ev:      Event{At: "t", Verb: "pr-open", Usage: &Usage{InputTokens: -1}},
+			wantMsg: "input_tokens",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			tc.setup(t, root)
+			err := Append(root, tc.runID, tc.ev)
+			if err == nil {
+				t.Fatal("Append succeeded, want error")
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("err = %v, want it to mention %q", err, tc.wantMsg)
+			}
+		})
+	}
+}
+
+func TestLoadAllMissingDirReturnsEmptyAndCreatesNothing(t *testing.T) {
+	root := t.TempDir()
+	docs, err := LoadAll(root)
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if docs != nil {
+		t.Errorf("docs = %+v, want nil", docs)
+	}
+	if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(Dir))); !os.IsNotExist(err) {
+		t.Errorf("metrics dir exists after LoadAll on an empty repo (err = %v), want ErrNotExist", err)
+	}
+}
+
+func TestLoadAllFailClosedOnCorruptFile(t *testing.T) {
+	root := t.TempDir()
+	writeDoc(t, root, "run-1", `{"schema_version":1,"run_id":"run-1","unknown_field":true,"events":[]}`)
+	_, err := LoadAll(root)
+	if err == nil {
+		t.Fatal("LoadAll succeeded over an unknown field, want error")
+	}
+	if !strings.Contains(err.Error(), "run-1.json") {
+		t.Errorf("err = %v, want it to name the file", err)
+	}
+}
+
+func TestUsageValidate(t *testing.T) {
+	var nilUsage *Usage
+	if err := nilUsage.Validate(); err != nil {
+		t.Errorf("nil Usage.Validate() = %v, want nil", err)
+	}
+	if err := (&Usage{}).Validate(); err != nil {
+		t.Errorf("zero Usage.Validate() = %v, want nil", err)
+	}
+	cases := []Usage{
+		{InputTokens: -1},
+		{OutputTokens: -1},
+		{CacheReadTokens: -1},
+		{CacheCreationTokens: -1},
+		{DurationMS: -1},
+	}
+	for _, u := range cases {
+		if err := u.Validate(); err == nil {
+			t.Errorf("Usage%+v.Validate() = nil, want an error", u)
+		}
+	}
+}

--- a/internal/run/abandon.go
+++ b/internal/run/abandon.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/state"
 )
 
@@ -105,6 +106,14 @@ func Abandon(ctx context.Context, env Env, reqJSON []byte) (*AbandonResult, erro
 	issue.Phase = state.PhaseAbandoned
 	if err := c.save(); err != nil {
 		return nil, wrapAfterMutation(err)
+	}
+
+	if err := c.recordMetric(metrics.Event{
+		Verb:        "abandon",
+		IssueNumber: issue.Number,
+		Reason:      req.Reason,
+	}); err != nil {
+		return nil, err
 	}
 
 	return &AbandonResult{

--- a/internal/run/activate.go
+++ b/internal/run/activate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kninetimmy/orch/internal/gitops"
 	"github.com/kninetimmy/orch/internal/manifest"
 	"github.com/kninetimmy/orch/internal/memhub"
+	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/routing"
 	"github.com/kninetimmy/orch/internal/state"
 )
@@ -300,6 +301,31 @@ func Activate(ctx context.Context, env Env, reqJSON []byte) (*ActivationResult, 
 	if err := state.Save(env.RepoRoot, st); err != nil {
 		return nil, wrapAfterEnter(err)
 	}
+
+	// Metrics (PRD §21): one activate event per issue, gated on the
+	// same cfg.Metrics.Enabled every lifecycle verb checks. Activation
+	// has no verbCtx to hang recordMetric off, so this is a small
+	// gated loop rather than a restructure.
+	if cfg.Metrics.Enabled {
+		for j := range st.Run.Issues {
+			iss := &st.Run.Issues[j]
+			d := iss.Decision
+			ev := metrics.Event{
+				At:                 env.nowStamp(),
+				Verb:               "activate",
+				IssueNumber:        iss.Number,
+				Role:               string(d.Role),
+				Executor:           &d.Executor,
+				Reviewer:           &d.Reviewer,
+				ReviewerDowngraded: d.ReviewerDowngraded,
+				Rationale:          d.Rationale,
+			}
+			if err := metrics.Append(env.RepoRoot, st.Run.ID, ev); err != nil {
+				return nil, wrapAfterEnter(fmt.Errorf("record metrics: %w", err))
+			}
+		}
+	}
+
 	return result, nil
 }
 

--- a/internal/run/block.go
+++ b/internal/run/block.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/state"
 )
 
@@ -85,6 +86,15 @@ func Block(ctx context.Context, env Env, reqJSON []byte) (*BlockResult, error) {
 	}
 	if err := gh.SetStatus(ctx, issue.Number, ghops.StatusBlocked); err != nil {
 		return nil, wrapAfterMutation(err)
+	}
+
+	if err := c.recordMetric(metrics.Event{
+		Verb:        "block",
+		IssueNumber: issue.Number,
+		BlockClass:  req.Class,
+		RunStopped:  runStopped,
+	}); err != nil {
+		return nil, err
 	}
 
 	return &BlockResult{

--- a/internal/run/civerb.go
+++ b/internal/run/civerb.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/state"
 )
 
@@ -82,6 +83,14 @@ func CI(ctx context.Context, env Env, reqJSON []byte) (*CIResult, error) {
 		return nil, err
 	}
 	if err := writeManifest(ctx, gh, iss, pr, m); err != nil {
+		return nil, err
+	}
+
+	if err := c.recordMetric(metrics.Event{
+		Verb:        "ci",
+		IssueNumber: issue.Number,
+		CIState:     string(summary.State),
+	}); err != nil {
 		return nil, err
 	}
 

--- a/internal/run/cleanup.go
+++ b/internal/run/cleanup.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/kninetimmy/orch/internal/gitops"
+	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/state"
 )
 
@@ -91,6 +92,13 @@ func Cleanup(ctx context.Context, env Env, reqJSON []byte) (*CleanupResult, erro
 	issue.Phase = state.PhaseCleaned
 	if err := c.save(); err != nil {
 		return nil, wrapAfterMutation(err)
+	}
+
+	if err := c.recordMetric(metrics.Event{
+		Verb:        "cleanup",
+		IssueNumber: issue.Number,
+	}); err != nil {
+		return nil, err
 	}
 
 	return &CleanupResult{

--- a/internal/run/complete.go
+++ b/internal/run/complete.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/kninetimmy/orch/internal/gitops"
+	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/state"
 )
 
@@ -87,6 +88,14 @@ func Complete(ctx context.Context, env Env, reqJSON []byte) (*CompleteResult, er
 
 	if err := state.CompleteDelivery(env.RepoRoot); err != nil {
 		return nil, wrapAfterMutation(err)
+	}
+
+	if err := c.recordMetric(metrics.Event{
+		Verb:      "complete",
+		Merged:    merged,
+		Abandoned: abandoned,
+	}); err != nil {
+		return nil, err
 	}
 
 	return &CompleteResult{

--- a/internal/run/dispatch.go
+++ b/internal/run/dispatch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/gitops"
 	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/state"
 )
 
@@ -88,6 +89,18 @@ func Dispatch(ctx context.Context, env Env, reqJSON []byte) (*DispatchResult, er
 
 	issue.Phase = state.PhaseDispatched
 	if err := c.save(); err != nil {
+		return nil, err
+	}
+
+	if err := c.recordMetric(metrics.Event{
+		Verb:               "dispatch",
+		IssueNumber:        issue.Number,
+		Role:               string(issue.Decision.Role),
+		Executor:           &issue.Decision.Executor,
+		Reviewer:           &issue.Decision.Reviewer,
+		ReviewerDowngraded: issue.Decision.ReviewerDowngraded,
+		Rationale:          issue.Decision.Rationale,
+	}); err != nil {
 		return nil, err
 	}
 

--- a/internal/run/escalate.go
+++ b/internal/run/escalate.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/routing"
 	"github.com/kninetimmy/orch/internal/state"
 )
@@ -131,6 +132,18 @@ func escalateReroute(ctx context.Context, env Env, c *verbCtx, gh *ghops.GH, out
 
 	executor := outcome.Decision.Executor
 	reviewer := outcome.Decision.Reviewer
+
+	if err := c.recordMetric(metrics.Event{
+		Verb:         "escalate",
+		IssueNumber:  issue.Number,
+		EscalateKind: string(routing.OutcomeReroute),
+		Executor:     &executor,
+		Reviewer:     &reviewer,
+		Reason:       outcome.Reason,
+	}); err != nil {
+		return nil, err
+	}
+
 	return &EscalateResult{
 		SchemaVersion: EscalateSchemaVersion,
 		IssueNumber:   issue.Number,
@@ -155,6 +168,16 @@ func escalateReturnToArchitect(ctx context.Context, c *verbCtx, gh *ghops.GH, ou
 	if err := gh.SetStatus(ctx, issue.Number, ghops.StatusNeedsHuman); err != nil {
 		return nil, wrapAfterMutation(err)
 	}
+
+	if err := c.recordMetric(metrics.Event{
+		Verb:         "escalate",
+		IssueNumber:  issue.Number,
+		EscalateKind: string(routing.OutcomeReturnToArchitect),
+		Reason:       outcome.Reason,
+	}); err != nil {
+		return nil, err
+	}
+
 	return &EscalateResult{
 		SchemaVersion: EscalateSchemaVersion,
 		IssueNumber:   issue.Number,

--- a/internal/run/merge.go
+++ b/internal/run/merge.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/state"
 )
 
@@ -145,6 +146,13 @@ func Merge(ctx context.Context, env Env, reqJSON []byte) (*MergeResult, error) {
 	issue.Phase = state.PhaseMerged
 	if err := c.save(); err != nil {
 		return nil, wrapAfterMutation(err)
+	}
+
+	if err := c.recordMetric(metrics.Event{
+		Verb:        "merge",
+		IssueNumber: issue.Number,
+	}); err != nil {
+		return nil, err
 	}
 
 	return &MergeResult{

--- a/internal/run/mergereport.go
+++ b/internal/run/mergereport.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/kninetimmy/orch/internal/ghops"
+	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/state"
 )
 
@@ -90,6 +91,13 @@ func MergeReport(ctx context.Context, env Env, reqJSON []byte) (*MergeReportResu
 	}
 	if err := gh.SetStatus(ctx, issue.Number, ghops.StatusNeedsHuman); err != nil {
 		return nil, wrapAfterMutation(err)
+	}
+
+	if err := c.recordMetric(metrics.Event{
+		Verb:        "merge-report",
+		IssueNumber: issue.Number,
+	}); err != nil {
+		return nil, err
 	}
 
 	result := &MergeReportResult{

--- a/internal/run/metrics.go
+++ b/internal/run/metrics.go
@@ -1,0 +1,24 @@
+package run
+
+import (
+	"fmt"
+
+	"github.com/kninetimmy/orch/internal/metrics"
+)
+
+// recordMetric appends a metrics event for this run when metrics are
+// enabled. It runs at the very end of a verb's success path, after
+// every state/GitHub mutation, so a recorded event always describes a
+// completed verb; a failure is a post-mutation error (PRD §21 is
+// fail-closed like everything else — disable metrics to bypass a
+// broken disk).
+func (c *verbCtx) recordMetric(ev metrics.Event) error {
+	if !c.cfg.Metrics.Enabled {
+		return nil
+	}
+	ev.At = c.env.nowStamp()
+	if err := metrics.Append(c.env.RepoRoot, c.st.Run.ID, ev); err != nil {
+		return wrapAfterMutation(fmt.Errorf("record metrics: %w", err))
+	}
+	return nil
+}

--- a/internal/run/metrics_test.go
+++ b/internal/run/metrics_test.go
@@ -1,0 +1,266 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+	"github.com/kninetimmy/orch/internal/metrics"
+	"github.com/kninetimmy/orch/internal/paths"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// metricsEnabledConfigTOML mirrors testConfigTOML with metrics enabled,
+// for the tests in this file that need Metrics.Enabled true on disk.
+const metricsEnabledConfigTOML = testConfigTOML + "\n[metrics]\nenabled = true\n"
+
+// setupDeliveryRepoWithConfig mirrors verb_unit_test.go's
+// setupDeliveryRepo but writes tomlContent instead of the fixed
+// testConfigTOML, so a test can flip Metrics.Enabled without touching
+// the shared helper every other verb test relies on.
+func setupDeliveryRepoWithConfig(t *testing.T, tomlContent, planRev string, issues []state.Issue) string {
+	t.Helper()
+	root := setupRepo(t, tomlContent)
+	planned := make([]state.Issue, len(issues))
+	for i := range issues {
+		planned[i] = state.Issue{PlanID: issues[i].PlanID, Phase: state.PhasePlanned}
+	}
+	st, err := state.EnterDelivery(root, "claude", state.PlanRef{Title: "t", Digest: "sha256:x", ConfigRevision: planRev}, planned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Run.Issues = issues
+	if err := state.Save(root, st); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// newActivateRepoWithConfig mirrors activate_test.go's
+// newActivateRepoWithIgnore but writes tomlContent instead of the fixed
+// testConfigTOML, so the activation metrics test can enable metrics on
+// disk.
+func newActivateRepoWithConfig(t *testing.T, tomlContent string) string {
+	t.Helper()
+	setupGitEnv(t)
+	root, err := paths.Canonical(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawGit(t, root, "init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(fullGitignore), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".orchestrator"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".orchestrator", "config.toml"), []byte(tomlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rawGit(t, root, "add", "-A")
+	rawGit(t, root, "commit", "-m", "initial")
+	return root
+}
+
+func loadMetricsDocs(t *testing.T, root string) []metrics.Document {
+	t.Helper()
+	docs, err := metrics.LoadAll(root)
+	if err != nil {
+		t.Fatalf("metrics.LoadAll: %v", err)
+	}
+	return docs
+}
+
+// assertNoMetricsDir pins the PRD §23 acceptance criterion: disabled
+// metrics create no storage at all.
+func assertNoMetricsDir(t *testing.T, root string) {
+	t.Helper()
+	if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(metrics.Dir))); !os.IsNotExist(err) {
+		t.Errorf("metrics dir exists (stat err = %v), want absent", err)
+	}
+}
+
+// reviewApproveJSON builds a valid Review request for issue 1, echoing
+// the routed reviewer implementerDecision() carries.
+func reviewApproveJSON(usage string) string {
+	extra := ""
+	if usage != "" {
+		extra = `,"usage":` + usage
+	}
+	return `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"}` + extra + `}`
+}
+
+// TestReviewRecordsMetricWhenEnabled pins internal/run/metrics.go's
+// wiring for one verb (review, per the spec's dispatch-or-review
+// choice — review needs no git sandbox, only scripted gh): with
+// metrics enabled, a successful Review call records exactly one event
+// carrying the verb-specific fields the spec's table names.
+func TestReviewRecordsMetricWhenEnabled(t *testing.T) {
+	root := setupDeliveryRepoWithConfig(t, metricsEnabledConfigTOML, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
+	body := baseManifestBody(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-1"),
+		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghSetPRBodyCall(10),
+	}}
+	usageJSON := `{"input_tokens":100,"output_tokens":50,"cache_read_tokens":10,"cache_creation_tokens":5,"duration_ms":1200}`
+	_, err := Review(context.Background(), ghEnv(root, script), []byte(reviewApproveJSON(usageJSON)))
+	if err != nil {
+		t.Fatalf("Review: %v", err)
+	}
+	script.AssertExhausted()
+
+	docs := loadMetricsDocs(t, root)
+	if len(docs) != 1 {
+		t.Fatalf("docs = %+v, want 1", docs)
+	}
+	st := loadRun(t, root)
+	if docs[0].RunID != st.Run.ID {
+		t.Errorf("doc run id = %q, want %q", docs[0].RunID, st.Run.ID)
+	}
+	if len(docs[0].Events) != 1 {
+		t.Fatalf("events = %+v, want 1", docs[0].Events)
+	}
+	ev := docs[0].Events[0]
+	if ev.Verb != "review" || ev.IssueNumber != 1 {
+		t.Errorf("event verb/issue = %q/%d", ev.Verb, ev.IssueNumber)
+	}
+	if ev.Verdict != "approve" || ev.ReviewCycles != 1 {
+		t.Errorf("event verdict/cycles = %q/%d, want approve/1", ev.Verdict, ev.ReviewCycles)
+	}
+	if ev.Reviewer == nil || ev.Reviewer.Model != "claude-opus-4-8" || ev.Reviewer.Effort != "high" {
+		t.Errorf("event reviewer = %+v, want the routed reviewer", ev.Reviewer)
+	}
+	if ev.Usage == nil || ev.Usage.InputTokens != 100 || ev.Usage.OutputTokens != 50 || ev.Usage.DurationMS != 1200 {
+		t.Errorf("event usage = %+v, want the request's usage", ev.Usage)
+	}
+	if ev.At != fixedNow().Format(time.RFC3339) {
+		t.Errorf("event at = %q, want the fixed clock stamp", ev.At)
+	}
+}
+
+// TestReviewMetricsDisabledCreatesNoStorage pins PRD §23: the same
+// successful verb call against the ordinary (metrics-disabled)
+// testConfigTOML never creates .orchestrator/metrics at all.
+func TestReviewMetricsDisabledCreatesNoStorage(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
+	body := baseManifestBody(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-1"),
+		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghSetPRBodyCall(10),
+	}}
+	_, err := Review(context.Background(), ghEnv(root, script), []byte(reviewApproveJSON("")))
+	if err != nil {
+		t.Fatalf("Review: %v", err)
+	}
+	script.AssertExhausted()
+	assertNoMetricsDir(t, root)
+}
+
+// TestReviewNegativeUsageIsBadRequestBeforeMutation pins the wire
+// validation the spec adds to Review's request-validation block: a
+// negative usage field is rejected as ErrBadRequest before loadVerb
+// ever runs, so no gh call happens and state is untouched.
+func TestReviewNegativeUsageIsBadRequestBeforeMutation(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
+	before := stateBytes(t, root)
+	script := &execxtest.Script{T: t}
+	req := reviewApproveJSON(`{"input_tokens":-1}`)
+	_, err := Review(context.Background(), ghEnv(root, script), []byte(req))
+	if !errors.Is(err, ErrBadRequest) {
+		t.Fatalf("err = %v, want ErrBadRequest", err)
+	}
+	script.AssertExhausted()
+	if got := stateBytes(t, root); string(got) != string(before) {
+		t.Error("state changed on a negative-usage review request")
+	}
+	assertNoMetricsDir(t, root)
+}
+
+// TestPROpenNegativeUsageIsBadRequestBeforeMutation is the pr-open
+// half of the same wire validation.
+func TestPROpenNegativeUsageIsBadRequestBeforeMutation(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhaseDispatched)})
+	before := stateBytes(t, root)
+	script := &execxtest.Script{T: t}
+	req := `{"schema_version":1,"issue_number":1,"verifications":[{"name":"go test","result":"pass"}],"usage":{"duration_ms":-5}}`
+	_, err := PROpen(context.Background(), ghEnv(root, script), []byte(req))
+	if !errors.Is(err, ErrBadRequest) {
+		t.Fatalf("err = %v, want ErrBadRequest", err)
+	}
+	script.AssertExhausted()
+	if got := stateBytes(t, root); string(got) != string(before) {
+		t.Error("state changed on a negative-usage pr-open request")
+	}
+	assertNoMetricsDir(t, root)
+}
+
+// TestActivateRecordsOneMetricPerIssueWhenEnabled pins activate.go's
+// gated per-issue metrics loop (the verb has no verbCtx, so it appends
+// directly rather than through recordMetric).
+func TestActivateRecordsOneMetricPerIssueWhenEnabled(t *testing.T) {
+	root := newActivateRepoWithConfig(t, metricsEnabledConfigTOML)
+	calls := fullTaxonomyScript()
+	calls = append(calls,
+		ghIssueCreateCall("Issue A", []string{"ready", "feature", "implementer", "standard"}, 1),
+		ghIssueCreateCall("Issue B", []string{"ready", "feature", "specialist", "critical"}, 2),
+	)
+	script := &execxtest.Script{T: t, Calls: calls}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	result, err := Activate(context.Background(), env, activationJSON(t, twoIssuePlanJSON()))
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	script.AssertExhausted()
+
+	docs := loadMetricsDocs(t, root)
+	if len(docs) != 1 {
+		t.Fatalf("docs = %+v, want 1", docs)
+	}
+	if docs[0].RunID != result.RunID {
+		t.Errorf("doc run id = %q, want %q", docs[0].RunID, result.RunID)
+	}
+	if len(docs[0].Events) != 2 {
+		t.Fatalf("events = %+v, want one activate event per issue", docs[0].Events)
+	}
+	for i, want := range []struct {
+		issueNumber int
+		role        string
+	}{
+		{1, "implementer"},
+		{2, "specialist"},
+	} {
+		ev := docs[0].Events[i]
+		if ev.Verb != "activate" || ev.IssueNumber != want.issueNumber || ev.Role != want.role {
+			t.Errorf("event[%d] = %+v, want verb=activate issue=%d role=%s", i, ev, want.issueNumber, want.role)
+		}
+		if ev.Executor == nil || ev.Rationale == "" {
+			t.Errorf("event[%d] missing executor/rationale: %+v", i, ev)
+		}
+	}
+}
+
+// TestActivateMetricsDisabledCreatesNoStorage is activation's §23 pin:
+// the ordinary metrics-disabled testConfigTOML never creates
+// .orchestrator/metrics.
+func TestActivateMetricsDisabledCreatesNoStorage(t *testing.T) {
+	root := newActivateRepo(t)
+	calls := fullTaxonomyScript()
+	calls = append(calls, ghIssueCreateCall("Fix the status lock race", []string{"ready", "bug", "implementer", "standard"}, 1))
+	script := &execxtest.Script{T: t, Calls: calls}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	if _, err := Activate(context.Background(), env, activationJSON(t, validPlanJSON())); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	script.AssertExhausted()
+	assertNoMetricsDir(t, root)
+}

--- a/internal/run/propen.go
+++ b/internal/run/propen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/gitops"
 	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/state"
 )
 
@@ -32,6 +33,9 @@ type PROpenRequest struct {
 	SchemaVersion int                 `json:"schema_version"`
 	IssueNumber   int                 `json:"issue_number"`
 	Verifications []VerificationInput `json:"verifications"`
+	// Usage is adapter-reported model usage for this PR-open call
+	// (PRD §21 "where available"); optional and best-effort.
+	Usage *metrics.Usage `json:"usage,omitempty"`
 }
 
 // PROpenResult reports the opened PR.
@@ -57,6 +61,9 @@ func PROpen(ctx context.Context, env Env, reqJSON []byte) (*PROpenResult, error)
 	}
 	if req.SchemaVersion != PROpenSchemaVersion {
 		return nil, fmt.Errorf("%w: schema_version %d is unsupported (this build supports %d)", ErrBadRequest, req.SchemaVersion, PROpenSchemaVersion)
+	}
+	if err := req.Usage.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrBadRequest, err)
 	}
 	verifications, err := buildVerifications(req.Verifications, env.nowStamp())
 	if err != nil {
@@ -143,6 +150,14 @@ func PROpen(ctx context.Context, env Env, reqJSON []byte) (*PROpenResult, error)
 	}
 	if err := c.save(); err != nil {
 		return nil, wrapAfterMutation(err)
+	}
+
+	if err := c.recordMetric(metrics.Event{
+		Verb:        "pr-open",
+		IssueNumber: issue.Number,
+		Usage:       req.Usage,
+	}); err != nil {
+		return nil, err
 	}
 
 	return &PROpenResult{

--- a/internal/run/review.go
+++ b/internal/run/review.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/state"
 )
 
@@ -30,6 +31,9 @@ type ReviewRequest struct {
 	Verdict         string             `json:"verdict"`
 	Summary         string             `json:"summary"`
 	Reviewer        manifest.Selection `json:"reviewer"`
+	// Usage is adapter-reported model usage for this review cycle
+	// (PRD §21 "where available"); optional and best-effort.
+	Usage *metrics.Usage `json:"usage,omitempty"`
 }
 
 // ReviewResult reports the recorded review cycle.
@@ -61,6 +65,9 @@ func Review(ctx context.Context, env Env, reqJSON []byte) (*ReviewResult, error)
 	}
 	if req.Summary == "" {
 		return nil, fmt.Errorf("%w: review summary must not be empty (PRD §12.11: one consolidated report per cycle)", ErrBadRequest)
+	}
+	if err := req.Usage.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrBadRequest, err)
 	}
 
 	c, err := loadVerb(env, req.IssueNumber, []state.Phase{state.PhasePROpen, state.PhaseInReview}, false)
@@ -115,6 +122,17 @@ func Review(ctx context.Context, env Env, reqJSON []byte) (*ReviewResult, error)
 		if err := gh.SetStatus(ctx, issue.Number, ghops.StatusInProgress); err != nil {
 			return nil, wrapAfterMutation(err)
 		}
+	}
+
+	if err := c.recordMetric(metrics.Event{
+		Verb:         "review",
+		IssueNumber:  issue.Number,
+		Verdict:      req.Verdict,
+		ReviewCycles: issue.ReviewCycles,
+		Reviewer:     &req.Reviewer,
+		Usage:        req.Usage,
+	}); err != nil {
+		return nil, err
 	}
 
 	return &ReviewResult{


### PR DESCRIPTION
## What

Implements task 20 (PRD §21/§22), the last stubbed §22 human command and the last v1 item:

- **internal/metrics** — the mechanical, policy-free PRD §21 recorder: one schema-versioned JSON document per Delivery run at `.orchestrator/metrics/<run-id>.json`, written with state.json's atomic temp+rename shape, fail-closed on corrupt files, unknown schema versions, run-id mismatch, and unvalidated run-id path input. `LoadAll` (the read path) never creates the directory.
- **Run-engine wiring** — every lifecycle verb records one event at the very end of its success path, gated on `cfg.Metrics.Enabled`; activation records one `activate` event per issue carrying the routing decision and rationale. A metrics write failure is a fail-closed post-mutation error (`wrapAfterMutation`). Disabled metrics never call the recorder, so **disabled metrics create no storage at all** (PRD §23 criterion, pinned by tests at both the verb and activation layers).
- **Additive `usage` wire field** on the pr-open and review requests (same schema versions; precedent: tasks 16/19): optional adapter-reported token/cache/duration counts, validated non-negative before any mutation. Both delivery skills document it as best-effort — report only what the host actually gives, never estimate.
- **`orch metrics`** — replaces the fail-closed stub: version line first (doctor convention), enabled state, then a per-run summary (issues merged/abandoned/blocked by class, escalations, review cycles + first-pass approve rate, last CI state per issue, summed usage). Read-only; running it never creates storage.
- **Adapters** bumped 0.2.0 → 0.3.0 (skill content changed), README drops the "not implemented yet" note.

## Why

PRD §21 metrics were designed in but never recorded anywhere; `orch metrics` was the last §22 command failing closed. With this, all eight human commands work and v1's command surface is complete.

Token/duration "where available" (PRD §21) is resolved via the optional usage field: the engine never runs models, so the adapters — which do see subagent token totals — supply it best-effort.

## Verification

- `gofmt` clean; `go build`, `go vet`, `go test ./...` green on all 21 packages (new test suites for the package, the run wiring incl. the no-storage-when-disabled pins, and the CLI command).
- Live smoke against a built binary: summary output over a realistic 8-event fixture run, the empty-history path (confirmed no directory is created), and the uninitialized-repo error path.

Supersedes #35 (closed by GitHub when its stacked base branch merged and was deleted; a closed PR with a force-pushed head cannot be reopened). Same content, rebased onto main after #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
