### PR TITLE
Carry the approved work and honest effort delivery through the manifest and dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,10 +339,11 @@ alone via the routing table — the model never picks its own reviewer.
 The gate also runs the memhub health/recall check described above,
 gated by `memhub.mode`. Activation then creates the GitHub label
 taxonomy, one issue per task carrying a structured **audit record**
-(rendered markdown plus canonical JSON in a managed body region —
-exact model, effort, and routing rationale, mirrored onto the PR), and
-one branch + isolated worktree per issue under
-`.orchestrator/worktrees/`.
+(rendered markdown plus canonical JSON in a managed body region — the
+approved objective, acceptance criteria, and required tests, plus the
+exact model, effort, how the host actually delivered that effort, and
+the routing rationale, mirrored onto the PR), and one branch +
+isolated worktree per issue under `.orchestrator/worktrees/`.
 
 Each issue then walks a closed lifecycle driven by plumbing verbs:
 `dispatch` (dependencies must be merged; branch fast-forwarded onto

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -131,9 +131,11 @@ Work issues in wave order, never more than `concurrency.max_subagents`
 in flight at once. For each issue:
 
 1. **Dispatch** — `orch run dispatch` with
-   `{"schema_version": 1, "issue_number": N}`. Result
+   `{"schema_version": 2, "issue_number": N}`. Result
    (`DispatchResult`): `branch`, `worktree`, `executor`, `reviewer`,
-   `rationale`.
+   `rationale`, `objective`, `acceptance_criteria`, `required_tests`.
+   The last three are the approved plan text; transcribe them into the
+   spawn prompt verbatim, never from memory or paraphrase.
 
 2. **Spawn the executor** — spawn `orch-implementer` or
    `orch-specialist` (per the routed role) via the Task tool, passing
@@ -151,8 +153,9 @@ in flight at once. For each issue:
    depth for this task."; `low` → "Work fast and economically; this
    task does not need deep reasoning." (The exact routed effort is
    recorded server-side regardless; this cue only shapes in-session
-   behavior.) Include the worktree path, branch, objective, acceptance
-   criteria, and required tests in the prompt.
+   behavior.) Include the worktree path, branch, and `DispatchResult`'s
+   `objective`, `acceptance_criteria`, and `required_tests` in the
+   prompt.
 
    Before spawning, you (the Architect) perform whatever memhub recall
    is relevant to the issue, with the main checkout as cwd — never a

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -134,8 +134,6 @@ in flight at once. For each issue:
    `{"schema_version": 2, "issue_number": N}`. Result
    (`DispatchResult`): `branch`, `worktree`, `executor`, `reviewer`,
    `rationale`, `objective`, `acceptance_criteria`, `required_tests`.
-   The last three are the approved plan text; transcribe them into the
-   spawn prompt verbatim, never from memory or paraphrase.
 
 2. **Spawn the executor** — spawn `orch-implementer` or
    `orch-specialist` (per the routed role) via the Task tool, passing
@@ -153,9 +151,8 @@ in flight at once. For each issue:
    depth for this task."; `low` → "Work fast and economically; this
    task does not need deep reasoning." (The exact routed effort is
    recorded server-side regardless; this cue only shapes in-session
-   behavior.) Include the worktree path, branch, and `DispatchResult`'s
-   `objective`, `acceptance_criteria`, and `required_tests` in the
-   prompt.
+   behavior.) Include the worktree path, branch, objective, acceptance
+   criteria, and required tests in the prompt.
 
    Before spawning, you (the Architect) perform whatever memhub recall
    is relevant to the issue, with the main checkout as cwd — never a

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -135,8 +135,6 @@ in flight at once. For each issue:
    `{"schema_version": 2, "issue_number": N}`. Result
    (`DispatchResult`): `branch`, `worktree`, `executor`, `reviewer`,
    `rationale`, `objective`, `acceptance_criteria`, `required_tests`.
-   The last three are the approved plan text; transcribe them into the
-   dispatch prompt verbatim, never from memory or paraphrase.
 
 2. **Dispatch the executor** — dispatch `orch-implementer` or
    `orch-specialist` (per the routed role) by naming the agent in your
@@ -159,8 +157,8 @@ in flight at once. For each issue:
    Effort is a real host parameter on Codex, pinned in the dispatched
    agent's own TOML — there is no prompt cue to layer on top of it; the
    opening line is a statement of fact, not a behavioral nudge. Include
-   the worktree path, branch, and `DispatchResult`'s `objective`,
-   `acceptance_criteria`, and `required_tests` in the prompt.
+   the worktree path, branch, objective, acceptance criteria, and
+   required tests in the prompt.
 
    Before dispatching, you (the Architect) perform whatever memhub
    recall is relevant to the issue, with the main checkout as cwd —

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -132,9 +132,11 @@ Work issues in wave order, never more than `concurrency.max_subagents`
 in flight at once. For each issue:
 
 1. **Dispatch** — `orch run dispatch` with
-   `{"schema_version": 1, "issue_number": N}`. Result
+   `{"schema_version": 2, "issue_number": N}`. Result
    (`DispatchResult`): `branch`, `worktree`, `executor`, `reviewer`,
-   `rationale`.
+   `rationale`, `objective`, `acceptance_criteria`, `required_tests`.
+   The last three are the approved plan text; transcribe them into the
+   dispatch prompt verbatim, never from memory or paraphrase.
 
 2. **Dispatch the executor** — dispatch `orch-implementer` or
    `orch-specialist` (per the routed role) by naming the agent in your
@@ -157,8 +159,8 @@ in flight at once. For each issue:
    Effort is a real host parameter on Codex, pinned in the dispatched
    agent's own TOML — there is no prompt cue to layer on top of it; the
    opening line is a statement of fact, not a behavioral nudge. Include
-   the worktree path, branch, objective, acceptance criteria, and
-   required tests in the prompt.
+   the worktree path, branch, and `DispatchResult`'s `objective`,
+   `acceptance_criteria`, and `required_tests` in the prompt.
 
    Before dispatching, you (the Architect) perform whatever memhub
    recall is relevant to the issue, with the main checkout as cwd —

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -122,7 +122,7 @@ func TestRunStatusNeverReadsStdin(t *testing.T) {
 // valid document yields ExitError, never ExitUsage.
 func TestRunLifecycleVerbsAreRouted(t *testing.T) {
 	verbs := map[string]string{
-		"dispatch":     `{"schema_version":1,"issue_number":1}`,
+		"dispatch":     `{"schema_version":2,"issue_number":1}`,
 		"pr-open":      `{"schema_version":1,"issue_number":1,"verifications":[{"name":"t","result":"pass"}]}`,
 		"review":       `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"h","verdict":"approve","summary":"s","reviewer":{"model":"m","effort":"e"}}`,
 		"escalate":     `{"schema_version":1,"issue_number":1,"trigger":"architectural-ambiguity","detail":"x"}`,

--- a/internal/execx/execxtest/script.go
+++ b/internal/execx/execxtest/script.go
@@ -43,7 +43,21 @@ type Script struct {
 	T     *testing.T
 	Calls []Call
 
-	next int
+	next   int
+	stdins []string
+}
+
+// StdinAt returns the standard input the i-th consumed call received
+// (0-based, "" when that call had none). It exists for bodies a test
+// wants to assert on structurally — parse the posted issue body and
+// check the record — rather than spell out byte-for-byte in a Call.Stdin
+// expectation, which would only restate the code that produced it.
+func (s *Script) StdinAt(i int) string {
+	s.T.Helper()
+	if i < 0 || i >= len(s.stdins) {
+		s.T.Fatalf("StdinAt(%d): only %d calls were made", i, len(s.stdins))
+	}
+	return s.stdins[i]
 }
 
 // Run asserts that c matches the next scripted call and returns its
@@ -67,16 +81,23 @@ func (s *Script) Run(_ context.Context, c execx.Cmd) (execx.Result, error) {
 	if want.Env != nil && !slices.Equal(c.Env, want.Env) {
 		s.T.Fatalf("call %d: %s env\ngot  %q\nwant %q", s.next, c.Name, c.Env, want.Env)
 	}
-	if want.Stdin != "" {
-		if c.Stdin == nil {
-			s.T.Fatalf("call %d: %s stdin\ngot  no stdin\nwant %q", s.next, c.Name, want.Stdin)
-		}
+	// Stdin is always drained and recorded, so StdinAt can answer for any
+	// call, not only the ones carrying an expectation.
+	stdin := ""
+	if c.Stdin != nil {
 		got, err := io.ReadAll(c.Stdin)
 		if err != nil {
 			s.T.Fatalf("call %d: %s stdin read: %v", s.next, c.Name, err)
 		}
-		if string(got) != want.Stdin {
-			s.T.Fatalf("call %d: %s stdin\ngot  %q\nwant %q", s.next, c.Name, got, want.Stdin)
+		stdin = string(got)
+	}
+	s.stdins = append(s.stdins, stdin)
+	if want.Stdin != "" {
+		if c.Stdin == nil {
+			s.T.Fatalf("call %d: %s stdin\ngot  no stdin\nwant %q", s.next, c.Name, want.Stdin)
+		}
+		if stdin != want.Stdin {
+			s.T.Fatalf("call %d: %s stdin\ngot  %q\nwant %q", s.next, c.Name, stdin, want.Stdin)
 		}
 	}
 	if want.Err != nil {

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -1,11 +1,12 @@
 // Package manifest renders and parses the PRD §13 audit record that
-// every Orch issue and PR body carries: the selected role, the exact
-// executor/reviewer model+effort, the routing rationale, escalations
-// and substitutions, the config revision, and named verification
-// commands and results. Resume/recovery (PRD §23: interrupted runs
-// resume) rebuilds run state from these posted bodies, so the record
-// must render into a managed markdown region AND parse back out
-// losslessly.
+// every Orch issue and PR body carries: the approved objective,
+// acceptance criteria, and required tests; the selected role, the exact
+// executor/reviewer model+effort and how the host actually delivered
+// that effort; the routing rationale, escalations and substitutions, the
+// config revision, and named verification commands and results.
+// Resume/recovery (PRD §23: interrupted runs resume) rebuilds run state
+// from these posted bodies, so the record must render into a managed
+// markdown region AND parse back out losslessly.
 //
 // Like gitops and ghops the package is policy-free: it owns the schema,
 // the managed region, and drift detection, while the run engine decides
@@ -33,7 +34,13 @@ import (
 // SchemaVersion is the manifest schema this build renders and parses.
 // It lives only in the JSON record (see Manifest.SchemaVersion); the
 // markers are locators, never a second source of truth.
-const SchemaVersion = 1
+//
+// v2 adds the approved work text (objective, acceptance criteria,
+// required tests) and the effort-delivery mechanism. There is no
+// migration from v1: a v1 record is missing fields v2 requires, so Parse
+// rejects it through the unsupported-version path rather than accept a
+// record whose approved work would silently read as empty.
+const SchemaVersion = 2
 
 // BeginMarker and EndMarker delimit the managed region. A line is a
 // marker only if, after stripping at most one trailing "\r", it equals
@@ -72,6 +79,26 @@ type Selection struct {
 	Effort string `json:"effort"`
 }
 
+// EffortDelivery records how the host actually applied the routed
+// reasoning effort to the executor it spawned. An effort is a real host
+// parameter on one host and only a sentence in a prompt on another, and
+// a record that names an effort without saying which implies an
+// enforcement the host may not provide. The set is closed; which value a
+// host warrants is the run engine's call, not this package's.
+type EffortDelivery string
+
+const (
+	// EffortDeliveryParameter means the host applied the routed effort as
+	// an actual model parameter (Codex pins model_reasoning_effort in the
+	// dispatched agent's own TOML).
+	EffortDeliveryParameter EffortDelivery = "parameter"
+	// EffortDeliveryPromptCue means the host has no per-spawn effort knob,
+	// so the routed effort reached the executor only as a cue in its
+	// prompt (Claude Code subagents). The recorded effort is then the
+	// routing decision, not an enforced setting.
+	EffortDeliveryPromptCue EffortDelivery = "prompt-cue"
+)
+
 // Escalation records a routing change: an escalation to a stronger
 // selection or a substitution of an equivalent one. From and To are the
 // selections before and after; At is a caller-supplied RFC3339 UTC
@@ -99,15 +126,26 @@ type Verification struct {
 // Manifest is the canonical audit record. SchemaVersion is first and
 // mandatory, exactly like internal/state: Render refuses to write and
 // Parse refuses to accept any other version rather than guess.
+//
+// Objective, AcceptanceCriteria, and RequiredTests are the approved plan
+// text verbatim. They belong in the record, not in run state alone,
+// because resume rebuilds an interrupted run's issues from these posted
+// bodies: a field held only in state comes back empty after a resume,
+// and the dispatch that follows would hand an executor an empty
+// objective without saying so.
 type Manifest struct {
-	SchemaVersion    int            `json:"schema_version"`
-	Role             Role           `json:"role"`
-	Executor         Selection      `json:"executor"`
-	RoutingRationale string         `json:"routing_rationale"`
-	Reviewer         Selection      `json:"reviewer"`
-	Escalations      []Escalation   `json:"escalations,omitempty"`
-	ConfigRevision   string         `json:"config_revision"`
-	Verifications    []Verification `json:"verifications,omitempty"`
+	SchemaVersion      int            `json:"schema_version"`
+	Objective          string         `json:"objective"`
+	AcceptanceCriteria []string       `json:"acceptance_criteria"`
+	RequiredTests      []string       `json:"required_tests"`
+	Role               Role           `json:"role"`
+	Executor           Selection      `json:"executor"`
+	RoutingRationale   string         `json:"routing_rationale"`
+	Reviewer           Selection      `json:"reviewer"`
+	EffortDelivery     EffortDelivery `json:"effort_delivery"`
+	Escalations        []Escalation   `json:"escalations,omitempty"`
+	ConfigRevision     string         `json:"config_revision"`
+	Verifications      []Verification `json:"verifications,omitempty"`
 }
 
 // validate reports the first schema-completeness violation in m. Render
@@ -117,6 +155,15 @@ func (m Manifest) validate() error {
 	if m.SchemaVersion != SchemaVersion {
 		return fmt.Errorf("schema_version %d is unsupported (this build renders %d; regenerate the record)", m.SchemaVersion, SchemaVersion)
 	}
+	if m.Objective == "" {
+		return errors.New("objective is empty")
+	}
+	if err := validateTextList("acceptance_criteria", m.AcceptanceCriteria); err != nil {
+		return err
+	}
+	if err := validateTextList("required_tests", m.RequiredTests); err != nil {
+		return err
+	}
 	if !validRole(m.Role) {
 		return fmt.Errorf("role %q is not one of %s", m.Role, strings.Join(roleNames(), ", "))
 	}
@@ -125,6 +172,9 @@ func (m Manifest) validate() error {
 	}
 	if err := validateSelection("reviewer", m.Reviewer); err != nil {
 		return err
+	}
+	if !validEffortDelivery(m.EffortDelivery) {
+		return fmt.Errorf("effort_delivery %q is not one of %s", m.EffortDelivery, strings.Join(effortDeliveryNames(), ", "))
 	}
 	if m.RoutingRationale == "" {
 		return errors.New("routing_rationale is empty")
@@ -140,6 +190,23 @@ func (m Manifest) validate() error {
 	for i, v := range m.Verifications {
 		if err := validateVerification(v); err != nil {
 			return fmt.Errorf("verifications[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// validateTextList requires a non-empty list of non-empty entries — the
+// same floor the plan gate already enforces on an approved issue's
+// acceptance criteria and required tests. An issue that cannot pass the
+// gate without them must not reach an audit record without them either,
+// because dispatch transcribes this text into the executor's prompt.
+func validateTextList(field string, values []string) error {
+	if len(values) == 0 {
+		return fmt.Errorf("%s is empty", field)
+	}
+	for i, v := range values {
+		if v == "" {
+			return fmt.Errorf("%s[%d] is empty", field, i)
 		}
 	}
 	return nil
@@ -197,4 +264,17 @@ func roleNames() []string {
 		string(RoleArchitect), string(RoleScout), string(RoleImplementer),
 		string(RoleSpecialist), string(RoleReviewer),
 	}
+}
+
+func validEffortDelivery(d EffortDelivery) bool {
+	switch d {
+	case EffortDeliveryParameter, EffortDeliveryPromptCue:
+		return true
+	default:
+		return false
+	}
+}
+
+func effortDeliveryNames() []string {
+	return []string{string(EffortDeliveryParameter), string(EffortDeliveryPromptCue)}
 }

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -5,24 +5,40 @@ import (
 	"testing"
 )
 
+// fixtureObjective is the approved objective every fixture but the
+// hostile one carries, pinned as a constant so a drift case can rewrite
+// it by exact bytes without guessing at the fixture's text.
+const fixtureObjective = "Ship the manifest round trip."
+
 // minimalManifest is a valid record with no escalations or
 // verifications — the smallest thing Render accepts.
 func minimalManifest() Manifest {
 	return Manifest{
-		SchemaVersion:    SchemaVersion,
-		Role:             RoleImplementer,
-		Executor:         Selection{Model: "opus-4-8", Effort: "high"},
-		RoutingRationale: "Selected implementer for a bounded single-file change.",
-		Reviewer:         Selection{Model: "gpt-5.6-sol", Effort: "medium"},
-		ConfigRevision:   "cfg-2026-07-10",
+		SchemaVersion:      SchemaVersion,
+		Objective:          fixtureObjective,
+		AcceptanceCriteria: []string{"Render and Parse agree on every field."},
+		RequiredTests:      []string{"go test ./internal/manifest/..."},
+		Role:               RoleImplementer,
+		Executor:           Selection{Model: "opus-4-8", Effort: "high"},
+		RoutingRationale:   "Selected implementer for a bounded single-file change.",
+		Reviewer:           Selection{Model: "gpt-5.6-sol", Effort: "medium"},
+		EffortDelivery:     EffortDeliveryParameter,
+		ConfigRevision:     "cfg-2026-07-10",
 	}
 }
 
-// fullManifest exercises every optional field: two escalations (an
-// escalation with a role and At, a substitution without) and three
+// fullManifest exercises every optional field and every repeatable one:
+// multi-entry acceptance criteria and required tests, two escalations
+// (an escalation with a role and At, a substitution without), and three
 // verifications, the last a CI-state entry with no command.
 func fullManifest() Manifest {
 	m := minimalManifest()
+	m.AcceptanceCriteria = []string{
+		"Render and Parse agree on every field.",
+		"A hand-edited region fails closed.",
+	}
+	m.RequiredTests = []string{"go test ./internal/manifest/...", "go vet ./..."}
+	m.EffortDelivery = EffortDeliveryPromptCue
 	m.Escalations = []Escalation{
 		{
 			Kind:   "escalation",
@@ -48,23 +64,32 @@ func fullManifest() Manifest {
 }
 
 // hostileManifest packs marker-forging and markdown-breaking content
-// into every free-text field: a rationale containing "-->", a line
-// equal to EndMarker, a CRLF pair, and a <script> tag; a command with
-// backticks, pipes, and an ampersand; a model with a pipe; a config
-// revision with all three entity characters; an escalation whose reason
-// is a data-close and whose At smuggles a begin-marker line; and a
-// verification whose name, result, and At each smuggle a marker or
-// data-comment line. Render must escape all of it so the region still
-// contains exactly one of each structural line and parses back.
+// into every free-text field: an objective and an acceptance criterion
+// each smuggling a marker line, a required test that is exactly the
+// data-close; a rationale containing "-->", a line equal to EndMarker, a
+// CRLF pair, and a <script> tag; a command with backticks, pipes, and an
+// ampersand; a model with a pipe; a config revision with all three
+// entity characters; an escalation whose reason is a data-close and
+// whose At smuggles a begin-marker line; and a verification whose name,
+// result, and At each smuggle a marker or data-comment line. Render must
+// escape all of it so the region still contains exactly one of each
+// structural line and parses back.
 func hostileManifest() Manifest {
 	return Manifest{
 		SchemaVersion: SchemaVersion,
+		Objective:     "Objective ending in " + dataClose + "\n" + BeginMarker + "\nand more.",
+		AcceptanceCriteria: []string{
+			"Criterion with a marker line\n" + EndMarker,
+			"Criterion with &<> entities and a | pipe.",
+		},
+		RequiredTests: []string{dataClose, "go test -run 'A|B' ./..."},
 		Role:          RoleReviewer,
 		Executor:      Selection{Model: "weird|model", Effort: "high"},
 		RoutingRationale: "Rationale with a marker attempt -->\r\n" +
 			EndMarker + "\n" +
 			"and a <script>alert(1)</script> tag.",
 		Reviewer:       Selection{Model: "opus-4-8", Effort: "low"},
+		EffortDelivery: EffortDeliveryPromptCue,
 		ConfigRevision: "rev&<>",
 		Escalations: []Escalation{
 			{
@@ -91,13 +116,21 @@ func TestValidateRejects(t *testing.T) {
 		mutate func(*Manifest)
 		want   string
 	}{
-		"bad schema version":        {func(m *Manifest) { m.SchemaVersion = 2 }, "schema_version 2 is unsupported"},
+		"superseded schema version": {func(m *Manifest) { m.SchemaVersion = 1 }, "schema_version 1 is unsupported"},
+		"future schema version":     {func(m *Manifest) { m.SchemaVersion = 3 }, "schema_version 3 is unsupported"},
 		"absent schema version":     {func(m *Manifest) { m.SchemaVersion = 0 }, "schema_version 0 is unsupported"},
+		"empty objective":           {func(m *Manifest) { m.Objective = "" }, "objective is empty"},
+		"no acceptance criteria":    {func(m *Manifest) { m.AcceptanceCriteria = nil }, "acceptance_criteria is empty"},
+		"empty acceptance criteria": {func(m *Manifest) { m.AcceptanceCriteria[1] = "" }, "acceptance_criteria[1] is empty"},
+		"no required tests":         {func(m *Manifest) { m.RequiredTests = nil }, "required_tests is empty"},
+		"empty required test":       {func(m *Manifest) { m.RequiredTests[0] = "" }, "required_tests[0] is empty"},
 		"unknown role":              {func(m *Manifest) { m.Role = "wizard" }, `role "wizard" is not one of`},
 		"empty executor model":      {func(m *Manifest) { m.Executor.Model = "" }, "executor.model is empty"},
 		"empty executor effort":     {func(m *Manifest) { m.Executor.Effort = "" }, "executor.effort is empty"},
 		"empty reviewer model":      {func(m *Manifest) { m.Reviewer.Model = "" }, "reviewer.model is empty"},
 		"empty reviewer effort":     {func(m *Manifest) { m.Reviewer.Effort = "" }, "reviewer.effort is empty"},
+		"absent effort delivery":    {func(m *Manifest) { m.EffortDelivery = "" }, `effort_delivery "" is not one of`},
+		"unknown effort delivery":   {func(m *Manifest) { m.EffortDelivery = "telepathy" }, `effort_delivery "telepathy" is not one of`},
 		"empty rationale":           {func(m *Manifest) { m.RoutingRationale = "" }, "routing_rationale is empty"},
 		"empty config revision":     {func(m *Manifest) { m.ConfigRevision = "" }, "config_revision is empty"},
 		"bad escalation kind":       {func(m *Manifest) { m.Escalations[0].Kind = "demotion" }, `escalations[0]: kind "demotion" is not one of`},

--- a/internal/manifest/parse_test.go
+++ b/internal/manifest/parse_test.go
@@ -122,8 +122,8 @@ func TestParseBadManifest(t *testing.T) {
 		"unterminated data":    BeginMarker + "\n" + dataOpen + "\n{}\n" + EndMarker,
 		"double data comment":  BeginMarker + "\n" + dataOpen + "\n{}\n" + dataClose + "\n" + dataOpen + "\n{}\n" + dataClose + "\n" + EndMarker,
 		"bad json":             BeginMarker + "\n" + dataOpen + "\nthis is not json\n" + dataClose + "\n" + EndMarker,
-		"schema version zero":  tamperJSON(valid, `"schema_version": 1`, `"schema_version": 0`),
-		"schema version two":   tamperJSON(valid, `"schema_version": 1`, `"schema_version": 2`),
+		"schema version zero":  tamperJSON(valid, `"schema_version": 2`, `"schema_version": 0`),
+		"schema version three": tamperJSON(valid, `"schema_version": 2`, `"schema_version": 3`),
 		"schema absent":        BeginMarker + "\n" + dataOpen + "\n{\"role\":\"implementer\"}\n" + dataClose + "\n" + EndMarker,
 		"invalid record":       tamperJSON(valid, `"role": "implementer"`, `"role": "wizard"`),
 	}
@@ -137,6 +137,62 @@ func TestParseBadManifest(t *testing.T) {
 	}
 }
 
+// schemaOneRegion is a genuine schema-1 record, frozen byte-for-byte as
+// the v1 renderer emitted it. It is not a v2 render with a tampered
+// version number: it is the real thing this build must refuse, missing
+// exactly the objective, acceptance criteria, required tests, and
+// effort-delivery fields v2 requires.
+const schemaOneRegion = BeginMarker + `
+### Orch audit record
+
+| Field | Value |
+| --- | --- |
+| Role | ` + "`implementer`" + ` |
+| Executor | ` + "`opus-4-8`" + ` — effort ` + "`high`" + ` |
+| Reviewer | ` + "`gpt-5.6-sol`" + ` — effort ` + "`medium`" + ` |
+| Config revision | ` + "`cfg-2026-07-10`" + ` |
+
+**Routing rationale:** Selected implementer for a bounded single-file change.
+
+**Escalations:** _none_
+
+**Verification:** _none_
+
+` + dataOpen + `
+{
+  "schema_version": 1,
+  "role": "implementer",
+  "executor": {
+    "model": "opus-4-8",
+    "effort": "high"
+  },
+  "routing_rationale": "Selected implementer for a bounded single-file change.",
+  "reviewer": {
+    "model": "gpt-5.6-sol",
+    "effort": "medium"
+  },
+  "config_revision": "cfg-2026-07-10"
+}
+` + dataClose + `
+` + EndMarker
+
+// TestParseRejectsSchemaOneRecord proves a v1 record fails closed through
+// the unsupported-version path — named as such, before the drift compare
+// — rather than decoding into a v2 struct whose approved work would read
+// as empty. There is no migration: the missing fields cannot be invented.
+func TestParseRejectsSchemaOneRecord(t *testing.T) {
+	_, err := Parse(schemaOneRegion)
+	if !errors.Is(err, ErrBadManifest) {
+		t.Fatalf("err = %v, want ErrBadManifest", err)
+	}
+	if !strings.Contains(err.Error(), "schema_version 1 is unsupported") {
+		t.Errorf("err %q does not name the unsupported version", err)
+	}
+	if errors.Is(err, ErrDrift) {
+		t.Error("a v1 record was reported as drift; the version check must come first")
+	}
+}
+
 func TestParseDrift(t *testing.T) {
 	base := mustRender(t, fullManifest())
 	cases := map[string]string{
@@ -144,8 +200,8 @@ func TestParseDrift(t *testing.T) {
 		"blank line inserted":   strings.Replace(base, "### Orch audit record\n", "### Orch audit record\n\n", 1),
 		"sentence inserted":     strings.Replace(base, "**Verification:**", "An extra human sentence.\n\n**Verification:**", 1),
 		"json keys reordered": strings.Replace(base,
-			"{\n  \"schema_version\": 1,\n  \"role\": \"implementer\",",
-			"{\n  \"role\": \"implementer\",\n  \"schema_version\": 1,", 1),
+			"{\n  \"schema_version\": 2,\n  \"objective\": \""+fixtureObjective+"\",",
+			"{\n  \"objective\": \""+fixtureObjective+"\",\n  \"schema_version\": 2,", 1),
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/manifest/render.go
+++ b/internal/manifest/render.go
@@ -42,17 +42,20 @@ func Render(m Manifest) (string, error) {
 }
 
 // writeHuman renders the human-readable markdown between the begin
-// marker and the data comment. Its shape is fixed: a heading, a summary
-// table, the routing rationale as a paragraph (never a table cell), then
-// the escalations and verifications sections, each always present so the
+// marker and the data comment. Its shape is fixed and follows the JSON
+// record's field order: a heading, the approved work, a summary table,
+// the routing rationale as a paragraph (never a table cell), then the
+// escalations and verifications sections, each always present so the
 // layout is deterministic.
 func writeHuman(b *strings.Builder, m Manifest) {
 	b.WriteString("### Orch audit record\n\n")
+	writeWork(b, m)
 	b.WriteString("| Field | Value |\n")
 	b.WriteString("| --- | --- |\n")
 	fmt.Fprintf(b, "| Role | %s |\n", mdCodeCell(string(m.Role)))
 	fmt.Fprintf(b, "| Executor | %s — effort %s |\n", mdCodeCell(m.Executor.Model), mdCodeCell(m.Executor.Effort))
 	fmt.Fprintf(b, "| Reviewer | %s — effort %s |\n", mdCodeCell(m.Reviewer.Model), mdCodeCell(m.Reviewer.Effort))
+	fmt.Fprintf(b, "| Effort delivery | %s — %s |\n", mdCodeCell(string(m.EffortDelivery)), effortDeliveryNote(m.EffortDelivery))
 	fmt.Fprintf(b, "| Config revision | %s |\n", mdCodeCell(m.ConfigRevision))
 	b.WriteByte('\n')
 	fmt.Fprintf(b, "**Routing rationale:** %s\n", mdText(m.RoutingRationale))
@@ -60,6 +63,44 @@ func writeHuman(b *strings.Builder, m Manifest) {
 	writeEscalations(b, m.Escalations)
 	b.WriteByte('\n')
 	writeVerifications(b, m.Verifications)
+}
+
+// writeWork renders the approved work the record carries: the objective
+// as a paragraph, then the acceptance criteria and the required tests as
+// bullet lists (tests are commands, so they render as code spans).
+//
+// It repeats prose the created issue body already carries above the
+// managed region, deliberately: the drift check compares a re-render of
+// the decoded record against the found region, so a field with no human
+// view is a field whose only view is the hidden JSON, and every one of
+// these carries text an executor is handed as approved.
+func writeWork(b *strings.Builder, m Manifest) {
+	fmt.Fprintf(b, "**Objective:** %s\n\n", mdText(m.Objective))
+	b.WriteString("**Acceptance criteria:**\n")
+	for _, ac := range m.AcceptanceCriteria {
+		fmt.Fprintf(b, "- %s\n", mdText(ac))
+	}
+	b.WriteString("\n**Required tests:**\n")
+	for _, rt := range m.RequiredTests {
+		fmt.Fprintf(b, "- %s\n", mdCode(rt))
+	}
+	b.WriteByte('\n')
+}
+
+// effortDeliveryNote is the clause rendered beside an EffortDelivery
+// value in the summary table. Without it the table names an exact effort
+// next to nothing that says whether the host enforced it, which reads as
+// a guarantee the host may not have made.
+func effortDeliveryNote(d EffortDelivery) string {
+	switch d {
+	case EffortDeliveryParameter:
+		return "the host applied the routed effort as a real model parameter"
+	case EffortDeliveryPromptCue:
+		return "this host has no effort parameter; the routed effort reached the executor as a prompt cue only"
+	default:
+		// Unreachable: validate rejects any other value before Render.
+		return "unrecognized effort delivery"
+	}
 }
 
 func writeEscalations(b *strings.Builder, es []Escalation) {

--- a/internal/manifest/testdata/full.golden.md
+++ b/internal/manifest/testdata/full.golden.md
@@ -1,11 +1,22 @@
 <!-- orch:manifest:begin -->
 ### Orch audit record
 
+**Objective:** Ship the manifest round trip.
+
+**Acceptance criteria:**
+- Render and Parse agree on every field.
+- A hand-edited region fails closed.
+
+**Required tests:**
+- `go test ./internal/manifest/...`
+- `go vet ./...`
+
 | Field | Value |
 | --- | --- |
 | Role | `implementer` |
 | Executor | `opus-4-8` — effort `high` |
 | Reviewer | `gpt-5.6-sol` — effort `medium` |
+| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
 | Config revision | `cfg-2026-07-10` |
 
 **Routing rationale:** Selected implementer for a bounded single-file change.
@@ -21,7 +32,16 @@
 
 <!-- orch:manifest:data
 {
-  "schema_version": 1,
+  "schema_version": 2,
+  "objective": "Ship the manifest round trip.",
+  "acceptance_criteria": [
+    "Render and Parse agree on every field.",
+    "A hand-edited region fails closed."
+  ],
+  "required_tests": [
+    "go test ./internal/manifest/...",
+    "go vet ./..."
+  ],
   "role": "implementer",
   "executor": {
     "model": "opus-4-8",
@@ -32,6 +52,7 @@
     "model": "gpt-5.6-sol",
     "effort": "medium"
   },
+  "effort_delivery": "prompt-cue",
   "escalations": [
     {
       "kind": "escalation",

--- a/internal/manifest/testdata/hostile.golden.md
+++ b/internal/manifest/testdata/hostile.golden.md
@@ -1,11 +1,25 @@
 <!-- orch:manifest:begin -->
 ### Orch audit record
 
+**Objective:** Objective ending in --&gt;
+&lt;!-- orch:manifest:begin --&gt;
+and more.
+
+**Acceptance criteria:**
+- Criterion with a marker line
+&lt;!-- orch:manifest:end --&gt;
+- Criterion with &amp;&lt;&gt; entities and a | pipe.
+
+**Required tests:**
+- `-->`
+- `go test -run 'A|B' ./...`
+
 | Field | Value |
 | --- | --- |
 | Role | `reviewer` |
 | Executor | `weird\|model` — effort `high` |
 | Reviewer | `opus-4-8` — effort `low` |
+| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
 | Config revision | `rev&<>` |
 
 **Routing rationale:** Rationale with a marker attempt --&gt;
@@ -24,7 +38,16 @@ and a &lt;script&gt;alert(1)&lt;/script&gt; tag.
 
 <!-- orch:manifest:data
 {
-  "schema_version": 1,
+  "schema_version": 2,
+  "objective": "Objective ending in --\u003e\n\u003c!-- orch:manifest:begin --\u003e\nand more.",
+  "acceptance_criteria": [
+    "Criterion with a marker line\n\u003c!-- orch:manifest:end --\u003e",
+    "Criterion with \u0026\u003c\u003e entities and a | pipe."
+  ],
+  "required_tests": [
+    "--\u003e",
+    "go test -run 'A|B' ./..."
+  ],
   "role": "reviewer",
   "executor": {
     "model": "weird|model",
@@ -35,6 +58,7 @@ and a &lt;script&gt;alert(1)&lt;/script&gt; tag.
     "model": "opus-4-8",
     "effort": "low"
   },
+  "effort_delivery": "prompt-cue",
   "escalations": [
     {
       "kind": "escalation",

--- a/internal/manifest/testdata/minimal.golden.md
+++ b/internal/manifest/testdata/minimal.golden.md
@@ -1,11 +1,20 @@
 <!-- orch:manifest:begin -->
 ### Orch audit record
 
+**Objective:** Ship the manifest round trip.
+
+**Acceptance criteria:**
+- Render and Parse agree on every field.
+
+**Required tests:**
+- `go test ./internal/manifest/...`
+
 | Field | Value |
 | --- | --- |
 | Role | `implementer` |
 | Executor | `opus-4-8` — effort `high` |
 | Reviewer | `gpt-5.6-sol` — effort `medium` |
+| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
 | Config revision | `cfg-2026-07-10` |
 
 **Routing rationale:** Selected implementer for a bounded single-file change.
@@ -16,7 +25,14 @@
 
 <!-- orch:manifest:data
 {
-  "schema_version": 1,
+  "schema_version": 2,
+  "objective": "Ship the manifest round trip.",
+  "acceptance_criteria": [
+    "Render and Parse agree on every field."
+  ],
+  "required_tests": [
+    "go test ./internal/manifest/..."
+  ],
   "role": "implementer",
   "executor": {
     "model": "opus-4-8",
@@ -27,6 +43,7 @@
     "model": "gpt-5.6-sol",
     "effort": "medium"
   },
+  "effort_delivery": "parameter",
   "config_revision": "cfg-2026-07-10"
 }
 -->

--- a/internal/routing/escalate_test.go
+++ b/internal/routing/escalate_test.go
@@ -355,13 +355,17 @@ func TestEscalateManifestRoundTrip(t *testing.T) {
 				t.Fatalf("kind = %q, want reroute", out.Kind)
 			}
 			m := manifest.Manifest{
-				SchemaVersion:    manifest.SchemaVersion,
-				Role:             out.Decision.Role,
-				Executor:         out.Decision.Executor,
-				RoutingRationale: out.Decision.Rationale,
-				Reviewer:         out.Decision.Reviewer,
-				Escalations:      out.Escalations,
-				ConfigRevision:   "cfg-2026-07-11",
+				SchemaVersion:      manifest.SchemaVersion,
+				Objective:          "Reroute an escalated issue.",
+				AcceptanceCriteria: []string{"The rerouted decision renders."},
+				RequiredTests:      []string{"go test ./internal/routing/..."},
+				Role:               out.Decision.Role,
+				Executor:           out.Decision.Executor,
+				RoutingRationale:   out.Decision.Rationale,
+				Reviewer:           out.Decision.Reviewer,
+				EffortDelivery:     manifest.EffortDeliveryParameter,
+				Escalations:        out.Escalations,
+				ConfigRevision:     "cfg-2026-07-11",
 			}
 			if _, err := manifest.Render(m); err != nil {
 				t.Fatalf("manifest.Render on escalated decision: %v", err)

--- a/internal/run/activate.go
+++ b/internal/run/activate.go
@@ -155,6 +155,10 @@ func Activate(ctx context.Context, env Env, reqJSON []byte) (*ActivationResult, 
 	if err != nil {
 		return nil, err
 	}
+	delivery, err := effortDelivery(plan.Host)
+	if err != nil {
+		return nil, err
+	}
 	denylist := modelDenylist(cfg)
 	decisionByID := make(map[string]routing.Decision, len(plan.Issues))
 	labelsByID := make(map[string]ghops.Labels, len(plan.Issues))
@@ -225,16 +229,20 @@ func Activate(ctx context.Context, env Env, reqJSON []byte) (*ActivationResult, 
 	ordered := plan.issuesInWaveOrder()
 	stateIssues := make([]state.Issue, len(ordered))
 	for i, pi := range ordered {
-		// Persist the plan's dependency edges, wave, and the derived
-		// routing decision so the PR B verbs can enforce dependencies and
-		// spawn executors without re-taking the plan document.
+		// Persist the plan's dependency edges, wave, approved work text,
+		// and the derived routing decision so the PR B verbs can enforce
+		// dependencies and spawn executors on approved text without
+		// re-taking the plan document.
 		stateIssues[i] = state.Issue{
-			PlanID:    pi.ID,
-			Title:     pi.Title,
-			Phase:     state.PhasePlanned,
-			DependsOn: pi.DependsOn,
-			Wave:      pi.Wave,
-			Decision:  fromRoutingDecision(decisionByID[pi.ID]),
+			PlanID:             pi.ID,
+			Title:              pi.Title,
+			Phase:              state.PhasePlanned,
+			DependsOn:          pi.DependsOn,
+			Wave:               pi.Wave,
+			Objective:          pi.Objective,
+			AcceptanceCriteria: pi.AcceptanceCriteria,
+			RequiredTests:      pi.RequiredTests,
+			Decision:           fromRoutingDecision(decisionByID[pi.ID]),
 		}
 	}
 	planRef := state.PlanRef{
@@ -258,12 +266,16 @@ func Activate(ctx context.Context, env Env, reqJSON []byte) (*ActivationResult, 
 
 		body := issueBody(pi, waveByID, digest)
 		body, err = manifest.Upsert(body, manifest.Manifest{
-			SchemaVersion:    manifest.SchemaVersion,
-			Role:             d.Role,
-			Executor:         d.Executor,
-			RoutingRationale: d.Rationale,
-			Reviewer:         d.Reviewer,
-			ConfigRevision:   cfg.ConfigRevision,
+			SchemaVersion:      manifest.SchemaVersion,
+			Objective:          pi.Objective,
+			AcceptanceCriteria: pi.AcceptanceCriteria,
+			RequiredTests:      pi.RequiredTests,
+			Role:               d.Role,
+			Executor:           d.Executor,
+			RoutingRationale:   d.Rationale,
+			Reviewer:           d.Reviewer,
+			EffortDelivery:     delivery,
+			ConfigRevision:     cfg.ConfigRevision,
 		})
 		if err != nil {
 			return nil, wrapAfterEnter(err)

--- a/internal/run/activate_test.go
+++ b/internal/run/activate_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/gitops"
 	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/manifest"
 	"github.com/kninetimmy/orch/internal/paths"
 	"github.com/kninetimmy/orch/internal/state"
 )
@@ -280,6 +281,65 @@ func TestActivateHappyPathTwoIssuesTwoWaves(t *testing.T) {
 		if got.PlanID != want.PlanID || got.Phase != want.Phase || got.Number != want.Number || got.Branch != want.Branch || got.Worktree != want.Worktree {
 			t.Errorf("Issues[%d] = %+v, want %+v", i, got, want)
 		}
+	}
+}
+
+// TestActivateRecordsApprovedWork proves activation writes the approved
+// plan text to both places the rest of the lifecycle reads it from: run
+// state (which dispatch transcribes into the spawn prompt) and the
+// issue's audit record (which resume rebuilds state from). It also pins
+// the effort-delivery mechanism the record names for a claude run: the
+// host has no per-spawn effort knob, so the routed effort is a prompt
+// cue, and the record must say so rather than imply an enforcement.
+func TestActivateRecordsApprovedWork(t *testing.T) {
+	root := newActivateRepo(t)
+	taxonomy := fullTaxonomyScript()
+	calls := append(taxonomy,
+		ghIssueCreateCall("Issue A", []string{"ready", "feature", "implementer", "standard"}, 1),
+		ghIssueCreateCall("Issue B", []string{"ready", "feature", "specialist", "critical"}, 2),
+	)
+	script := &execxtest.Script{T: t, Calls: calls}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+	if _, err := Activate(context.Background(), env, activationJSON(t, twoIssuePlanJSON())); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	script.AssertExhausted()
+
+	// The posted audit record carries the approved work and the honest
+	// effort-delivery mechanism.
+	m, err := manifest.Parse(script.StdinAt(len(taxonomy)))
+	if err != nil {
+		t.Fatalf("Parse the created issue body: %v", err)
+	}
+	if m.SchemaVersion != manifest.SchemaVersion {
+		t.Errorf("schema_version = %d, want %d", m.SchemaVersion, manifest.SchemaVersion)
+	}
+	if m.Objective != "Do A" {
+		t.Errorf("objective = %q, want the plan's", m.Objective)
+	}
+	if len(m.AcceptanceCriteria) != 1 || m.AcceptanceCriteria[0] != "A works" {
+		t.Errorf("acceptance_criteria = %q, want the plan's", m.AcceptanceCriteria)
+	}
+	if len(m.RequiredTests) != 1 || m.RequiredTests[0] != "go test ./..." {
+		t.Errorf("required_tests = %q, want the plan's", m.RequiredTests)
+	}
+	if m.EffortDelivery != manifest.EffortDeliveryPromptCue {
+		t.Errorf("effort_delivery = %q, want %q for a claude run", m.EffortDelivery, manifest.EffortDeliveryPromptCue)
+	}
+
+	// Run state carries the same text, so dispatch never has to re-read
+	// the plan or recall it.
+	st, err := state.Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := st.Run.Issues[0]
+	if a.Objective != "Do A" || len(a.AcceptanceCriteria) != 1 || len(a.RequiredTests) != 1 {
+		t.Errorf("issue a approved work = %+v, want the plan's objective, criteria, and tests", a)
+	}
+	b := st.Run.Issues[1]
+	if b.Objective != "Do B" {
+		t.Errorf("issue b objective = %q, want the plan's", b.Objective)
 	}
 }
 

--- a/internal/run/derive.go
+++ b/internal/run/derive.go
@@ -37,6 +37,25 @@ func hostProfile(cfg *config.Config, host string) (routing.Profile, error) {
 	}, nil
 }
 
+// effortDelivery reports how host actually applies a routed reasoning
+// effort to a spawned executor, for the audit record. Codex pins
+// model_reasoning_effort in the dispatched agent's own TOML, so the
+// routed effort is a real parameter there; Claude Code subagent spawns
+// take no effort knob, so it reaches the executor only as a prompt cue.
+// An unknown host is an error rather than a guess: recording an effort
+// without saying how it was delivered is the claim this field exists to
+// stop making.
+func effortDelivery(host string) (manifest.EffortDelivery, error) {
+	switch host {
+	case "codex":
+		return manifest.EffortDeliveryParameter, nil
+	case "claude":
+		return manifest.EffortDeliveryPromptCue, nil
+	default:
+		return "", fmt.Errorf("host %q has no recorded effort-delivery mechanism", host)
+	}
+}
+
 // issueTask converts a plan issue's facts into the routing.Task Decide
 // consumes.
 func issueTask(i PlanIssue) routing.Task {

--- a/internal/run/derive_test.go
+++ b/internal/run/derive_test.go
@@ -24,6 +24,28 @@ func TestHostProfile(t *testing.T) {
 	}
 }
 
+// TestEffortDelivery pins the per-host mechanism the audit record names:
+// Codex applies the routed effort as a real parameter, Claude only as a
+// prompt cue, and an unrecognized host is an error rather than a guess.
+func TestEffortDelivery(t *testing.T) {
+	cases := map[string]manifest.EffortDelivery{
+		"codex":  manifest.EffortDeliveryParameter,
+		"claude": manifest.EffortDeliveryPromptCue,
+	}
+	for host, want := range cases {
+		got, err := effortDelivery(host)
+		if err != nil {
+			t.Fatalf("effortDelivery(%s): %v", host, err)
+		}
+		if got != want {
+			t.Errorf("effortDelivery(%s) = %q, want %q", host, got, want)
+		}
+	}
+	if _, err := effortDelivery("fable"); err == nil {
+		t.Error("effortDelivery accepted an unknown host")
+	}
+}
+
 func TestDecideIssueFacts(t *testing.T) {
 	cfg := testConfigTwoHosts()
 	profile, err := hostProfile(cfg, "claude")

--- a/internal/run/dispatch.go
+++ b/internal/run/dispatch.go
@@ -13,8 +13,11 @@ import (
 )
 
 // DispatchSchemaVersion is the dispatch request/result schema this build
-// accepts and emits.
-const DispatchSchemaVersion = 1
+// accepts and emits. v2 adds the approved objective, acceptance
+// criteria, and required tests to the result, so an adapter's spawn
+// prompt is a transcription of what a human approved rather than the
+// Architect's recollection of it.
+const DispatchSchemaVersion = 2
 
 // DispatchRequest asks to hand one worktree-ready issue to its executor.
 type DispatchRequest struct {
@@ -24,7 +27,8 @@ type DispatchRequest struct {
 
 // DispatchResult carries what the adapter needs to spawn the executor
 // into the issue's worktree (PRD §12 step 8): the branch, the
-// repo-relative worktree, and the routing selection.
+// repo-relative worktree, the routing selection, and the approved work
+// the executor is being handed.
 type DispatchResult struct {
 	SchemaVersion int                `json:"schema_version"`
 	IssueNumber   int                `json:"issue_number"`
@@ -33,6 +37,13 @@ type DispatchResult struct {
 	Executor      manifest.Selection `json:"executor"`
 	Reviewer      manifest.Selection `json:"reviewer"`
 	Rationale     string             `json:"rationale"`
+	// Objective, AcceptanceCriteria, and RequiredTests are the approved
+	// plan text verbatim. The adapter transcribes them into the spawn
+	// prompt; it never paraphrases or re-derives them, because what the
+	// executor is told to build is what the human approved.
+	Objective          string   `json:"objective"`
+	AcceptanceCriteria []string `json:"acceptance_criteria"`
+	RequiredTests      []string `json:"required_tests"`
 }
 
 // Dispatch moves a worktree-ready issue to dispatched: it enforces the
@@ -59,6 +70,9 @@ func Dispatch(ctx context.Context, env Env, reqJSON []byte) (*DispatchResult, er
 	issue := c.issue()
 	if issue.Decision == nil {
 		return nil, fmt.Errorf("issue #%d has no routing decision; run `orch abort`", issue.Number)
+	}
+	if err := checkApprovedWork(issue); err != nil {
+		return nil, err
 	}
 	if err := checkDependencies(c.st.Run, issue); err != nil {
 		return nil, err
@@ -105,14 +119,41 @@ func Dispatch(ctx context.Context, env Env, reqJSON []byte) (*DispatchResult, er
 	}
 
 	return &DispatchResult{
-		SchemaVersion: DispatchSchemaVersion,
-		IssueNumber:   issue.Number,
-		Branch:        issue.Branch,
-		Worktree:      issue.Worktree,
-		Executor:      issue.Decision.Executor,
-		Reviewer:      issue.Decision.Reviewer,
-		Rationale:     issue.Decision.Rationale,
+		SchemaVersion:      DispatchSchemaVersion,
+		IssueNumber:        issue.Number,
+		Branch:             issue.Branch,
+		Worktree:           issue.Worktree,
+		Executor:           issue.Decision.Executor,
+		Reviewer:           issue.Decision.Reviewer,
+		Rationale:          issue.Decision.Rationale,
+		Objective:          issue.Objective,
+		AcceptanceCriteria: issue.AcceptanceCriteria,
+		RequiredTests:      issue.RequiredTests,
 	}, nil
+}
+
+// checkApprovedWork fails closed when the issue carries no approved work
+// text. Activation copies it from the plan and resume repopulates it
+// from the audit record, so the only way to reach dispatch without it is
+// a run activated by a build older than the schema-2 record — where
+// dispatching anyway would hand the executor an empty objective and say
+// nothing about it. Resume is the remediation because the issue body,
+// not run state, is the durable home of the approved text.
+func checkApprovedWork(issue *state.Issue) error {
+	var missing []string
+	if issue.Objective == "" {
+		missing = append(missing, "objective")
+	}
+	if len(issue.AcceptanceCriteria) == 0 {
+		missing = append(missing, "acceptance criteria")
+	}
+	if len(issue.RequiredTests) == 0 {
+		missing = append(missing, "required tests")
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf("issue #%d carries no %s; run `orch resume` to repopulate the approved work from its audit record", issue.Number, strings.Join(missing, ", "))
 }
 
 // checkDependencies fails closed unless every issue in issue.DependsOn is

--- a/internal/run/dispatch.go
+++ b/internal/run/dispatch.go
@@ -133,12 +133,18 @@ func Dispatch(ctx context.Context, env Env, reqJSON []byte) (*DispatchResult, er
 }
 
 // checkApprovedWork fails closed when the issue carries no approved work
-// text. Activation copies it from the plan and resume repopulates it
-// from the audit record, so the only way to reach dispatch without it is
-// a run activated by a build older than the schema-2 record — where
-// dispatching anyway would hand the executor an empty objective and say
-// nothing about it. Resume is the remediation because the issue body,
-// not run state, is the durable home of the approved text.
+// text. Activation copies it from the plan, so the only way to reach
+// dispatch without it is a run activated by a build older than the
+// schema-2 audit record — where dispatching anyway would hand the
+// executor an empty objective and say nothing about it.
+//
+// The remediation is abort, never resume. State missing the approved
+// work implies an issue body still carrying a schema-1 record, which
+// this build's manifest.Parse rejects; resume would therefore take its
+// failure path and block the issue rather than repopulate anything,
+// leaving the operator worse off than before they followed the advice.
+// Naming one concrete command for an unrepairable version mismatch
+// follows state.Load's precedent.
 func checkApprovedWork(issue *state.Issue) error {
 	var missing []string
 	if issue.Objective == "" {
@@ -153,7 +159,7 @@ func checkApprovedWork(issue *state.Issue) error {
 	if len(missing) == 0 {
 		return nil
 	}
-	return fmt.Errorf("issue #%d carries no %s; run `orch resume` to repopulate the approved work from its audit record", issue.Number, strings.Join(missing, ", "))
+	return fmt.Errorf("issue #%d carries no %s; this run predates the schema-2 audit record and cannot be repaired in place — run `orch abort` to return to assist, then re-plan and re-activate", issue.Number, strings.Join(missing, ", "))
 }
 
 // checkDependencies fails closed unless every issue in issue.DependsOn is

--- a/internal/run/lifecycle_test.go
+++ b/internal/run/lifecycle_test.go
@@ -21,22 +21,42 @@ import (
 // reads in the scripted transcript match exactly.
 const prFieldsRun = "number,state,title,url,headRefName,baseRefName,headRefOid,mergeStateStatus,mergedAt,body"
 
+// fixtureObjective and the two fixture lists are the approved work every
+// run-package fixture carries. The scripted audit records below and
+// fixtureIssue's state both use them, so resume — which repopulates the
+// approved work from the record — reads back what state already holds
+// and stays a byte-level no-op on a converged fixture.
+const fixtureObjective = "Fix the status lock race."
+
+func fixtureAcceptance() []string { return []string{"No data race under -race."} }
+
+func fixtureTests() []string { return []string{"go test ./..."} }
+
 // baseManifestBody renders a minimal valid audit record on some prose, so
 // a scripted issue view returns a body manifest.Parse accepts.
 func baseManifestBody(t *testing.T) string {
 	t.Helper()
-	body, err := manifest.Upsert("**Objective**\n\ndo it\n", manifest.Manifest{
-		SchemaVersion:    manifest.SchemaVersion,
-		Role:             manifest.RoleImplementer,
-		Executor:         manifest.Selection{Model: "claude-sonnet-5", Effort: "xhigh"},
-		RoutingRationale: "impl",
-		Reviewer:         manifest.Selection{Model: "claude-opus-4-8", Effort: "high"},
-		ConfigRevision:   "r1",
-	})
+	body, err := manifest.Upsert("**Objective**\n\ndo it\n", baseManifest())
 	if err != nil {
 		t.Fatal(err)
 	}
 	return body
+}
+
+// baseManifest is the audit record the scripted issue bodies carry.
+func baseManifest() manifest.Manifest {
+	return manifest.Manifest{
+		SchemaVersion:      manifest.SchemaVersion,
+		Objective:          fixtureObjective,
+		AcceptanceCriteria: fixtureAcceptance(),
+		RequiredTests:      fixtureTests(),
+		Role:               manifest.RoleImplementer,
+		Executor:           manifest.Selection{Model: "claude-sonnet-5", Effort: "xhigh"},
+		RoutingRationale:   "impl",
+		Reviewer:           manifest.Selection{Model: "claude-opus-4-8", Effort: "high"},
+		EffortDelivery:     manifest.EffortDeliveryPromptCue,
+		ConfigRevision:     "r1",
+	}
 }
 
 func jsonQuote(t *testing.T, s string) string {
@@ -188,10 +208,23 @@ func TestLifecycleWalk(t *testing.T) {
 	script.AssertExhausted()
 	wantPhase(t, root, 1, state.PhaseWorktreeReady)
 
-	// dispatch.
-	runVerb(t, root, Dispatch, `{"schema_version":1,"issue_number":1}`,
+	// dispatch. The result is the adapter's whole spawn brief, so it must
+	// carry the approved work verbatim alongside the routed selection.
+	dispatched := runVerb(t, root, Dispatch, `{"schema_version":2,"issue_number":1}`,
 		ghAuth(), ghRepoViewCall("main"), ghSetStatusCall(1, ghops.StatusInProgress))
 	wantPhase(t, root, 1, state.PhaseDispatched)
+	if dispatched.Objective != "Make status reporting race-free" {
+		t.Errorf("dispatch objective = %q, want the approved plan text", dispatched.Objective)
+	}
+	if len(dispatched.AcceptanceCriteria) != 1 || dispatched.AcceptanceCriteria[0] != "no data race under -race" {
+		t.Errorf("dispatch acceptance criteria = %q, want the approved plan text", dispatched.AcceptanceCriteria)
+	}
+	if len(dispatched.RequiredTests) != 1 || dispatched.RequiredTests[0] != "go test ./..." {
+		t.Errorf("dispatch required tests = %q, want the approved plan text", dispatched.RequiredTests)
+	}
+	if dispatched.SchemaVersion != DispatchSchemaVersion {
+		t.Errorf("dispatch schema_version = %d, want %d", dispatched.SchemaVersion, DispatchSchemaVersion)
+	}
 
 	// The executor commits work into the worktree.
 	wtDir := filepath.Join(root, ".orchestrator", "worktrees", "issue-1")

--- a/internal/run/propen.go
+++ b/internal/run/propen.go
@@ -199,14 +199,16 @@ func buildVerifications(inputs []VerificationInput, stamp string) ([]manifest.Ve
 }
 
 // prProse is the human-readable portion of a PR body: a one-line summary,
-// the Closes link that closes the issue on merge (PRD §12 step 17), and
-// the plan digest. The full objective and acceptance criteria live on
-// the linked issue.
+// the Closes link that closes the issue on merge (PRD §12 step 17), the
+// plan digest, and a pointer to the audit record. The objective and
+// acceptance criteria are not restated in the prose because the record
+// upsertCapped appends below it carries them, on the PR exactly as on
+// the issue (manifest schema 2).
 func prProse(issue *state.Issue, digest string) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "Delivers issue #%d: %s\n\n", issue.Number, issue.Title)
 	fmt.Fprintf(&b, "Closes #%d\n\n", issue.Number)
 	fmt.Fprintf(&b, "**Plan digest:** `%s`\n\n", digest)
-	b.WriteString("The full objective and acceptance criteria are on the linked issue.\n")
+	b.WriteString("The approved objective and acceptance criteria are in the audit record below.\n")
 	return b.String()
 }

--- a/internal/run/resume.go
+++ b/internal/run/resume.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/kninetimmy/orch/internal/config"
 	"github.com/kninetimmy/orch/internal/ghops"
@@ -121,17 +122,29 @@ type ResumeDoc struct {
 // zero API calls (planned, cleaned, abandoned).
 type issueObservations struct {
 	read          bool
-	issueState    string    // "" when the issue was not read
-	manifestOK    *bool     // nil when the manifest was not parsed
-	manifestErr   error     // set when manifestOK points to false
-	verifications int       // verification count in the audit record
-	pr            *ghops.PR // issue.PRNumber read (pr-open onward)
-	prForBranch   *ghops.PR // open PR for the branch (worktree-ready/dispatched)
+	issueState    string        // "" when the issue was not read
+	manifestOK    *bool         // nil when the manifest was not parsed
+	manifestErr   error         // set when manifestOK points to false
+	verifications int           // verification count in the audit record
+	work          *approvedWork // nil unless the audit record parsed cleanly
+	pr            *ghops.PR     // issue.PRNumber read (pr-open onward)
+	prForBranch   *ghops.PR     // open PR for the branch (worktree-ready/dispatched)
 	ciRead        bool
 	ci            ghops.CIState
 	localBranch   *bool
 	worktree      *bool
 	remoteBranch  *bool
+}
+
+// approvedWork is the approved plan text an audit record carries. Run
+// state holds the same three fields, but the record is their durable
+// home: state.json is machine-local and an interrupted run is rebuilt
+// from the posted bodies, so resume carries them back rather than let a
+// resumed run dispatch an empty objective.
+type approvedWork struct {
+	objective          string
+	acceptanceCriteria []string
+	requiredTests      []string
 }
 
 // outcome is reconcileIssue's verdict for one issue: the resulting action
@@ -146,6 +159,10 @@ type outcome struct {
 	adoptWorktree string
 	// clearApproval drops ApprovedHeadOID and LastReviewVerdict (demotion).
 	clearApproval bool
+	// work is the approved text read back from the audit record, applied
+	// on every classification alike (it is a fact the record proves, not a
+	// consequence of the verdict). nil leaves the issue's copy untouched.
+	work *approvedWork
 	// warnings are run-level notices appended to ResumeDoc.Warnings.
 	warnings []string
 }
@@ -345,6 +362,12 @@ func applyOutcome(iss *state.Issue, o outcome) bool {
 		iss.LastReviewVerdict = ""
 		changed = true
 	}
+	if o.work != nil && !sameWork(iss, *o.work) {
+		iss.Objective = o.work.objective
+		iss.AcceptanceCriteria = o.work.acceptanceCriteria
+		iss.RequiredTests = o.work.requiredTests
+		changed = true
+	}
 	// A blocked outcome records its reason; every other outcome clears any
 	// stale BlockedReason so an unblocked issue leaves the phase cleanly.
 	reason := ""
@@ -356,6 +379,14 @@ func applyOutcome(iss *state.Issue, o outcome) bool {
 		changed = true
 	}
 	return changed
+}
+
+// sameWork reports whether iss already carries w, so a converged resume
+// stays a byte-level no-op instead of rewriting identical text.
+func sameWork(iss *state.Issue, w approvedWork) bool {
+	return iss.Objective == w.objective &&
+		slices.Equal(iss.AcceptanceCriteria, w.acceptanceCriteria) &&
+		slices.Equal(iss.RequiredTests, w.requiredTests)
 }
 
 // --- classify (pure) ---
@@ -376,12 +407,18 @@ func reconcileIssue(iss state.Issue, obs issueObservations) outcome {
 		// R1: planned and issue-created issues (and any issue missing the
 		// fields a blocked phase requires) can never be blocked — fall back
 		// to keep plus a run-level warning.
-		return outcome{
+		o = outcome{
 			action: ActionKept, phase: iss.Phase,
 			reason:   "kept; classification wanted to block but the issue lacks the number, branch, worktree, or routing decision a blocked phase requires",
 			warnings: []string{fmt.Sprintf("issue %s (%s) could not be blocked (missing number, branch, worktree, or routing decision); run `orch abort`", iss.PlanID, iss.Phase)},
 		}
 	}
+	// The approved work rides on every outcome the table can produce, so
+	// a resumed run dispatches the text an unresumed run would no matter
+	// which row classified the issue. It is nil unless the audit record
+	// parsed cleanly, so a blocked or unparsed record never overwrites
+	// what state already holds.
+	o.work = obs.work
 	return o
 }
 
@@ -767,6 +804,11 @@ func observeIssue(ctx context.Context, gh *ghops.GH, git *gitops.Git, worktrees 
 			yes := true
 			obs.manifestOK = &yes
 			obs.verifications = len(m.Verifications)
+			obs.work = &approvedWork{
+				objective:          m.Objective,
+				acceptanceCriteria: m.AcceptanceCriteria,
+				requiredTests:      m.RequiredTests,
+			}
 		}
 	}
 
@@ -808,7 +850,10 @@ func observeIssue(ctx context.Context, gh *ghops.GH, git *gitops.Git, worktrees 
 }
 
 // parsesManifest reports the phases whose audit record resume parses:
-// issue-created through awaiting-merge.
+// issue-created through awaiting-merge. Every one of them both
+// classifies on the record's health and repopulates the approved work
+// from it, so an issue that was resumed dispatches the same text an
+// issue that was not would.
 func parsesManifest(p state.Phase) bool {
 	switch p {
 	case state.PhaseIssueCreated, state.PhaseWorktreeReady, state.PhaseDispatched,

--- a/internal/run/resume_test.go
+++ b/internal/run/resume_test.go
@@ -463,6 +463,91 @@ func TestResumeSafeAtEveryPhase(t *testing.T) {
 	}
 }
 
+// --- Approved work repopulation ---
+
+// TestResumeRepopulatesApprovedWork proves that on every phase where
+// resume parses the audit record it also carries the approved work back
+// into run state, so a resumed run dispatches the text an unresumed run
+// would. Each fixture starts with the work stripped — the shape a run
+// activated by a pre-schema-2 build has, and the shape a resume would
+// otherwise leave behind silently. A second, identical resume must then
+// be a byte-level no-op: repopulation converges instead of rewriting.
+func TestResumeRepopulatesApprovedWork(t *testing.T) {
+	body := baseManifestBody(t)
+	phases := []state.Phase{
+		state.PhaseIssueCreated, state.PhaseWorktreeReady, state.PhaseDispatched,
+		state.PhasePROpen, state.PhaseInReview, state.PhaseAwaitingMerge,
+		state.PhaseBlocked,
+	}
+	for _, ph := range phases {
+		t.Run(string(ph), func(t *testing.T) {
+			iss := fixtureIssue("a", 1, ph)
+			iss.Objective = ""
+			iss.AcceptanceCriteria = nil
+			iss.RequiredTests = nil
+			root := setupDeliveryGitRepo(t, "r1", []state.Issue{iss})
+
+			var calls []execxtest.Call
+			switch ph {
+			case state.PhaseIssueCreated:
+				calls = []execxtest.Call{ghAuth(), ghIssueViewCall(t, 1, "OPEN", body)}
+			case state.PhaseWorktreeReady, state.PhaseDispatched, state.PhaseBlocked:
+				createBranchWorktree(t, root, "orch/issue-1")
+				calls = []execxtest.Call{ghAuth(), ghIssueViewCall(t, 1, "OPEN", body), ghPRListEmptyCall("orch/issue-1")}
+			case state.PhasePROpen, state.PhaseInReview:
+				createBranchWorktree(t, root, "orch/issue-1")
+				calls = []execxtest.Call{ghAuth(), ghIssueViewCall(t, 1, "OPEN", body), ghPRViewCall(10, "OPEN", "head"), ghRollupEmptyCall(10)}
+			case state.PhaseAwaitingMerge:
+				calls = []execxtest.Call{ghAuth(), ghIssueViewCall(t, 1, "OPEN", body), ghPRViewCall(10, "OPEN", "head-oid")}
+			}
+
+			_, script := resumeMux(t, root, ResumeRequest{}, calls...)
+			script.AssertExhausted()
+
+			got := loadRun(t, root).Run.Issues[0]
+			if got.Objective != fixtureObjective {
+				t.Errorf("objective = %q, want the record's %q", got.Objective, fixtureObjective)
+			}
+			if len(got.AcceptanceCriteria) != 1 || got.AcceptanceCriteria[0] != fixtureAcceptance()[0] {
+				t.Errorf("acceptance criteria = %q, want the record's %q", got.AcceptanceCriteria, fixtureAcceptance())
+			}
+			if len(got.RequiredTests) != 1 || got.RequiredTests[0] != fixtureTests()[0] {
+				t.Errorf("required tests = %q, want the record's %q", got.RequiredTests, fixtureTests())
+			}
+
+			before := stateBytes(t, root)
+			_, script2 := resumeMux(t, root, ResumeRequest{}, calls...)
+			script2.AssertExhausted()
+			if string(stateBytes(t, root)) != string(before) {
+				t.Error("a converged repopulation rewrote state")
+			}
+		})
+	}
+}
+
+// TestResumeKeepsApprovedWorkWhenRecordUnusable proves an unreadable
+// audit record contributes nothing: resume blocks on the drift, and the
+// approved work state already holds survives untouched rather than being
+// overwritten with the empty strings a failed parse would yield.
+func TestResumeKeepsApprovedWorkWhenRecordUnusable(t *testing.T) {
+	iss := fixtureIssue("a", 1, state.PhaseWorktreeReady)
+	o := reconcileIssue(iss, issueObservations{
+		read: true, issueState: "OPEN",
+		manifestOK: pbool(false), manifestErr: manifest.ErrDrift,
+		localBranch: pbool(true), worktree: pbool(true),
+	})
+	if o.action != ActionBlocked {
+		t.Fatalf("action = %q, want blocked on a drifted record", o.action)
+	}
+	if o.work != nil {
+		t.Fatal("a drifted record contributed approved work")
+	}
+	applyOutcome(&iss, o)
+	if iss.Objective != fixtureObjective || len(iss.AcceptanceCriteria) != 1 || len(iss.RequiredTests) != 1 {
+		t.Errorf("approved work was disturbed: %+v", iss)
+	}
+}
+
 // --- Integration: adopt an orphan PR left by a crashed pr-open ---
 
 // TestResumeAdoptsOrphanPR simulates a pr-open that created the PR but
@@ -482,7 +567,7 @@ func TestResumeAdoptsOrphanPR(t *testing.T) {
 	}
 	script.AssertExhausted()
 
-	runVerb(t, root, Dispatch, `{"schema_version":1,"issue_number":1}`,
+	runVerb(t, root, Dispatch, `{"schema_version":2,"issue_number":1}`,
 		ghAuth(), ghRepoViewCall("main"), ghSetStatusCall(1, ghops.StatusInProgress))
 
 	wtDir := filepath.Join(root, ".orchestrator", "worktrees", "issue-1")
@@ -592,15 +677,9 @@ func prJSONStdout(number int, prState, headOID string) string {
 // verification, the evidence resume requires to adopt an orphan PR.
 func manifestBodyWithVerification(t *testing.T) string {
 	t.Helper()
-	body, err := manifest.Upsert("**Objective**\n\ndo it\n", manifest.Manifest{
-		SchemaVersion:    manifest.SchemaVersion,
-		Role:             manifest.RoleImplementer,
-		Executor:         manifest.Selection{Model: "claude-sonnet-5", Effort: "xhigh"},
-		RoutingRationale: "impl",
-		Reviewer:         manifest.Selection{Model: "claude-opus-4-8", Effort: "high"},
-		ConfigRevision:   "r1",
-		Verifications:    []manifest.Verification{{Name: "go test", Result: "pass", At: "2026-07-11T12:00:00Z"}},
-	})
+	m := baseManifest()
+	m.Verifications = []manifest.Verification{{Name: "go test", Result: "pass", At: "2026-07-11T12:00:00Z"}}
+	body, err := manifest.Upsert("**Objective**\n\ndo it\n", m)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/run/verb_unit_test.go
+++ b/internal/run/verb_unit_test.go
@@ -46,16 +46,20 @@ func downgradedDecision() *state.Decision {
 }
 
 // fixtureIssue builds a state.Issue satisfying validateIssues for phase,
-// with the routing fields populated for the dispatched-onward phases.
+// with the routing fields populated for the dispatched-onward phases and
+// the approved work matching baseManifest's record.
 func fixtureIssue(planID string, number int, phase state.Phase) state.Issue {
 	iss := state.Issue{
-		PlanID:   planID,
-		Title:    "T",
-		Phase:    phase,
-		Number:   number,
-		Branch:   fmt.Sprintf("orch/issue-%d", number),
-		Worktree: fmt.Sprintf(".orchestrator/worktrees/issue-%d", number),
-		Decision: implementerDecision(),
+		PlanID:             planID,
+		Title:              "T",
+		Phase:              phase,
+		Number:             number,
+		Branch:             fmt.Sprintf("orch/issue-%d", number),
+		Worktree:           fmt.Sprintf(".orchestrator/worktrees/issue-%d", number),
+		Objective:          fixtureObjective,
+		AcceptanceCriteria: fixtureAcceptance(),
+		RequiredTests:      fixtureTests(),
+		Decision:           implementerDecision(),
 	}
 	switch phase {
 	case state.PhasePROpen, state.PhaseInReview:
@@ -114,7 +118,7 @@ func TestDispatchDependencyEnforcement(t *testing.T) {
 
 	// Unmet: a is not merged/cleaned.
 	script := &execxtest.Script{T: t}
-	_, err := Dispatch(context.Background(), ghEnv(root, script), []byte(`{"schema_version":1,"issue_number":2}`))
+	_, err := Dispatch(context.Background(), ghEnv(root, script), []byte(`{"schema_version":2,"issue_number":2}`))
 	if !errors.Is(err, ErrDependencyUnmet) {
 		t.Fatalf("err = %v, want ErrDependencyUnmet", err)
 	}
@@ -127,11 +131,45 @@ func TestDispatchDependencyEnforcement(t *testing.T) {
 		t.Fatal(err)
 	}
 	script = &execxtest.Script{T: t}
-	_, err = Dispatch(context.Background(), ghEnv(root, script), []byte(`{"schema_version":1,"issue_number":2}`))
+	_, err = Dispatch(context.Background(), ghEnv(root, script), []byte(`{"schema_version":2,"issue_number":2}`))
 	if !errors.Is(err, ErrDependencyAbandoned) {
 		t.Fatalf("err = %v, want ErrDependencyAbandoned", err)
 	}
 	script.AssertExhausted()
+}
+
+// TestDispatchWithoutApprovedWorkFailsClosed proves dispatch refuses an
+// issue whose approved work is missing — the shape a run activated by a
+// pre-schema-2 build has — instead of handing the executor an empty
+// objective, and names resume as the remediation. It fails before any
+// git or gh call and leaves state untouched.
+func TestDispatchWithoutApprovedWorkFailsClosed(t *testing.T) {
+	cases := map[string]func(*state.Issue){
+		"no objective":           func(iss *state.Issue) { iss.Objective = "" },
+		"no acceptance criteria": func(iss *state.Issue) { iss.AcceptanceCriteria = nil },
+		"no required tests":      func(iss *state.Issue) { iss.RequiredTests = nil },
+	}
+	for name, strip := range cases {
+		t.Run(name, func(t *testing.T) {
+			iss := fixtureIssue("a", 1, state.PhaseWorktreeReady)
+			strip(&iss)
+			root := setupDeliveryRepo(t, "r1", []state.Issue{iss})
+			before := stateBytes(t, root)
+
+			script := &execxtest.Script{T: t}
+			_, err := Dispatch(context.Background(), ghEnv(root, script), []byte(`{"schema_version":2,"issue_number":1}`))
+			if err == nil {
+				t.Fatal("Dispatch accepted an issue with no approved work")
+			}
+			if !strings.Contains(err.Error(), "orch resume") {
+				t.Errorf("err %v does not name the resume remediation", err)
+			}
+			script.AssertExhausted() // failed before any git/gh call
+			if string(stateBytes(t, root)) != string(before) {
+				t.Error("state changed on a failed dispatch")
+			}
+		})
+	}
 }
 
 // --- Config drift ---
@@ -139,7 +177,7 @@ func TestDispatchDependencyEnforcement(t *testing.T) {
 func TestConfigDriftFailsClosed(t *testing.T) {
 	root := setupDeliveryRepo(t, "r2", []state.Issue{fixtureIssue("a", 1, state.PhaseWorktreeReady)})
 	script := &execxtest.Script{T: t}
-	_, err := Dispatch(context.Background(), ghEnv(root, script), []byte(`{"schema_version":1,"issue_number":1}`))
+	_, err := Dispatch(context.Background(), ghEnv(root, script), []byte(`{"schema_version":2,"issue_number":1}`))
 	if !errors.Is(err, ErrConfigDrift) {
 		t.Fatalf("err = %v, want ErrConfigDrift", err)
 	}
@@ -415,18 +453,11 @@ func TestTruncateDetail(t *testing.T) {
 
 func TestUpsertCappedDropsOldestDetails(t *testing.T) {
 	big := strings.Repeat("x", 25000)
-	m := manifest.Manifest{
-		SchemaVersion:    manifest.SchemaVersion,
-		Role:             manifest.RoleImplementer,
-		Executor:         manifest.Selection{Model: "m", Effort: "e"},
-		RoutingRationale: "r",
-		Reviewer:         manifest.Selection{Model: "m", Effort: "e"},
-		ConfigRevision:   "r1",
-		Verifications: []manifest.Verification{
-			{Name: "v1", Result: "pass", Detail: big, At: "t1"},
-			{Name: "v2", Result: "pass", Detail: big, At: "t2"},
-			{Name: "v3", Result: "pass", Detail: big, At: "t3"},
-		},
+	m := baseManifest()
+	m.Verifications = []manifest.Verification{
+		{Name: "v1", Result: "pass", Detail: big, At: "t1"},
+		{Name: "v2", Result: "pass", Detail: big, At: "t2"},
+		{Name: "v3", Result: "pass", Detail: big, At: "t3"},
 	}
 	body, err := upsertCapped("prose", m)
 	if err != nil {
@@ -456,15 +487,8 @@ func TestUpsertCappedDropsOldestDetails(t *testing.T) {
 
 func TestUpsertCappedHardFails(t *testing.T) {
 	prose := strings.Repeat("y", githubBodyLimit)
-	m := manifest.Manifest{
-		SchemaVersion:    manifest.SchemaVersion,
-		Role:             manifest.RoleImplementer,
-		Executor:         manifest.Selection{Model: "m", Effort: "e"},
-		RoutingRationale: "r",
-		Reviewer:         manifest.Selection{Model: "m", Effort: "e"},
-		ConfigRevision:   "r1",
-		Verifications:    []manifest.Verification{{Name: "v", Result: "pass", Detail: "d", At: "t"}},
-	}
+	m := baseManifest()
+	m.Verifications = []manifest.Verification{{Name: "v", Result: "pass", Detail: "d", At: "t"}}
 	_, err := upsertCapped(prose, m)
 	if !errors.Is(err, ErrBodyTooLarge) {
 		t.Fatalf("err = %v, want ErrBodyTooLarge", err)

--- a/internal/run/verb_unit_test.go
+++ b/internal/run/verb_unit_test.go
@@ -141,8 +141,10 @@ func TestDispatchDependencyEnforcement(t *testing.T) {
 // TestDispatchWithoutApprovedWorkFailsClosed proves dispatch refuses an
 // issue whose approved work is missing — the shape a run activated by a
 // pre-schema-2 build has — instead of handing the executor an empty
-// objective, and names resume as the remediation. It fails before any
-// git or gh call and leaves state untouched.
+// objective. It names abort, not resume: the same run's issue body still
+// carries a schema-1 record, so a resume would block the issue rather
+// than repair it. It fails before any git or gh call and leaves state
+// untouched.
 func TestDispatchWithoutApprovedWorkFailsClosed(t *testing.T) {
 	cases := map[string]func(*state.Issue){
 		"no objective":           func(iss *state.Issue) { iss.Objective = "" },
@@ -161,8 +163,11 @@ func TestDispatchWithoutApprovedWorkFailsClosed(t *testing.T) {
 			if err == nil {
 				t.Fatal("Dispatch accepted an issue with no approved work")
 			}
-			if !strings.Contains(err.Error(), "orch resume") {
-				t.Errorf("err %v does not name the resume remediation", err)
+			if !strings.Contains(err.Error(), "orch abort") {
+				t.Errorf("err %v does not name the abort remediation", err)
+			}
+			if strings.Contains(err.Error(), "orch resume") {
+				t.Errorf("err %v names resume, which blocks this issue instead of repairing it", err)
 			}
 			script.AssertExhausted() // failed before any git/gh call
 			if string(stateBytes(t, root)) != string(before) {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -140,6 +140,17 @@ type Issue struct {
 	DependsOn []string `json:"depends_on,omitempty"`
 	Wave      int      `json:"wave,omitempty"`
 
+	// Objective, AcceptanceCriteria, and RequiredTests are the approved
+	// plan text, copied at EnterDelivery so dispatch hands the executor a
+	// transcription of what a human approved rather than a recollection
+	// of it. They are optional in the persisted file rather than required
+	// by validateIssues because a run activated by a build older than the
+	// schema-2 audit record carries none; `orch resume` repopulates them
+	// from the issue body, which is their durable home.
+	Objective          string   `json:"objective,omitempty"`
+	AcceptanceCriteria []string `json:"acceptance_criteria,omitempty"`
+	RequiredTests      []string `json:"required_tests,omitempty"`
+
 	// Decision is the current routing for the issue, set at activation
 	// and updated by escalate. Required from the dispatched phase onward.
 	Decision *Decision `json:"decision,omitempty"`


### PR DESCRIPTION
Delivers issue #51: Carry the approved work and honest effort delivery through the manifest and dispatch

Closes #51

**Plan digest:** `sha256:a445c0066bafbfa17cb7d0c321823b7c4296a815fcf01f96ef6a1fc8164ff5e6`

The full objective and acceptance criteria are on the linked issue.

<!-- orch:manifest:begin -->
### Orch audit record

| Field | Value |
| --- | --- |
| Role | `specialist` |
| Executor | `claude-opus-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to a specialist with a strong reviewer because risk domains (data-integrity) and the task is unusually difficult.

**Escalations:** _none_

**Verification:**
- **build** — pass — `go build ./...` — no output (2026-07-26T14:49:11Z)
- **vet** — pass — `go vet ./...` — no output (2026-07-26T14:49:11Z)
- **full-test-suite** — pass — `go test ./...` — all 21 packages ok, 0 failures (2026-07-26T14:49:11Z)
- **gofmt** — pass — `gofmt -l .` — empty output; no unformatted files (2026-07-26T14:49:11Z)
- **review-cycle-1** — request-changes — Request-changes at head 9ad197b. All eight acceptance criteria are met and were independently verified, including hostile-tested escaping of the new fields and a resume repopulation proven idempotent by byte-comparing state.json across two identical runs. Two blocking items, both small. First: checkApprovedWork's remediation at internal/run/dispatch.go:156 tells the operator to run `orch resume`, but the reviewer traced every reachable state and resume cannot repopulate in the only scenario the guard fires. State-without-work implies a schema-1 issue body, which this build's Parse now rejects, so resume classifies the issue blocked instead of repopulating it. The message is wrong every time it fires; `orch abort` plus re-plan and re-activate is the real path. This is the same class of defect the issue exists to remove, reintroduced in code no criterion requested. Second, scope: two of the four SKILL.md edits deliver issue #53's acceptance criteria 1 and 2 verbatim (the transcribe-verbatim sentence and the rewritten spawn-step instruction), while the schema_version number and the DispatchResult field list are genuinely required here. Because both plugin.json files are still 0.3.0, those edits reach no installed session and so buy no consistency at this commit. Rulings on the executor's four flagged calls: the DispatchSchemaVersion bump is correct, matching the house one-constant-both-directions idiom, and failing closed on v1 is the point, since a v1 adapter is one still supplying the objective from Architect recall. Rendering the new fields into human markdown is required rather than tidy, because Parse re-renders the decoded record and byte-compares, so a JSON-only field's tamper is structurally undetectable. Omitting the state.SchemaVersion bump is sound, since state.Load uses plain Unmarshal without DisallowUnknownFields. Release sequencing to record before any release: merge #51, then #53's plugin bump, then cut the release, then users update binary and plugin t … [truncated by orch] (2026-07-26T15:03:45Z)
- **review-cycle-2** — approve — Approve at head 1ee2593. All eight acceptance criteria independently re-verified after the fix commit. Cycle 1's two blocking findings are resolved, and the resolutions were traced rather than taken on trust. The checkApprovedWork remediation now names `orch abort`, and the reviewer confirmed both halves: resume genuinely cannot repair the only reachable case (a pre-schema-2 activation whose v1 body Parse rejects, routing observeIssue to the block path), and abort plus re-plan/re-activate genuinely recovers, since state.Abort touches no branches, worktrees, or issues and re-activation keys new paths off new issue numbers so stale artifacts cannot collide. The SKILL.md revert is exact by construction: git diff origin/main...HEAD -- adapters/ is the complete delta at four changed lines, two per file, so the two prescriptive sentences are byte-identical to main. Both plugin.json files remain 0.3.0, preserving the #51 then #53 then release sequencing. The new pr-open sentence is true: Upsert appends the record below the prose, and upsertCapped only ever drops verification details, never the work fields, so it stays true under the cap and hard-fails rather than silently shedding them. All three items the human declined are confirmed absent. Verification evidence reproduced by the reviewer at this exact head, recorded here because the engine cannot accept a verifications array once an issue is in-review: go build ./... exit 0; go vet ./... exit 0; gofmt -l . empty; go test ./... exit 0 with 22 ok, 3 no-test-files (cmd/orch, internal/adaptertest, internal/execx/execxtest), 25 packages total. This corrects the cycle-1 verification detail, which recorded 21 packages and described head 9ad197b rather than the merged head. All six required CI checks are SUCCESS with head_sha confirmed as 1ee2593. One non-blocking finding: a comment new in this PR at internal/state/state.go lines 143-149 still offers orch resume as the reason the work fields are optional, contradicting dispatch … [truncated by orch] (2026-07-26T15:23:04Z)
- **required-ci** — passing — test (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass (2026-07-26T15:23:07Z)

<!-- orch:manifest:data
{
  "schema_version": 1,
  "role": "specialist",
  "executor": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to a specialist with a strong reviewer because risk domains (data-integrity) and the task is unusually difficult.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "no output",
      "at": "2026-07-26T14:49:11Z"
    },
    {
      "name": "vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "no output",
      "at": "2026-07-26T14:49:11Z"
    },
    {
      "name": "full-test-suite",
      "command": "go test ./...",
      "result": "pass",
      "detail": "all 21 packages ok, 0 failures",
      "at": "2026-07-26T14:49:11Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "empty output; no unformatted files",
      "at": "2026-07-26T14:49:11Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "Request-changes at head 9ad197b. All eight acceptance criteria are met and were independently verified, including hostile-tested escaping of the new fields and a resume repopulation proven idempotent by byte-comparing state.json across two identical runs. Two blocking items, both small. First: checkApprovedWork's remediation at internal/run/dispatch.go:156 tells the operator to run `orch resume`, but the reviewer traced every reachable state and resume cannot repopulate in the only scenario the guard fires. State-without-work implies a schema-1 issue body, which this build's Parse now rejects, so resume classifies the issue blocked instead of repopulating it. The message is wrong every time it fires; `orch abort` plus re-plan and re-activate is the real path. This is the same class of defect the issue exists to remove, reintroduced in code no criterion requested. Second, scope: two of the four SKILL.md edits deliver issue #53's acceptance criteria 1 and 2 verbatim (the transcribe-verbatim sentence and the rewritten spawn-step instruction), while the schema_version number and the DispatchResult field list are genuinely required here. Because both plugin.json files are still 0.3.0, those edits reach no installed session and so buy no consistency at this commit. Rulings on the executor's four flagged calls: the DispatchSchemaVersion bump is correct, matching the house one-constant-both-directions idiom, and failing closed on v1 is the point, since a v1 adapter is one still supplying the objective from Architect recall. Rendering the new fields into human markdown is required rather than tidy, because Parse re-renders the decoded record and byte-compares, so a JSON-only field's tamper is structurally undetectable. Omitting the state.SchemaVersion bump is sound, since state.Load uses plain Unmarshal without DisallowUnknownFields. Release sequencing to record before any release: merge #51, then #53's plugin bump, then cut the release, then users update binary and plugin t … [truncated by orch]",
      "at": "2026-07-26T15:03:45Z"
    },
    {
      "name": "review-cycle-2",
      "result": "approve",
      "detail": "Approve at head 1ee2593. All eight acceptance criteria independently re-verified after the fix commit. Cycle 1's two blocking findings are resolved, and the resolutions were traced rather than taken on trust. The checkApprovedWork remediation now names `orch abort`, and the reviewer confirmed both halves: resume genuinely cannot repair the only reachable case (a pre-schema-2 activation whose v1 body Parse rejects, routing observeIssue to the block path), and abort plus re-plan/re-activate genuinely recovers, since state.Abort touches no branches, worktrees, or issues and re-activation keys new paths off new issue numbers so stale artifacts cannot collide. The SKILL.md revert is exact by construction: git diff origin/main...HEAD -- adapters/ is the complete delta at four changed lines, two per file, so the two prescriptive sentences are byte-identical to main. Both plugin.json files remain 0.3.0, preserving the #51 then #53 then release sequencing. The new pr-open sentence is true: Upsert appends the record below the prose, and upsertCapped only ever drops verification details, never the work fields, so it stays true under the cap and hard-fails rather than silently shedding them. All three items the human declined are confirmed absent. Verification evidence reproduced by the reviewer at this exact head, recorded here because the engine cannot accept a verifications array once an issue is in-review: go build ./... exit 0; go vet ./... exit 0; gofmt -l . empty; go test ./... exit 0 with 22 ok, 3 no-test-files (cmd/orch, internal/adaptertest, internal/execx/execxtest), 25 packages total. This corrects the cycle-1 verification detail, which recorded 21 packages and described head 9ad197b rather than the merged head. All six required CI checks are SUCCESS with head_sha confirmed as 1ee2593. One non-blocking finding: a comment new in this PR at internal/state/state.go lines 143-149 still offers orch resume as the reason the work fields are optional, contradicting dispatch … [truncated by orch]",
      "at": "2026-07-26T15:23:04Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "at": "2026-07-26T15:23:07Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->