### PR TITLE
ghops.RequiredCI: treat empty stdout from gh pr checks --required as an empty required set

### DIFF
--- a/internal/ghops/checks.go
+++ b/internal/ghops/checks.go
@@ -73,6 +73,11 @@ func (g *GH) RequiredCI(ctx context.Context, number int) (CISummary, error) {
 		// the human-output mode; with --json, gh 2.87.3 exits 0 in
 		// every state (verified live, fact 17). All three are accepted
 		// so the state derivation below owns the signal either way.
+		// When the repo has checks but branch protection marks none of
+		// them required, gh 2.87.3 exits 0 with empty stdout (not `[]`)
+		// and the stderr notice "no required checks reported on the
+		// '<branch>' branch" (verified live, dogfooded run #1). Treat
+		// that as zero required checks rather than a parse failure.
 	default:
 		return CISummary{}, fmt.Errorf("gh pr checks in %s exited %d: %s", g.root, res.ExitCode, strings.TrimSpace(res.Stderr))
 	}
@@ -82,8 +87,10 @@ func (g *GH) RequiredCI(ctx context.Context, number int) (CISummary, error) {
 		Bucket string `json:"bucket"`
 		Link   string `json:"link"`
 	}
-	if err := json.Unmarshal([]byte(res.Stdout), &decoded); err != nil {
-		return CISummary{}, fmt.Errorf("gh pr checks in %s returned unparsable JSON: %w", g.root, err)
+	if trimmed := strings.TrimSpace(res.Stdout); trimmed != "" {
+		if err := json.Unmarshal([]byte(trimmed), &decoded); err != nil {
+			return CISummary{}, fmt.Errorf("gh pr checks in %s returned unparsable JSON: %w", g.root, err)
+		}
 	}
 	required := make([]Check, len(decoded))
 	for i, c := range decoded {

--- a/internal/ghops/checks_test.go
+++ b/internal/ghops/checks_test.go
@@ -112,6 +112,65 @@ func TestRequiredCINoneRequired(t *testing.T) {
 	}
 }
 
+// TestRequiredCINoRequiredChecksDiscoveryEmptyStdout pins the gh 2.87.3
+// shape discovered live in this repo's first dogfooded Delivery run:
+// a repo with CI checks but none marked required by branch protection
+// makes `pr checks --required` exit 0 with empty stdout (not `[]`)
+// and the stderr notice below, rather than the `[]` this package's
+// other no-required-checks test scripts.
+func TestRequiredCINoRequiredChecksDiscoveryEmptyStdout(t *testing.T) {
+	root := tempRoot(t)
+	call := checksCall(root, "", 0)
+	call.Stderr = "no required checks reported on the 'main' branch"
+	g, script := openScripted(t, root,
+		rollupCall(root, `{"statusCheckRollup":[{},{}]}`),
+		call,
+	)
+	sum, err := g.RequiredCI(context.Background(), 43)
+	if err != nil {
+		t.Fatalf("RequiredCI: %v", err)
+	}
+	script.AssertExhausted()
+	if sum.State != CINoChecks || sum.Total != 2 || len(sum.Required) != 0 {
+		t.Errorf("sum = %+v, want no-checks with Total 2 and no required checks", sum)
+	}
+}
+
+// TestRequiredCIWhitespaceOnlyStdout confirms whitespace-only stdout
+// (e.g. a stray newline) is treated the same as truly empty stdout,
+// not as malformed JSON.
+func TestRequiredCIWhitespaceOnlyStdout(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root,
+		rollupCall(root, `{"statusCheckRollup":[{},{}]}`),
+		checksCall(root, "\n  \t\n", 0),
+	)
+	sum, err := g.RequiredCI(context.Background(), 43)
+	if err != nil {
+		t.Fatalf("RequiredCI: %v", err)
+	}
+	script.AssertExhausted()
+	if sum.State != CINoChecks || sum.Total != 2 || len(sum.Required) != 0 {
+		t.Errorf("sum = %+v, want no-checks with Total 2 and no required checks", sum)
+	}
+}
+
+// TestRequiredCIMalformedStdout confirms non-empty stdout that isn't
+// valid JSON still fails closed rather than being silently treated as
+// no required checks.
+func TestRequiredCIMalformedStdout(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root,
+		rollupCall(root, `{"statusCheckRollup":[{}]}`),
+		checksCall(root, "not json", 0),
+	)
+	_, err := g.RequiredCI(context.Background(), 43)
+	script.AssertExhausted()
+	if err == nil || !strings.Contains(err.Error(), "returned unparsable JSON") {
+		t.Fatalf("err = %v, want unparsable JSON error", err)
+	}
+}
+
 func TestRequiredCIUnexpectedExit(t *testing.T) {
 	root := tempRoot(t)
 	g, script := openScripted(t, root,


### PR DESCRIPTION
Delivers issue #42: ghops.RequiredCI: treat empty stdout from gh pr checks --required as an empty required set

Closes #42

**Plan digest:** `sha256:9378ca6a9e810d74b77ed67cb786ac1743f56c8deaa830db5c2ddd242ab812f9`

The full objective and acceptance criteria are on the linked issue.

<!-- orch:manifest:begin -->
### Orch audit record

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-sonnet-5` — effort `high` |
| Config revision | `sha256:9b47b44bb3c7` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **build** — pass — `go build ./...` — no output, exit 0 (worktree at 9bb3b8c) (2026-07-13T16:00:01Z)
- **vet** — pass — `go vet ./...` — no output, exit 0 (2026-07-13T16:00:01Z)
- **test** — pass — `go test ./...` — all packages ok; 9 RequiredCI tests pass individually incl. 3 new (empty stdout, whitespace-only, malformed non-empty) (2026-07-13T16:00:01Z)
- **gofmt** — pass — `gofmt -l .` — no files listed (clean) (2026-07-13T16:00:01Z)
- **review-cycle-1** — approve — All six acceptance criteria met at 9bb3b8c, verified with independent build/vet/test/gofmt runs (green, CI 6/6): empty and whitespace-only stdout from the --required probe now derive CINoChecks with the rollup Total via the existing deriveCIState path, malformed non-empty stdout still fails closed with the unchanged unparsable-JSON error, three new scripted-transcript tests faithfully pin the live gh 2.87.3 shape including the stderr notice, the existing []-shape test is byte-for-byte untouched, and the diff is exactly checks.go plus checks_test.go. The reviewer confirmed the section 10 safe-downgrade framing held: the change is mechanical and required no unrouted judgment. Two non-blocking nits recorded (comment cites 'dogfooded run #1' rather than a fact number; the new test's doc comment describes but does not name task 38). (2026-07-13T16:05:36Z)
- **required-ci** — passing — test (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass (2026-07-13T16:05:44Z)

<!-- orch:manifest:data
{
  "schema_version": 1,
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "claude-sonnet-5",
    "effort": "high"
  },
  "config_revision": "sha256:9b47b44bb3c7",
  "verifications": [
    {
      "name": "build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "no output, exit 0 (worktree at 9bb3b8c)",
      "at": "2026-07-13T16:00:01Z"
    },
    {
      "name": "vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "no output, exit 0",
      "at": "2026-07-13T16:00:01Z"
    },
    {
      "name": "test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "all packages ok; 9 RequiredCI tests pass individually incl. 3 new (empty stdout, whitespace-only, malformed non-empty)",
      "at": "2026-07-13T16:00:01Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "no files listed (clean)",
      "at": "2026-07-13T16:00:01Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "All six acceptance criteria met at 9bb3b8c, verified with independent build/vet/test/gofmt runs (green, CI 6/6): empty and whitespace-only stdout from the --required probe now derive CINoChecks with the rollup Total via the existing deriveCIState path, malformed non-empty stdout still fails closed with the unchanged unparsable-JSON error, three new scripted-transcript tests faithfully pin the live gh 2.87.3 shape including the stderr notice, the existing []-shape test is byte-for-byte untouched, and the diff is exactly checks.go plus checks_test.go. The reviewer confirmed the section 10 safe-downgrade framing held: the change is mechanical and required no unrouted judgment. Two non-blocking nits recorded (comment cites 'dogfooded run #1' rather than a fact number; the new test's doc comment describes but does not name task 38).",
      "at": "2026-07-13T16:05:36Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "at": "2026-07-13T16:05:44Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->