### PR TITLE
Add a newer-release-available check to orch doctor

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -95,6 +95,13 @@ type fakeRunner struct {
 	memhubStatusStderr string
 	memhubRecallExit   int
 	memhubRecallStderr string
+	// releaseTag, releaseExit, and releaseStderr script the release
+	// check's `gh api .../releases/latest` call (zero releaseExit with
+	// an empty releaseTag reports "v0.0.0-test", a harmless default
+	// only reachable by tests that stamp Version).
+	releaseTag    string
+	releaseExit   int
+	releaseStderr string
 }
 
 func (f fakeRunner) Run(_ context.Context, c execx.Cmd) (execx.Result, error) {
@@ -120,6 +127,15 @@ func (f fakeRunner) Run(_ context.Context, c execx.Cmd) (execx.Result, error) {
 				j = `{"nameWithOwner":"o/r","defaultBranchRef":{"name":"main"},"url":"https://github.com/o/r"}`
 			}
 			return execx.Result{Stdout: j}, nil
+		case "api":
+			if f.releaseExit != 0 {
+				return execx.Result{Stderr: f.releaseStderr, ExitCode: f.releaseExit}, nil
+			}
+			tag := f.releaseTag
+			if tag == "" {
+				tag = "v0.0.0-test"
+			}
+			return execx.Result{Stdout: tag + "\n"}, nil
 		}
 	case "memhub":
 		switch c.Args[0] {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -56,6 +56,22 @@ func runDoctor(env Env) error {
 			default:
 				fmt.Fprintf(env.Stdout, "ok    gh repository: %s\n", repo.NameWithOwner)
 			}
+
+			// Best-effort per task 39: a broken network, missing
+			// release, or malformed response degrades to a note and
+			// never fails doctor. Skipped entirely on unstamped "dev"
+			// builds, which have nothing meaningful to compare.
+			if Version != "dev" {
+				latest, relErr := ghops.LatestRelease(context.Background(), env.Runner, env.RepoRoot)
+				switch {
+				case relErr != nil:
+					fmt.Fprintf(env.Stdout, "note  release check: %v\n", relErr)
+				case latest != Version:
+					fmt.Fprintf(env.Stdout, "note  newer release available: installed %s, latest %s; re-run the installer to update\n", Version, latest)
+				default:
+					fmt.Fprintf(env.Stdout, "ok    release: up to date (%s)\n", Version)
+				}
+			}
 		}
 	}
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -287,6 +287,73 @@ func exitedPID(t *testing.T) int {
 	return pid
 }
 
+func TestDoctorReleaseCheckSkippedOnDevVersion(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	// Version defaults to "dev" (no test in this package stamps it
+	// beforehand), so the release check must not run at all.
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	out := stdout.String()
+	if strings.Contains(out, "release") {
+		t.Errorf("release check ran on a dev build:\n%s", out)
+	}
+}
+
+func TestDoctorReleaseCheckUpToDate(t *testing.T) {
+	old := Version
+	Version = "v1.2.3"
+	t.Cleanup(func() { Version = old })
+
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	env.Runner = fakeRunner{toplevel: env.RepoRoot, releaseTag: "v1.2.3"}
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "ok    release: up to date (v1.2.3)") {
+		t.Errorf("stdout missing up-to-date release note:\n%s", stdout.String())
+	}
+}
+
+func TestDoctorReleaseCheckNewerAvailable(t *testing.T) {
+	old := Version
+	Version = "v1.2.3"
+	t.Cleanup(func() { Version = old })
+
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	env.Runner = fakeRunner{toplevel: env.RepoRoot, releaseTag: "v1.3.0"}
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "note  newer release available: installed v1.2.3, latest v1.3.0; re-run the installer to update") {
+		t.Errorf("stdout missing newer-release note:\n%s", out)
+	}
+}
+
+func TestDoctorReleaseCheckQueryFailureDegradesToNote(t *testing.T) {
+	old := Version
+	Version = "v1.2.3"
+	t.Cleanup(func() { Version = old })
+
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	env.Runner = fakeRunner{toplevel: env.RepoRoot, releaseExit: 1, releaseStderr: "HTTP 500: internal error"}
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (release check must never fail doctor)\n%s", code, ExitOK, stdout.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "note  release check:") {
+		t.Errorf("stdout missing release-failure note:\n%s", out)
+	}
+	if strings.Contains(out, "FAIL") {
+		t.Errorf("release query failure produced a FAIL line:\n%s", out)
+	}
+}
+
 func TestDoctorNotesLocalOverride(t *testing.T) {
 	env, stdout, _ := testEnv(t)
 	writeConfig(t, env.RepoRoot, validTOML)

--- a/internal/ghops/release.go
+++ b/internal/ghops/release.go
@@ -1,0 +1,46 @@
+package ghops
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kninetimmy/orch/internal/execx"
+)
+
+// UpstreamRepo is the fixed github.com/kninetimmy/orch repository
+// whose release cadence orch checks itself against. It is never the
+// working repository (which may be an unrelated project, or orch
+// itself under active development), so LatestRelease takes no GH
+// receiver and does not resolve a repo from the working directory.
+const UpstreamRepo = "kninetimmy/orch"
+
+// LatestRelease returns the tag name of UpstreamRepo's latest
+// published release via `gh api .../releases/latest`, read through
+// --jq so the tag is extracted machine-side rather than parsed from
+// human-readable output. It is a standalone function rather than a GH
+// method: the query is fixed to UpstreamRepo regardless of which
+// repository dir belongs to, so it needs only an injected
+// execx.Runner and a working directory for the invocation (gh
+// requires one; the query itself does not depend on it). Any error —
+// gh missing, unauthenticated, offline, or a malformed response — is
+// returned as data for the caller to degrade, never panics or exits.
+func LatestRelease(ctx context.Context, r execx.Runner, dir string) (string, error) {
+	res, err := r.Run(ctx, execx.Cmd{
+		Name: "gh",
+		Args: []string{"api", "repos/" + UpstreamRepo + "/releases/latest", "--jq", ".tag_name"},
+		Dir:  dir,
+		Env:  ghEnv,
+	})
+	if err != nil {
+		return "", err
+	}
+	if res.ExitCode != 0 {
+		return "", fmt.Errorf("gh api repos/%s/releases/latest exited %d: %s", UpstreamRepo, res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	tag := strings.TrimSpace(res.Stdout)
+	if tag == "" {
+		return "", fmt.Errorf("gh api repos/%s/releases/latest returned no tag_name", UpstreamRepo)
+	}
+	return tag, nil
+}

--- a/internal/ghops/release_test.go
+++ b/internal/ghops/release_test.go
@@ -1,0 +1,70 @@
+package ghops
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+)
+
+func TestLatestRelease(t *testing.T) {
+	root := tempRoot(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name:   "gh",
+		Args:   []string{"api", "repos/" + UpstreamRepo + "/releases/latest", "--jq", ".tag_name"},
+		Dir:    root,
+		Env:    ghTestEnv,
+		Stdout: "v0.2.0\n",
+	}}}
+	tag, err := LatestRelease(context.Background(), script, root)
+	if err != nil {
+		t.Fatalf("LatestRelease: %v", err)
+	}
+	if tag != "v0.2.0" {
+		t.Errorf("tag = %q, want %q", tag, "v0.2.0")
+	}
+	script.AssertExhausted()
+}
+
+func TestLatestReleaseNonZeroExit(t *testing.T) {
+	root := tempRoot(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name:   "gh",
+		Args:   []string{"api", "repos/" + UpstreamRepo + "/releases/latest", "--jq", ".tag_name"},
+		Dir:    root,
+		Env:    ghTestEnv,
+		Stderr: "HTTP 404: Not Found",
+		Exit:   1,
+	}}}
+	if _, err := LatestRelease(context.Background(), script, root); err == nil {
+		t.Fatal("LatestRelease: want error on non-zero exit")
+	}
+}
+
+func TestLatestReleaseEmptyTag(t *testing.T) {
+	root := tempRoot(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name: "gh",
+		Args: []string{"api", "repos/" + UpstreamRepo + "/releases/latest", "--jq", ".tag_name"},
+		Dir:  root,
+		Env:  ghTestEnv,
+	}}}
+	if _, err := LatestRelease(context.Background(), script, root); err == nil {
+		t.Fatal("LatestRelease: want error on empty tag_name")
+	}
+}
+
+func TestLatestReleaseRunnerError(t *testing.T) {
+	root := tempRoot(t)
+	sentinel := errors.New("spawn failed")
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name: "gh",
+		Args: []string{"api", "repos/" + UpstreamRepo + "/releases/latest", "--jq", ".tag_name"},
+		Err:  sentinel,
+	}}}
+	_, err := LatestRelease(context.Background(), script, root)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want wrapped runner error", err)
+	}
+}


### PR DESCRIPTION
Delivers issue #45: Add a newer-release-available check to orch doctor

Closes #45

**Plan digest:** `sha256:74f77320cd638b7ea4f5e62355f34bb07281d1ab4c8e51feea8abb4b59416ac7`

The full objective and acceptance criteria are on the linked issue.

<!-- orch:manifest:begin -->
### Orch audit record

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-4-8` — effort `xhigh` |
| Config revision | `sha256:9b47b44bb3c7` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.

**Escalations:** _none_

**Verification:**
- **go build** — pass — `go build ./...` — no output; all packages build (2026-07-13T16:57:49Z)
- **go vet** — pass — `go vet ./...` — no output (2026-07-13T16:57:49Z)
- **go test** — pass — `go test ./...` — all 20 packages ok, including new internal/cli doctor release-check tests and internal/ghops release tests (2026-07-13T16:57:49Z)
- **gofmt** — pass — `gofmt -l .` — no files listed; formatting clean (2026-07-13T16:57:49Z)
- **review-cycle-1** — approve — Consolidated opus-4-8/xhigh review: all six acceptance criteria met with evidence. Standalone policy-free ghops.LatestRelease queries the fixed upstream repo via the injected runner with a pinned argument vector (no net/http); doctor gates the check on stamped Version + gh presence + auth, emits exactly the specified note/ok lines, and can never FAIL or affect exit code (never touches the check closure). Scope tight (5 files, single commit), tests pin argv transcript and exit-0-on-failure behavior, no security concerns (compile-time const only in argv), manifest accurate, best-effort inversion justified in a comment. Non-blocking notes: context.Background matches existing doctor probes; installed-ahead-of-latest prints the note per spec; macOS/Windows CI legs were still queued at review time — confirm green before merge. (2026-07-13T17:01:41Z)
- **required-ci** — passing — test (macos-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass (2026-07-13T17:01:53Z)

<!-- orch:manifest:data
{
  "schema_version": 1,
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.",
  "reviewer": {
    "model": "claude-opus-4-8",
    "effort": "xhigh"
  },
  "config_revision": "sha256:9b47b44bb3c7",
  "verifications": [
    {
      "name": "go build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "no output; all packages build",
      "at": "2026-07-13T16:57:49Z"
    },
    {
      "name": "go vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "no output",
      "at": "2026-07-13T16:57:49Z"
    },
    {
      "name": "go test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "all 20 packages ok, including new internal/cli doctor release-check tests and internal/ghops release tests",
      "at": "2026-07-13T16:57:49Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "no files listed; formatting clean",
      "at": "2026-07-13T16:57:49Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Consolidated opus-4-8/xhigh review: all six acceptance criteria met with evidence. Standalone policy-free ghops.LatestRelease queries the fixed upstream repo via the injected runner with a pinned argument vector (no net/http); doctor gates the check on stamped Version + gh presence + auth, emits exactly the specified note/ok lines, and can never FAIL or affect exit code (never touches the check closure). Scope tight (5 files, single commit), tests pin argv transcript and exit-0-on-failure behavior, no security concerns (compile-time const only in argv), manifest accurate, best-effort inversion justified in a comment. Non-blocking notes: context.Background matches existing doctor probes; installed-ahead-of-latest prints the note per spec; macOS/Windows CI legs were still queued at review time — confirm green before merge.",
      "at": "2026-07-13T17:01:41Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (macos-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "at": "2026-07-13T17:01:53Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->