### PR TITLE
Correct the delivery skills' request-changes loop and PowerShell-incompatible stdin form

### DIFF
--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -22,10 +22,14 @@ faithfully.
 1. Write the request JSON to a scratch file in the OS temp directory,
    **outside the repository** (never inside the working tree or a
    worktree).
-2. Run `orch run <verb> < <scratch-file>` and capture stdout. On
-   Windows PowerShell, `<` is rejected ("The '<' operator is reserved
-   for future use."); use
-   `Get-Content -Raw <scratch-file> | orch run <verb>` instead.
+2. Run `orch run <verb> < <scratch-file>` and capture stdout.
+   PowerShell (5.1 and pwsh 7) rejects `<` ("The '<' operator is
+   reserved for future use."); use the pipe form instead:
+   `Get-Content -Raw <scratch-file> | orch run <verb>`. On Windows
+   PowerShell 5.1 specifically, that pipe alone silently corrupts
+   non-ASCII (em dashes, `§`) into `?`; guard it with
+   `$OutputEncoding = New-Object System.Text.UTF8Encoding $false;
+   Get-Content -Raw -Encoding UTF8 <scratch-file> | orch run <verb>`.
 3. Exit 0: parse stdout as the verb's JSON result.
 4. Non-zero exit: the engine refused. Present the stderr message
    **verbatim** — never paraphrase, never retry blind, never work
@@ -214,9 +218,10 @@ in flight at once. For each issue:
    `usage` is optional (PRD §21), same rule as PR-open: only report
    what the reviewer subagent's Task result actually carries.
    `request-changes` loops the same executor in the **same worktree**
-   on the same branch: it fixes, then a **fresh** reviewer is spawned
-   (step 4) and `orch run review` is called again. `orch run pr-open`
-   is not reachable a second time. `approve` continues.
+   on the same branch: it fixes and pushes, then a **fresh** reviewer
+   is spawned (step 4) and `orch run review` is called again.
+   `orch run pr-open` is not reachable a second time. `approve`
+   continues.
 
 6. **CI** — `orch run ci` with
    `{"schema_version": 1, "issue_number": N}` records the honest

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -22,7 +22,10 @@ faithfully.
 1. Write the request JSON to a scratch file in the OS temp directory,
    **outside the repository** (never inside the working tree or a
    worktree).
-2. Run `orch run <verb> < <scratch-file>` and capture stdout.
+2. Run `orch run <verb> < <scratch-file>` and capture stdout. On
+   Windows PowerShell, `<` is rejected ("The '<' operator is reserved
+   for future use."); use
+   `Get-Content -Raw <scratch-file> | orch run <verb>` instead.
 3. Exit 0: parse stdout as the verb's JSON result.
 4. Non-zero exit: the engine refused. Present the stderr message
    **verbatim** — never paraphrase, never retry blind, never work
@@ -210,8 +213,10 @@ in flight at once. For each issue:
 
    `usage` is optional (PRD §21), same rule as PR-open: only report
    what the reviewer subagent's Task result actually carries.
-   `request-changes` loops the same executor in the **same worktree**,
-   then repeats from PR-open. `approve` continues.
+   `request-changes` loops the same executor in the **same worktree**
+   on the same branch: it fixes, then a **fresh** reviewer is spawned
+   (step 4) and `orch run review` is called again. `orch run pr-open`
+   is not reachable a second time. `approve` continues.
 
 6. **CI** — `orch run ci` with
    `{"schema_version": 1, "issue_number": N}` records the honest

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -22,7 +22,10 @@ faithfully.
 1. Write the request JSON to a scratch file in the OS temp directory,
    **outside the repository** (never inside the working tree or a
    worktree).
-2. Run `orch run <verb> < <scratch-file>` and capture stdout.
+2. Run `orch run <verb> < <scratch-file>` and capture stdout. On
+   Windows PowerShell, `<` is rejected ("The '<' operator is reserved
+   for future use."); use
+   `Get-Content -Raw <scratch-file> | orch run <verb>` instead.
 3. Exit 0: parse stdout as the verb's JSON result.
 4. Non-zero exit: the engine refused. Present the stderr message
    **verbatim** — never paraphrase, never retry blind, never work
@@ -219,8 +222,11 @@ in flight at once. For each issue:
 
    `usage` is optional (PRD §21), same rule as PR-open: only report
    what the reviewer agent's own reporting actually gives you.
-   `request-changes` loops the same executor in the **same worktree**,
-   then repeats from PR-open. `approve` continues.
+   `request-changes` loops the same executor in the **same worktree**
+   on the same branch: it fixes, then a **fresh** reviewer is
+   dispatched (step 4) and `orch run review` is called again.
+   `orch run pr-open` is not reachable a second time. `approve`
+   continues.
 
 6. **CI** — `orch run ci` with
    `{"schema_version": 1, "issue_number": N}` records the honest

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -22,10 +22,14 @@ faithfully.
 1. Write the request JSON to a scratch file in the OS temp directory,
    **outside the repository** (never inside the working tree or a
    worktree).
-2. Run `orch run <verb> < <scratch-file>` and capture stdout. On
-   Windows PowerShell, `<` is rejected ("The '<' operator is reserved
-   for future use."); use
-   `Get-Content -Raw <scratch-file> | orch run <verb>` instead.
+2. Run `orch run <verb> < <scratch-file>` and capture stdout.
+   PowerShell (5.1 and pwsh 7) rejects `<` ("The '<' operator is
+   reserved for future use."); use the pipe form instead:
+   `Get-Content -Raw <scratch-file> | orch run <verb>`. On Windows
+   PowerShell 5.1 specifically, that pipe alone silently corrupts
+   non-ASCII (em dashes, `§`) into `?`; guard it with
+   `$OutputEncoding = New-Object System.Text.UTF8Encoding $false;
+   Get-Content -Raw -Encoding UTF8 <scratch-file> | orch run <verb>`.
 3. Exit 0: parse stdout as the verb's JSON result.
 4. Non-zero exit: the engine refused. Present the stderr message
    **verbatim** — never paraphrase, never retry blind, never work
@@ -223,8 +227,8 @@ in flight at once. For each issue:
    `usage` is optional (PRD §21), same rule as PR-open: only report
    what the reviewer agent's own reporting actually gives you.
    `request-changes` loops the same executor in the **same worktree**
-   on the same branch: it fixes, then a **fresh** reviewer is
-   dispatched (step 4) and `orch run review` is called again.
+   on the same branch: it fixes and pushes, then a **fresh** reviewer
+   is dispatched (step 4) and `orch run review` is called again.
    `orch run pr-open` is not reachable a second time. `approve`
    continues.
 


### PR DESCRIPTION
Delivers issue #57: Correct the delivery skills' request-changes loop and PowerShell-incompatible stdin form

Closes #57

**Plan digest:** `sha256:f93feb2fe842240aa6990a1a553ab0aaf575400ab787908ed4057fe1f33c3d0c`

The full objective and acceptance criteria are on the linked issue.

<!-- orch:manifest:begin -->
### Orch audit record

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.

**Escalations:** _none_

**Verification:**
- **go-build** — pass — `go build ./...` — Run by the executor from the issue-57 worktree root; no output. (2026-07-26T16:44:21Z)
- **go-vet** — pass — `go vet ./...` — Run by the executor from the issue-57 worktree root; no output. (2026-07-26T16:44:21Z)
- **gofmt** — pass — `gofmt -l .` — Run by the executor from the issue-57 worktree root; printed nothing, so no file needs reformatting. (2026-07-26T16:44:21Z)
- **go-test** — pass — `go test ./...` — Run by the executor from the issue-57 worktree root; all packages ok, including adapters/claude, adapters/codex and internal/run. internal/adaptertest reported [no test files], which is expected: it is a test-support package consumed by both adapters' plugin_test.go, not itself under test. (2026-07-26T16:44:21Z)
- **review-cycle-1** — approve — APPROVE. All six acceptance criteria met at head 72dfe0a. Three non-blocking observations recorded below.

AC1 (step-5 sentence corrected): met in both files. The false 'then repeats from PR-open' is gone; the new text names same executor, same branch, same worktree, a fresh reviewer at step 4, orch run review again, and pr-open unreachable a second time.

AC2 (accuracy against the engine): met, verified independently rather than trusted. propen.go:73 loads with []state.Phase{state.PhaseDispatched} only; review.go:73 accepts {PhasePROpen, PhaseInReview} and review.go:102 sets PhaseInReview on every cycle, so cycle 2 lands on a phase review accepts and the documented loop closes. The only forward assignment of PhaseDispatched is dispatch.go:104, reachable only from worktree-ready (dispatch.go:66); resume.go:461-473 returns dispatched only when PRNumber == 0 and resume.go:436 lowers a dispatched keep to worktree-ready; propen.go:106 fails closed on an existing open PR. The reviewer also confirmed the corrected loop does not strand an operator downstream: civerb.go:56 accepts in-review, mergereport.go:59 requires in-review, merge.go:67 requires awaiting-merge.

AC3 (Windows-usable stdin form): met, verified empirically on this machine with -NoProfile and a scratchpad probe binary. powershell.exe 5.1.26100.8875 and pwsh 7.6.4 both reject the POSIX form with exactly the quoted text 'The '&lt;' operator is reserved for future use.'; the documented Get-Content -Raw pipe form delivers stdin on both at exit 0. The pipe appends a trailing CRLF, which is harmless because decodeRequest (lifecycle.go:183-193) uses a json.Decoder whose More() returns false on trailing whitespace; no BOM is prepended. Every '&lt;' in the new prose sits inside a code span.

AC4 (parity): met. The new step-2 block is byte-identical between the two files; step 5 differs only in spawned/dispatched, which is correct — the Claude file's steps say Spawn and the Codex file's say Dispatch, so flattening to one v … [truncated by orch] (2026-07-26T16:55:27Z)
- **review-cycle-2** — approve — APPROVE — PR #58 at 859db17, cycle 2, fresh reviewer. All six acceptance criteria met; no blocking findings. Three non-blocking findings listed first so the 2000-rune detail cap cannot drop them.

NON-BLOCKING 1: the manifest's four verification entries stay pinned to cycle 1's head — pr-open is the only verb that writes Verifications and is unreachable a second time, which is memhub task 42's exact defect. Not introduced by this PR; the reviewer re-ran all four at this head and they pass. 2: verificationDetailCap (manifestbody.go:17) is 2000 runes and truncated cycle 1's summary mid-AC4, losing its AC5/AC6 findings. 3: an unquoted &lt;scratch-file&gt; path containing a space fails positional binding — loudly, and the pre-existing POSIX form shares the property.

Engine claims re-verified rather than inherited from cycle 1: propen.go:73 gates pr-open to dispatched only; review.go:73 accepts pr-open/in-review and review.go:102 sets in-review every cycle, so the documented loop closes; resume's derivedPhase returns dispatched only when PRNumber==0 and rederive lowers a dispatched keep to worktree-ready, so pr-open is unreachable a second time even under resume. New check cycle 1 did not make: guard.go:159 writablePhase includes in-review, so the documented second cycle is actually executable and not blocked by the pre-write guard.

'it fixes and pushes' is accurate and non-contradictory: propen.go:113 is the only non-test delivery push, gitops.Push is git push -u (a clean no-op when current), and both hosts' orch-implementer contracts already say to commit and push as you go. It closes a real silent hole — review.go only compares reviewed_head_oid to the live PR head, so an unpushed fix yields a matching OID over unfixed code with no engine refusal.

Encoding guard proven correct, minimal and side-effect-safe on powershell.exe 5.1.26100.8875 and pwsh 7.6.4 with a stdin-hexdump probe over an 85-byte UTF-8 fixture: plain pipe on 5.1 gives 'Verdict ??? approve' at exit 0; -Enc … [truncated by orch] (2026-07-26T17:30:25Z)
- **required-ci** — passing — test (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass (2026-07-26T17:30:28Z)

<!-- orch:manifest:data
{
  "schema_version": 1,
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "go-build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "Run by the executor from the issue-57 worktree root; no output.",
      "at": "2026-07-26T16:44:21Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Run by the executor from the issue-57 worktree root; no output.",
      "at": "2026-07-26T16:44:21Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Run by the executor from the issue-57 worktree root; printed nothing, so no file needs reformatting.",
      "at": "2026-07-26T16:44:21Z"
    },
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Run by the executor from the issue-57 worktree root; all packages ok, including adapters/claude, adapters/codex and internal/run. internal/adaptertest reported [no test files], which is expected: it is a test-support package consumed by both adapters' plugin_test.go, not itself under test.",
      "at": "2026-07-26T16:44:21Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "APPROVE. All six acceptance criteria met at head 72dfe0a. Three non-blocking observations recorded below.\n\nAC1 (step-5 sentence corrected): met in both files. The false 'then repeats from PR-open' is gone; the new text names same executor, same branch, same worktree, a fresh reviewer at step 4, orch run review again, and pr-open unreachable a second time.\n\nAC2 (accuracy against the engine): met, verified independently rather than trusted. propen.go:73 loads with []state.Phase{state.PhaseDispatched} only; review.go:73 accepts {PhasePROpen, PhaseInReview} and review.go:102 sets PhaseInReview on every cycle, so cycle 2 lands on a phase review accepts and the documented loop closes. The only forward assignment of PhaseDispatched is dispatch.go:104, reachable only from worktree-ready (dispatch.go:66); resume.go:461-473 returns dispatched only when PRNumber == 0 and resume.go:436 lowers a dispatched keep to worktree-ready; propen.go:106 fails closed on an existing open PR. The reviewer also confirmed the corrected loop does not strand an operator downstream: civerb.go:56 accepts in-review, mergereport.go:59 requires in-review, merge.go:67 requires awaiting-merge.\n\nAC3 (Windows-usable stdin form): met, verified empirically on this machine with -NoProfile and a scratchpad probe binary. powershell.exe 5.1.26100.8875 and pwsh 7.6.4 both reject the POSIX form with exactly the quoted text 'The '\u003c' operator is reserved for future use.'; the documented Get-Content -Raw pipe form delivers stdin on both at exit 0. The pipe appends a trailing CRLF, which is harmless because decodeRequest (lifecycle.go:183-193) uses a json.Decoder whose More() returns false on trailing whitespace; no BOM is prepended. Every '\u003c' in the new prose sits inside a code span.\n\nAC4 (parity): met. The new step-2 block is byte-identical between the two files; step 5 differs only in spawned/dispatched, which is correct — the Claude file's steps say Spawn and the Codex file's say Dispatch, so flattening to one v … [truncated by orch]",
      "at": "2026-07-26T16:55:27Z"
    },
    {
      "name": "review-cycle-2",
      "result": "approve",
      "detail": "APPROVE — PR #58 at 859db17, cycle 2, fresh reviewer. All six acceptance criteria met; no blocking findings. Three non-blocking findings listed first so the 2000-rune detail cap cannot drop them.\n\nNON-BLOCKING 1: the manifest's four verification entries stay pinned to cycle 1's head — pr-open is the only verb that writes Verifications and is unreachable a second time, which is memhub task 42's exact defect. Not introduced by this PR; the reviewer re-ran all four at this head and they pass. 2: verificationDetailCap (manifestbody.go:17) is 2000 runes and truncated cycle 1's summary mid-AC4, losing its AC5/AC6 findings. 3: an unquoted \u003cscratch-file\u003e path containing a space fails positional binding — loudly, and the pre-existing POSIX form shares the property.\n\nEngine claims re-verified rather than inherited from cycle 1: propen.go:73 gates pr-open to dispatched only; review.go:73 accepts pr-open/in-review and review.go:102 sets in-review every cycle, so the documented loop closes; resume's derivedPhase returns dispatched only when PRNumber==0 and rederive lowers a dispatched keep to worktree-ready, so pr-open is unreachable a second time even under resume. New check cycle 1 did not make: guard.go:159 writablePhase includes in-review, so the documented second cycle is actually executable and not blocked by the pre-write guard.\n\n'it fixes and pushes' is accurate and non-contradictory: propen.go:113 is the only non-test delivery push, gitops.Push is git push -u (a clean no-op when current), and both hosts' orch-implementer contracts already say to commit and push as you go. It closes a real silent hole — review.go only compares reviewed_head_oid to the live PR head, so an unpushed fix yields a matching OID over unfixed code with no engine refusal.\n\nEncoding guard proven correct, minimal and side-effect-safe on powershell.exe 5.1.26100.8875 and pwsh 7.6.4 with a stdin-hexdump probe over an 85-byte UTF-8 fixture: plain pipe on 5.1 gives 'Verdict ??? approve' at exit 0; -Enc … [truncated by orch]",
      "at": "2026-07-26T17:30:25Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "at": "2026-07-26T17:30:28Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->