### PR TITLE
Let the audit record take verification evidence after a review, and stop truncating review summaries

### DIFF
--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -211,6 +211,7 @@ in flight at once. For each issue:
    {"schema_version": 1, "issue_number": N, "reviewed_head_oid": "...",
     "verdict": "approve|request-changes", "summary": "...",
     "reviewer": {"model": "...", "effort": "..."},
+    "verifications": [{"name": "...", "command": "...", "result": "...", "detail": "..."}],
     "usage": {"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0,
                "cache_creation_tokens": 0, "duration_ms": 0}}
    ```
@@ -220,7 +221,10 @@ in flight at once. For each issue:
    `request-changes` loops the same executor in the **same worktree**
    on the same branch: it fixes and pushes, then a **fresh** reviewer
    is spawned (step 4) and `orch run review` is called again.
-   `orch run pr-open` is not reachable a second time. `approve`
+   `orch run pr-open` is not reachable a second time, so `verifications`
+   is optional and takes pr-open's input shape — use it to carry
+   evidence re-run on the fix commit (e.g. tests re-run before
+   requesting the next review) into the audit record. `approve`
    continues.
 
 6. **CI** — `orch run ci` with

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -220,6 +220,7 @@ in flight at once. For each issue:
    {"schema_version": 1, "issue_number": N, "reviewed_head_oid": "...",
     "verdict": "approve|request-changes", "summary": "...",
     "reviewer": {"model": "...", "effort": "..."},
+    "verifications": [{"name": "...", "command": "...", "result": "...", "detail": "..."}],
     "usage": {"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0,
                "cache_creation_tokens": 0, "duration_ms": 0}}
    ```
@@ -229,7 +230,10 @@ in flight at once. For each issue:
    `request-changes` loops the same executor in the **same worktree**
    on the same branch: it fixes and pushes, then a **fresh** reviewer
    is dispatched (step 4) and `orch run review` is called again.
-   `orch run pr-open` is not reachable a second time. `approve`
+   `orch run pr-open` is not reachable a second time, so
+   `verifications` is optional and takes pr-open's input shape — use
+   it to carry evidence re-run on the fix commit (e.g. tests re-run
+   before requesting the next review) into the audit record. `approve`
    continues.
 
 6. **CI** — `orch run ci` with

--- a/internal/run/manifestbody.go
+++ b/internal/run/manifestbody.go
@@ -16,6 +16,15 @@ import (
 const (
 	// verificationDetailCap bounds one Verification.Detail (characters).
 	verificationDetailCap = 2000
+	// reviewDetailCap bounds a review-cycle Verification.Detail
+	// (characters). A consolidated review summary spanning several
+	// acceptance criteria routinely exceeds verificationDetailCap (task
+	// 46: cycle 1 of issue #57 was cut mid-criterion, permanently
+	// dropping the reviewer's remaining findings), so review-cycle
+	// entries get their own, larger allowance. It stays well under
+	// bodyCapHeadroom, which remains the backstop that rotates or fails
+	// closed regardless of which cap produced a detail.
+	reviewDetailCap = 10000
 	// verificationTruncationMarker flags a detail cut to the cap.
 	verificationTruncationMarker = " … [truncated by orch]"
 	// bodyCapHeadroom is the rendered-body ceiling the engine keeps under
@@ -31,11 +40,24 @@ const (
 // appending the truncation marker when it cuts (PRD §23: the canonical
 // Name/Result/At always survive; only free-text detail is bounded).
 func truncateDetail(detail string) string {
+	return truncateAt(detail, verificationDetailCap)
+}
+
+// truncateReviewDetail caps a review-cycle detail at reviewDetailCap
+// runes (see reviewDetailCap), appending the same truncation marker when
+// it cuts.
+func truncateReviewDetail(detail string) string {
+	return truncateAt(detail, reviewDetailCap)
+}
+
+// truncateAt caps detail at limit runes, appending the truncation marker
+// when it cuts.
+func truncateAt(detail string, limit int) string {
 	r := []rune(detail)
-	if len(r) <= verificationDetailCap {
+	if len(r) <= limit {
 		return detail
 	}
-	return string(r[:verificationDetailCap]) + verificationTruncationMarker
+	return string(r[:limit]) + verificationTruncationMarker
 }
 
 // applyDecision overwrites m's current routing fields (role, executor,

--- a/internal/run/manifestbody.go
+++ b/internal/run/manifestbody.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/manifest"
@@ -21,10 +22,25 @@ const (
 	// acceptance criteria routinely exceeds verificationDetailCap (task
 	// 46: cycle 1 of issue #57 was cut mid-criterion, permanently
 	// dropping the reviewer's remaining findings), so review-cycle
-	// entries get their own, larger allowance. It stays well under
-	// bodyCapHeadroom, which remains the backstop that rotates or fails
-	// closed regardless of which cap produced a detail.
-	reviewDetailCap = 10000
+	// entries get their own, larger allowance — but not an unbounded one.
+	//
+	// Every Detail renders twice — once as a human-readable markdown
+	// bullet, once inside the canonical JSON data comment below it — so
+	// its cost against the body is roughly double its rune count for
+	// plain ASCII text, and more for HTML-escaped ("&", "<", ">") or
+	// multi-byte runes, which both renders escape. Measured directly
+	// with manifest.Upsert against this issue's own audit record (#59/PR
+	// #61) with its one review cycle stripped — a ~10,300-byte base
+	// carrying the approved work, routing table, and five pr-open
+	// verifications — about 4 maximal-length review cycles fit at this
+	// cap before bodyCapHeadroom's 60,000-byte ceiling starts rotating
+	// detail out, versus roughly 11 at the smaller verificationDetailCap.
+	// Rotation drops the OLDEST verification's detail first
+	// (upsertCapped), which means pr-open's mandatory PRD §15 test
+	// evidence would be discarded before an early review-cycle summary;
+	// this cap is kept well short of that trade becoming routine rather
+	// than rare.
+	reviewDetailCap = 6000
 	// verificationTruncationMarker flags a detail cut to the cap.
 	verificationTruncationMarker = " … [truncated by orch]"
 	// bodyCapHeadroom is the rendered-body ceiling the engine keeps under
@@ -83,6 +99,38 @@ func setVerification(m *manifest.Manifest, v manifest.Verification) {
 		}
 	}
 	m.Verifications = append(m.Verifications, v)
+}
+
+// engineVerificationNames are the singleton verification names the
+// engine's own verbs write through setVerification's replace-by-name
+// path: required-ci (civerb.go), merge (merge.go), and abandoned
+// (abandon.go).
+var engineVerificationNames = map[string]bool{
+	"required-ci": true,
+	"merge":       true,
+	"abandoned":   true,
+}
+
+// reviewCycleNamePattern matches the per-cycle names Review appends
+// (review-cycle-<n>), which is the same shape a caller-supplied
+// verification must also avoid — that write is an append, not a
+// replace-by-name, so a caller-supplied entry under an existing cycle's
+// name would sit as a permanent, confusing duplicate rather than being
+// superseded.
+var reviewCycleNamePattern = regexp.MustCompile(`^review-cycle-[0-9]+$`)
+
+// rejectEngineOwnedNames fails closed with ErrBadRequest naming the
+// first verification in vs whose name collides with an engine-owned
+// singleton or a review-cycle-N entry, so the audit record's
+// engine-written entries can never be quietly overwritten — or quietly
+// duplicated — by a caller-supplied verification of the same name.
+func rejectEngineOwnedNames(vs []manifest.Verification) error {
+	for _, v := range vs {
+		if engineVerificationNames[v.Name] || reviewCycleNamePattern.MatchString(v.Name) {
+			return fmt.Errorf("%w: verification name %q is engine-owned and cannot be supplied by a caller", ErrBadRequest, v.Name)
+		}
+	}
+	return nil
 }
 
 // prForIssue reads the issue's PR when it has one (PRNumber > 0), or

--- a/internal/run/propen.go
+++ b/internal/run/propen.go
@@ -169,11 +169,23 @@ func PROpen(ctx context.Context, env Env, reqJSON []byte) (*PROpenResult, error)
 }
 
 // buildVerifications converts the supplied inputs into manifest
-// verifications, requiring at least one (PRD §15), stamping missing At
-// with stamp, and truncating each Detail to the body-cap ceiling.
+// verifications, requiring at least one (PRD §15: pr-open's completion
+// evidence is mandatory), and otherwise defers to convertVerifications.
 func buildVerifications(inputs []VerificationInput, stamp string) ([]manifest.Verification, error) {
 	if len(inputs) == 0 {
 		return nil, fmt.Errorf("%w: pr-open requires at least one verification (PRD §15: completion needs targeted-test evidence)", ErrBadRequest)
+	}
+	return convertVerifications(inputs, stamp)
+}
+
+// convertVerifications converts the supplied inputs into manifest
+// verifications, stamping missing At with stamp and truncating each
+// Detail to the body-cap ceiling. An empty inputs converts to a nil
+// slice with no error, so callers for whom verifications are optional
+// (review) can treat "none supplied" as valid.
+func convertVerifications(inputs []VerificationInput, stamp string) ([]manifest.Verification, error) {
+	if len(inputs) == 0 {
+		return nil, nil
 	}
 	out := make([]manifest.Verification, len(inputs))
 	for i, in := range inputs {

--- a/internal/run/propen.go
+++ b/internal/run/propen.go
@@ -18,7 +18,11 @@ const PROpenSchemaVersion = 1
 
 // VerificationInput is one required-test evidence entry the executor
 // supplies (PRD §15: completion requires targeted-test evidence). A
-// missing At is stamped by the engine.
+// missing At is stamped by the engine. Name must not collide with an
+// engine-owned verification (required-ci, merge, abandoned, or
+// review-cycle-<n>) — those are reserved so the engine's own record can
+// never be quietly overwritten or duplicated by a caller-supplied entry
+// (rejectEngineOwnedNames).
 type VerificationInput struct {
 	Name    string `json:"name"`
 	Command string `json:"command,omitempty"`
@@ -67,6 +71,9 @@ func PROpen(ctx context.Context, env Env, reqJSON []byte) (*PROpenResult, error)
 	}
 	verifications, err := buildVerifications(req.Verifications, env.nowStamp())
 	if err != nil {
+		return nil, err
+	}
+	if err := rejectEngineOwnedNames(verifications); err != nil {
 		return nil, err
 	}
 

--- a/internal/run/review.go
+++ b/internal/run/review.go
@@ -31,6 +31,13 @@ type ReviewRequest struct {
 	Verdict         string             `json:"verdict"`
 	Summary         string             `json:"summary"`
 	Reviewer        manifest.Selection `json:"reviewer"`
+	// Verifications is optional evidence gathered on this review cycle
+	// (for example, tests re-run on a fix commit), using the same
+	// {name, command, result, detail} input shape pr-open accepts. Each
+	// entry is replace-by-name upserted into the manifest alongside the
+	// review-cycle-N entry this verb already writes, so resubmitting the
+	// same name updates that entry rather than duplicating it.
+	Verifications []VerificationInput `json:"verifications,omitempty"`
 	// Usage is adapter-reported model usage for this review cycle
 	// (PRD §21 "where available"); optional and best-effort.
 	Usage *metrics.Usage `json:"usage,omitempty"`
@@ -50,8 +57,11 @@ type ReviewResult struct {
 // enforces PRD §14's "review begins only after the PR stops changing" by
 // requiring the reviewed head OID to equal the PR's live head — a stale
 // review is rejected so the reviewer re-reads. It advances the issue to
-// in-review, appends the cycle to the issue and PR audit records, and,
-// on request-changes, sets the status back to in-progress.
+// in-review, appends the cycle to the issue and PR audit records
+// alongside any caller-supplied verification evidence (replace-by-name,
+// so a fix-commit re-run reaches the record even though the issue is no
+// longer in phase dispatched), and, on request-changes, sets the status
+// back to in-progress.
 func Review(ctx context.Context, env Env, reqJSON []byte) (*ReviewResult, error) {
 	var req ReviewRequest
 	if err := decodeRequest(reqJSON, &req); err != nil {
@@ -68,6 +78,10 @@ func Review(ctx context.Context, env Env, reqJSON []byte) (*ReviewResult, error)
 	}
 	if err := req.Usage.Validate(); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrBadRequest, err)
+	}
+	verifications, err := convertVerifications(req.Verifications, env.nowStamp())
+	if err != nil {
+		return nil, err
 	}
 
 	c, err := loadVerb(env, req.IssueNumber, []state.Phase{state.PhasePROpen, state.PhaseInReview}, false)
@@ -108,10 +122,13 @@ func Review(ctx context.Context, env Env, reqJSON []byte) (*ReviewResult, error)
 	if err != nil {
 		return nil, wrapAfterMutation(err)
 	}
+	for _, v := range verifications {
+		setVerification(&m, v)
+	}
 	m.Verifications = append(m.Verifications, manifest.Verification{
 		Name:   fmt.Sprintf("review-cycle-%d", issue.ReviewCycles),
 		Result: req.Verdict,
-		Detail: truncateDetail(req.Summary),
+		Detail: truncateReviewDetail(req.Summary),
 		At:     env.nowStamp(),
 	})
 	if err := writeManifest(ctx, gh, iss, &pr, m); err != nil {

--- a/internal/run/review.go
+++ b/internal/run/review.go
@@ -36,7 +36,11 @@ type ReviewRequest struct {
 	// {name, command, result, detail} input shape pr-open accepts. Each
 	// entry is replace-by-name upserted into the manifest alongside the
 	// review-cycle-N entry this verb already writes, so resubmitting the
-	// same name updates that entry rather than duplicating it.
+	// same name updates that entry rather than duplicating it. A name
+	// colliding with an engine-owned entry (required-ci, merge,
+	// abandoned, or review-cycle-<n>) is rejected — those are never
+	// caller-suppliable, so the engine's own record can never be quietly
+	// overwritten or duplicated.
 	Verifications []VerificationInput `json:"verifications,omitempty"`
 	// Usage is adapter-reported model usage for this review cycle
 	// (PRD §21 "where available"); optional and best-effort.
@@ -81,6 +85,9 @@ func Review(ctx context.Context, env Env, reqJSON []byte) (*ReviewResult, error)
 	}
 	verifications, err := convertVerifications(req.Verifications, env.nowStamp())
 	if err != nil {
+		return nil, err
+	}
+	if err := rejectEngineOwnedNames(verifications); err != nil {
 		return nil, err
 	}
 

--- a/internal/run/verb_unit_test.go
+++ b/internal/run/verb_unit_test.go
@@ -384,6 +384,25 @@ func TestReviewWrongReviewerIsPure(t *testing.T) {
 	}
 }
 
+// TestReviewBadVerificationIsBadRequestBeforeMutation proves a malformed
+// entry in review's optional verifications array is rejected as
+// ErrBadRequest before loadVerb ever runs (the same wire-validation
+// ordering as usage), so no gh call happens and state is untouched.
+func TestReviewBadVerificationIsBadRequestBeforeMutation(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
+	before := stateBytes(t, root)
+	script := &execxtest.Script{T: t}
+	req := `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head","verdict":"approve","summary":"s","reviewer":{"model":"claude-opus-4-8","effort":"high"},"verifications":[{"name":"","result":"pass"}]}`
+	_, err := Review(context.Background(), ghEnv(root, script), []byte(req))
+	if !errors.Is(err, ErrBadRequest) {
+		t.Fatalf("err = %v, want ErrBadRequest", err)
+	}
+	script.AssertExhausted()
+	if got := stateBytes(t, root); string(got) != string(before) {
+		t.Error("state changed on a review request carrying a bad verification")
+	}
+}
+
 func TestBlockGitHubUnavailableIsPure(t *testing.T) {
 	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhaseDispatched)})
 	before := stateBytes(t, root)
@@ -500,6 +519,164 @@ func TestUpsertCappedHardFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), fmt.Sprint(githubBodyLimit)) {
 		t.Errorf("err %v does not name GitHub's limit %d", err, githubBodyLimit)
+	}
+}
+
+// --- Review verifications (issue #59) ---
+
+// TestReviewWritesSuppliedVerifications proves review accepts an
+// optional verifications array using pr-open's {name, command, result,
+// detail} input shape, on an issue already in phase in-review, and that
+// the review-cycle-N entry the verb already writes still lands alongside
+// it (AC1, AC2).
+func TestReviewWritesSuppliedVerifications(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhaseInReview)})
+	body := baseManifestBody(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-1"),
+		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghSetPRBodyCall(10),
+	}}
+	req := `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"},"verifications":[{"name":"go test ./...","result":"pass","detail":"22 packages ok"}]}`
+	res, err := Review(context.Background(), ghEnv(root, script), []byte(req))
+	if err != nil {
+		t.Fatalf("Review: %v", err)
+	}
+	script.AssertExhausted()
+	if res.ReviewCycles != 1 {
+		t.Fatalf("review cycles = %d, want 1", res.ReviewCycles)
+	}
+
+	m, err := manifest.Parse(script.StdinAt(3))
+	if err != nil {
+		t.Fatalf("Parse the posted issue body: %v", err)
+	}
+	var supplied, cycle *manifest.Verification
+	for i := range m.Verifications {
+		switch m.Verifications[i].Name {
+		case "go test ./...":
+			supplied = &m.Verifications[i]
+		case "review-cycle-1":
+			cycle = &m.Verifications[i]
+		}
+	}
+	if supplied == nil || supplied.Result != "pass" || supplied.Detail != "22 packages ok" {
+		t.Errorf("supplied verification = %+v, want a matching entry in the audit record", supplied)
+	}
+	if cycle == nil || cycle.Result != "approve" || cycle.Detail != "looks good" {
+		t.Errorf("review-cycle-1 = %+v, want the verdict/summary the verb already writes", cycle)
+	}
+}
+
+// TestReviewVerificationReplacesByName proves a caller-supplied
+// verification whose name already exists in the record is replaced in
+// place, not duplicated — the same replace-by-name upsert setVerification
+// gives the engine-owned singletons (AC1).
+func TestReviewVerificationReplacesByName(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
+	seeded := baseManifest()
+	seeded.Verifications = []manifest.Verification{{Name: "go test ./...", Result: "fail", Detail: "2 failures", At: "t0"}}
+	body, err := manifest.Upsert("**Objective**\n\ndo it\n", seeded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-1"),
+		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghSetPRBodyCall(10),
+	}}
+	req := `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"},"verifications":[{"name":"go test ./...","result":"pass","detail":"all green"}]}`
+	if _, err := Review(context.Background(), ghEnv(root, script), []byte(req)); err != nil {
+		t.Fatalf("Review: %v", err)
+	}
+	script.AssertExhausted()
+
+	m, err := manifest.Parse(script.StdinAt(3))
+	if err != nil {
+		t.Fatalf("Parse the posted issue body: %v", err)
+	}
+	count := 0
+	for _, v := range m.Verifications {
+		if v.Name != "go test ./..." {
+			continue
+		}
+		count++
+		if v.Result != "pass" || v.Detail != "all green" {
+			t.Errorf("verification = %+v, want the resubmitted result/detail", v)
+		}
+	}
+	if count != 1 {
+		t.Errorf("%q appears %d times, want 1 (replace-by-name, not append)", "go test ./...", count)
+	}
+}
+
+// TestReviewSummaryRoundTripsUnderReviewDetailCap proves a review summary
+// longer than verificationDetailCap but shorter than reviewDetailCap
+// carries through to the audit record with no truncation marker (AC3).
+func TestReviewSummaryRoundTripsUnderReviewDetailCap(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
+	body := baseManifestBody(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-1"),
+		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghSetPRBodyCall(10),
+	}}
+	summary := strings.Repeat("a", verificationDetailCap+500)
+	if len(summary) >= reviewDetailCap {
+		t.Fatalf("fixture summary length %d must stay under reviewDetailCap %d", len(summary), reviewDetailCap)
+	}
+	req := fmt.Sprintf(`{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":%q,"reviewer":{"model":"claude-opus-4-8","effort":"high"}}`, summary)
+	if _, err := Review(context.Background(), ghEnv(root, script), []byte(req)); err != nil {
+		t.Fatalf("Review: %v", err)
+	}
+	script.AssertExhausted()
+
+	m, err := manifest.Parse(script.StdinAt(3))
+	if err != nil {
+		t.Fatalf("Parse the posted issue body: %v", err)
+	}
+	for _, v := range m.Verifications {
+		if v.Name != "review-cycle-1" {
+			continue
+		}
+		if v.Detail != summary {
+			t.Errorf("review-cycle-1 detail length = %d, want the untruncated %d-rune summary", len([]rune(v.Detail)), len([]rune(summary)))
+		}
+		if strings.Contains(v.Detail, verificationTruncationMarker) {
+			t.Error("review-cycle-1 detail carries the truncation marker though it is under reviewDetailCap")
+		}
+	}
+}
+
+// TestReviewSuppliedVerificationStillCappedAtVerificationDetailCap proves
+// a caller-supplied verification's detail — as opposed to the
+// review-cycle-N entry — remains bounded by the existing, smaller
+// verificationDetailCap, unchanged (AC4).
+func TestReviewSuppliedVerificationStillCappedAtVerificationDetailCap(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
+	body := baseManifestBody(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-1"),
+		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghSetPRBodyCall(10),
+	}}
+	long := strings.Repeat("x", verificationDetailCap+500)
+	req := fmt.Sprintf(`{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"},"verifications":[{"name":"go test","result":"pass","detail":%q}]}`, long)
+	if _, err := Review(context.Background(), ghEnv(root, script), []byte(req)); err != nil {
+		t.Fatalf("Review: %v", err)
+	}
+	script.AssertExhausted()
+
+	m, err := manifest.Parse(script.StdinAt(3))
+	if err != nil {
+		t.Fatalf("Parse the posted issue body: %v", err)
+	}
+	for _, v := range m.Verifications {
+		if v.Name != "go test" {
+			continue
+		}
+		if !strings.HasSuffix(v.Detail, verificationTruncationMarker) {
+			t.Errorf("supplied verification detail not truncated at verificationDetailCap: suffix %q", v.Detail[len(v.Detail)-40:])
+		}
+		if len([]rune(v.Detail)) != verificationDetailCap+len([]rune(verificationTruncationMarker)) {
+			t.Errorf("supplied verification detail length = %d, want verificationDetailCap+marker", len([]rune(v.Detail)))
+		}
 	}
 }
 

--- a/internal/run/verb_unit_test.go
+++ b/internal/run/verb_unit_test.go
@@ -475,6 +475,24 @@ func TestTruncateDetail(t *testing.T) {
 	}
 }
 
+// TestTruncateReviewDetail is truncateDetail's cut-path pin but for
+// reviewDetailCap: unchanged under the cap, and a detail over it gets
+// the same truncation marker at reviewDetailCap runes rather than
+// verificationDetailCap's smaller one.
+func TestTruncateReviewDetail(t *testing.T) {
+	if got := truncateReviewDetail("short"); got != "short" {
+		t.Errorf("truncateReviewDetail(short) = %q, want unchanged", got)
+	}
+	long := strings.Repeat("x", reviewDetailCap+500)
+	got := truncateReviewDetail(long)
+	if !strings.HasSuffix(got, verificationTruncationMarker) {
+		t.Errorf("truncated detail missing marker: %q", got[len(got)-40:])
+	}
+	if len([]rune(got)) != reviewDetailCap+len([]rune(verificationTruncationMarker)) {
+		t.Errorf("truncated length = %d, want reviewDetailCap + marker", len([]rune(got)))
+	}
+}
+
 func TestUpsertCappedDropsOldestDetails(t *testing.T) {
 	big := strings.Repeat("x", 25000)
 	m := baseManifest()
@@ -632,16 +650,21 @@ func TestReviewSummaryRoundTripsUnderReviewDetailCap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse the posted issue body: %v", err)
 	}
+	found := false
 	for _, v := range m.Verifications {
 		if v.Name != "review-cycle-1" {
 			continue
 		}
+		found = true
 		if v.Detail != summary {
 			t.Errorf("review-cycle-1 detail length = %d, want the untruncated %d-rune summary", len([]rune(v.Detail)), len([]rune(summary)))
 		}
 		if strings.Contains(v.Detail, verificationTruncationMarker) {
 			t.Error("review-cycle-1 detail carries the truncation marker though it is under reviewDetailCap")
 		}
+	}
+	if !found {
+		t.Fatal("review-cycle-1 entry not found in the posted audit record")
 	}
 }
 
@@ -667,16 +690,84 @@ func TestReviewSuppliedVerificationStillCappedAtVerificationDetailCap(t *testing
 	if err != nil {
 		t.Fatalf("Parse the posted issue body: %v", err)
 	}
+	found := false
 	for _, v := range m.Verifications {
 		if v.Name != "go test" {
 			continue
 		}
+		found = true
 		if !strings.HasSuffix(v.Detail, verificationTruncationMarker) {
 			t.Errorf("supplied verification detail not truncated at verificationDetailCap: suffix %q", v.Detail[len(v.Detail)-40:])
 		}
 		if len([]rune(v.Detail)) != verificationDetailCap+len([]rune(verificationTruncationMarker)) {
 			t.Errorf("supplied verification detail length = %d, want verificationDetailCap+marker", len([]rune(v.Detail)))
 		}
+	}
+	if !found {
+		t.Fatal("supplied \"go test\" verification not found in the posted audit record")
+	}
+}
+
+// engineOwnedVerificationNames are the names Change 2 reserves: the
+// three singletons the engine's own verbs write by replace-by-name, and
+// one name matching the review-cycle-<n> pattern Review generates.
+var engineOwnedVerificationNames = []string{"required-ci", "merge", "abandoned", "review-cycle-1"}
+
+// TestReviewRejectsEngineOwnedVerificationNames proves a caller-supplied
+// verification whose name collides with an engine-owned entry is
+// rejected as ErrBadRequest before loadVerb ever runs — naming the
+// offending name — so no gh call happens and state is untouched.
+func TestReviewRejectsEngineOwnedVerificationNames(t *testing.T) {
+	for _, name := range engineOwnedVerificationNames {
+		t.Run(name, func(t *testing.T) {
+			root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
+			before := stateBytes(t, root)
+			script := &execxtest.Script{T: t}
+			req := fmt.Sprintf(`{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head","verdict":"approve","summary":"s","reviewer":{"model":"claude-opus-4-8","effort":"high"},"verifications":[{"name":%q,"result":"pass"}]}`, name)
+			_, err := Review(context.Background(), ghEnv(root, script), []byte(req))
+			if !errors.Is(err, ErrBadRequest) {
+				t.Fatalf("err = %v, want ErrBadRequest", err)
+			}
+			if !strings.Contains(err.Error(), name) {
+				t.Errorf("err %v does not name the offending verification %q", err, name)
+			}
+			script.AssertExhausted()
+			if got := stateBytes(t, root); string(got) != string(before) {
+				t.Error("state changed on a review request carrying an engine-owned verification name")
+			}
+		})
+	}
+}
+
+// TestPROpenRejectsEngineOwnedVerificationNames extends the same
+// reservation to pr-open's verifications array. pr-open runs before any
+// of these engine entries exist, but a caller-supplied entry under one
+// of these names would still land in the record: for the singletons, it
+// would sit until the corresponding engine verb next overwrites it
+// (required-ci/merge/abandoned all replace-by-name); for a
+// review-cycle-N name, Review's write is an append, not a replace, so it
+// would become a permanent, confusing duplicate once that cycle really
+// runs. Reserving the names uniformly, on every verb that accepts
+// caller-supplied verifications, closes both.
+func TestPROpenRejectsEngineOwnedVerificationNames(t *testing.T) {
+	for _, name := range engineOwnedVerificationNames {
+		t.Run(name, func(t *testing.T) {
+			root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhaseDispatched)})
+			before := stateBytes(t, root)
+			script := &execxtest.Script{T: t}
+			req := fmt.Sprintf(`{"schema_version":1,"issue_number":1,"verifications":[{"name":%q,"result":"pass"}]}`, name)
+			_, err := PROpen(context.Background(), ghEnv(root, script), []byte(req))
+			if !errors.Is(err, ErrBadRequest) {
+				t.Fatalf("err = %v, want ErrBadRequest", err)
+			}
+			if !strings.Contains(err.Error(), name) {
+				t.Errorf("err %v does not name the offending verification %q", err, name)
+			}
+			script.AssertExhausted()
+			if got := stateBytes(t, root); string(got) != string(before) {
+				t.Error("state changed on a pr-open request carrying an engine-owned verification name")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Delivers issue #59: Let the audit record take verification evidence after a review, and stop truncating review summaries

Closes #59

**Plan digest:** `sha256:a70520220ef6c39522d5901556fb0a4cf52d4f861997934ed655dd7a8217b6b4`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Open a path for verification evidence gathered after a review to reach the audit record, and give review-cycle verification details an allowance large enough to hold a consolidated review summary. Today orch run pr-open is the only verb accepting a caller-supplied verifications array and it accepts only phase dispatched, so evidence re-run on a fix commit can never enter the record; separately, verificationDetailCap truncates every detail at 2000 runes, which cut a real reviewer's summary mid-criterion and permanently dropped its remaining findings. Neither change alters how an existing Verification entry renders, so both stay at manifest schema 2. The civerb.go precedent is the model to follow: it already accepts pr-open, in-review and awaiting-merge and writes through the replace-by-name upsert.

**Acceptance criteria:**
- orch run review accepts an optional verifications array in its request, using the same {name, command, result, detail} input shape orch run pr-open accepts, and writes each supplied entry into the manifest through the existing replace-by-name upsert.
- A verification supplied through orch run review on an issue in phase in-review lands in that issue's audit record, and the review-cycle-N entry the verb already writes is still written unchanged alongside it.
- Review-cycle verification details are bounded by a named constant distinct from verificationDetailCap and larger than 2000 runes, and a review summary shorter than that new constant round-trips into the audit record with no truncation marker.
- Verification details that are not review-cycle entries remain bounded by the existing 2000-rune verificationDetailCap, unchanged.
- Both adapters' orch-delivery SKILL.md document the verifications field on the orch run review request, and the shared adapter drift pins in internal/adaptertest still pass.

**Required tests:**
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **go-build** — pass — `go build ./...` — exit 0, no output. (2026-07-26T19:43:57Z)
- **go-vet** — pass — `go vet ./...` — exit 0, no output. (2026-07-26T19:43:57Z)
- **go-test** — pass — `go test ./... -count=1` — All packages passed:
ok github.com/kninetimmy/orch 0.439s
ok github.com/kninetimmy/orch/adapters/claude 0.497s
ok github.com/kninetimmy/orch/adapters/codex 0.446s
ok github.com/kninetimmy/orch/internal/agents 0.502s
ok github.com/kninetimmy/orch/internal/bootstrap 11.067s
ok github.com/kninetimmy/orch/internal/cli 2.186s
ok github.com/kninetimmy/orch/internal/config 0.770s
ok github.com/kninetimmy/orch/internal/execx 0.749s
ok github.com/kninetimmy/orch/internal/ghops 1.982s
ok github.com/kninetimmy/orch/internal/gitops 5.071s
ok github.com/kninetimmy/orch/internal/guard 0.992s
ok github.com/kninetimmy/orch/internal/instructions 0.654s
ok github.com/kninetimmy/orch/internal/interview 0.812s
ok github.com/kninetimmy/orch/internal/lockfile 0.892s
ok github.com/kninetimmy/orch/internal/manifest 0.559s
ok github.com/kninetimmy/orch/internal/memhub 0.497s
ok github.com/kninetimmy/orch/internal/metrics 0.625s
ok github.com/kninetimmy/orch/internal/paths 0.604s
ok github.com/kninetimmy/orch/internal/question 0.541s
ok github.com/kninetimmy/orch/internal/routing 0.545s
ok github.com/kninetimmy/orch/internal/run 18.627s
ok github.com/kninetimmy/orch/internal/state 0.749s

cmd/orch, internal/execx/execxtest and internal/adaptertest report no test files; that is pre-existing state (adaptertest is test-support only, consumed by both adapter packages' plugin_test.go), not a result of this change. (2026-07-26T19:43:57Z)
- **gofmt** — pass — `gofmt -l .` — exit 0, no output (nothing to format). (2026-07-26T19:43:57Z)
- **adapter-drift-pins** — pass — `go test ./adapters/claude ./adapters/codex -run 'TestSkillOrchRunVerbsAreReal|TestSkillStatementLiteralsPinnedToRunConstants' -count=1` — AC5-specific evidence: the executor ran the shared drift pins by name in both adapter packages after editing the two orch-delivery SKILL.md files, confirming the documented verb tokens and statement literals still match internal/run's live constants. Included in the full go test ./... run above; called out separately because AC5 is the criterion it gates. (2026-07-26T19:43:57Z)
- **review-cycle-1** — approve — VERDICT: approve. All 5 acceptance criteria met, scope clean, 6/6 required CI green at cbfa5e5.

BLOCKING: none.

NON-BLOCKING (4):
1. reviewDetailCap=10000 is defensible but aggressive, and its doc comment understates the cost. A Detail renders TWICE (human bullet + JSON data comment), so 1 rune is about 2 body bytes ASCII, about 6 with an em-dash, about 10 escaped. Measured on a 9,417-byte base modelled on this PR's own record: maximal summaries fit 12 review cycles at cap 2000 versus only 2 at cap 10000 before rotation starts. No new hard-fail risk (with all details dropped the body is tiny, so ErrBodyTooLarge stays unreachable from details), but rotation drops OLDEST first, so pr-open's PRD 15 evidence is discarded before cycle-1's summary. Suggest 4000-6000, or keep 10000 and correct the comment.
2. Caller-supplied names on review flow through the same replace-by-name upsert as the engine singletons, so a review call can overwrite required-ci, merge, abandoned, or an earlier review-cycle-N. Verified this bypasses NO gate: merge-report reads CI live via gh.RequiredCI and the verdict from run state; resume's verification-count row is dispatched-phase only. Audit integrity only; consider reserving those names.
3. Two new tests loop with continue and no found-flag, so they would pass vacuously if the entry vanished. I mutation-tested all four new tests; each dies on the right regression. Style, not substance.
4. Untested: truncateReviewDetail's cut path (over 10000 produces the marker), and pr-open's at-least-one-verification error this PR refactored into buildVerifications (pre-existing gap).

Evidence re-run independently at head: go build ./..., go vet ./..., gofmt -l ., go test ./... -count=1 (22 ok, 3 no-test-files), plus both adapter drift pins by name - all pass. Manifest record verified accurate; internal/manifest untouched, schema stays 2, issue-60 boundary held. (2026-07-26T19:54:55Z)
- **review-cycle-2** — approve — VERDICT: approve. All 5 ACs hold at a13c7dd, scope clean, 6/6 required CI green at that exact SHA, tests non-vacuous (9 mutations run, each killed the intended test).

BLOCKING: none.

MEASUREMENT: the implementer is right and the shipped doc comment's figures are correct. Reproduced with real manifest.Upsert on PR #61's live body with review-cycle-1 stripped: base 10,362 bytes; max cycles under bodyCapHeadroom = 4 at cap 6000, 11 at 2000, 2 at 10000 - all four implementer numbers reproduce exactly. Cycle-1's 9,417/12 differs only in its base (a modelled record, not the live one). Per-cycle cost = 2*cap+188 bytes ASCII, 6*cap+188 em-dash, so 'renders twice / roughly double' holds. The pr-open reservation is sound: Review APPENDS review-cycle-N (verified in code), so a planted name would be a permanent duplicate; applying it to both verbs is what keeps AC1's 'same input shape as pr-open' literally true.

NON-BLOCKING (4):
1. Same method on ISSUE #59's body (the durable audit home; base 12,157) gives 3 cycles at 6000, not 4 (11 at 2000, same). The comment says '#59/PR #61' but quotes the PR body's base, so it is self-consistent; '3-4' would be tighter.
2. Neither SKILL.md documents the reserved names. A reviewer naming its CI evidence 'required-ci' gets a hard ErrBadRequest mid-delivery - recoverable (the error names the offender), but one clause in the skill would prevent it.
3. decodeRequest uses DisallowUnknownFields, so the installed v0.4.0 orch rejects a review request carrying 'verifications'. Heeded: this cycle-2 record was submitted without that field.
4. Review() calls env.nowStamp() twice, so supplied entries and the cycle entry can differ by a second. Cosmetic.

CAVEAT ON RECORD: the five pr-open entries were stamped at cbfa5e5 and carry no commit OID (the gap issue #60 closes), so they do not themselves attest to a13c7dd. The reviewer re-ran all four required tests at a13c7dd independently - that is this cycle's evidence. (2026-07-26T20:22:47Z)
- **required-ci** — passing — test (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass (2026-07-26T20:22:58Z)

<!-- orch:manifest:data
{
  "schema_version": 2,
  "objective": "Open a path for verification evidence gathered after a review to reach the audit record, and give review-cycle verification details an allowance large enough to hold a consolidated review summary. Today orch run pr-open is the only verb accepting a caller-supplied verifications array and it accepts only phase dispatched, so evidence re-run on a fix commit can never enter the record; separately, verificationDetailCap truncates every detail at 2000 runes, which cut a real reviewer's summary mid-criterion and permanently dropped its remaining findings. Neither change alters how an existing Verification entry renders, so both stay at manifest schema 2. The civerb.go precedent is the model to follow: it already accepts pr-open, in-review and awaiting-merge and writes through the replace-by-name upsert.",
  "acceptance_criteria": [
    "orch run review accepts an optional verifications array in its request, using the same {name, command, result, detail} input shape orch run pr-open accepts, and writes each supplied entry into the manifest through the existing replace-by-name upsert.",
    "A verification supplied through orch run review on an issue in phase in-review lands in that issue's audit record, and the review-cycle-N entry the verb already writes is still written unchanged alongside it.",
    "Review-cycle verification details are bounded by a named constant distinct from verificationDetailCap and larger than 2000 runes, and a review summary shorter than that new constant round-trips into the audit record with no truncation marker.",
    "Verification details that are not review-cycle entries remain bounded by the existing 2000-rune verificationDetailCap, unchanged.",
    "Both adapters' orch-delivery SKILL.md document the verifications field on the orch run review request, and the shared adapter drift pins in internal/adaptertest still pass."
  ],
  "required_tests": [
    "go build ./...",
    "go vet ./...",
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "go-build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "exit 0, no output.",
      "at": "2026-07-26T19:43:57Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "exit 0, no output.",
      "at": "2026-07-26T19:43:57Z"
    },
    {
      "name": "go-test",
      "command": "go test ./... -count=1",
      "result": "pass",
      "detail": "All packages passed:\nok github.com/kninetimmy/orch 0.439s\nok github.com/kninetimmy/orch/adapters/claude 0.497s\nok github.com/kninetimmy/orch/adapters/codex 0.446s\nok github.com/kninetimmy/orch/internal/agents 0.502s\nok github.com/kninetimmy/orch/internal/bootstrap 11.067s\nok github.com/kninetimmy/orch/internal/cli 2.186s\nok github.com/kninetimmy/orch/internal/config 0.770s\nok github.com/kninetimmy/orch/internal/execx 0.749s\nok github.com/kninetimmy/orch/internal/ghops 1.982s\nok github.com/kninetimmy/orch/internal/gitops 5.071s\nok github.com/kninetimmy/orch/internal/guard 0.992s\nok github.com/kninetimmy/orch/internal/instructions 0.654s\nok github.com/kninetimmy/orch/internal/interview 0.812s\nok github.com/kninetimmy/orch/internal/lockfile 0.892s\nok github.com/kninetimmy/orch/internal/manifest 0.559s\nok github.com/kninetimmy/orch/internal/memhub 0.497s\nok github.com/kninetimmy/orch/internal/metrics 0.625s\nok github.com/kninetimmy/orch/internal/paths 0.604s\nok github.com/kninetimmy/orch/internal/question 0.541s\nok github.com/kninetimmy/orch/internal/routing 0.545s\nok github.com/kninetimmy/orch/internal/run 18.627s\nok github.com/kninetimmy/orch/internal/state 0.749s\n\ncmd/orch, internal/execx/execxtest and internal/adaptertest report no test files; that is pre-existing state (adaptertest is test-support only, consumed by both adapter packages' plugin_test.go), not a result of this change.",
      "at": "2026-07-26T19:43:57Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "exit 0, no output (nothing to format).",
      "at": "2026-07-26T19:43:57Z"
    },
    {
      "name": "adapter-drift-pins",
      "command": "go test ./adapters/claude ./adapters/codex -run 'TestSkillOrchRunVerbsAreReal|TestSkillStatementLiteralsPinnedToRunConstants' -count=1",
      "result": "pass",
      "detail": "AC5-specific evidence: the executor ran the shared drift pins by name in both adapter packages after editing the two orch-delivery SKILL.md files, confirming the documented verb tokens and statement literals still match internal/run's live constants. Included in the full go test ./... run above; called out separately because AC5 is the criterion it gates.",
      "at": "2026-07-26T19:43:57Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "VERDICT: approve. All 5 acceptance criteria met, scope clean, 6/6 required CI green at cbfa5e5.\n\nBLOCKING: none.\n\nNON-BLOCKING (4):\n1. reviewDetailCap=10000 is defensible but aggressive, and its doc comment understates the cost. A Detail renders TWICE (human bullet + JSON data comment), so 1 rune is about 2 body bytes ASCII, about 6 with an em-dash, about 10 escaped. Measured on a 9,417-byte base modelled on this PR's own record: maximal summaries fit 12 review cycles at cap 2000 versus only 2 at cap 10000 before rotation starts. No new hard-fail risk (with all details dropped the body is tiny, so ErrBodyTooLarge stays unreachable from details), but rotation drops OLDEST first, so pr-open's PRD 15 evidence is discarded before cycle-1's summary. Suggest 4000-6000, or keep 10000 and correct the comment.\n2. Caller-supplied names on review flow through the same replace-by-name upsert as the engine singletons, so a review call can overwrite required-ci, merge, abandoned, or an earlier review-cycle-N. Verified this bypasses NO gate: merge-report reads CI live via gh.RequiredCI and the verdict from run state; resume's verification-count row is dispatched-phase only. Audit integrity only; consider reserving those names.\n3. Two new tests loop with continue and no found-flag, so they would pass vacuously if the entry vanished. I mutation-tested all four new tests; each dies on the right regression. Style, not substance.\n4. Untested: truncateReviewDetail's cut path (over 10000 produces the marker), and pr-open's at-least-one-verification error this PR refactored into buildVerifications (pre-existing gap).\n\nEvidence re-run independently at head: go build ./..., go vet ./..., gofmt -l ., go test ./... -count=1 (22 ok, 3 no-test-files), plus both adapter drift pins by name - all pass. Manifest record verified accurate; internal/manifest untouched, schema stays 2, issue-60 boundary held.",
      "at": "2026-07-26T19:54:55Z"
    },
    {
      "name": "review-cycle-2",
      "result": "approve",
      "detail": "VERDICT: approve. All 5 ACs hold at a13c7dd, scope clean, 6/6 required CI green at that exact SHA, tests non-vacuous (9 mutations run, each killed the intended test).\n\nBLOCKING: none.\n\nMEASUREMENT: the implementer is right and the shipped doc comment's figures are correct. Reproduced with real manifest.Upsert on PR #61's live body with review-cycle-1 stripped: base 10,362 bytes; max cycles under bodyCapHeadroom = 4 at cap 6000, 11 at 2000, 2 at 10000 - all four implementer numbers reproduce exactly. Cycle-1's 9,417/12 differs only in its base (a modelled record, not the live one). Per-cycle cost = 2*cap+188 bytes ASCII, 6*cap+188 em-dash, so 'renders twice / roughly double' holds. The pr-open reservation is sound: Review APPENDS review-cycle-N (verified in code), so a planted name would be a permanent duplicate; applying it to both verbs is what keeps AC1's 'same input shape as pr-open' literally true.\n\nNON-BLOCKING (4):\n1. Same method on ISSUE #59's body (the durable audit home; base 12,157) gives 3 cycles at 6000, not 4 (11 at 2000, same). The comment says '#59/PR #61' but quotes the PR body's base, so it is self-consistent; '3-4' would be tighter.\n2. Neither SKILL.md documents the reserved names. A reviewer naming its CI evidence 'required-ci' gets a hard ErrBadRequest mid-delivery - recoverable (the error names the offender), but one clause in the skill would prevent it.\n3. decodeRequest uses DisallowUnknownFields, so the installed v0.4.0 orch rejects a review request carrying 'verifications'. Heeded: this cycle-2 record was submitted without that field.\n4. Review() calls env.nowStamp() twice, so supplied entries and the cycle entry can differ by a second. Cosmetic.\n\nCAVEAT ON RECORD: the five pr-open entries were stamped at cbfa5e5 and carry no commit OID (the gap issue #60 closes), so they do not themselves attest to a13c7dd. The reviewer re-ran all four required tests at a13c7dd independently - that is this cycle's evidence.",
      "at": "2026-07-26T20:22:47Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "at": "2026-07-26T20:22:58Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->