### PR TITLE
Make the delivery skills transcribe dispatched work and state effort delivery honestly

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "kninetimmy" },
   "metadata": {
     "description": "Host adapters for the Orch development orchestrator",
-    "version": "0.3.0"
+    "version": "0.4.0"
   },
   "plugins": [
     {

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Claude Code host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -78,8 +78,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.3.0" {
-		t.Errorf("version = %q, want 0.3.0", m.Version)
+	if m.Version != "0.4.0" {
+		t.Errorf("version = %q, want 0.4.0", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -66,6 +66,16 @@ every one you declare must already exist in the repo — activation fails
 closed at a read-only preflight if any is missing (create it with
 `gh label create <name>` or drop it from the plan).
 
+Write `acceptance_criteria` and `required_tests` as a floor, not a
+survey. Each acceptance criterion names one behavior that must hold once
+the issue is done — a specific, checkable outcome an executor can
+satisfy and a reviewer can confirm without guessing — never an
+open-ended instruction like "handle edge cases" or "add tests" that
+leaves the bar for "done" to be invented later. Each required test names
+the exact command that gates the change (`go test ./...`, `gofmt -l .`);
+it is not an invitation for comprehensive coverage, just the check this
+change must pass.
+
 ## Plan gate
 
 Call `orch run plan` with the `PlanDoc` on stdin. The result is a
@@ -149,10 +159,16 @@ in flight at once. For each issue:
 
    followed by one sentence: `xhigh`/`high` → "Use maximum reasoning
    depth for this task."; `low` → "Work fast and economically; this
-   task does not need deep reasoning." (The exact routed effort is
-   recorded server-side regardless; this cue only shapes in-session
-   behavior.) Include the worktree path, branch, objective, acceptance
-   criteria, and required tests in the prompt.
+   task does not need deep reasoning." Claude Code subagent spawns take
+   no effort parameter, so this sentence is the only way the routed
+   effort reaches the executor: the host enforces the routed *model*
+   (via the Task tool override above, or by refusing to spawn) but only
+   *conveys* the routed effort as this prompt cue — nothing checks that
+   the executor actually reasoned at that depth. Transcribe
+   `DispatchResult.objective`, `.acceptance_criteria`, and
+   `.required_tests` into the prompt **verbatim** — this is the text a
+   human approved at the plan gate, not the Architect's recollection of
+   it — along with the worktree path and branch.
 
    Before spawning, you (the Architect) perform whatever memhub recall
    is relevant to the issue, with the main checkout as cwd — never a

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Codex CLI host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -79,8 +79,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.3.0" {
-		t.Errorf("version = %q, want 0.3.0", m.Version)
+	if m.Version != "0.4.0" {
+		t.Errorf("version = %q, want 0.4.0", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -66,6 +66,16 @@ every one you declare must already exist in the repo — activation fails
 closed at a read-only preflight if any is missing (create it with
 `gh label create <name>` or drop it from the plan).
 
+Write `acceptance_criteria` and `required_tests` as a floor, not a
+survey. Each acceptance criterion names one behavior that must hold once
+the issue is done — a specific, checkable outcome an executor can
+satisfy and a reviewer can confirm without guessing — never an
+open-ended instruction like "handle edge cases" or "add tests" that
+leaves the bar for "done" to be invented later. Each required test names
+the exact command that gates the change (`go test ./...`, `gofmt -l .`);
+it is not an invitation for comprehensive coverage, just the check this
+change must pass.
+
 ## Plan gate
 
 Call `orch run plan` with the `PlanDoc` on stdin. The result is a
@@ -154,11 +164,16 @@ in flight at once. For each issue:
    Routed selection: <model> @ <effort>
    ```
 
-   Effort is a real host parameter on Codex, pinned in the dispatched
-   agent's own TOML — there is no prompt cue to layer on top of it; the
-   opening line is a statement of fact, not a behavioral nudge. Include
-   the worktree path, branch, objective, acceptance criteria, and
-   required tests in the prompt.
+   Effort is a real host parameter on Codex: the host enforces both the
+   routed model and the routed effort together, through the TOML-match
+   rule above — `model_reasoning_effort` is pinned in the dispatched
+   agent's own installed TOML, not layered on afterward, so there is no
+   prompt cue standing in for it the way there is on Claude. The opening
+   line is a statement of fact, not a behavioral nudge. Transcribe
+   `DispatchResult.objective`, `.acceptance_criteria`, and
+   `.required_tests` into the prompt **verbatim** — this is the text a
+   human approved at the plan gate, not the Architect's recollection of
+   it — along with the worktree path and branch.
 
    Before dispatching, you (the Architect) perform whatever memhub
    recall is relevant to the issue, with the main checkout as cwd —


### PR DESCRIPTION
Delivers issue #53: Make the delivery skills transcribe dispatched work and state effort delivery honestly

Closes #53

**Plan digest:** `sha256:a445c0066bafbfa17cb7d0c321823b7c4296a815fcf01f96ef6a1fc8164ff5e6`

The full objective and acceptance criteria are on the linked issue.

<!-- orch:manifest:begin -->
### Orch audit record

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **adapter-tests** — pass — `go test ./adapters/...` — ok github.com/kninetimmy/orch/adapters/claude 0.335s; ok github.com/kninetimmy/orch/adapters/codex 0.338s. Includes the drift-pinning checks and TestMarketplaceEntryConsistency. (2026-07-26T15:31:26Z)
- **full-test-suite** — pass — `go test ./...` — 25 packages, count confirmed mechanically via go list ./...; every package reports ok or [no test files], none fail. (2026-07-26T15:31:26Z)
- **gofmt** — pass — `gofmt -l .` — empty output; no unformatted files (2026-07-26T15:31:26Z)
- **vet** — pass — `go vet ./...` — clean, no output. Run for sanity; not one of the issue's required tests. (2026-07-26T15:31:26Z)
- **review-cycle-1** — approve — Approve at head 1c62cf9. All six acceptance criteria met, scope exactly right at seven files and one commit, every claimed verification reproduced. Criterion 1 was satisfied upstream by #51 and the executor reported that accurately rather than re-claiming it: the reviewer traced authorship with git log -L and read #55's commit message, confirming this PR delivers precisely the two edits #55 reverted, no more and no less. Criterion 2's transcription sentence is byte-identical across hosts and matches the DispatchResult doc comment in the engine, so skill and code now assert the same contract. Criterion 3 correctly diverges per host against internal/run/derive.go's mapping: Claude states the host enforces the routed model but only conveys effort as a prompt cue with nothing checking it, matching EffortDeliveryPromptCue; Codex states model and effort are enforced together through the pinned TOML, matching EffortDeliveryParameter and verified against all five shipped agent TOMLs. Criterion 4's plan guidance is the plan-side complement of merged #52's executor-side boundary, with no contradiction between them. Criterion 5 is complete: a repo-wide grep for the previous version returns nothing outside .git. The marketplace.json bump, not named in the issue, is required by construction rather than scope creep: TestMarketplaceEntryConsistency asserts plugin and marketplace versions are equal, and commit e81245f set the identical lockstep precedent at 0.2.0. Criterion 6's verb-token check was confirmed to do what the criterion claims. The out-of-scope false claim that request-changes repeats from pr-open is confirmed untouched, was independently confirmed false, and remains recorded for a future issue. Evidence reproduced at this head: go test ./adapters/... pass; go test ./... exit 0 across 25 packages confirmed independently via go list, 22 ok and 3 no-test-files, zero failures; gofmt -l . empty; go vet and go build clean; all six required CI checks pass. Record-hygiene not … [truncated by orch] (2026-07-26T15:38:48Z)
- **required-ci** — passing — lint=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass (2026-07-26T15:38:52Z)

<!-- orch:manifest:data
{
  "schema_version": 1,
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "adapter-tests",
      "command": "go test ./adapters/...",
      "result": "pass",
      "detail": "ok github.com/kninetimmy/orch/adapters/claude 0.335s; ok github.com/kninetimmy/orch/adapters/codex 0.338s. Includes the drift-pinning checks and TestMarketplaceEntryConsistency.",
      "at": "2026-07-26T15:31:26Z"
    },
    {
      "name": "full-test-suite",
      "command": "go test ./...",
      "result": "pass",
      "detail": "25 packages, count confirmed mechanically via go list ./...; every package reports ok or [no test files], none fail.",
      "at": "2026-07-26T15:31:26Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "empty output; no unformatted files",
      "at": "2026-07-26T15:31:26Z"
    },
    {
      "name": "vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "clean, no output. Run for sanity; not one of the issue's required tests.",
      "at": "2026-07-26T15:31:26Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approve at head 1c62cf9. All six acceptance criteria met, scope exactly right at seven files and one commit, every claimed verification reproduced. Criterion 1 was satisfied upstream by #51 and the executor reported that accurately rather than re-claiming it: the reviewer traced authorship with git log -L and read #55's commit message, confirming this PR delivers precisely the two edits #55 reverted, no more and no less. Criterion 2's transcription sentence is byte-identical across hosts and matches the DispatchResult doc comment in the engine, so skill and code now assert the same contract. Criterion 3 correctly diverges per host against internal/run/derive.go's mapping: Claude states the host enforces the routed model but only conveys effort as a prompt cue with nothing checking it, matching EffortDeliveryPromptCue; Codex states model and effort are enforced together through the pinned TOML, matching EffortDeliveryParameter and verified against all five shipped agent TOMLs. Criterion 4's plan guidance is the plan-side complement of merged #52's executor-side boundary, with no contradiction between them. Criterion 5 is complete: a repo-wide grep for the previous version returns nothing outside .git. The marketplace.json bump, not named in the issue, is required by construction rather than scope creep: TestMarketplaceEntryConsistency asserts plugin and marketplace versions are equal, and commit e81245f set the identical lockstep precedent at 0.2.0. Criterion 6's verb-token check was confirmed to do what the criterion claims. The out-of-scope false claim that request-changes repeats from pr-open is confirmed untouched, was independently confirmed false, and remains recorded for a future issue. Evidence reproduced at this head: go test ./adapters/... pass; go test ./... exit 0 across 25 packages confirmed independently via go list, 22 ok and 3 no-test-files, zero failures; gofmt -l . empty; go vet and go build clean; all six required CI checks pass. Record-hygiene not … [truncated by orch]",
      "at": "2026-07-26T15:38:48Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "lint=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass",
      "at": "2026-07-26T15:38:52Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->