### PR TITLE
Add orch render-agents: render Codex agent TOMLs from config

### DIFF
--- a/ORCH-PRD.md
+++ b/ORCH-PRD.md
@@ -504,6 +504,7 @@ orch configure-local
 orch resume
 orch abort
 orch metrics
+orch render-agents
 ```
 
 There is no manual Delivery command. Plan approval activates Delivery, and completion returns to

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -104,7 +104,11 @@ decision, not an oversight).
    Codex plugins cannot bundle agent definitions, so this copy is a
    separate manual step every install of this adapter needs, not
    something the plugin installs for you — the marketplace install in
-   step 2 does not remove it.
+   step 2 does not remove it. `orch render-agents` (PRD §22) is the
+   mechanical alternative to a manual copy: it renders the same five
+   files, with `model`/`model_reasoning_effort` substituted from the
+   repository's own `hosts.codex.roles`, into the project's
+   `.codex/agents/` directly.
 5. Enable the `request_user_input` question primitive — verified on
    codex-cli 0.144.1, both of these in `~/.codex/config.toml`:
 
@@ -156,12 +160,12 @@ bugs:
   `orch-reviewer-safe` exists specifically so the §10 safe-downgrade row
   has a real installed TOML to dispatch, instead of dead-ending at that
   same stop-and-tell-human rule on every routine downgrade.
-- **A configured non-default model requires hand-editing the installed
-  TOMLs.** There is no `orch` verb today that renders an agent TOML from
-  `config.toml`'s routing configuration; a repository that overrides the
-  §10 defaults has to hand-edit the five files under `.codex/agents/` to
-  match. A future verb that renders TOMLs from config is a plausible
-  follow-up, out of scope for this adapter.
+- **A configured non-default model is applied by `orch render-agents`,
+  not automatically.** A repository that overrides the §10 defaults
+  must run `orch render-agents` (PRD §22) itself — install and upgrade
+  do not run it for you — to re-render the five files under
+  `.codex/agents/` from the current `hosts.codex.roles` before the
+  override takes effect for dispatched agents.
 - **An unrecognized future `apply_patch` envelope directive denies,
   fail-closed.** `internal/guard`'s envelope parser treats any `*** `
   directive line it does not already recognize as a malformed envelope

--- a/adapters/codex/embed.go
+++ b/adapters/codex/embed.go
@@ -1,0 +1,16 @@
+package codex
+
+import "embed"
+
+// AgentTOMLs embeds the five shipped Codex agent definitions under
+// agents/ verbatim (LF-only, byte-identical to what this plugin ships,
+// since go:embed reads the file at build time). internal/agents reads
+// from this embed.FS to render `.codex/agents/*.toml` from the
+// effective configuration, so the shipped adapter files and `orch
+// render-agents`'s output share exactly one canonical source and
+// cannot silently diverge: any edit to a file under agents/ changes
+// what both the plugin ships and the render command produces, in the
+// same build.
+//
+//go:embed agents/*.toml
+var AgentTOMLs embed.FS

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -1,0 +1,191 @@
+// Package agents renders the five Codex agent TOMLs `orch
+// render-agents` writes into <repo>/.codex/agents/ (PRD §22): each
+// file's model and model_reasoning_effort are substituted from the
+// effective configuration's hosts.codex.roles, but the surrounding
+// body — name, description, developer_instructions — is the canonical
+// shipped text embedded from adapters/codex/agents/*.toml
+// (adapters/codex/embed.go's AgentTOMLs). That embed is the one
+// source of truth: this package never carries its own copy of the
+// prose, so the shipped plugin files and this package's rendered
+// output cannot silently diverge from one another.
+package agents
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/kninetimmy/orch/adapters/codex"
+	"github.com/kninetimmy/orch/internal/config"
+)
+
+// Dir is the repo-relative, slash-form destination directory `orch
+// render-agents` writes into. It is a machine-local artifact (like
+// config.local.toml), not a committed one: a repository's own
+// .gitignore, not this package, decides whether it is tracked.
+const Dir = ".codex/agents"
+
+// roleFile pairs one hosts.codex.roles key with the canonical TOML
+// file stem it renders. review_downgrade maps to orch-reviewer-safe:
+// the §10 safe-review-downgrade profile has no role of its own file
+// name (see adapters/codex/README.md).
+type roleFile struct {
+	role string
+	stem string
+}
+
+// roleFiles lists the five agent files this package renders, in the
+// same fixed order every run produces them.
+var roleFiles = []roleFile{
+	{"scout", "orch-scout"},
+	{"implementer", "orch-implementer"},
+	{"specialist", "orch-specialist"},
+	{"reviewer", "orch-reviewer"},
+	{"review_downgrade", "orch-reviewer-safe"},
+}
+
+// File is one rendered agent TOML: Name is the file stem (e.g.
+// "orch-scout", no extension), Content its fully substituted bytes.
+type File struct {
+	Name    string
+	Content []byte
+}
+
+// profileFor returns role's RoleProfile from roles. role is always one
+// of roleFiles' five keys; architect has no agent file (the Architect
+// is the host session itself, never a dispatched agent).
+func profileFor(roles config.Roles, role string) config.RoleProfile {
+	switch role {
+	case "scout":
+		return roles.Scout
+	case "implementer":
+		return roles.Implementer
+	case "specialist":
+		return roles.Specialist
+	case "reviewer":
+		return roles.Reviewer
+	case "review_downgrade":
+		return roles.ReviewDowngrade
+	default:
+		// Unreachable: roleFiles is the only caller and is closed.
+		return config.RoleProfile{}
+	}
+}
+
+// Render produces the five agent TOMLs for h's roles, in roleFiles
+// order. h must not be nil — the caller (`orch render-agents`) fails
+// closed before calling Render when hosts.codex is not enabled.
+func Render(h *config.Host) ([]File, error) {
+	if h == nil {
+		return nil, errors.New("agents.Render: codex host is nil")
+	}
+	files := make([]File, 0, len(roleFiles))
+	for _, rf := range roleFiles {
+		canonical, err := codex.AgentTOMLs.ReadFile("agents/" + rf.stem + ".toml")
+		if err != nil {
+			return nil, fmt.Errorf("read canonical %s.toml: %w", rf.stem, err)
+		}
+		profile := profileFor(h.Roles, rf.role)
+		content, err := substitute(canonical, profile.Model, profile.Effort)
+		if err != nil {
+			return nil, fmt.Errorf("render %s.toml: %w", rf.stem, err)
+		}
+		files = append(files, File{Name: rf.stem, Content: content})
+	}
+	return files, nil
+}
+
+// developerInstructionsHeader marks where every canonical agent TOML's
+// substitutable header (name, description, model,
+// model_reasoning_effort) ends and its role-specific prose begins.
+// substitute never rewrites anything at or past this marker, so a
+// coincidental mention of a model name inside the prose is never
+// touched.
+const developerInstructionsHeader = "\ndeveloper_instructions = \"\"\"\n"
+
+var modelLine = regexp.MustCompile(`(?m)^model = "[^"]*"$`)
+var effortLine = regexp.MustCompile(`(?m)^model_reasoning_effort = "[^"]*"$`)
+
+// substitute replaces canonical's model and model_reasoning_effort
+// values with model and effort, leaving every other byte — including
+// the entire developer_instructions body — untouched. It fails closed
+// if canonical does not have the expected shape (missing
+// developer_instructions marker, or not exactly one model /
+// model_reasoning_effort line in the header), rather than silently
+// rewriting the wrong line or leaving a value unsubstituted.
+func substitute(canonical []byte, model, effort string) ([]byte, error) {
+	s := string(canonical)
+	idx := strings.Index(s, developerInstructionsHeader)
+	if idx < 0 {
+		return nil, errors.New("canonical TOML has no developer_instructions block")
+	}
+	header, rest := s[:idx], s[idx:]
+
+	header, err := replaceOneLine(header, modelLine, fmt.Sprintf("model = %q", model))
+	if err != nil {
+		return nil, fmt.Errorf("model: %w", err)
+	}
+	header, err = replaceOneLine(header, effortLine, fmt.Sprintf("model_reasoning_effort = %q", effort))
+	if err != nil {
+		return nil, fmt.Errorf("model_reasoning_effort: %w", err)
+	}
+	return []byte(header + rest), nil
+}
+
+// replaceOneLine replaces pattern's single match in s with replacement,
+// failing closed if pattern matches zero or more than one line.
+func replaceOneLine(s string, pattern *regexp.Regexp, replacement string) (string, error) {
+	n := len(pattern.FindAllStringIndex(s, -1))
+	if n != 1 {
+		return "", fmt.Errorf("expected exactly one match for %s in header, found %d", pattern.String(), n)
+	}
+	return pattern.ReplaceAllLiteralString(s, replacement), nil
+}
+
+// Write atomically writes each of files into repoRoot's Dir, creating
+// the directory if absent and overwriting any existing file: a temp
+// file in the same directory, synced, then renamed over the
+// destination (internal/config.WriteLocal's shape, which also replaces
+// atomically on Windows). On any single file's failure the files
+// written before it are left in place; the failing file's own prior
+// content, if any, is left untouched and its temp file removed on a
+// best-effort basis.
+func Write(repoRoot string, files []File) error {
+	dir := filepath.Join(repoRoot, filepath.FromSlash(Dir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", Dir, err)
+	}
+	for _, f := range files {
+		path := filepath.Join(dir, f.Name+".toml")
+		if err := writeAtomic(path, dir, f.Content); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeAtomic(path, dir string, data []byte) error {
+	f, err := os.CreateTemp(dir, "agent-*.tmp")
+	if err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	tmp := f.Name()
+	_, err = f.Write(data)
+	if err == nil {
+		err = f.Sync()
+	}
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	if err == nil {
+		err = os.Rename(tmp, path)
+	}
+	if err != nil {
+		_ = os.Remove(tmp) // best effort; the prior file, if any, is untouched
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -1,0 +1,242 @@
+package agents
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/kninetimmy/orch/adapters/codex"
+	"github.com/kninetimmy/orch/internal/adaptertest"
+	"github.com/kninetimmy/orch/internal/config"
+)
+
+// defaultCodexHost builds a *config.Host whose roles equal the PRD §10
+// codex defaults (adaptertest.Profile("codex"), the same fixture
+// adapters/codex/plugin_test.go's TestAgentTOMLs pins the shipped
+// files against).
+func defaultCodexHost() *config.Host {
+	p := adaptertest.Profile("codex")
+	rp := func(role string) config.RoleProfile {
+		return config.RoleProfile{Model: p[role].Model, Effort: p[role].Effort}
+	}
+	return &config.Host{Roles: config.Roles{
+		Architect:       rp("scout"), // architect has no agent file; value irrelevant here
+		Scout:           rp("scout"),
+		Implementer:     rp("implementer"),
+		Specialist:      rp("specialist"),
+		Reviewer:        rp("reviewer"),
+		ReviewDowngrade: rp("reviewer-safe"),
+	}}
+}
+
+// TestRenderDefaultProfileByteIdenticalToShipped pins acceptance
+// criterion 3: with hosts.codex.roles equal to the PRD §10 defaults,
+// every rendered file is byte-identical to its shipped counterpart
+// under adapters/codex/agents/ (read here through the same embed
+// Render itself uses, since that embed is the single canonical
+// source — see adapters/codex/embed.go).
+func TestRenderDefaultProfileByteIdenticalToShipped(t *testing.T) {
+	files, err := Render(defaultCodexHost())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if len(files) != 5 {
+		t.Fatalf("Render returned %d files, want 5", len(files))
+	}
+	for _, f := range files {
+		want, err := codex.AgentTOMLs.ReadFile("agents/" + f.Name + ".toml")
+		if err != nil {
+			t.Fatalf("read shipped %s.toml: %v", f.Name, err)
+		}
+		if string(f.Content) != string(want) {
+			t.Errorf("%s.toml does not match shipped file\n--- got ---\n%s\n--- want ---\n%s", f.Name, f.Content, want)
+		}
+	}
+}
+
+// TestRenderOrderAndNames pins the exact five file stems Render
+// produces, in order.
+func TestRenderOrderAndNames(t *testing.T) {
+	files, err := Render(defaultCodexHost())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	want := []string{"orch-scout", "orch-implementer", "orch-specialist", "orch-reviewer", "orch-reviewer-safe"}
+	if len(files) != len(want) {
+		t.Fatalf("got %d files, want %d", len(files), len(want))
+	}
+	for i, f := range files {
+		if f.Name != want[i] {
+			t.Errorf("files[%d].Name = %q, want %q", i, f.Name, want[i])
+		}
+	}
+}
+
+// agentTOML mirrors adapters/codex/plugin_test.go's strict decode
+// shape, so this package's own tests can assert a rendered file still
+// parses and carries the substituted values without duplicating that
+// file's private type.
+type agentTOML struct {
+	Name                  string `toml:"name"`
+	Description           string `toml:"description"`
+	DeveloperInstructions string `toml:"developer_instructions"`
+	Model                 string `toml:"model"`
+	ModelReasoningEffort  string `toml:"model_reasoning_effort"`
+}
+
+// TestRenderOverrideSubstitution asserts a non-default configuration's
+// model/effort values land in the rendered TOML, and only there: name,
+// description, and developer_instructions stay exactly the shipped
+// prose.
+func TestRenderOverrideSubstitution(t *testing.T) {
+	h := &config.Host{Roles: config.Roles{
+		Scout:           config.RoleProfile{Model: "gpt-9000", Effort: "low"},
+		Implementer:     config.RoleProfile{Model: "gpt-9000", Effort: "high"},
+		Specialist:      config.RoleProfile{Model: "gpt-9000-ultra", Effort: "medium"},
+		Reviewer:        config.RoleProfile{Model: "gpt-9000-ultra", Effort: "medium"},
+		ReviewDowngrade: config.RoleProfile{Model: "gpt-9000", Effort: "high"},
+	}}
+	files, err := Render(h)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	want := map[string]config.RoleProfile{
+		"orch-scout":         h.Roles.Scout,
+		"orch-implementer":   h.Roles.Implementer,
+		"orch-specialist":    h.Roles.Specialist,
+		"orch-reviewer":      h.Roles.Reviewer,
+		"orch-reviewer-safe": h.Roles.ReviewDowngrade,
+	}
+	for _, f := range files {
+		var a agentTOML
+		meta, err := toml.Decode(string(f.Content), &a)
+		if err != nil {
+			t.Fatalf("decode %s: %v", f.Name, err)
+		}
+		if undecoded := meta.Undecoded(); len(undecoded) != 0 {
+			t.Errorf("%s: unrecognized keys %v", f.Name, undecoded)
+		}
+		wp := want[f.Name]
+		if a.Model != wp.Model {
+			t.Errorf("%s: model = %q, want %q", f.Name, a.Model, wp.Model)
+		}
+		if a.ModelReasoningEffort != wp.Effort {
+			t.Errorf("%s: model_reasoning_effort = %q, want %q", f.Name, a.ModelReasoningEffort, wp.Effort)
+		}
+		if a.Name != f.Name {
+			t.Errorf("%s: name = %q, want %q", f.Name, a.Name, f.Name)
+		}
+		if a.Description == "" {
+			t.Errorf("%s: description is empty", f.Name)
+		}
+		if a.DeveloperInstructions == "" {
+			t.Errorf("%s: developer_instructions is empty", f.Name)
+		}
+
+		shipped, err := codex.AgentTOMLs.ReadFile("agents/" + f.Name + ".toml")
+		if err != nil {
+			t.Fatalf("read shipped %s.toml: %v", f.Name, err)
+		}
+		var sa agentTOML
+		if _, err := toml.Decode(string(shipped), &sa); err != nil {
+			t.Fatalf("decode shipped %s: %v", f.Name, err)
+		}
+		if a.Description != sa.Description {
+			t.Errorf("%s: description changed from shipped text", f.Name)
+		}
+		if a.DeveloperInstructions != sa.DeveloperInstructions {
+			t.Errorf("%s: developer_instructions changed from shipped text", f.Name)
+		}
+	}
+}
+
+func TestRenderNilHostFailsClosed(t *testing.T) {
+	if _, err := Render(nil); err == nil {
+		t.Error("Render(nil) succeeded, want an error")
+	}
+}
+
+// TestRenderNoTrailingCR guards the LF-only convention render.go's
+// package documents: a rendered file must never introduce a carriage
+// return the shipped source did not already contain.
+func TestRenderNoTrailingCR(t *testing.T) {
+	files, err := Render(defaultCodexHost())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	for _, f := range files {
+		if strings.Contains(string(f.Content), "\r") {
+			t.Errorf("%s: rendered content contains a carriage return", f.Name)
+		}
+	}
+}
+
+func TestWriteCreatesDirectoryAndFiles(t *testing.T) {
+	root := t.TempDir()
+	files, err := Render(defaultCodexHost())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if err := Write(root, files); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	dir := filepath.Join(root, filepath.FromSlash(Dir))
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 5 {
+		t.Fatalf("wrote %d files, want 5", len(entries))
+	}
+	for _, f := range files {
+		got, err := os.ReadFile(filepath.Join(dir, f.Name+".toml"))
+		if err != nil {
+			t.Fatalf("read written %s: %v", f.Name, err)
+		}
+		if string(got) != string(f.Content) {
+			t.Errorf("%s: written content does not match Render's output", f.Name)
+		}
+	}
+
+	// Left-over temp files must never survive a successful Write.
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp") {
+			t.Errorf("leftover temp file %q in %s", e.Name(), dir)
+		}
+	}
+}
+
+// TestWriteOverwritesExisting asserts a second Write replaces stale
+// content rather than leaving it or appending to it.
+func TestWriteOverwritesExisting(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, filepath.FromSlash(Dir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := filepath.Join(dir, "orch-scout.toml")
+	if err := os.WriteFile(stale, []byte("stale content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := Render(defaultCodexHost())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if err := Write(root, files); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := os.ReadFile(stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), "stale content") {
+		t.Error("stale content survived Write")
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -74,6 +74,7 @@ func commands() []command {
 		{"resume", "Reconcile an interrupted Delivery run against GitHub and continue", runResume},
 		{"abort", "Stop dispatch and return to Assist", noArgs("abort", runAbort)},
 		{"metrics", "Show local metrics", noArgs("metrics", cmdMetrics)},
+		{"render-agents", "Render the five Codex agent TOMLs from configuration into .codex/agents/", noArgs("render-agents", runRenderAgents)},
 		{"run", "Adapter plumbing: Delivery run verbs (JSON stdin/stdout; not a human command)", runRunVerb},
 		{"guard", "Adapter plumbing: pre-write enforcement for host hooks (not a human command)", runGuard},
 		{"hook", "Adapter plumbing: host lifecycle-event verbs (not a human command)", runHook},

--- a/internal/cli/renderagents.go
+++ b/internal/cli/renderagents.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/kninetimmy/orch/internal/agents"
+	"github.com/kninetimmy/orch/internal/config"
+)
+
+// runRenderAgents implements `orch render-agents` (PRD §22): it loads
+// the effective configuration (config.Load: committed config.toml plus
+// any config.local.toml overlay) and, when hosts.codex is enabled,
+// renders the five Codex agent TOMLs into <repo>/.codex/agents/ from
+// hosts.codex.roles — the mechanical alternative to hand-editing the
+// installed TOMLs adapters/codex/README.md's install step 4 and known
+// limitations both point to. It fails closed (config.Load already
+// fails closed on a missing or invalid configuration) when the repo is
+// not orch-initialized, the configuration is invalid, or hosts.codex
+// is not enabled.
+func runRenderAgents(env Env) error {
+	cfg, err := config.Load(env.RepoRoot)
+	if err != nil {
+		return err
+	}
+	if cfg.Hosts.Codex == nil {
+		return fmt.Errorf("hosts.codex is not enabled in configuration; enable it with `orch configure` before running `orch render-agents`")
+	}
+
+	files, err := agents.Render(cfg.Hosts.Codex)
+	if err != nil {
+		return err
+	}
+	if err := agents.Write(env.RepoRoot, files); err != nil {
+		return err
+	}
+	for _, f := range files {
+		fmt.Fprintf(env.Stdout, "wrote %s/%s.toml\n", agents.Dir, f.Name)
+	}
+	return nil
+}

--- a/internal/cli/renderagents_test.go
+++ b/internal/cli/renderagents_test.go
@@ -1,0 +1,249 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/kninetimmy/orch/adapters/codex"
+	"github.com/kninetimmy/orch/internal/agents"
+)
+
+// validCodexTOML is a minimal valid configuration enabling only the
+// codex host, at the PRD §10 default model profile (the same values
+// adaptertest.Profile("codex") and adapters/codex/plugin_test.go's
+// TestAgentTOMLs pin the shipped files against).
+const validCodexTOML = `
+schema_version  = 1
+config_revision = "r1"
+
+[memhub]
+mode = "off"
+
+[hosts.codex.roles.architect]
+model  = "gpt-5.6-sol"
+effort = "high"
+
+[hosts.codex.roles.scout]
+model  = "gpt-5.6-terra"
+effort = "low"
+
+[hosts.codex.roles.implementer]
+model  = "gpt-5.6-terra"
+effort = "high"
+
+[hosts.codex.roles.specialist]
+model  = "gpt-5.6-sol"
+effort = "medium"
+
+[hosts.codex.roles.reviewer]
+model  = "gpt-5.6-sol"
+effort = "medium"
+
+[hosts.codex.roles.review_downgrade]
+model  = "gpt-5.6-terra"
+effort = "high"
+`
+
+// validCodexOverrideTOML enables only the codex host with model/effort
+// values that diverge from the PRD §10 defaults.
+const validCodexOverrideTOML = `
+schema_version  = 1
+config_revision = "r1"
+
+[memhub]
+mode = "off"
+
+[hosts.codex.roles.architect]
+model  = "gpt-9000-ultra"
+effort = "high"
+
+[hosts.codex.roles.scout]
+model  = "gpt-9000"
+effort = "low"
+
+[hosts.codex.roles.implementer]
+model  = "gpt-9000"
+effort = "high"
+
+[hosts.codex.roles.specialist]
+model  = "gpt-9000-ultra"
+effort = "medium"
+
+[hosts.codex.roles.reviewer]
+model  = "gpt-9000-ultra"
+effort = "medium"
+
+[hosts.codex.roles.review_downgrade]
+model  = "gpt-9000"
+effort = "high"
+`
+
+var renderedAgentFiles = []string{
+	"orch-scout", "orch-implementer", "orch-specialist", "orch-reviewer", "orch-reviewer-safe",
+}
+
+func TestRenderAgentsNotInitialized(t *testing.T) {
+	env, _, stderr := testEnv(t)
+	if code := Run([]string{"render-agents"}, env); code != ExitError {
+		t.Errorf("exit = %d, want %d", code, ExitError)
+	}
+	if !strings.Contains(stderr.String(), "not initialized") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRenderAgentsInvalidConfig(t *testing.T) {
+	env, _, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, "schema_version = 1\n")
+	if code := Run([]string{"render-agents"}, env); code != ExitError {
+		t.Errorf("exit = %d, want %d", code, ExitError)
+	}
+	if !strings.Contains(stderr.String(), "invalid configuration") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRenderAgentsCodexDisabledRefusal(t *testing.T) {
+	env, _, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML) // claude-only fixture
+	if code := Run([]string{"render-agents"}, env); code != ExitError {
+		t.Errorf("exit = %d, want %d", code, ExitError)
+	}
+	if !strings.Contains(stderr.String(), "hosts.codex is not enabled") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(env.RepoRoot, filepath.FromSlash(agents.Dir))); !os.IsNotExist(err) {
+		t.Errorf(".codex/agents exists after refusal (stat err = %v), want absent", err)
+	}
+}
+
+func TestRenderAgentsUnexpectedArgument(t *testing.T) {
+	env, _, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validCodexTOML)
+	if code := Run([]string{"render-agents", "extra"}, env); code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
+	}
+	if !strings.Contains(stderr.String(), "unexpected argument") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRenderAgentsDefaultProfileByteIdentical(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validCodexTOML)
+	if code := Run([]string{"render-agents"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+
+	dir := filepath.Join(env.RepoRoot, filepath.FromSlash(agents.Dir))
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 5 {
+		t.Fatalf("wrote %d files, want 5", len(entries))
+	}
+
+	for _, name := range renderedAgentFiles {
+		got, err := os.ReadFile(filepath.Join(dir, name+".toml"))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		want, err := codex.AgentTOMLs.ReadFile("agents/" + name + ".toml")
+		if err != nil {
+			t.Fatalf("read shipped %s: %v", name, err)
+		}
+		if string(got) != string(want) {
+			t.Errorf("%s.toml does not match shipped file", name)
+		}
+		if !strings.Contains(stdout.String(), "wrote "+agents.Dir+"/"+name+".toml") {
+			t.Errorf("stdout missing write confirmation for %s:\n%s", name, stdout.String())
+		}
+	}
+}
+
+type renderedAgentTOML struct {
+	Name                  string `toml:"name"`
+	Description           string `toml:"description"`
+	DeveloperInstructions string `toml:"developer_instructions"`
+	Model                 string `toml:"model"`
+	ModelReasoningEffort  string `toml:"model_reasoning_effort"`
+}
+
+func TestRenderAgentsOverrideSubstitution(t *testing.T) {
+	env, _, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validCodexOverrideTOML)
+	if code := Run([]string{"render-agents"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d", code, ExitOK)
+	}
+
+	dir := filepath.Join(env.RepoRoot, filepath.FromSlash(agents.Dir))
+	want := map[string]struct{ model, effort string }{
+		"orch-scout":         {"gpt-9000", "low"},
+		"orch-implementer":   {"gpt-9000", "high"},
+		"orch-specialist":    {"gpt-9000-ultra", "medium"},
+		"orch-reviewer":      {"gpt-9000-ultra", "medium"},
+		"orch-reviewer-safe": {"gpt-9000", "high"},
+	}
+	for name, wp := range want {
+		data, err := os.ReadFile(filepath.Join(dir, name+".toml"))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		var a renderedAgentTOML
+		if _, err := toml.Decode(string(data), &a); err != nil {
+			t.Fatalf("decode %s: %v", name, err)
+		}
+		if a.Model != wp.model {
+			t.Errorf("%s: model = %q, want %q", name, a.Model, wp.model)
+		}
+		if a.ModelReasoningEffort != wp.effort {
+			t.Errorf("%s: model_reasoning_effort = %q, want %q", name, a.ModelReasoningEffort, wp.effort)
+		}
+		if a.Name != name {
+			t.Errorf("%s: name = %q, want %q", name, a.Name, name)
+		}
+		if a.Description == "" || a.DeveloperInstructions == "" {
+			t.Errorf("%s: description or developer_instructions empty", name)
+		}
+	}
+}
+
+// TestRenderAgentsOverwritesStaleFile asserts a second run replaces
+// hand-edited content rather than leaving it in place.
+func TestRenderAgentsOverwritesStaleFile(t *testing.T) {
+	env, _, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validCodexTOML)
+	dir := filepath.Join(env.RepoRoot, filepath.FromSlash(agents.Dir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "orch-scout.toml"), []byte("hand-edited"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := Run([]string{"render-agents"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d", code, ExitOK)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "orch-scout.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), "hand-edited") {
+		t.Error("hand-edited content survived render-agents")
+	}
+}
+
+func TestRenderAgentsInHelp(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	if code := Run([]string{"help"}, env); code != ExitOK {
+		t.Errorf("exit = %d, want %d", code, ExitOK)
+	}
+	if !strings.Contains(stdout.String(), "render-agents") {
+		t.Errorf("help output missing render-agents:\n%s", stdout.String())
+	}
+}


### PR DESCRIPTION
Delivers issue #39: Add orch render-agents: render Codex agent TOMLs from config

Closes #39

**Plan digest:** `sha256:18854e68c574a9283e8cabe5fc1314c89f84d439e08ab363f379d76940c30e2d`

The full objective and acceptance criteria are on the linked issue.

<!-- orch:manifest:begin -->
### Orch audit record

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-4-8` — effort `xhigh` |
| Config revision | `sha256:9b47b44bb3c7` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **build** — pass — `go build ./...` — no output, exit 0 (run in worktree at fbbad34) (2026-07-13T15:21:46Z)
- **vet** — pass — `go vet ./...` — no output, exit 0 (2026-07-13T15:21:46Z)
- **test** — pass — `go test ./...` — all packages ok, including adapters/codex TestAgentTOMLs (5 subtests) and new internal/agents + internal/cli render-agents tests (2026-07-13T15:21:46Z)
- **gofmt** — pass — `gofmt -l .` — no files listed (clean) (2026-07-13T15:21:46Z)
- **review-cycle-1** — approve — All nine acceptance criteria verified met at fbbad344, with build/vet/test/gofmt re-run independently (all green) and CI passing on all platforms. Substitution is header-scoped and fails closed on zero-or-many header-line matches; writes are atomic temp+rename; exit codes (1 fail-closed, 2 usage) individually pinned by tests; the shipped adapters/codex/agents TOMLs are the single go:embed canonical source so rendered output cannot diverge without a test failure; PRD section 22 and Codex README updates accurate; PR manifest honest. Two non-blocking theoretical notes recorded (Go %q vs TOML escaping for control-character model names; engine-imports-adapter dependency edge accepted as the mechanism for the single-source requirement). (2026-07-13T15:26:40Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, test (macos-latest)=pass, test (windows-latest)=pass, scripts (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass (2026-07-13T15:30:14Z)

<!-- orch:manifest:data
{
  "schema_version": 1,
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-4-8",
    "effort": "xhigh"
  },
  "config_revision": "sha256:9b47b44bb3c7",
  "verifications": [
    {
      "name": "build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "no output, exit 0 (run in worktree at fbbad34)",
      "at": "2026-07-13T15:21:46Z"
    },
    {
      "name": "vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "no output, exit 0",
      "at": "2026-07-13T15:21:46Z"
    },
    {
      "name": "test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "all packages ok, including adapters/codex TestAgentTOMLs (5 subtests) and new internal/agents + internal/cli render-agents tests",
      "at": "2026-07-13T15:21:46Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "no files listed (clean)",
      "at": "2026-07-13T15:21:46Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "All nine acceptance criteria verified met at fbbad344, with build/vet/test/gofmt re-run independently (all green) and CI passing on all platforms. Substitution is header-scoped and fails closed on zero-or-many header-line matches; writes are atomic temp+rename; exit codes (1 fail-closed, 2 usage) individually pinned by tests; the shipped adapters/codex/agents TOMLs are the single go:embed canonical source so rendered output cannot diverge without a test failure; PRD section 22 and Codex README updates accurate; PR manifest honest. Two non-blocking theoretical notes recorded (Go %q vs TOML escaping for control-character model names; engine-imports-adapter dependency edge accepted as the mechanism for the single-source requirement).",
      "at": "2026-07-13T15:26:40Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, test (macos-latest)=pass, test (windows-latest)=pass, scripts (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass",
      "at": "2026-07-13T15:30:14Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->