### PR TITLE
Stamp verification entries with their commit OID at manifest schema 3, and correct two impossible remediations

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "kninetimmy" },
   "metadata": {
     "description": "Host adapters for the Orch development orchestrator",
-    "version": "0.4.0"
+    "version": "0.5.0"
   },
   "plugins": [
     {

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Claude Code host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -78,8 +78,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.4.0" {
-		t.Errorf("version = %q, want 0.4.0", m.Version)
+	if m.Version != "0.5.0" {
+		t.Errorf("version = %q, want 0.5.0", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Codex CLI host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -79,8 +79,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.4.0" {
-		t.Errorf("version = %q, want 0.4.0", m.Version)
+	if m.Version != "0.5.0" {
+		t.Errorf("version = %q, want 0.5.0", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -3,10 +3,11 @@
 // acceptance criteria, and required tests; the selected role, the exact
 // executor/reviewer model+effort and how the host actually delivered
 // that effort; the routing rationale, escalations and substitutions, the
-// config revision, and named verification commands and results.
-// Resume/recovery (PRD §23: interrupted runs resume) rebuilds run state
-// from these posted bodies, so the record must render into a managed
-// markdown region AND parse back out losslessly.
+// config revision, and named verification commands and results with the
+// commit each was gathered at. Resume/recovery (PRD §23: interrupted
+// runs resume) rebuilds run state from these posted bodies, so the
+// record must render into a managed markdown region AND parse back out
+// losslessly.
 //
 // Like gitops and ghops the package is policy-free: it owns the schema,
 // the managed region, and drift detection, while the run engine decides
@@ -35,12 +36,21 @@ import (
 // It lives only in the JSON record (see Manifest.SchemaVersion); the
 // markers are locators, never a second source of truth.
 //
-// v2 adds the approved work text (objective, acceptance criteria,
-// required tests) and the effort-delivery mechanism. There is no
-// migration from v1: a v1 record is missing fields v2 requires, so Parse
-// rejects it through the unsupported-version path rather than accept a
-// record whose approved work would silently read as empty.
-const SchemaVersion = 2
+// v2 added the approved work text (objective, acceptance criteria,
+// required tests) and the effort-delivery mechanism. v3 adds the commit
+// OID each verification was gathered at (Verification.CommitOID).
+//
+// There is no migration, in either direction. Reading down: a v1 record
+// is missing the approved work, which would silently decode as empty,
+// and a v2 record's verifications would decode as gathered at no commit
+// — which in v3 is a claim about the evidence, not an absence of one —
+// so Parse rejects both through the unsupported-version path. Reading
+// up: an older binary handed a newer record would drop the field it
+// does not know on decode, re-render without it, and fail the drift
+// compare with ErrDrift, accusing a human of a hand edit nobody made.
+// Raising this constant is what makes the version check fire first and
+// say the true thing, so it must rise with every rendered field.
+const SchemaVersion = 3
 
 // BeginMarker and EndMarker delimit the managed region. A line is a
 // marker only if, after stripping at most one trailing "\r", it equals
@@ -115,12 +125,28 @@ type Escalation struct {
 // Verification records one named check and its outcome. Command is
 // empty for CI-state entries that report a status without a local
 // command; Result is a free string ("pass", "CLEAN", ...).
+//
+// CommitOID is the commit the check was gathered at, so evidence from
+// an earlier head stays distinguishable from evidence at the head that
+// merges. The run engine stamps it from a head it read itself and
+// accepts none from a caller; which head that is per verb is the
+// engine's business, not this package's.
+//
+// It is optional, and an empty value is a claim, not a gap: it says no
+// commit was in scope when the entry was written. Requiring one instead
+// would force the engine either to invent an OID naming a commit the
+// entry is not about, or to fail Render at a site with no head to read
+// — after that verb's GitHub mutations had already landed, leaving the
+// operator a half-finished record and no remedy. The format is
+// unvalidated, exactly as At carries whatever timestamp it was given:
+// this package owns the schema, not the vocabulary.
 type Verification struct {
-	Name    string `json:"name"`
-	Command string `json:"command,omitempty"`
-	Result  string `json:"result"`
-	Detail  string `json:"detail,omitempty"`
-	At      string `json:"at,omitempty"`
+	Name      string `json:"name"`
+	Command   string `json:"command,omitempty"`
+	Result    string `json:"result"`
+	Detail    string `json:"detail,omitempty"`
+	CommitOID string `json:"commit_oid,omitempty"`
+	At        string `json:"at,omitempty"`
 }
 
 // Manifest is the canonical audit record. SchemaVersion is first and
@@ -151,9 +177,16 @@ type Manifest struct {
 // validate reports the first schema-completeness violation in m. Render
 // treats a violation as a caller bug and returns it plainly; Parse
 // re-wraps a decoded record's violation as ErrBadManifest.
+//
+// The version mismatch names `orch abort` instead of telling the
+// operator to regenerate the record. Nothing regenerates a posted
+// record: every body-reading verb fails closed on this same check, so
+// an operator who followed that advice had no command to run. Naming
+// one concrete command for an unrepairable version mismatch follows
+// state.Load's precedent (internal/state/state.go).
 func (m Manifest) validate() error {
 	if m.SchemaVersion != SchemaVersion {
-		return fmt.Errorf("schema_version %d is unsupported (this build renders %d; regenerate the record)", m.SchemaVersion, SchemaVersion)
+		return fmt.Errorf("schema_version %d is unsupported (this build renders %d; a posted record cannot be migrated in place — run `orch abort` to return to assist, then re-plan and re-activate)", m.SchemaVersion, SchemaVersion)
 	}
 	if m.Objective == "" {
 		return errors.New("objective is empty")

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -27,10 +27,21 @@ func minimalManifest() Manifest {
 	}
 }
 
+// fixtureCommitOID is the head the fixture's stamped verifications were
+// gathered at, and fixtureFixOID a later head one of them was re-run on,
+// so a golden shows two entries that disagree about which commit they
+// speak for — the distinction the field exists to make.
+const (
+	fixtureCommitOID = "3f6a1c9d8b2e4057a1c3e5079b2d4f6081a3c5e7"
+	fixtureFixOID    = "c5e70981a3f6b2d4079b1c3e52e40578b2e4a1c3"
+)
+
 // fullManifest exercises every optional field and every repeatable one:
 // multi-entry acceptance criteria and required tests, two escalations
 // (an escalation with a role and At, a substitution without), and three
-// verifications, the last a CI-state entry with no command.
+// verifications, the last a CI-state entry with no command. Two carry a
+// commit OID and disagree about which one; the middle entry carries none,
+// so the golden pins both the stamped and the unstamped render.
 func fullManifest() Manifest {
 	m := minimalManifest()
 	m.AcceptanceCriteria = []string{
@@ -56,9 +67,9 @@ func fullManifest() Manifest {
 		},
 	}
 	m.Verifications = []Verification{
-		{Name: "targeted-tests", Command: "go test ./internal/manifest/...", Result: "pass", At: "2026-07-10T14:20:00Z"},
+		{Name: "targeted-tests", Command: "go test ./internal/manifest/...", Result: "pass", CommitOID: fixtureCommitOID, At: "2026-07-10T14:20:00Z"},
 		{Name: "vet", Command: "go vet ./...", Result: "pass", Detail: "no findings"},
-		{Name: "ci", Result: "CLEAN", Detail: "required checks green", At: "2026-07-10T14:45:00Z"},
+		{Name: "ci", Result: "CLEAN", Detail: "required checks green", CommitOID: fixtureFixOID, At: "2026-07-10T14:45:00Z"},
 	}
 	return m
 }
@@ -71,9 +82,9 @@ func fullManifest() Manifest {
 // ampersand; a model with a pipe; a config revision with all three
 // entity characters; an escalation whose reason is a data-close and
 // whose At smuggles a begin-marker line; and a verification whose name,
-// result, and At each smuggle a marker or data-comment line. Render must
-// escape all of it so the region still contains exactly one of each
-// structural line and parses back.
+// result, commit OID, and At each smuggle a marker or data-comment line.
+// Render must escape all of it so the region still contains exactly one
+// of each structural line and parses back.
 func hostileManifest() Manifest {
 	return Manifest{
 		SchemaVersion: SchemaVersion,
@@ -102,10 +113,11 @@ func hostileManifest() Manifest {
 		},
 		Verifications: []Verification{
 			{
-				Name:    "targeted-tests\n" + EndMarker,
-				Command: "go test -run 'A|B' ./... `backtick` && echo done",
-				Result:  "pass\n" + dataOpen,
-				At:      "2026-07-10T14:20:00Z\n" + dataClose,
+				Name:      "targeted-tests\n" + EndMarker,
+				Command:   "go test -run 'A|B' ./... `backtick` && echo done",
+				Result:    "pass\n" + dataOpen,
+				CommitOID: "deadbeef\n" + BeginMarker,
+				At:        "2026-07-10T14:20:00Z\n" + dataClose,
 			},
 		},
 	}
@@ -116,8 +128,9 @@ func TestValidateRejects(t *testing.T) {
 		mutate func(*Manifest)
 		want   string
 	}{
-		"superseded schema version": {func(m *Manifest) { m.SchemaVersion = 1 }, "schema_version 1 is unsupported"},
-		"future schema version":     {func(m *Manifest) { m.SchemaVersion = 3 }, "schema_version 3 is unsupported"},
+		"original schema version":   {func(m *Manifest) { m.SchemaVersion = 1 }, "schema_version 1 is unsupported"},
+		"superseded schema version": {func(m *Manifest) { m.SchemaVersion = 2 }, "schema_version 2 is unsupported"},
+		"future schema version":     {func(m *Manifest) { m.SchemaVersion = 4 }, "schema_version 4 is unsupported"},
 		"absent schema version":     {func(m *Manifest) { m.SchemaVersion = 0 }, "schema_version 0 is unsupported"},
 		"empty objective":           {func(m *Manifest) { m.Objective = "" }, "objective is empty"},
 		"no acceptance criteria":    {func(m *Manifest) { m.AcceptanceCriteria = nil }, "acceptance_criteria is empty"},
@@ -152,6 +165,42 @@ func TestValidateRejects(t *testing.T) {
 				t.Errorf("error %q does not mention %q", err, tt.want)
 			}
 		})
+	}
+}
+
+// TestUnsupportedVersionNamesARealRemediation pins the half of the
+// remediation fix that lives in validate. The message an operator meets
+// on a superseded record must name a command that exists and can
+// actually recover: nothing "regenerates" a posted record, and every
+// body-reading verb fails closed on this same check, so an operator who
+// followed the old advice had nothing to run.
+func TestUnsupportedVersionNamesARealRemediation(t *testing.T) {
+	m := fullManifest()
+	m.SchemaVersion = SchemaVersion - 1
+	_, err := Render(m)
+	if err == nil {
+		t.Fatal("Render accepted a superseded schema version")
+	}
+	if !strings.Contains(err.Error(), "orch abort") {
+		t.Errorf("error %q does not name the abort remediation", err)
+	}
+	if strings.Contains(err.Error(), "regenerate the record") {
+		t.Errorf("error %q still names a remediation that does not exist", err)
+	}
+}
+
+// TestVerificationCommitOIDIsOptional pins the deliberate choice that an
+// empty commit OID validates. One engine site genuinely has no head to
+// read — an issue abandoned before its PR ever opened — and a required
+// field would fail Render there after that verb's GitHub mutations had
+// already landed, leaving a half-written record and no remedy.
+func TestVerificationCommitOIDIsOptional(t *testing.T) {
+	m := fullManifest()
+	for i := range m.Verifications {
+		m.Verifications[i].CommitOID = ""
+	}
+	if err := m.validate(); err != nil {
+		t.Fatalf("validate rejected verifications carrying no commit OID: %v", err)
 	}
 }
 

--- a/internal/manifest/parse_test.go
+++ b/internal/manifest/parse_test.go
@@ -1,7 +1,9 @@
 package manifest
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -122,8 +124,8 @@ func TestParseBadManifest(t *testing.T) {
 		"unterminated data":    BeginMarker + "\n" + dataOpen + "\n{}\n" + EndMarker,
 		"double data comment":  BeginMarker + "\n" + dataOpen + "\n{}\n" + dataClose + "\n" + dataOpen + "\n{}\n" + dataClose + "\n" + EndMarker,
 		"bad json":             BeginMarker + "\n" + dataOpen + "\nthis is not json\n" + dataClose + "\n" + EndMarker,
-		"schema version zero":  tamperJSON(valid, `"schema_version": 2`, `"schema_version": 0`),
-		"schema version three": tamperJSON(valid, `"schema_version": 2`, `"schema_version": 3`),
+		"schema version zero":  tamperJSON(valid, `"schema_version": 3`, `"schema_version": 0`),
+		"schema version four":  tamperJSON(valid, `"schema_version": 3`, `"schema_version": 4`),
 		"schema absent":        BeginMarker + "\n" + dataOpen + "\n{\"role\":\"implementer\"}\n" + dataClose + "\n" + EndMarker,
 		"invalid record":       tamperJSON(valid, `"role": "implementer"`, `"role": "wizard"`),
 	}
@@ -138,10 +140,10 @@ func TestParseBadManifest(t *testing.T) {
 }
 
 // schemaOneRegion is a genuine schema-1 record, frozen byte-for-byte as
-// the v1 renderer emitted it. It is not a v2 render with a tampered
+// the v1 renderer emitted it. It is not a later render with a tampered
 // version number: it is the real thing this build must refuse, missing
 // exactly the objective, acceptance criteria, required tests, and
-// effort-delivery fields v2 requires.
+// effort-delivery fields v2 required.
 const schemaOneRegion = BeginMarker + `
 ### Orch audit record
 
@@ -178,8 +180,9 @@ const schemaOneRegion = BeginMarker + `
 
 // TestParseRejectsSchemaOneRecord proves a v1 record fails closed through
 // the unsupported-version path — named as such, before the drift compare
-// — rather than decoding into a v2 struct whose approved work would read
-// as empty. There is no migration: the missing fields cannot be invented.
+// — rather than decoding into this build's struct with approved work
+// that would read as empty. There is no migration: the missing fields
+// cannot be invented.
 func TestParseRejectsSchemaOneRecord(t *testing.T) {
 	_, err := Parse(schemaOneRegion)
 	if !errors.Is(err, ErrBadManifest) {
@@ -193,6 +196,124 @@ func TestParseRejectsSchemaOneRecord(t *testing.T) {
 	}
 }
 
+// schemaTwoRegion is a genuine schema-2 record, frozen byte-for-byte as
+// the v2 renderer emitted it: the minimal fixture plus one verification,
+// which — being v2 — names no commit it was gathered at.
+const schemaTwoRegion = BeginMarker + `
+### Orch audit record
+
+**Objective:** Ship the manifest round trip.
+
+**Acceptance criteria:**
+- Render and Parse agree on every field.
+
+**Required tests:**
+- ` + "`go test ./internal/manifest/...`" + `
+
+| Field | Value |
+| --- | --- |
+| Role | ` + "`implementer`" + ` |
+| Executor | ` + "`opus-4-8`" + ` — effort ` + "`high`" + ` |
+| Reviewer | ` + "`gpt-5.6-sol`" + ` — effort ` + "`medium`" + ` |
+| Effort delivery | ` + "`parameter`" + ` — the host applied the routed effort as a real model parameter |
+| Config revision | ` + "`cfg-2026-07-10`" + ` |
+
+**Routing rationale:** Selected implementer for a bounded single-file change.
+
+**Escalations:** _none_
+
+**Verification:**
+- **targeted-tests** — pass — ` + "`go test ./internal/manifest/...`" + ` (2026-07-10T14:20:00Z)
+
+` + dataOpen + `
+{
+  "schema_version": 2,
+  "objective": "Ship the manifest round trip.",
+  "acceptance_criteria": [
+    "Render and Parse agree on every field."
+  ],
+  "required_tests": [
+    "go test ./internal/manifest/..."
+  ],
+  "role": "implementer",
+  "executor": {
+    "model": "opus-4-8",
+    "effort": "high"
+  },
+  "routing_rationale": "Selected implementer for a bounded single-file change.",
+  "reviewer": {
+    "model": "gpt-5.6-sol",
+    "effort": "medium"
+  },
+  "effort_delivery": "parameter",
+  "config_revision": "cfg-2026-07-10",
+  "verifications": [
+    {
+      "name": "targeted-tests",
+      "command": "go test ./internal/manifest/...",
+      "result": "pass",
+      "at": "2026-07-10T14:20:00Z"
+    }
+  ]
+}
+` + dataClose + `
+` + EndMarker
+
+// TestSchemaTwoRegionIsAGenuineRender guards the fixture above against a
+// typo. No verification in it carries a commit OID, so a v2 render and a
+// v3 render of the same record differ in exactly one place — the
+// schema_version line — and re-rendering the frozen region's own decoded
+// record at this build's version must reproduce it byte for byte. Without
+// this check a mangled fixture would still be rejected, and the rejection
+// test below would pass for the wrong reason.
+func TestSchemaTwoRegionIsAGenuineRender(t *testing.T) {
+	jsonText, err := extractData(schemaTwoRegion)
+	if err != nil {
+		t.Fatalf("extractData: %v", err)
+	}
+	var m Manifest
+	if err := json.Unmarshal([]byte(jsonText), &m); err != nil {
+		t.Fatalf("decode the frozen record: %v", err)
+	}
+	if m.SchemaVersion != 2 {
+		t.Fatalf("frozen record schema_version = %d, want 2", m.SchemaVersion)
+	}
+	m.SchemaVersion = SchemaVersion
+	got, err := Render(m)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	want := tamperJSON(schemaTwoRegion, `"schema_version": 2`, fmt.Sprintf(`"schema_version": %d`, SchemaVersion))
+	if got != want {
+		t.Errorf("the frozen region is not a v2 render of its own record\n--- re-rendered ---\n%s\n--- frozen, version raised ---\n%s", got, want)
+	}
+}
+
+// TestParseRejectsSchemaTwoRecord proves the immediately superseded
+// record fails closed through the same unsupported-version path, before
+// the drift compare, and that the error names a remediation that exists.
+//
+// Nothing else would catch it. A v2 record decodes cleanly into this
+// build's struct and re-renders to the same bytes but for the version
+// line, so its verifications would silently read as gathered at no
+// commit — which in v3 is a claim about the evidence, not the absence of
+// one — and the OID they lack cannot be recovered after the fact.
+func TestParseRejectsSchemaTwoRecord(t *testing.T) {
+	_, err := Parse(schemaTwoRegion)
+	if !errors.Is(err, ErrBadManifest) {
+		t.Fatalf("err = %v, want ErrBadManifest", err)
+	}
+	if !strings.Contains(err.Error(), "schema_version 2 is unsupported") {
+		t.Errorf("err %q does not name the unsupported version", err)
+	}
+	if errors.Is(err, ErrDrift) {
+		t.Error("a v2 record was reported as drift; the version check must come first")
+	}
+	if !strings.Contains(err.Error(), "orch abort") {
+		t.Errorf("err %q does not name a remediation that exists", err)
+	}
+}
+
 func TestParseDrift(t *testing.T) {
 	base := mustRender(t, fullManifest())
 	cases := map[string]string{
@@ -200,8 +321,8 @@ func TestParseDrift(t *testing.T) {
 		"blank line inserted":   strings.Replace(base, "### Orch audit record\n", "### Orch audit record\n\n", 1),
 		"sentence inserted":     strings.Replace(base, "**Verification:**", "An extra human sentence.\n\n**Verification:**", 1),
 		"json keys reordered": strings.Replace(base,
-			"{\n  \"schema_version\": 2,\n  \"objective\": \""+fixtureObjective+"\",",
-			"{\n  \"objective\": \""+fixtureObjective+"\",\n  \"schema_version\": 2,", 1),
+			"{\n  \"schema_version\": 3,\n  \"objective\": \""+fixtureObjective+"\",",
+			"{\n  \"objective\": \""+fixtureObjective+"\",\n  \"schema_version\": 3,", 1),
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/manifest/render.go
+++ b/internal/manifest/render.go
@@ -153,10 +153,15 @@ func writeVerifications(b *strings.Builder, vs []Verification) {
 
 // verificationBullet renders one verification as a single list line:
 //
-//   - **<name>** — <result> — `<command>` — <detail> (<at>)
+//   - **<name>** — <result> — `<command>` — <detail> — commit `<oid>` (<at>)
 //
-// The command, detail, and timestamp segments are omitted when their
-// fields are empty.
+// The command, detail, commit, and timestamp segments are omitted when
+// their fields are empty. The commit appears here and not only in the
+// canonical JSON deliberately: the drift check compares a re-render
+// against the found region, so a field with no human view is a field
+// whose only view is the hidden data comment — and this one is what
+// tells a reader whether the evidence above it was gathered at the head
+// that merged or at an earlier one.
 func verificationBullet(v Verification) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "- **%s** — %s", mdText(v.Name), mdText(v.Result))
@@ -165,6 +170,9 @@ func verificationBullet(v Verification) string {
 	}
 	if v.Detail != "" {
 		fmt.Fprintf(&b, " — %s", mdText(v.Detail))
+	}
+	if v.CommitOID != "" {
+		fmt.Fprintf(&b, " — commit %s", mdCode(v.CommitOID))
 	}
 	if v.At != "" {
 		fmt.Fprintf(&b, " (%s)", mdText(v.At))

--- a/internal/manifest/render_test.go
+++ b/internal/manifest/render_test.go
@@ -46,6 +46,30 @@ func TestRenderGolden(t *testing.T) {
 	}
 }
 
+// TestRenderShowsCommitOIDInBothViews pins the commit OID into the human
+// markdown as well as the canonical JSON. A field emitted only into the
+// data comment is invisible to anyone reading the record on GitHub —
+// where the comment does not display at all — and the drift check would
+// still pass, so nothing else would catch the omission.
+func TestRenderShowsCommitOIDInBothViews(t *testing.T) {
+	got, err := Render(fullManifest())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	human, data, ok := strings.Cut(got, "\n"+dataOpen+"\n")
+	if !ok {
+		t.Fatal("could not split the region into its human and JSON views")
+	}
+	for _, oid := range []string{fixtureCommitOID, fixtureFixOID} {
+		if !strings.Contains(human, oid) {
+			t.Errorf("the human markdown does not show commit %s", oid)
+		}
+		if !strings.Contains(data, `"commit_oid": "`+oid+`"`) {
+			t.Errorf("the canonical JSON does not carry commit_oid %s", oid)
+		}
+	}
+}
+
 func TestRenderDeterministic(t *testing.T) {
 	for name, m := range goldenCases() {
 		t.Run(name, func(t *testing.T) {

--- a/internal/manifest/testdata/full.golden.md
+++ b/internal/manifest/testdata/full.golden.md
@@ -26,13 +26,13 @@
 - substitution: `opus-4-8` (effort `high`) → `opus-4-8` (effort `medium`) — Downgraded effort after the fix landed.
 
 **Verification:**
-- **targeted-tests** — pass — `go test ./internal/manifest/...` (2026-07-10T14:20:00Z)
+- **targeted-tests** — pass — `go test ./internal/manifest/...` — commit `3f6a1c9d8b2e4057a1c3e5079b2d4f6081a3c5e7` (2026-07-10T14:20:00Z)
 - **vet** — pass — `go vet ./...` — no findings
-- **ci** — CLEAN — required checks green (2026-07-10T14:45:00Z)
+- **ci** — CLEAN — required checks green — commit `c5e70981a3f6b2d4079b1c3e52e40578b2e4a1c3` (2026-07-10T14:45:00Z)
 
 <!-- orch:manifest:data
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "objective": "Ship the manifest round trip.",
   "acceptance_criteria": [
     "Render and Parse agree on every field.",
@@ -87,6 +87,7 @@
       "name": "targeted-tests",
       "command": "go test ./internal/manifest/...",
       "result": "pass",
+      "commit_oid": "3f6a1c9d8b2e4057a1c3e5079b2d4f6081a3c5e7",
       "at": "2026-07-10T14:20:00Z"
     },
     {
@@ -99,6 +100,7 @@
       "name": "ci",
       "result": "CLEAN",
       "detail": "required checks green",
+      "commit_oid": "c5e70981a3f6b2d4079b1c3e52e40578b2e4a1c3",
       "at": "2026-07-10T14:45:00Z"
     }
   ]

--- a/internal/manifest/testdata/hostile.golden.md
+++ b/internal/manifest/testdata/hostile.golden.md
@@ -33,12 +33,12 @@ and a &lt;script&gt;alert(1)&lt;/script&gt; tag.
 **Verification:**
 - **targeted-tests
 &lt;!-- orch:manifest:end --&gt;** — pass
-&lt;!-- orch:manifest:data — ``go test -run 'A|B' ./... `backtick` && echo done`` (2026-07-10T14:20:00Z
+&lt;!-- orch:manifest:data — ``go test -run 'A|B' ./... `backtick` && echo done`` — commit `deadbeef <!-- orch:manifest:begin -->` (2026-07-10T14:20:00Z
 --&gt;)
 
 <!-- orch:manifest:data
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "objective": "Objective ending in --\u003e\n\u003c!-- orch:manifest:begin --\u003e\nand more.",
   "acceptance_criteria": [
     "Criterion with a marker line\n\u003c!-- orch:manifest:end --\u003e",
@@ -80,6 +80,7 @@ and a &lt;script&gt;alert(1)&lt;/script&gt; tag.
       "name": "targeted-tests\n\u003c!-- orch:manifest:end --\u003e",
       "command": "go test -run 'A|B' ./... `backtick` \u0026\u0026 echo done",
       "result": "pass\n\u003c!-- orch:manifest:data",
+      "commit_oid": "deadbeef\n\u003c!-- orch:manifest:begin --\u003e",
       "at": "2026-07-10T14:20:00Z\n--\u003e"
     }
   ]

--- a/internal/manifest/testdata/minimal.golden.md
+++ b/internal/manifest/testdata/minimal.golden.md
@@ -25,7 +25,7 @@
 
 <!-- orch:manifest:data
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "objective": "Ship the manifest round trip.",
   "acceptance_criteria": [
     "Render and Parse agree on every field."

--- a/internal/run/abandon.go
+++ b/internal/run/abandon.go
@@ -66,12 +66,15 @@ func Abandon(ctx context.Context, env Env, reqJSON []byte) (*AbandonResult, erro
 		return nil, err
 	}
 
-	// Close an open PR (if any).
+	// Close an open PR (if any), keeping its head as the commit the work
+	// was abandoned at.
+	headOID := ""
 	if issue.PRNumber > 0 {
 		pr, err := gh.PR(ctx, issue.PRNumber)
 		if err != nil {
 			return nil, err
 		}
+		headOID = pr.HeadRefOid
 		if pr.State == "OPEN" {
 			if err := gh.ClosePR(ctx, issue.PRNumber, ghops.ExplicitConfirmation()); err != nil {
 				return nil, err
@@ -79,16 +82,22 @@ func Abandon(ctx context.Context, env Env, reqJSON []byte) (*AbandonResult, erro
 		}
 	}
 
-	// Record the abandonment on the durable issue audit record.
+	// Record the abandonment on the durable issue audit record. This is
+	// the one entry that can carry no commit: an issue abandoned before
+	// pr-open has no pushed head, and its branch may hold no commits of
+	// its own at all, so an OID here would name a commit the abandonment
+	// is not about. The empty value says that, and abandon must be able
+	// to finish regardless — its PR close has already happened.
 	iss, m, err := readIssueManifest(ctx, gh, issue.Number)
 	if err != nil {
 		return nil, err
 	}
 	setVerification(&m, manifest.Verification{
-		Name:   "abandoned",
-		Result: "abandoned",
-		Detail: truncateDetail(req.Reason),
-		At:     env.nowStamp(),
+		Name:      "abandoned",
+		Result:    "abandoned",
+		Detail:    truncateDetail(req.Reason),
+		CommitOID: headOID,
+		At:        env.nowStamp(),
 	})
 	issueBody, err := upsertCapped(iss.Body, m)
 	if err != nil {

--- a/internal/run/civerb.go
+++ b/internal/run/civerb.go
@@ -72,16 +72,21 @@ func CI(ctx context.Context, env Env, reqJSON []byte) (*CIResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	setVerification(&m, manifest.Verification{
-		Name:   "required-ci",
-		Result: string(summary.State),
-		Detail: truncateDetail(ciDetail(summary)),
-		At:     env.nowStamp(),
-	})
+	// The PR is read before the entry is written, not after, because its
+	// head is the commit this CI state describes: a rollup read at an
+	// earlier head must not be indistinguishable in the record from one
+	// read at the head that merges.
 	pr, err := prForIssue(ctx, gh, issue)
 	if err != nil {
 		return nil, err
 	}
+	setVerification(&m, manifest.Verification{
+		Name:      "required-ci",
+		Result:    string(summary.State),
+		Detail:    truncateDetail(ciDetail(summary)),
+		CommitOID: prHeadOID(pr),
+		At:        env.nowStamp(),
+	})
 	if err := writeManifest(ctx, gh, iss, pr, m); err != nil {
 		return nil, err
 	}

--- a/internal/run/lifecycle_test.go
+++ b/internal/run/lifecycle_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/kninetimmy/orch/internal/execx"
@@ -151,9 +152,11 @@ func newLifecycleRepo(t *testing.T) string {
 	return root
 }
 
-// runVerb runs one lifecycle verb against a mux runner (real git,
-// scripted gh) and asserts the scripted gh transcript was fully consumed.
-func runVerb[T any](t *testing.T, root string, fn func(context.Context, Env, []byte) (T, error), reqJSON string, calls ...execxtest.Call) T {
+// runVerbScript runs one lifecycle verb against a mux runner (real git,
+// scripted gh), asserts the scripted gh transcript was fully consumed,
+// and hands back the script so a caller can assert on a body the verb
+// posted (Script.StdinAt) and not only on the resulting phase.
+func runVerbScript[T any](t *testing.T, root string, fn func(context.Context, Env, []byte) (T, error), reqJSON string, calls ...execxtest.Call) (T, *execxtest.Script) {
 	t.Helper()
 	script := &execxtest.Script{T: t, Calls: calls}
 	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
@@ -162,7 +165,34 @@ func runVerb[T any](t *testing.T, root string, fn func(context.Context, Env, []b
 		t.Fatalf("verb: %v", err)
 	}
 	script.AssertExhausted()
+	return out, script
+}
+
+// runVerb is runVerbScript for the common case that only needs the
+// verb's own result.
+func runVerb[T any](t *testing.T, root string, fn func(context.Context, Env, []byte) (T, error), reqJSON string, calls ...execxtest.Call) T {
+	t.Helper()
+	out, _ := runVerbScript(t, root, fn, reqJSON, calls...)
 	return out
+}
+
+// findVerification returns the named entry from the audit record in a
+// posted body, failing the test when the body does not parse or carries
+// no such entry — so an assertion cannot pass vacuously against an entry
+// that silently stopped being written.
+func findVerification(t *testing.T, body, name string) manifest.Verification {
+	t.Helper()
+	m, err := manifest.Parse(body)
+	if err != nil {
+		t.Fatalf("parse the posted audit record: %v", err)
+	}
+	for _, v := range m.Verifications {
+		if v.Name == name {
+			return v
+		}
+	}
+	t.Fatalf("verification %q not found in the posted audit record", name)
+	return manifest.Verification{}
 }
 
 func loadRun(t *testing.T, root string) *state.State {
@@ -234,12 +264,21 @@ func TestLifecycleWalk(t *testing.T) {
 	rawGit(t, wtDir, "add", "-A")
 	rawGit(t, wtDir, "commit", "-m", "work")
 
-	// pr-open.
-	runVerb(t, root, PROpen, `{"schema_version":1,"issue_number":1,"verifications":[{"name":"go test","result":"pass"}]}`,
+	// pr-open. The evidence the executor reports is stamped by the engine
+	// with the head it just pushed — read from git here, since the record
+	// is written before the PR exists to read a head from — and the same
+	// stamped record is mirrored onto the PR body it creates.
+	_, prOpen := runVerbScript(t, root, PROpen, `{"schema_version":1,"issue_number":1,"verifications":[{"name":"go test","result":"pass"}]}`,
 		ghAuth(), ghRepoViewCall("main"), ghPRListEmptyCall(branch),
 		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1),
 		ghCreatePRCall(branch, title, 10), ghSetStatusCall(1, ghops.StatusAwaitingReview))
 	wantPhase(t, root, 1, state.PhasePROpen)
+	pushedHead := strings.TrimSpace(rawGit(t, wtDir, "rev-parse", "HEAD"))
+	for view, posted := range map[string]string{"issue body": prOpen.StdinAt(4), "PR body": prOpen.StdinAt(5)} {
+		if got := findVerification(t, posted, "go test").CommitOID; got != pushedHead {
+			t.Errorf("%s: pr-open verification commit = %q, want the pushed head %q", view, got, pushedHead)
+		}
+	}
 
 	// review: request-changes.
 	runVerb(t, root, Review, `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"request-changes","summary":"fix things","reviewer":{"model":"claude-opus-4-8","effort":"high"}}`,

--- a/internal/run/manifestbody.go
+++ b/internal/run/manifestbody.go
@@ -54,7 +54,8 @@ const (
 
 // truncateDetail caps one detail string at verificationDetailCap runes,
 // appending the truncation marker when it cuts (PRD §23: the canonical
-// Name/Result/At always survive; only free-text detail is bounded).
+// Name/Result/CommitOID/At always survive, here and under upsertCapped's
+// rotation; only free-text detail is bounded).
 func truncateDetail(detail string) string {
 	return truncateAt(detail, verificationDetailCap)
 }
@@ -99,6 +100,35 @@ func setVerification(m *manifest.Manifest, v manifest.Verification) {
 		}
 	}
 	m.Verifications = append(m.Verifications, v)
+}
+
+// stampCommitOID records oid as the commit every verification in vs was
+// gathered at (manifest.Verification.CommitOID).
+//
+// The engine stamps it and no verb accepts one on the wire. A
+// caller-supplied OID would be an unverifiable claim about which commit
+// an executor's or reviewer's evidence speaks for — exactly the claim
+// the field exists to make checkable — so each verb passes a head it
+// read itself: the pushed branch head at pr-open, the PR's live head at
+// review and ci, the merged head at merge.
+//
+// An empty oid is left as-is rather than treated as an error: it is the
+// honest reading at the one site with no head to read (abandon.go, on an
+// issue abandoned before its PR opened), and manifest.Verification
+// documents why inventing one there would be worse.
+func stampCommitOID(vs []manifest.Verification, oid string) {
+	for i := range vs {
+		vs[i].CommitOID = oid
+	}
+}
+
+// prHeadOID is pr's head commit, or "" when the issue has no PR to read
+// one from (prForIssue returns nil below phase pr-open).
+func prHeadOID(pr *ghops.PR) string {
+	if pr == nil {
+		return ""
+	}
+	return pr.HeadRefOid
 }
 
 // engineVerificationNames are the singleton verification names the

--- a/internal/run/merge.go
+++ b/internal/run/merge.go
@@ -129,11 +129,15 @@ func Merge(ctx context.Context, env Env, reqJSON []byte) (*MergeResult, error) {
 	}
 
 	// The issue body is the durable audit home once the PR is merged.
+	// The stamped commit is the merged head — the approval pinned it, the
+	// merge matched it — which is what makes every earlier entry in the
+	// record readable as "gathered before the commit that shipped" or not.
 	setVerification(&m, manifest.Verification{
-		Name:   "merge",
-		Result: "merged",
-		Detail: truncateDetail(fmt.Sprintf("%s merge at %s", c.cfg.Merge.Strategy, pr.HeadRefOid)),
-		At:     env.nowStamp(),
+		Name:      "merge",
+		Result:    "merged",
+		Detail:    truncateDetail(fmt.Sprintf("%s merge at %s", c.cfg.Merge.Strategy, pr.HeadRefOid)),
+		CommitOID: pr.HeadRefOid,
+		At:        env.nowStamp(),
 	})
 	issueBody, err := upsertCapped(iss.Body, m)
 	if err != nil {

--- a/internal/run/propen.go
+++ b/internal/run/propen.go
@@ -23,6 +23,11 @@ const PROpenSchemaVersion = 1
 // review-cycle-<n>) — those are reserved so the engine's own record can
 // never be quietly overwritten or duplicated by a caller-supplied entry
 // (rejectEngineOwnedNames).
+//
+// There is deliberately no commit-OID field: the commit an entry was
+// gathered at is stamped by the engine from a head it read itself
+// (stampCommitOID), so the record's answer to "which commit is this
+// evidence about" is never a caller's assertion.
 type VerificationInput struct {
 	Name    string `json:"name"`
 	Command string `json:"command,omitempty"`
@@ -120,6 +125,18 @@ func PROpen(ctx context.Context, env Env, reqJSON []byte) (*PROpenResult, error)
 	if err := git.Push(ctx, worktree, "origin", issue.Branch); err != nil {
 		return nil, err
 	}
+	// The evidence above was gathered against the commits just pushed, so
+	// the branch head is the commit it speaks for. It is read here, after
+	// the push, and not offered as a request field: the executor reports
+	// what it ran, the engine says where. The PR cannot supply it — the
+	// record is written to the issue body before CreatePR, so there is no
+	// PR to read a head from yet.
+	headOID, err := git.RevParse(ctx, issue.Branch)
+	if err != nil {
+		return nil, err
+	}
+	stampCommitOID(verifications, headOID)
+
 	iss, m, err := readIssueManifest(ctx, gh, issue.Number)
 	if err != nil {
 		return nil, err
@@ -190,6 +207,10 @@ func buildVerifications(inputs []VerificationInput, stamp string) ([]manifest.Ve
 // Detail to the body-cap ceiling. An empty inputs converts to a nil
 // slice with no error, so callers for whom verifications are optional
 // (review) can treat "none supplied" as valid.
+//
+// It leaves CommitOID unset: both callers run this while validating the
+// request, before any GitHub or git read, so the head is not known yet.
+// Each applies stampCommitOID once it has read one.
 func convertVerifications(inputs []VerificationInput, stamp string) ([]manifest.Verification, error) {
 	if len(inputs) == 0 {
 		return nil, nil

--- a/internal/run/review.go
+++ b/internal/run/review.go
@@ -129,14 +129,21 @@ func Review(ctx context.Context, env Env, reqJSON []byte) (*ReviewResult, error)
 	if err != nil {
 		return nil, wrapAfterMutation(err)
 	}
+	// Every entry this cycle writes is stamped with the PR's live head as
+	// the engine read it, not with the request's ReviewedHeadOID. The two
+	// are equal — the staleness check above rejects the cycle otherwise —
+	// but the record's provenance should not rest on a request field even
+	// when that field was just validated.
+	stampCommitOID(verifications, pr.HeadRefOid)
 	for _, v := range verifications {
 		setVerification(&m, v)
 	}
 	m.Verifications = append(m.Verifications, manifest.Verification{
-		Name:   fmt.Sprintf("review-cycle-%d", issue.ReviewCycles),
-		Result: req.Verdict,
-		Detail: truncateReviewDetail(req.Summary),
-		At:     env.nowStamp(),
+		Name:      fmt.Sprintf("review-cycle-%d", issue.ReviewCycles),
+		Result:    req.Verdict,
+		Detail:    truncateReviewDetail(req.Summary),
+		CommitOID: pr.HeadRefOid,
+		At:        env.nowStamp(),
 	})
 	if err := writeManifest(ctx, gh, iss, &pr, m); err != nil {
 		return nil, wrapAfterMutation(err)

--- a/internal/run/verb_unit_test.go
+++ b/internal/run/verb_unit_test.go
@@ -771,6 +771,168 @@ func TestPROpenRejectsEngineOwnedVerificationNames(t *testing.T) {
 	}
 }
 
+// --- Verification commit OIDs (issue #60) ---
+
+// TestReviewStampsTheReviewedHead proves review stamps every entry it
+// writes — the caller-supplied evidence and the review-cycle entry alike
+// — with the PR head the engine read, so a fix commit's re-run evidence
+// is distinguishable from the evidence pr-open recorded at an earlier
+// head.
+func TestReviewStampsTheReviewedHead(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhaseInReview)})
+	body := baseManifestBody(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-2"),
+		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghSetPRBodyCall(10),
+	}}
+	req := `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-2","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"},"verifications":[{"name":"go test ./...","result":"pass"}]}`
+	if _, err := Review(context.Background(), ghEnv(root, script), []byte(req)); err != nil {
+		t.Fatalf("Review: %v", err)
+	}
+	script.AssertExhausted()
+	for _, name := range []string{"go test ./...", "review-cycle-1"} {
+		if got := findVerification(t, script.StdinAt(3), name).CommitOID; got != "head-oid-2" {
+			t.Errorf("%s commit = %q, want the PR's live head", name, got)
+		}
+	}
+}
+
+// TestCIStampsThePRHead proves the required-ci singleton carries the head
+// its rollup was read at. The entry is replaced by name on every poll, so
+// without the stamp a CI state read before a fix commit and one read
+// after it are the same bytes in the record.
+func TestCIStampsThePRHead(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhaseInReview)})
+	body := baseManifestBody(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(), ghRollupEmptyCall(10), ghIssueViewCall(t, 1, "OPEN", body),
+		ghPRViewCall(10, "OPEN", "head-oid-3"), ghSetIssueBodyCall(1), ghSetPRBodyCall(10),
+	}}
+	if _, err := CI(context.Background(), ghEnv(root, script), []byte(`{"schema_version":1,"issue_number":1}`)); err != nil {
+		t.Fatalf("CI: %v", err)
+	}
+	script.AssertExhausted()
+	if got := findVerification(t, script.StdinAt(4), "required-ci").CommitOID; got != "head-oid-3" {
+		t.Errorf("required-ci commit = %q, want the PR's live head", got)
+	}
+}
+
+// TestMergeStampsTheMergedHead proves the terminal merge entry names the
+// commit that actually merged — the head the human approval pinned and
+// `gh pr merge --match-head-commit` matched — which is the reference every
+// earlier entry in the record is read against.
+func TestMergeStampsTheMergedHead(t *testing.T) {
+	iss := fixtureIssue("a", 1, state.PhaseAwaitingMerge)
+	iss.ApprovedHeadOID = "head-oid-2"
+	root := setupDeliveryRepo(t, "r1", []state.Issue{iss})
+	body := baseManifestBody(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-2"), ghRollupEmptyCall(10),
+		ghMergePRCall(10, "head-oid-2"), ghPRViewCall(10, "MERGED", "head-oid-2"),
+		ghSetStatusCall(1, ghops.StatusDelivered),
+		ghIssueViewCall(t, 1, "OPEN", body), ghCloseIssueCall(1), ghSetIssueBodyCall(1),
+	}}
+	req := `{"schema_version":1,"issue_number":1,"approval":{"pr_number":10,"head_oid":"head-oid-2","approved_by":"a","approved_at":"2026-07-11T12:00:00Z","statement":"approve-merge"}}`
+	if _, err := Merge(context.Background(), ghEnv(root, script), []byte(req)); err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	script.AssertExhausted()
+	if got := findVerification(t, script.StdinAt(8), "merge").CommitOID; got != "head-oid-2" {
+		t.Errorf("merge commit = %q, want the merged head", got)
+	}
+}
+
+// TestAbandonStampsThePRHeadWhenThereIsOne proves abandon records the
+// head the work was dropped at when the issue had a PR to read one from.
+func TestAbandonStampsThePRHeadWhenThereIsOne(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
+	body := baseManifestBody(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-4"),
+		{Name: "gh", Args: []string{"pr", "close", "10"}},
+		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghCloseIssueCall(1),
+	}}
+	req := `{"schema_version":1,"issue_number":1,"reason":"scope dropped","statement":"abandon-issue"}`
+	if _, err := Abandon(context.Background(), ghEnv(root, script), []byte(req)); err != nil {
+		t.Fatalf("Abandon: %v", err)
+	}
+	script.AssertExhausted()
+	if got := findVerification(t, script.StdinAt(4), "abandoned").CommitOID; got != "head-oid-4" {
+		t.Errorf("abandoned commit = %q, want the closed PR's head", got)
+	}
+}
+
+// TestAbandonWithoutAPRRecordsNoCommit is the empty-OID case, and the
+// reason the field is optional. An issue abandoned before pr-open has no
+// pushed head — its branch may hold no commits of its own at all — so
+// there is no commit the abandonment is about. The entry must still be
+// written: abandon has already closed the PR and the issue by the time it
+// renders, so a required field would fail here with nothing left to run.
+func TestAbandonWithoutAPRRecordsNoCommit(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhaseDispatched)})
+	body := baseManifestBody(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(), ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghCloseIssueCall(1),
+	}}
+	req := `{"schema_version":1,"issue_number":1,"reason":"scope dropped","statement":"abandon-issue"}`
+	if _, err := Abandon(context.Background(), ghEnv(root, script), []byte(req)); err != nil {
+		t.Fatalf("Abandon: %v", err)
+	}
+	script.AssertExhausted()
+	v := findVerification(t, script.StdinAt(2), "abandoned")
+	if v.CommitOID != "" {
+		t.Errorf("abandoned commit = %q, want empty: there was no head to read", v.CommitOID)
+	}
+	if v.Result != "abandoned" || v.Detail != "scope dropped" {
+		t.Errorf("abandoned entry = %+v, want the reason recorded despite the absent commit", v)
+	}
+	wantPhase(t, root, 1, state.PhaseAbandoned)
+}
+
+// TestVerificationInputRejectsACallerSuppliedCommitOID pins the wire
+// contract on both verbs that take verifications: VerificationInput has
+// no commit-OID field, and decodeRequest disallows unknown fields, so a
+// request asserting which commit its evidence speaks for is refused as
+// ErrBadRequest before any git or gh call rather than quietly ignored.
+// The record's answer to that question stays the engine's, never an
+// executor's or a reviewer's claim.
+func TestVerificationInputRejectsACallerSuppliedCommitOID(t *testing.T) {
+	verbs := map[string]struct {
+		fn    func(context.Context, Env, []byte) error
+		phase state.Phase
+		req   string
+	}{
+		"review": {
+			fn:    func(ctx context.Context, e Env, b []byte) error { _, err := Review(ctx, e, b); return err },
+			phase: state.PhaseInReview,
+			req:   `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"h","verdict":"approve","summary":"s","reviewer":{"model":"claude-opus-4-8","effort":"high"},"verifications":[{"name":"go test","result":"pass","commit_oid":"claimed-head"}]}`,
+		},
+		"pr-open": {
+			fn:    func(ctx context.Context, e Env, b []byte) error { _, err := PROpen(ctx, e, b); return err },
+			phase: state.PhaseDispatched,
+			req:   `{"schema_version":1,"issue_number":1,"verifications":[{"name":"go test","result":"pass","commit_oid":"claimed-head"}]}`,
+		},
+	}
+	for name, tc := range verbs {
+		t.Run(name, func(t *testing.T) {
+			root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, tc.phase)})
+			before := stateBytes(t, root)
+			script := &execxtest.Script{T: t}
+			err := tc.fn(context.Background(), ghEnv(root, script), []byte(tc.req))
+			if !errors.Is(err, ErrBadRequest) {
+				t.Fatalf("err = %v, want ErrBadRequest", err)
+			}
+			if !strings.Contains(err.Error(), "commit_oid") {
+				t.Errorf("err %v does not name the offending field", err)
+			}
+			script.AssertExhausted()
+			if got := stateBytes(t, root); string(got) != string(before) {
+				t.Error("state changed on a request claiming its own commit OID")
+			}
+		})
+	}
+}
+
 // --- Schema v3 persistence ---
 
 func TestActivatePersistsV3Fields(t *testing.T) {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -143,10 +143,17 @@ type Issue struct {
 	// Objective, AcceptanceCriteria, and RequiredTests are the approved
 	// plan text, copied at EnterDelivery so dispatch hands the executor a
 	// transcription of what a human approved rather than a recollection
-	// of it. They are optional in the persisted file rather than required
-	// by validateIssues because a run activated by a build older than the
-	// schema-2 audit record carries none; `orch resume` repopulates them
-	// from the issue body, which is their durable home.
+	// of it. Their durable home is the issue body's audit record, and
+	// `orch resume` repopulates them from it on every phase where it
+	// already parses that record.
+	//
+	// They are optional in the persisted file rather than required by
+	// validateIssues because a run activated by a build older than the
+	// schema-2 audit record carries none — and resume cannot repair that
+	// run. Its issue bodies still hold the older record manifest.Parse
+	// refuses, so resume takes its failure path and blocks the issue
+	// instead of repopulating anything. The remediation there is abort,
+	// never resume (internal/run/dispatch.go, checkApprovedWork).
 	Objective          string   `json:"objective,omitempty"`
 	AcceptanceCriteria []string `json:"acceptance_criteria,omitempty"`
 	RequiredTests      []string `json:"required_tests,omitempty"`


### PR DESCRIPTION
Delivers issue #60: Stamp verification entries with their commit OID at manifest schema 3, and correct two impossible remediations

Closes #60

**Plan digest:** `sha256:a70520220ef6c39522d5901556fb0a4cf52d4f861997934ed655dd7a8217b6b4`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Give every Verification entry the commit OID it was gathered at, so evidence from an earlier head is distinguishable from evidence at the head that merges. This changes what Render emits, and manifest.Parse re-renders the decoded record and byte-compares it against the region, so a v0.4.0 binary reading a record carrying the new field would pass the version check, silently drop the field, and fail with ErrDrift blaming a hand edit that never happened. The field therefore requires manifest.SchemaVersion 3, and per decision 24 the binary and the adapter plugins carrying it must ship as one release. Fold in the two operator-facing messages that name remediations which do not exist or cannot work, since one of them lives in the same validate function this change already rewrites.

**Acceptance criteria:**
- manifest.Verification carries a commit OID field and manifest.SchemaVersion is 3.
- Render emits the commit OID in both the human markdown view and the canonical JSON, so a record carrying one survives Parse's re-render byte-compare round-trip.
- The engine stamps the commit OID itself from the head it already reads at each site that writes a verification; no run verb accepts an operator-supplied OID in its request.
- Parse rejects a schema-2 record through the existing unsupported-version path, and that error names a remediation that exists, following internal/state/state.go's orch abort precedent instead of the current 'regenerate the record' text.
- The internal/state comment stating that orch resume repopulates the approved-work fields from the issue body is corrected to agree with internal/run/dispatch.go's 'The remediation is abort, never resume'.
- Both adapter plugin manifests and the root marketplace manifest declare version 0.5.0, so the schema-3 binary and the plugins that speak it ship as one release per decision 24.

**Required tests:**
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `specialist` |
| Executor | `claude-opus-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to a specialist with a strong reviewer because risk domains (migrations, data-integrity) and the task is unusually difficult.

**Escalations:** _none_

**Verification:**
- **go-build** — pass — `go build ./...` — exit 0, no output. (2026-07-26T20:49:06Z)
- **go-vet** — pass — `go vet ./...` — exit 0, no output. (2026-07-26T20:49:06Z)
- **go-test** — pass — `go clean -testcache && go test ./...` — Test cache cleared first, so every package genuinely re-ran. All packages pass:
ok github.com/kninetimmy/orch 0.542s
ok github.com/kninetimmy/orch/adapters/claude 0.545s
ok github.com/kninetimmy/orch/adapters/codex 0.577s
ok github.com/kninetimmy/orch/internal/agents 0.485s
ok github.com/kninetimmy/orch/internal/bootstrap 10.439s
ok github.com/kninetimmy/orch/internal/cli 1.233s
ok github.com/kninetimmy/orch/internal/config 0.476s
ok github.com/kninetimmy/orch/internal/execx 0.356s
ok github.com/kninetimmy/orch/internal/ghops 1.426s
ok github.com/kninetimmy/orch/internal/gitops 4.484s
ok github.com/kninetimmy/orch/internal/guard 0.507s
ok github.com/kninetimmy/orch/internal/instructions 0.390s
ok github.com/kninetimmy/orch/internal/interview 0.426s
ok github.com/kninetimmy/orch/internal/lockfile 0.344s
ok github.com/kninetimmy/orch/internal/manifest 0.276s
ok github.com/kninetimmy/orch/internal/memhub 0.251s
ok github.com/kninetimmy/orch/internal/metrics 0.340s
ok github.com/kninetimmy/orch/internal/paths 0.267s
ok github.com/kninetimmy/orch/internal/question 0.267s
ok github.com/kninetimmy/orch/internal/routing 0.270s
ok github.com/kninetimmy/orch/internal/run 18.245s
ok github.com/kninetimmy/orch/internal/state 0.479s

cmd/orch, internal/adaptertest and internal/execx/execxtest report no test files; pre-existing state, not a result of this change. (2026-07-26T20:49:06Z)
- **gofmt** — pass — `gofmt -l .` — exit 0, empty file list. (2026-07-26T20:49:06Z)
- **architect-scope-verification** — pass — `git diff --stat origin/main...573b186; git show 573b186:internal/manifest/manifest.go | grep 'SchemaVersion = |CommitOID'` — Architect re-verified the pushed branch independently rather than relying on the executor's self-report. Confirmed: one commit (573b186) ahead of main; 22 files, +604/-82; manifest.SchemaVersion = 3 and Verification.CommitOID present; all three plugin manifests (.claude-plugin/marketplace.json, adapters/claude/.claude-plugin/plugin.json, adapters/codex/.codex-plugin/plugin.json) declare 0.5.0 per decision 24; origin/main carries only the #61 squash merge (781d755) and none of this work.

Also confirmed the executor honored the mid-run binary prohibition: it reports running only go build/vet/test/gofmt, with no go install, no go build -o, and no orch invocation. This matters because decision 59 records that reinstalling orch mid-run makes Parse reject the running run's own schema-2 records, which would fail every remaining verb closed and cost the run's phase progress. (2026-07-26T20:49:06Z)
- **review-cycle-1** — approve — VERDICT: approve. All 6 ACs pass, 6/6 required CI green at 573b186, 13 mutations all killed, scope clean (22 files, +604/-82, one commit).

BLOCKING: none.

VERIFIED INDEPENDENTLY: AC2 round-trip property-tested over 4 shapes (OID present/absent/mixed/none) - all survive Parse's re-render byte-compare. Escaping attacked with 15 hostile OIDs x 3 details; region never forged, no CR survives. The frozen v2 fixture is a GENUINE v2 render - rebuilt at base 781d755 with the real v2 renderer, byte-identical, v2 Parse accepts it. Write sites grepped: exactly five; escalate/activate write manifests but no verifications. git grep '0.4.0' returns nothing.

EMPTY-OID DESIGN: sound, premise checked. Empty means 'no commit was in scope', not 'missing' - which holds only because v2 can never decode into v3 (validate runs before the drift compare and before anything reads Verifications). Pointer and required-sentinel alternatives were rejected because Render runs AFTER irreversible GitHub mutations in review/merge/abandon, so a validate() failure there is mid-verb with no repair command. Nothing outside render.go reads CommitOID.

NON-BLOCKING (7):
1. prHeadOID(nil) in civerb could emit empty too (unreachable); 'exactly one site' is a hair narrow.
2. Residual: a future site forgetting to stamp gives a silent false 'no commit' claim, policed by tests not validate(). Accepted trade.
3. propen.go:246 still reads '(manifest schema 2)' - accurate.
4. TestActivatePersistsV3Fields (run-state v3) collides in name with manifest v3. Pre-existing.
5. review stamps caller evidence with the PR head at record time - equal to the reviewed head via the staleness gate, not proof tests ran there.
6. merge's OID is the PR branch head, not the squash commit.
7. Each entry adds ~114 bytes, marginally shortening PR #61's cycle estimate.

RELEASE: merging does not ship 0.5.0. internal/cli.Version defaults to 'dev', ldflags-stamped only by release.yml from the tag; AC6 needs a v0.5.0 tag after merge. (2026-07-26T21:04:34Z)
- **required-ci** — passing — test (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass (2026-07-26T21:04:55Z)

<!-- orch:manifest:data
{
  "schema_version": 2,
  "objective": "Give every Verification entry the commit OID it was gathered at, so evidence from an earlier head is distinguishable from evidence at the head that merges. This changes what Render emits, and manifest.Parse re-renders the decoded record and byte-compares it against the region, so a v0.4.0 binary reading a record carrying the new field would pass the version check, silently drop the field, and fail with ErrDrift blaming a hand edit that never happened. The field therefore requires manifest.SchemaVersion 3, and per decision 24 the binary and the adapter plugins carrying it must ship as one release. Fold in the two operator-facing messages that name remediations which do not exist or cannot work, since one of them lives in the same validate function this change already rewrites.",
  "acceptance_criteria": [
    "manifest.Verification carries a commit OID field and manifest.SchemaVersion is 3.",
    "Render emits the commit OID in both the human markdown view and the canonical JSON, so a record carrying one survives Parse's re-render byte-compare round-trip.",
    "The engine stamps the commit OID itself from the head it already reads at each site that writes a verification; no run verb accepts an operator-supplied OID in its request.",
    "Parse rejects a schema-2 record through the existing unsupported-version path, and that error names a remediation that exists, following internal/state/state.go's orch abort precedent instead of the current 'regenerate the record' text.",
    "The internal/state comment stating that orch resume repopulates the approved-work fields from the issue body is corrected to agree with internal/run/dispatch.go's 'The remediation is abort, never resume'.",
    "Both adapter plugin manifests and the root marketplace manifest declare version 0.5.0, so the schema-3 binary and the plugins that speak it ship as one release per decision 24."
  ],
  "required_tests": [
    "go build ./...",
    "go vet ./...",
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "specialist",
  "executor": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to a specialist with a strong reviewer because risk domains (migrations, data-integrity) and the task is unusually difficult.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "go-build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "exit 0, no output.",
      "at": "2026-07-26T20:49:06Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "exit 0, no output.",
      "at": "2026-07-26T20:49:06Z"
    },
    {
      "name": "go-test",
      "command": "go clean -testcache \u0026\u0026 go test ./...",
      "result": "pass",
      "detail": "Test cache cleared first, so every package genuinely re-ran. All packages pass:\nok github.com/kninetimmy/orch 0.542s\nok github.com/kninetimmy/orch/adapters/claude 0.545s\nok github.com/kninetimmy/orch/adapters/codex 0.577s\nok github.com/kninetimmy/orch/internal/agents 0.485s\nok github.com/kninetimmy/orch/internal/bootstrap 10.439s\nok github.com/kninetimmy/orch/internal/cli 1.233s\nok github.com/kninetimmy/orch/internal/config 0.476s\nok github.com/kninetimmy/orch/internal/execx 0.356s\nok github.com/kninetimmy/orch/internal/ghops 1.426s\nok github.com/kninetimmy/orch/internal/gitops 4.484s\nok github.com/kninetimmy/orch/internal/guard 0.507s\nok github.com/kninetimmy/orch/internal/instructions 0.390s\nok github.com/kninetimmy/orch/internal/interview 0.426s\nok github.com/kninetimmy/orch/internal/lockfile 0.344s\nok github.com/kninetimmy/orch/internal/manifest 0.276s\nok github.com/kninetimmy/orch/internal/memhub 0.251s\nok github.com/kninetimmy/orch/internal/metrics 0.340s\nok github.com/kninetimmy/orch/internal/paths 0.267s\nok github.com/kninetimmy/orch/internal/question 0.267s\nok github.com/kninetimmy/orch/internal/routing 0.270s\nok github.com/kninetimmy/orch/internal/run 18.245s\nok github.com/kninetimmy/orch/internal/state 0.479s\n\ncmd/orch, internal/adaptertest and internal/execx/execxtest report no test files; pre-existing state, not a result of this change.",
      "at": "2026-07-26T20:49:06Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "exit 0, empty file list.",
      "at": "2026-07-26T20:49:06Z"
    },
    {
      "name": "architect-scope-verification",
      "command": "git diff --stat origin/main...573b186; git show 573b186:internal/manifest/manifest.go | grep 'SchemaVersion = |CommitOID'",
      "result": "pass",
      "detail": "Architect re-verified the pushed branch independently rather than relying on the executor's self-report. Confirmed: one commit (573b186) ahead of main; 22 files, +604/-82; manifest.SchemaVersion = 3 and Verification.CommitOID present; all three plugin manifests (.claude-plugin/marketplace.json, adapters/claude/.claude-plugin/plugin.json, adapters/codex/.codex-plugin/plugin.json) declare 0.5.0 per decision 24; origin/main carries only the #61 squash merge (781d755) and none of this work.\n\nAlso confirmed the executor honored the mid-run binary prohibition: it reports running only go build/vet/test/gofmt, with no go install, no go build -o, and no orch invocation. This matters because decision 59 records that reinstalling orch mid-run makes Parse reject the running run's own schema-2 records, which would fail every remaining verb closed and cost the run's phase progress.",
      "at": "2026-07-26T20:49:06Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "VERDICT: approve. All 6 ACs pass, 6/6 required CI green at 573b186, 13 mutations all killed, scope clean (22 files, +604/-82, one commit).\n\nBLOCKING: none.\n\nVERIFIED INDEPENDENTLY: AC2 round-trip property-tested over 4 shapes (OID present/absent/mixed/none) - all survive Parse's re-render byte-compare. Escaping attacked with 15 hostile OIDs x 3 details; region never forged, no CR survives. The frozen v2 fixture is a GENUINE v2 render - rebuilt at base 781d755 with the real v2 renderer, byte-identical, v2 Parse accepts it. Write sites grepped: exactly five; escalate/activate write manifests but no verifications. git grep '0.4.0' returns nothing.\n\nEMPTY-OID DESIGN: sound, premise checked. Empty means 'no commit was in scope', not 'missing' - which holds only because v2 can never decode into v3 (validate runs before the drift compare and before anything reads Verifications). Pointer and required-sentinel alternatives were rejected because Render runs AFTER irreversible GitHub mutations in review/merge/abandon, so a validate() failure there is mid-verb with no repair command. Nothing outside render.go reads CommitOID.\n\nNON-BLOCKING (7):\n1. prHeadOID(nil) in civerb could emit empty too (unreachable); 'exactly one site' is a hair narrow.\n2. Residual: a future site forgetting to stamp gives a silent false 'no commit' claim, policed by tests not validate(). Accepted trade.\n3. propen.go:246 still reads '(manifest schema 2)' - accurate.\n4. TestActivatePersistsV3Fields (run-state v3) collides in name with manifest v3. Pre-existing.\n5. review stamps caller evidence with the PR head at record time - equal to the reviewed head via the staleness gate, not proof tests ran there.\n6. merge's OID is the PR branch head, not the squash commit.\n7. Each entry adds ~114 bytes, marginally shortening PR #61's cycle estimate.\n\nRELEASE: merging does not ship 0.5.0. internal/cli.Version defaults to 'dev', ldflags-stamped only by release.yml from the tag; AC6 needs a v0.5.0 tag after merge.",
      "at": "2026-07-26T21:04:34Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "at": "2026-07-26T21:04:55Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->