### PR TITLE
Document reserved verification names, correct two doc comments, and bump the adapters to 0.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "kninetimmy" },
   "metadata": {
     "description": "Host adapters for the Orch development orchestrator",
-    "version": "0.5.0"
+    "version": "0.5.1"
   },
   "plugins": [
     {

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Claude Code host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -78,8 +78,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.0" {
-		t.Errorf("version = %q, want 0.5.0", m.Version)
+	if m.Version != "0.5.1" {
+		t.Errorf("version = %q, want 0.5.1", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -192,7 +192,10 @@ in flight at once. For each issue:
                "cache_creation_tokens": 0, "duration_ms": 0}}
    ```
 
-   At least one verification is required. `usage` is optional (PRD
+   At least one verification is required. The verification names
+   `required-ci`, `merge`, `abandoned`, and `review-cycle-<n>` are
+   engine-owned and are rejected with `ErrBadRequest` before any
+   mutation when supplied by a caller. `usage` is optional (PRD
    §21): supply only the fields the executor's Task result actually
    reports (token totals and duration), never an estimate. Result
    carries `pr_number`, `pr_url`.
@@ -224,8 +227,11 @@ in flight at once. For each issue:
    `orch run pr-open` is not reachable a second time, so `verifications`
    is optional and takes pr-open's input shape — use it to carry
    evidence re-run on the fix commit (e.g. tests re-run before
-   requesting the next review) into the audit record. `approve`
-   continues.
+   requesting the next review) into the audit record. The same
+   verification names as pr-open — `required-ci`, `merge`, `abandoned`,
+   and `review-cycle-<n>` — are engine-owned and are rejected with
+   `ErrBadRequest` before any mutation when supplied by a caller.
+   `approve` continues.
 
 6. **CI** — `orch run ci` with
    `{"schema_version": 1, "issue_number": N}` records the honest

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Codex CLI host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/codex/agents/orch-implementer.toml
+++ b/adapters/codex/agents/orch-implementer.toml
@@ -22,7 +22,7 @@ list you could check.
 
 ## Before your first edit
 
-Read: the GitHub issue, the project context in your spawn prompt, this
+Read: the GitHub issue, the project context in your dispatch prompt, this
 repository's AGENTS.md, and the package's existing conventions. Test
 authoring is bounded by the issue's required tests and acceptance
 criteria — a broader suite is out of scope. An AGENTS.md declaring no

--- a/adapters/codex/agents/orch-specialist.toml
+++ b/adapters/codex/agents/orch-specialist.toml
@@ -22,7 +22,7 @@ instructions are the actual boundary.
 
 ## Before your first edit
 
-Read: the GitHub issue, the project context in your spawn prompt, this
+Read: the GitHub issue, the project context in your dispatch prompt, this
 repository's AGENTS.md, and the package's existing conventions. Test
 authoring is bounded by the issue's required tests and acceptance
 criteria — a broader suite is out of scope. An AGENTS.md declaring no

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -79,8 +79,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.0" {
-		t.Errorf("version = %q, want 0.5.0", m.Version)
+	if m.Version != "0.5.1" {
+		t.Errorf("version = %q, want 0.5.1", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -197,7 +197,10 @@ in flight at once. For each issue:
                "cache_creation_tokens": 0, "duration_ms": 0}}
    ```
 
-   At least one verification is required. `usage` is optional (PRD
+   At least one verification is required. The verification names
+   `required-ci`, `merge`, `abandoned`, and `review-cycle-<n>` are
+   engine-owned and are rejected with `ErrBadRequest` before any
+   mutation when supplied by a caller. `usage` is optional (PRD
    §21): supply only the fields the executor's own reporting actually
    gives you, never an estimate. Result carries `pr_number`, `pr_url`.
 
@@ -233,8 +236,11 @@ in flight at once. For each issue:
    `orch run pr-open` is not reachable a second time, so
    `verifications` is optional and takes pr-open's input shape — use
    it to carry evidence re-run on the fix commit (e.g. tests re-run
-   before requesting the next review) into the audit record. `approve`
-   continues.
+   before requesting the next review) into the audit record. The same
+   verification names as pr-open — `required-ci`, `merge`, `abandoned`,
+   and `review-cycle-<n>` — are engine-owned and are rejected with
+   `ErrBadRequest` before any mutation when supplied by a caller.
+   `approve` continues.
 
 6. **CI** — `orch run ci` with
    `{"schema_version": 1, "issue_number": N}` records the honest

--- a/internal/run/manifestbody.go
+++ b/internal/run/manifestbody.go
@@ -30,16 +30,20 @@ const (
 	// plain ASCII text, and more for HTML-escaped ("&", "<", ">") or
 	// multi-byte runes, which both renders escape. Measured directly
 	// with manifest.Upsert against this issue's own audit record (#59/PR
-	// #61) with its one review cycle stripped — a ~10,300-byte base
-	// carrying the approved work, routing table, and five pr-open
-	// verifications — about 4 maximal-length review cycles fit at this
-	// cap before bodyCapHeadroom's 60,000-byte ceiling starts rotating
-	// detail out, versus roughly 11 at the smaller verificationDetailCap.
-	// Rotation drops the OLDEST verification's detail first
-	// (upsertCapped), which means pr-open's mandatory PRD §15 test
-	// evidence would be discarded before an early review-cycle summary;
-	// this cap is kept well short of that trade becoming routine rather
-	// than rare.
+	// #61) with its one review cycle stripped, at both bases
+	// writeManifest maintains: the issue body is the durable audit
+	// home, the PR body only a mirror of it while the PR stays open. A
+	// ~10,362-byte PR-body base (carrying the approved work, routing
+	// table, and five pr-open verifications) fits about 4
+	// maximal-length review cycles before bodyCapHeadroom's 60,000-byte
+	// ceiling starts rotating detail out; the larger ~12,157-byte
+	// issue-body base fits about 3. So this cap holds 3-4
+	// maximal-length review cycles in practice, versus roughly 11 at
+	// the smaller verificationDetailCap. Rotation drops the OLDEST
+	// verification's detail first (upsertCapped), which means
+	// pr-open's mandatory PRD §15 test evidence would be discarded
+	// before an early review-cycle summary; this cap is kept well
+	// short of that trade becoming routine rather than rare.
 	reviewDetailCap = 6000
 	// verificationTruncationMarker flags a detail cut to the cap.
 	verificationTruncationMarker = " … [truncated by orch]"


### PR DESCRIPTION
Delivers issue #63: Document reserved verification names, correct two doc comments, and bump the adapters to 0.5.1

Closes #63

**Plan digest:** `sha256:bfecbe740c7cdee2c9e148cb01c507eebd042cf18c9201f1c0b35e5268a04e83`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Close tasks 47, 48 and 50 as one documentation change, and bump the three plugin version sites from 0.5.0 to 0.5.1 so the corrected skill text can reach an installed host. All edits are to prose, one Go doc comment, and three JSON version strings; no engine behavior changes.

**Acceptance criteria:**
- Both adapters/claude/skills/orch-delivery/SKILL.md and adapters/codex/skills/orch-delivery/SKILL.md state that the verification names required-ci, merge, abandoned, and review-cycle-&lt;n&gt; are engine-owned and are rejected with ErrBadRequest before any mutation when supplied by a caller. The statement appears wherever the verifications field is documented for BOTH verbs it gates - the pr-open block and the review block - because internal/run/propen.go and internal/run/review.go each call rejectEngineOwnedNames.
- internal/run/manifestbody.go's reviewDetailCap doc comment identifies the issue body as the durable audit home and reports both measured bases rather than only the PR's: the PR-body base of about 10,362 bytes fitting about 4 maximal-length review cycles, and the issue-body base of about 12,157 bytes fitting about 3. The capacity claim reads 3-4 maximal-length review cycles rather than about 4. No constant value changes; reviewDetailCap stays 6000.
- adapters/codex/agents/orch-implementer.toml and adapters/codex/agents/orch-specialist.toml say dispatch prompt at every occurrence, and the phrase spawn prompt appears in neither file. The Claude .md agent files are left untouched and continue to say spawn prompt, which is correct for that host.
- adapters/claude/.claude-plugin/plugin.json, adapters/codex/.codex-plugin/plugin.json, and .claude-plugin/marketplace.json each declare version 0.5.1. No other file's version string changes, and internal/cli's Version default stays dev since release.yml stamps it from the tag.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-sonnet-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **go test ./...** — pass — `go test ./...` — Executor-reported, run against the final committed state 8d22c66 inside the issue-63 worktree: all packages ok. Covers the three pins that judge this change - root marketplace_test.go (version/description consistency between .claude-plugin/marketplace.json and both plugin.json files), adapters/claude/plugin_test.go and adapters/codex/plugin_test.go (TestPluginManifestStrict version literals, skill orch-run-verb tokens, statement literals against the live internal/run constants). — commit `8d22c66b48f4bf80d068c2ab852eced8a857b1ef` (2026-07-26T23:12:26Z)
- **go vet ./...** — pass — `go vet ./...` — Executor-reported, run against 8d22c66: clean, no output. — commit `8d22c66b48f4bf80d068c2ab852eced8a857b1ef` (2026-07-26T23:12:26Z)
- **gofmt -l .** — pass — `gofmt -l .` — Executor-reported, run against 8d22c66: clean, no files listed. Relevant because internal/run/manifestbody.go's reviewDetailCap doc comment was rewritten. — commit `8d22c66b48f4bf80d068c2ab852eced8a857b1ef` (2026-07-26T23:12:26Z)
- **architect-diff-review** — pass — `git show --stat HEAD; git show HEAD -- <paths>` — Architect independently inspected commit 8d22c66 before pr-open. 10 files, +41/-25, all four acceptance criteria satisfied and no out-of-scope edits. Specifically checked the one reinterpretation the executor flagged: AC4 says no other file's version string changes, and the executor also moved the hardcoded 0.5.0 literals in adapters/claude/plugin_test.go and adapters/codex/plugin_test.go to 0.5.1. Confirmed correct - TestPluginManifestStrict asserts the shipped manifest version, so the pin must track the artifact it pins or the required test go test ./... fails. The AC's intent was shipped-artifact version strings; internal/cli's Version default is untouched and still dev, as AC4 requires. — commit `8d22c66b48f4bf80d068c2ab852eced8a857b1ef` (2026-07-26T23:12:26Z)
- **architect-verification-of-review-claims** — pass — `Get-ChildItem internal/adaptertest; git grep -n "0\.5\.[01]" in the issue-63 worktree; Select-String version internal/adaptertest/adaptertest.go` — Architect re-checked the reviewer's two load-bearing factual claims rather than accepting them. (1) FALSIFIED: internal/adaptertest is not empty - adaptertest.go is present at 10,442 bytes. (2) UPHELD by direct evidence: adaptertest.go contains no 'version' reference at all, so it carries no version pin, and a worktree-wide grep at 8d22c66 shows exactly seven 0.5.1 occurrences (three shipped manifests, four test-literal lines) and zero remaining 0.5.0. The approve verdict is unaffected. — commit `8d22c66b48f4bf80d068c2ab852eced8a857b1ef` (2026-07-26T23:16:48Z)
- **review-cycle-1** — approve — Fresh claude-sonnet-5 @ high reviewer (the plan gate's routed downgrade), one consolidated pass at head 8d22c66. Verdict: approve, first pass, no blocking defects.

AC1 MET, verified against the engine rather than the prose alone: engineVerificationNames = {required-ci, merge, abandoned} plus reviewCycleNamePattern ^review-cycle-[0-9]+$ is exactly the set now documented, and propen.go:81 and review.go:90 both call rejectEngineOwnedNames. Both adapters' SKILL.md gained matching sentences in both the pr-open block and the review block.

AC2 MET: the comment names the issue body as the durable audit home and the PR body as a mirror while the PR is open, reports both measured bases (PR ~10,362 bytes / ~4 maximal cycles; issue ~12,157 bytes / ~3), and lands on the 3-4 claim. reviewDetailCap unchanged at 6000, bodyCapHeadroom unchanged at 60000. Reviewer noted the figures are framed as empirical manifest.Upsert measurements, consistent with the pre-existing comment's methodology, so they are not expected to reduce to (60000-base)/6000; no internal contradiction found.

AC3 MET: zero occurrences of 'spawn prompt' remain in either Codex TOML; the Claude .md agents are untouched and still say 'spawn prompt', which is correct for that host.

AC4 MET: all three manifests declare 0.5.1; internal/cli's Version default is untouched and still dev.

The executor's one flagged reinterpretation, judged independently by the reviewer and again by the Architect: moving the hardcoded 0.5.0 literals in adapters/claude/plugin_test.go and adapters/codex/plugin_test.go to 0.5.1 is correct and minimal. TestPluginManifestStrict asserts the version of the shipped manifest it loads from disk, so the pin must track the artifact it pins or go test ./... - a required test - fails on the intended AC4 bump. AC4's 'no other file's version string changes' governs shipped-artifact versions; internal/cli's dev default is untouched, as AC4 separately requires.

Scope: exactly 10 files, +41/-25, no creep beyond the four criteria. The reviewer independently reproduced go build ./..., go test ./... (all packages ok), go vet ./... (clean) and gofmt -l . (clean) in the worktree at 8d22c66. CI: all 6 required contexts pass - lint, test (ubuntu-latest, macos-latest, windows-latest), scripts (ubuntu-latest, windows-latest); run 30224754507 concluded success. The reviewer observed the windows test job pending mid-poll and reported the final state rather than the transient one. Security: no security-relevant surface is touched - prose, one Go doc comment, three JSON version strings, two test literals.

ARCHITECT CORRECTION TO THIS REVIEW, recorded because the audit record must not carry a false claim forward. The reviewer wrote that internal/adaptertest 'contains no .go files at all (package doesn't exist)'. That is false: internal/adaptertest/adaptertest.go exists at 10,442 bytes and is the shared cross-host parity layer both plugin_test.go files consume. The reviewer's conclusion nonetheless holds, and the Architect re-verified it directly: adaptertest.go contains no occurrence of 'version' in any form, so it holds no pin the 0.5.1 bump could strand, and a worktree-wide grep at 8d22c66 returns exactly the seven expected 0.5.1 sites with zero remaining 0.5.0. The defect was in the stated reason, not in the finding. — commit `8d22c66b48f4bf80d068c2ab852eced8a857b1ef` (2026-07-26T23:16:49Z)
- **required-ci** — passing — test (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass — commit `8d22c66b48f4bf80d068c2ab852eced8a857b1ef` (2026-07-26T23:17:00Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Close tasks 47, 48 and 50 as one documentation change, and bump the three plugin version sites from 0.5.0 to 0.5.1 so the corrected skill text can reach an installed host. All edits are to prose, one Go doc comment, and three JSON version strings; no engine behavior changes.",
  "acceptance_criteria": [
    "Both adapters/claude/skills/orch-delivery/SKILL.md and adapters/codex/skills/orch-delivery/SKILL.md state that the verification names required-ci, merge, abandoned, and review-cycle-\u003cn\u003e are engine-owned and are rejected with ErrBadRequest before any mutation when supplied by a caller. The statement appears wherever the verifications field is documented for BOTH verbs it gates - the pr-open block and the review block - because internal/run/propen.go and internal/run/review.go each call rejectEngineOwnedNames.",
    "internal/run/manifestbody.go's reviewDetailCap doc comment identifies the issue body as the durable audit home and reports both measured bases rather than only the PR's: the PR-body base of about 10,362 bytes fitting about 4 maximal-length review cycles, and the issue-body base of about 12,157 bytes fitting about 3. The capacity claim reads 3-4 maximal-length review cycles rather than about 4. No constant value changes; reviewDetailCap stays 6000.",
    "adapters/codex/agents/orch-implementer.toml and adapters/codex/agents/orch-specialist.toml say dispatch prompt at every occurrence, and the phrase spawn prompt appears in neither file. The Claude .md agent files are left untouched and continue to say spawn prompt, which is correct for that host.",
    "adapters/claude/.claude-plugin/plugin.json, adapters/codex/.codex-plugin/plugin.json, and .claude-plugin/marketplace.json each declare version 0.5.1. No other file's version string changes, and internal/cli's Version default stays dev since release.yml stamps it from the tag."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "claude-sonnet-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "go test ./...",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Executor-reported, run against the final committed state 8d22c66 inside the issue-63 worktree: all packages ok. Covers the three pins that judge this change - root marketplace_test.go (version/description consistency between .claude-plugin/marketplace.json and both plugin.json files), adapters/claude/plugin_test.go and adapters/codex/plugin_test.go (TestPluginManifestStrict version literals, skill orch-run-verb tokens, statement literals against the live internal/run constants).",
      "commit_oid": "8d22c66b48f4bf80d068c2ab852eced8a857b1ef",
      "at": "2026-07-26T23:12:26Z"
    },
    {
      "name": "go vet ./...",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Executor-reported, run against 8d22c66: clean, no output.",
      "commit_oid": "8d22c66b48f4bf80d068c2ab852eced8a857b1ef",
      "at": "2026-07-26T23:12:26Z"
    },
    {
      "name": "gofmt -l .",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Executor-reported, run against 8d22c66: clean, no files listed. Relevant because internal/run/manifestbody.go's reviewDetailCap doc comment was rewritten.",
      "commit_oid": "8d22c66b48f4bf80d068c2ab852eced8a857b1ef",
      "at": "2026-07-26T23:12:26Z"
    },
    {
      "name": "architect-diff-review",
      "command": "git show --stat HEAD; git show HEAD -- \u003cpaths\u003e",
      "result": "pass",
      "detail": "Architect independently inspected commit 8d22c66 before pr-open. 10 files, +41/-25, all four acceptance criteria satisfied and no out-of-scope edits. Specifically checked the one reinterpretation the executor flagged: AC4 says no other file's version string changes, and the executor also moved the hardcoded 0.5.0 literals in adapters/claude/plugin_test.go and adapters/codex/plugin_test.go to 0.5.1. Confirmed correct - TestPluginManifestStrict asserts the shipped manifest version, so the pin must track the artifact it pins or the required test go test ./... fails. The AC's intent was shipped-artifact version strings; internal/cli's Version default is untouched and still dev, as AC4 requires.",
      "commit_oid": "8d22c66b48f4bf80d068c2ab852eced8a857b1ef",
      "at": "2026-07-26T23:12:26Z"
    },
    {
      "name": "architect-verification-of-review-claims",
      "command": "Get-ChildItem internal/adaptertest; git grep -n \"0\\.5\\.[01]\" in the issue-63 worktree; Select-String version internal/adaptertest/adaptertest.go",
      "result": "pass",
      "detail": "Architect re-checked the reviewer's two load-bearing factual claims rather than accepting them. (1) FALSIFIED: internal/adaptertest is not empty - adaptertest.go is present at 10,442 bytes. (2) UPHELD by direct evidence: adaptertest.go contains no 'version' reference at all, so it carries no version pin, and a worktree-wide grep at 8d22c66 shows exactly seven 0.5.1 occurrences (three shipped manifests, four test-literal lines) and zero remaining 0.5.0. The approve verdict is unaffected.",
      "commit_oid": "8d22c66b48f4bf80d068c2ab852eced8a857b1ef",
      "at": "2026-07-26T23:16:48Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Fresh claude-sonnet-5 @ high reviewer (the plan gate's routed downgrade), one consolidated pass at head 8d22c66. Verdict: approve, first pass, no blocking defects.\n\nAC1 MET, verified against the engine rather than the prose alone: engineVerificationNames = {required-ci, merge, abandoned} plus reviewCycleNamePattern ^review-cycle-[0-9]+$ is exactly the set now documented, and propen.go:81 and review.go:90 both call rejectEngineOwnedNames. Both adapters' SKILL.md gained matching sentences in both the pr-open block and the review block.\n\nAC2 MET: the comment names the issue body as the durable audit home and the PR body as a mirror while the PR is open, reports both measured bases (PR ~10,362 bytes / ~4 maximal cycles; issue ~12,157 bytes / ~3), and lands on the 3-4 claim. reviewDetailCap unchanged at 6000, bodyCapHeadroom unchanged at 60000. Reviewer noted the figures are framed as empirical manifest.Upsert measurements, consistent with the pre-existing comment's methodology, so they are not expected to reduce to (60000-base)/6000; no internal contradiction found.\n\nAC3 MET: zero occurrences of 'spawn prompt' remain in either Codex TOML; the Claude .md agents are untouched and still say 'spawn prompt', which is correct for that host.\n\nAC4 MET: all three manifests declare 0.5.1; internal/cli's Version default is untouched and still dev.\n\nThe executor's one flagged reinterpretation, judged independently by the reviewer and again by the Architect: moving the hardcoded 0.5.0 literals in adapters/claude/plugin_test.go and adapters/codex/plugin_test.go to 0.5.1 is correct and minimal. TestPluginManifestStrict asserts the version of the shipped manifest it loads from disk, so the pin must track the artifact it pins or go test ./... - a required test - fails on the intended AC4 bump. AC4's 'no other file's version string changes' governs shipped-artifact versions; internal/cli's dev default is untouched, as AC4 separately requires.\n\nScope: exactly 10 files, +41/-25, no creep beyond the four criteria. The reviewer independently reproduced go build ./..., go test ./... (all packages ok), go vet ./... (clean) and gofmt -l . (clean) in the worktree at 8d22c66. CI: all 6 required contexts pass - lint, test (ubuntu-latest, macos-latest, windows-latest), scripts (ubuntu-latest, windows-latest); run 30224754507 concluded success. The reviewer observed the windows test job pending mid-poll and reported the final state rather than the transient one. Security: no security-relevant surface is touched - prose, one Go doc comment, three JSON version strings, two test literals.\n\nARCHITECT CORRECTION TO THIS REVIEW, recorded because the audit record must not carry a false claim forward. The reviewer wrote that internal/adaptertest 'contains no .go files at all (package doesn't exist)'. That is false: internal/adaptertest/adaptertest.go exists at 10,442 bytes and is the shared cross-host parity layer both plugin_test.go files consume. The reviewer's conclusion nonetheless holds, and the Architect re-verified it directly: adaptertest.go contains no occurrence of 'version' in any form, so it holds no pin the 0.5.1 bump could strand, and a worktree-wide grep at 8d22c66 returns exactly the seven expected 0.5.1 sites with zero remaining 0.5.0. The defect was in the stated reason, not in the finding.",
      "commit_oid": "8d22c66b48f4bf80d068c2ab852eced8a857b1ef",
      "at": "2026-07-26T23:16:49Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "8d22c66b48f4bf80d068c2ab852eced8a857b1ef",
      "at": "2026-07-26T23:17:00Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->