### PR TITLE
Ship orch-reviewer-safe for the Claude adapter and close the step 4 model gap

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "kninetimmy" },
   "metadata": {
     "description": "Host adapters for the Orch development orchestrator",
-    "version": "0.5.1"
+    "version": "0.5.2"
   },
   "plugins": [
     {

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Claude Code host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/claude/README.md
+++ b/adapters/claude/README.md
@@ -36,7 +36,7 @@ never re-derives a decision the engine already made.
 - `skills/orch-architect/SKILL.md` — the Architect's standing posture:
   never edit tracked files directly, never re-derive engine policy,
   the `orch run status --json` / PROJECT.md / memhub-recall session
-  ritual, mode conduct, the four-subagent whitelist and the
+  ritual, mode conduct, the five-subagent whitelist and the
   `concurrency.max_subagents` cap, and memhub write discipline.
 - `skills/orch-delivery/SKILL.md` — the Delivery wire contract: the
   scratch-file JSON request/response pattern for every `orch run <verb>`
@@ -56,11 +56,19 @@ never re-derives a decision the engine already made.
   bare human report first, then follows `orch-setup` for the interactive
   interview and terminal form; none duplicates `orch-setup`'s protocol.
 - `agents/orch-scout.md`, `agents/orch-implementer.md`,
-  `agents/orch-specialist.md`, `agents/orch-reviewer.md` — the four
-  role subagents the Architect spawns during Delivery, each with its own
-  model and tool whitelist (scout and reviewer carry no write tool; no
-  agent carries `Task` or any `mcp__` tool, so subagents have no memhub
-  write surface of their own).
+  `agents/orch-specialist.md`, `agents/orch-reviewer.md`,
+  `agents/orch-reviewer-safe.md` — the five role subagents the Architect
+  spawns during Delivery, each with its own model and tool whitelist
+  (scout, reviewer, and reviewer-safe carry no write tool; no agent
+  carries `Task` or any `mcp__` tool, so subagents have no memhub write
+  surface of their own). `orch-reviewer-safe` is the §10 safe-review
+  downgrade encoding: Claude Code's Task tool `model` parameter only
+  takes coarse tier aliases (`sonnet`/`opus`/`haiku`/`fable`), not an
+  exact version string, so the downgrade the engine computes for a
+  mechanical/low-risk/fully-specified/unsurprising issue has to be an
+  installed agent definition of its own — only its frontmatter can pin
+  `claude-sonnet-5` exactly — spawned by name exactly like
+  `orch-reviewer`.
 
 ## Install order
 

--- a/adapters/claude/agents/orch-reviewer-safe.md
+++ b/adapters/claude/agents/orch-reviewer-safe.md
@@ -1,0 +1,56 @@
+---
+name: orch-reviewer-safe
+description: Spawned by the Architect in place of orch-reviewer when DispatchResult.reviewer names the section 10 safe-downgrade profile — reviews the PR against its issue's acceptance criteria and produces one consolidated verdict for orch run review, the same job orch-reviewer does.
+tools: Read, Grep, Glob, Bash
+model: claude-sonnet-5
+---
+
+# Orch Reviewer (Safe Downgrade)
+
+You did not write this change. You are reviewing someone else's (or
+some other subagent's) work, spawned fresh for this review cycle with
+the PR's live head OID and the issue's objective and acceptance
+criteria in your prompt.
+
+You are the section 10 safe-downgrade reviewer profile: the Architect
+spawned you here, instead of `orch-reviewer`, because
+`DispatchResult.reviewer` named this profile — every downgrade fact for
+this issue held (mechanical, low-risk, fully-specified, unsurprising).
+That downgrade changes which model reviews, not how carefully — apply
+the same scrutiny `orch-reviewer` would.
+
+## What you check
+
+- **Acceptance criteria** — does the PR actually satisfy every
+  criterion the issue listed, not just something adjacent to it?
+- **Scope** — does the PR touch only what the issue asked for, without
+  unrelated changes riding along?
+- **Correctness** — read the diff and the surrounding code closely
+  enough to judge whether the change does what it claims to do.
+- **Tests** — are the required tests present and meaningful, not just
+  present in name?
+- **CI** — is required CI passing, and if not, why?
+- **Security** — anything that weakens a security boundary, leaks a
+  secret, or introduces an obviously unsafe pattern.
+- **Manifest accuracy** — does the issue/PR's audit record (routed
+  selection, verifications) match what actually happened?
+
+## How you look
+
+Your `Bash` access is for **read-only** investigation only: `git diff`,
+`git log`, `gh pr view`, `gh pr diff`, running the project's existing
+test/build commands to confirm evidence — never a write, a commit, or
+anything that changes the repository. You have no `Edit` or `Write`
+tool for the same reason: your job is to judge the change, not to fix
+it. If the change needs a fix, that is a `request-changes` verdict
+sent back to the executor, not something you do yourself.
+
+## Report
+
+Produce **one consolidated report** per review cycle — do not report
+findings piecemeal across several messages. State a clear verdict
+(`approve` or `request-changes`) and the reasoning behind it, covering
+every area above that is relevant to this change.
+
+A write denial from the pre-write guard is policy — report it to the
+Architect; do not work around it.

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -217,8 +217,8 @@ type agentSpec struct {
 // orch-reviewer-safe: Claude Code's Task tool model parameter only takes
 // coarse tier aliases (sonnet/opus/haiku/fable), not an exact version
 // string, so a per-spawn override cannot pin claude-sonnet-5 for the
-// section 10 safe-downgrade review — only an installed agent's
-// frontmatter can, which is why this fifth agent exists.
+// §10 safe-downgrade review — only an installed agent's frontmatter
+// can, which is why this fifth agent exists.
 var agentRoster = map[string]agentSpec{
 	"orch-scout":         {tools: []string{"Read", "Grep", "Glob", "WebFetch", "WebSearch"}},
 	"orch-implementer":   {tools: []string{"Read", "Grep", "Glob", "Edit", "Write", "NotebookEdit", "Bash"}},
@@ -239,10 +239,11 @@ var writeExcludedAgents = map[string]bool{"orch-scout": true, "orch-reviewer": t
 var writeTools = []string{"Write", "Edit", "MultiEdit", "NotebookEdit"}
 
 // TestAgentFrontmatter validates every agents/*.md file against the
-// committed §10 Claude profile: all four agents exist with a complete
-// frontmatter, scout and reviewer exclude every write tool, no agent
-// lists Task or an mcp__ tool (subagents have no memhub write surface),
-// and models match adaptertest.Profile("claude") for their role exactly.
+// committed §10 Claude profile: all five agents exist with a complete
+// frontmatter, scout, reviewer, and reviewer-safe exclude every write
+// tool, no agent lists Task or an mcp__ tool (subagents have no memhub
+// write surface), and models match adaptertest.Profile("claude") for
+// their role exactly.
 func TestAgentFrontmatter(t *testing.T) {
 	profile := adaptertest.Profile("claude")
 	for name, want := range agentRoster {

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -78,8 +78,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.1" {
-		t.Errorf("version = %q, want 0.5.1", m.Version)
+	if m.Version != "0.5.2" {
+		t.Errorf("version = %q, want 0.5.2", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")
@@ -212,23 +212,27 @@ type agentSpec struct {
 	tools []string
 }
 
-// agentRoster is the full four-agent Claude profile this plugin ships.
-// Profile("claude") also carries a "reviewer-safe" entry with no Claude
-// agent file — Claude Code has a per-spawn model override, so it needs
-// no safe-downgrade agent of its own, and this roster deliberately does
-// not require a fifth agent to exist.
+// agentRoster is the full five-agent Claude profile this plugin ships.
+// Profile("claude") also carries a "reviewer-safe" entry, matched here by
+// orch-reviewer-safe: Claude Code's Task tool model parameter only takes
+// coarse tier aliases (sonnet/opus/haiku/fable), not an exact version
+// string, so a per-spawn override cannot pin claude-sonnet-5 for the
+// section 10 safe-downgrade review — only an installed agent's
+// frontmatter can, which is why this fifth agent exists.
 var agentRoster = map[string]agentSpec{
-	"orch-scout":       {tools: []string{"Read", "Grep", "Glob", "WebFetch", "WebSearch"}},
-	"orch-implementer": {tools: []string{"Read", "Grep", "Glob", "Edit", "Write", "NotebookEdit", "Bash"}},
-	"orch-specialist":  {tools: []string{"Read", "Grep", "Glob", "Edit", "Write", "NotebookEdit", "Bash"}},
-	"orch-reviewer":    {tools: []string{"Read", "Grep", "Glob", "Bash"}},
+	"orch-scout":         {tools: []string{"Read", "Grep", "Glob", "WebFetch", "WebSearch"}},
+	"orch-implementer":   {tools: []string{"Read", "Grep", "Glob", "Edit", "Write", "NotebookEdit", "Bash"}},
+	"orch-specialist":    {tools: []string{"Read", "Grep", "Glob", "Edit", "Write", "NotebookEdit", "Bash"}},
+	"orch-reviewer":      {tools: []string{"Read", "Grep", "Glob", "Bash"}},
+	"orch-reviewer-safe": {tools: []string{"Read", "Grep", "Glob", "Bash"}},
 }
 
 // writeExcludedAgents are the roles that must never carry a write tool
 // (PRD-adjacent read-only-by-construction requirement): scout because it
-// only ever investigates, reviewer because "you did not write this
-// change" is enforced by its tool list, not just its prompt.
-var writeExcludedAgents = map[string]bool{"orch-scout": true, "orch-reviewer": true}
+// only ever investigates, reviewer and reviewer-safe because "you did
+// not write this change" is enforced by their tool list, not just their
+// prompt.
+var writeExcludedAgents = map[string]bool{"orch-scout": true, "orch-reviewer": true, "orch-reviewer-safe": true}
 
 // writeTools are the four tools the PreToolUse guard hook mediates; a
 // read-only agent must list none of them.

--- a/adapters/claude/skills/orch-architect/SKILL.md
+++ b/adapters/claude/skills/orch-architect/SKILL.md
@@ -34,7 +34,7 @@ directory) and what would change it (entering Delivery, or being inside
 the right worktree).
 
 The Architect's own job is orchestration: reading state, presenting
-decisions, and spawning the four `orch-*` subagents. Actual file changes
+decisions, and spawning the five `orch-*` subagents. Actual file changes
 are the subagents' job, each confined to its own worktree.
 
 ## Never re-derive engine rules
@@ -85,11 +85,12 @@ actually true about this repository, do the following, in order:
 
 ## Subagents
 
-You may only spawn the four `orch-*` agents: `orch-scout`,
-`orch-implementer`, `orch-specialist`, `orch-reviewer`. Each has its own
-tool whitelist and model in its agent definition — do not override
-either. Never spawn a general-purpose agent, and never spawn a subagent
-for anything outside these four roles.
+You may only spawn the five `orch-*` agents: `orch-scout`,
+`orch-implementer`, `orch-specialist`, `orch-reviewer`,
+`orch-reviewer-safe`. Each has its own tool whitelist and model in its
+agent definition — do not override either. Never spawn a
+general-purpose agent, and never spawn a subagent for anything outside
+these five roles.
 
 Respect the concurrency cap. `concurrency.max_subagents` in
 `.orchestrator/config.toml` is the **one** configuration key this

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -202,9 +202,12 @@ in flight at once. For each issue:
 
 4. **Spawn the reviewer** — once the PR stops changing, spawn the
    reviewer **fresh** (a new instance, not the executor continuing):
-   `orch-reviewer-safe` when `GateDoc`/`DispatchResult` reports
-   `reviewer_downgraded`, `orch-reviewer` otherwise. Spawn with **no
-   model override on either** — each agent's frontmatter pins its exact
+   `orch-reviewer-safe` when the routed reviewer names the §10
+   safe-downgrade profile — the `reviewer_downgraded` routing the
+   `GateDoc` showed at the plan gate, carried in
+   `DispatchResult.reviewer` and superseded by any later escalation's
+   new reviewer — `orch-reviewer` otherwise. Spawn with **no model
+   override on either** — each agent's frontmatter pins its exact
    model, so that pin is what runs. **If the host cannot honor the
    routed model, stop and tell the human — never spawn a different
    model and report the routed one as if it ran.** `reviewed_head_oid`

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -200,10 +200,16 @@ in flight at once. For each issue:
    reports (token totals and duration), never an estimate. Result
    carries `pr_number`, `pr_url`.
 
-4. **Spawn the reviewer** — once the PR stops changing, spawn
-   `orch-reviewer` **fresh** (a new instance, not the executor
-   continuing). `reviewed_head_oid` must be the PR's **live** head OID
-   at review time (e.g. via `gh pr view`), never a cached value.
+4. **Spawn the reviewer** — once the PR stops changing, spawn the
+   reviewer **fresh** (a new instance, not the executor continuing):
+   `orch-reviewer-safe` when `GateDoc`/`DispatchResult` reports
+   `reviewer_downgraded`, `orch-reviewer` otherwise. Spawn with **no
+   model override on either** — each agent's frontmatter pins its exact
+   model, so that pin is what runs. **If the host cannot honor the
+   routed model, stop and tell the human — never spawn a different
+   model and report the routed one as if it ran.** `reviewed_head_oid`
+   must be the PR's **live** head OID at review time (e.g. via `gh pr
+   view`), never a cached value.
 
 5. **Review** — the reviewer produces **one consolidated report**
    (acceptance criteria, scope, correctness, tests, CI, security,

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Codex CLI host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -79,8 +79,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.1" {
-		t.Errorf("version = %q, want 0.5.1", m.Version)
+	if m.Version != "0.5.2" {
+		t.Errorf("version = %q, want 0.5.2", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")


### PR DESCRIPTION
Delivers issue #65: Ship orch-reviewer-safe for the Claude adapter and close the step 4 model gap

Closes #65

**Plan digest:** `sha256:a77f460098c483e4c03bb6c57714820e247beceaf9e890415e598aae189b2f7b`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Give the Claude host an installed agent definition that pins the section 10 safe-downgrade reviewer model exactly, and make orch-delivery step 4 dispatch it by name when the engine routes a reviewer downgrade, so the reviewer recorded in the audit trail is always the reviewer that actually ran.

**Acceptance criteria:**
- adapters/claude/agents/orch-reviewer-safe.md exists with frontmatter name: orch-reviewer-safe, model: claude-sonnet-5, and tools: Read, Grep, Glob, Bash (the same read-only tool set orch-reviewer carries, with no write tool, no Task, and no mcp__ tool).
- Its description states that the Architect dispatches it in place of orch-reviewer when DispatchResult.reviewer names the section 10 safe-downgrade profile, and its body states that the downgrade changes which model reviews, not how carefully, while carrying the same review checklist (acceptance criteria, scope, correctness, tests, CI, security, manifest accuracy) and the same one-consolidated-verdict duty as orch-reviewer.
- agentRoster in adapters/claude/plugin_test.go includes orch-reviewer-safe with that tool set, writeExcludedAgents includes orch-reviewer-safe, and the comment asserting that Claude 'deliberately does not require a fifth agent to exist' is replaced by the reason the fifth agent now exists (the Task tool's model parameter takes tier aliases, not exact versions, so only frontmatter can pin claude-sonnet-5).
- adapters/claude/skills/orch-delivery/SKILL.md step 4 instructs the Architect to spawn orch-reviewer-safe when GateDoc/DispatchResult reports reviewer_downgraded, and orch-reviewer otherwise, with no model override on either spawn so the frontmatter pin is what runs, and states the same stop-and-tell-the-human rule step 2 carries for a routed model the host cannot honor.
- The three plugin version sites (.claude-plugin/marketplace.json metadata.version, adapters/claude/.claude-plugin/plugin.json, adapters/codex/.codex-plugin/plugin.json) read 0.5.2, and the hardcoded version pins in adapters/claude/plugin_test.go and adapters/codex/plugin_test.go match, so a version-cached plugin install picks up the new agent.

**Required tests:**
- `go test ./...`
- `gofmt -l .`
- `go vet ./...`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — All packages ok (24 packages, 2 with no test files, none failing). Run by the executor against the final committed and pushed state at 5fff705. — commit `5fff70553faa055cc640364ada986bcebd5ff94d` (2026-07-27T01:18:15Z)
- **gofmt** — pass — `gofmt -l .` — Empty output; no unformatted files. Run by the executor against the final committed and pushed state at 5fff705. — commit `5fff70553faa055cc640364ada986bcebd5ff94d` (2026-07-27T01:18:15Z)
- **go-vet** — pass — `go vet ./...` — Clean, no output. Run by the executor against the final committed and pushed state at 5fff705. — commit `5fff70553faa055cc640364ada986bcebd5ff94d` (2026-07-27T01:18:15Z)
- **reviewer-go-test** — pass — `go test ./... -count=1` — Re-run independently by the reviewer in the worktree at 5fff70553faa055cc640364ada986bcebd5ff94d. No failures. Corrects the pr-open count: 25 packages, 3 with no test files (cmd/orch, internal/adaptertest, internal/execx/execxtest). — commit `5fff70553faa055cc640364ada986bcebd5ff94d` (2026-07-27T01:27:23Z)
- **reviewer-gofmt** — pass — `gofmt -l .` — Re-run independently by the reviewer at 5fff705. Empty output. — commit `5fff70553faa055cc640364ada986bcebd5ff94d` (2026-07-27T01:27:23Z)
- **reviewer-go-vet** — pass — `go vet ./...` — Re-run independently by the reviewer at 5fff705. Clean, no output. — commit `5fff70553faa055cc640364ada986bcebd5ff94d` (2026-07-27T01:27:23Z)
- **reviewer-ci-observed** — pass — `gh pr checks 66` — All six required checks SUCCESS on workflow run 30229501745 at review time: test (ubuntu-latest), test (macos-latest), test (windows-latest), lint, scripts (ubuntu-latest), scripts (windows-latest). Observed by the reviewer, not the engine's own required-CI record. — commit `5fff70553faa055cc640364ada986bcebd5ff94d` (2026-07-27T01:27:23Z)
- **review-cycle-1** — request-changes — Core of the change is correct and all five acceptance criteria are met on their own terms, but the PR ships an instruction that another skill in the same session forbids, so the objective is not achieved when installed. Three blocking findings.

BLOCKING 1 - adapters/claude/skills/orch-architect/SKILL.md:88-92 still reads 'You may only spawn the four orch-* agents: orch-scout, orch-implementer, orch-specialist, orch-reviewer ... never spawn a subagent for anything outside these four roles.' orch-delivery's frontmatter says to load it after orch-architect, and the SessionStart hook loads orch-architect before any change, so both are guaranteed in context together. The conservative reading of a 'may only' whitelist beats a step instruction, leaving a downgraded review on orch-reviewer (opus) while the manifest records the sonnet safe profile - the exact audit-trail lie this issue exists to remove. adapters/codex/skills/orch-architect/SKILL.md:88-95 already enumerates five and names orch-reviewer-safe. Claude needs the same at :88-92 and at :37 ('spawning the four orch-* subagents'). Only the enumeration changes; the adjacent 'do not override either' clause is memhub task 52 and stays untouched.

BLOCKING 2 - adapters/claude/skills/orch-delivery/SKILL.md:205-206 keys the choice off a field the wire result does not carry, and off a value escalation invalidates. DispatchResult (internal/run/dispatch.go:32-47) has no reviewer_downgraded field; the same file contradicts itself at :152-154 where DispatchResult is enumerated without it. GateDoc does carry it (internal/run/gate.go:47) but that is the plan-gate snapshot: internal/routing/escalate.go:155-157 and :197 set ReviewerDowngraded=false on an executor reroute or a reviewer-uncertainty escalation, so after escalation a literal reading re-spawns orch-reviewer-safe while the engine has re-routed to the strong reviewer. The new agent file's own description and body already use the correct formulation ('DispatchResult.reviewer names the section 10 safe-downgrade profile'), as does Codex step 4; step 4 here is the only place in the tree using the wrong one.

BLOCKING 3 - adapters/claude/README.md:58-63 enumerates four agent files and calls them 'the four role subagents the Architect spawns during Delivery'; :39 says 'the four-subagent whitelist'. This PR made both false. adapters/codex/README.md:63-71 is the pattern to mirror - it lists five and explains why orch-reviewer-safe exists.

NON-BLOCKING - adapters/claude/plugin_test.go:241-245 TestAgentFrontmatter's doc comment still says 'all four agents exist' and 'scout and reviewer exclude every write tool'; the roster is now five and three roles are write-excluded. Same class of staleness the criteria already had corrected 20 lines above. Minor: the new comment at :215-221 says 'section 10' while the rest of the file uses the section symbol.

VERIFIED GOOD - Criterion 1: frontmatter name matches filename, tools byte-identical to orch-reviewer with no write tool/Task/mcp__, model exactly adaptertest.Profile('claude')['reviewer-safe'].Model; role derivation TrimPrefix gives 'reviewer-safe' and resolves; TestAgentFrontmatter/orch-reviewer-safe passes. Criterion 2: all seven checklist items and the consolidated-verdict duty present; the '(mechanical, low-risk, fully-specified, unsurprising)' parenthetical matches DowngradeFacts.Eligible() exactly. Criterion 3: roster and writeExcludedAgents entries are enforced both directions by the subtest, not decorative. Criterion 5: all three version sites read 0.5.2, both pins updated, no surviving 0.5.1 in the tree, and marketplace_test.go:170 cross-checks each plugin.json against metadata.version. Scope is clean: internal/adaptertest untouched, adapters/codex limited to the version string and its pin, step 2 contradiction untouched. Security: no boundary weakened, read-only by construction now mechanically enforced. All six required CI checks SUCCESS on run 30229501745.

SCOPE CALL AGREED - leaving the stale parenthetical at adapters/codex/plugin_test.go:279-282 ('Claude Code has no equivalent installed-TOML-match concern, since its Task tool takes a per-spawn model override') was the right call given the codex restriction; track as follow-up alongside task 52.

MANIFEST NOTE - the go-test verification detail recorded at pr-open says '24 packages, 2 with no test files'; the actual run reports 25 packages with 3 lacking test files (cmd/orch, internal/adaptertest, internal/execx/execxtest). The pass result is honest and reproducible; the count is corrected here rather than left to stand. — commit `5fff70553faa055cc640364ada986bcebd5ff94d` (2026-07-27T01:27:24Z)
- **fix-round-go-test** — pass — `go test -count=1 ./...` — Re-run uncached by the cycle-2 reviewer in the worktree at fd9d7bc2c5c7432fb1e97ebb6a3b2200a848b8d0: 25 packages, 0 failures, 3 with no test files (cmd/orch, internal/adaptertest, internal/execx/execxtest). This supersedes the executor's reported '24 packages, 2 with no test files', which was wrong in both rounds. — commit `fd9d7bc2c5c7432fb1e97ebb6a3b2200a848b8d0` (2026-07-27T01:40:44Z)
- **fix-round-go-build** — pass — `go build ./...` — Re-run by the cycle-2 reviewer at fd9d7bc. OK. — commit `fd9d7bc2c5c7432fb1e97ebb6a3b2200a848b8d0` (2026-07-27T01:40:44Z)
- **fix-round-gofmt** — pass — `gofmt -l .` — Re-run by the cycle-2 reviewer at fd9d7bc. Empty output. — commit `fd9d7bc2c5c7432fb1e97ebb6a3b2200a848b8d0` (2026-07-27T01:40:44Z)
- **fix-round-go-vet** — pass — `go vet ./...` — Re-run by the cycle-2 reviewer at fd9d7bc. Clean, no output. — commit `fd9d7bc2c5c7432fb1e97ebb6a3b2200a848b8d0` (2026-07-27T01:40:44Z)
- **fix-round-ci-observed** — pass — `gh run view 30229962705` — All six required checks SUCCESS on workflow run 30229962705, whose headSha is fd9d7bc2c5c7432fb1e97ebb6a3b2200a848b8d0: lint, test (ubuntu-latest), test (macos-latest), test (windows-latest), scripts (ubuntu-latest), scripts (windows-latest). PR reported MERGEABLE. Observed by the reviewer, not the engine's own required-CI record. — commit `fd9d7bc2c5c7432fb1e97ebb6a3b2200a848b8d0` (2026-07-27T01:40:44Z)
- **review-cycle-2** — approve — Fresh reviewer, cycle 2, at fd9d7bc (matches the PR live headRefOid and the worktree HEAD; clean, no uncommitted drift). Two commits on the branch, 5fff705 plus the cycle-1 fix round fd9d7bc, nine files changed, +118/-39. All five acceptance criteria pass, all three accepted cycle-1 items pass, and the non-blocking cleanup is done.

Criterion 1 - orch-reviewer-safe.md carries name: orch-reviewer-safe, model: claude-sonnet-5, tools byte-identical to orch-reviewer's line (no write tool, no Task, no mcp__). Frontmatter is four single-line scalars with no embedded colon-space, so plugin_test.go's naive parseFrontmatter parses it exactly. claude-sonnet-5 is exactly adaptertest.Profile('claude')['reviewer-safe'].Model and TrimPrefix yields the resolving role key.

Criterion 2 - description names the dispatch condition on DispatchResult.reviewer; body states the downgrade changes which model reviews, not how carefully, and diff confirms the seven-item checklist, 'How you look', and 'Report' sections are character-identical to orch-reviewer.md rather than paraphrased. The (mechanical, low-risk, fully-specified, unsurprising) parenthetical matches routing.DowngradeFacts.Eligible(). The agent prose says 'section 10' to mirror the Codex sibling TOML, which is host-file convention, distinct from the test-comment convention.

Criterion 3 - agentRoster and writeExcludedAgents both include the new agent and both are load-bearing: TestAgentFrontmatter/orch-reviewer-safe runs and asserts exact tool-set equality both directions, write-tool exclusion, and model equality. The old 'deliberately does not require a fifth agent to exist' comment is replaced by the tier-alias reason.

Criterion 4, judged against the corrected intent - PASS. Step 4 now keys on the routed reviewer selection sourced explicitly to DispatchResult.reviewer (dispatch.go:38); no instruction to read a reviewer_downgraded field off DispatchResult survives. reviewer_downgraded is attributed only to GateDoc, where it genuinely lives (gate.go:47). The 'superseded by any later escalation's new reviewer' clause is correct against escalate.go:155-157 and :196-197. 'No model override on either' and the verbatim step-2 stop-and-tell-the-human sentence are both present.

Criterion 5 - all three sites read 0.5.2, both pins updated, no 0.5.1 survives anywhere in the tree. marketplace_test.go:169-171 cross-checks each plugin.json against metadata.version, so the Codex bump was mechanically required, not incidental.

Accepted item A - word-diff of orch-architect SKILL.md shows exactly four token changes (four-&gt;five at :37, :88 and :93, plus orch-reviewer-safe added to the enumeration at :89-90). The adjacent 'do not override either' clause is preserved verbatim; nothing else moved. Item B is criterion 4 above. Item C - README.md:39 says five-subagent whitelist, :58-71 lists all five files, marks scout/reviewer/reviewer-safe as carrying no write tool, and gives the tier-alias rationale mirroring the Codex README.

Cross-file consistency sweep, searched rather than assumed (four|five|fifth, orch-reviewer, reviewer-safe|reviewer_downgraded|ReviewerDowngraded, per-spawn|model override|tier alias, 0.5.x across the tree): no file still describes a four-agent Claude roster. Remaining 'four' hits are unrelated. install.ps1, install.sh, AGENTS.md, ORCH-PRD.md and the root README carry no Claude agent-count claim; ORCH-PRD.md:251 already lists claude-sonnet-5/high as the safe-review-downgrade row, which the new agent now realizes.

Scope clean - internal/ and cmd/ have a zero-line diff so adaptertest.Profile is untouched; the Codex diff is exactly the version string plus its test pin; step 2's contradiction and the 'do not override either' clause are untouched.

Security - no boundary weakened. The new agent is read-only by construction and all three properties (no write tools, no Task, no mcp__) are mechanically enforced rather than asserted in prose. Widening the spawn whitelist by one read-only agent does not expand the write surface.

Manifest accuracy - routed selection, effort_delivery prompt-cue honesty, escalations none, and the review-cycle-1 entry with its request-changes verdict all match what happened.

FOUR NON-BLOCKING OBSERVATIONS, deliberately NOT fixed in this PR and to be tracked as follow-ups: (1) step 5 still says to echo DispatchResult.reviewer verbatim, but review.go:102 compares the submission against issue.Decision.Reviewer, the current decision, so after an escalation the stale dispatch-time value would be refused - pre-existing in BOTH adapters, made visible by step 4's new supersession wording, worth its own cross-host issue. (2) Claude has no frontmatter-match rule: Codex step 2 requires the routed pair to match an installed TOML exactly, but nothing tells the Claude Architect to confirm the frontmatter pin equals DispatchResult.reviewer.model, so a repo overriding hosts.claude.roles.review_downgrade would reintroduce the divergence this issue closes; the new stop-and-tell-the-human sentence is only a partial backstop. (3) README.md:135 still parenthesizes read-only enforcement as '(scout and reviewer must never write)', now also true of reviewer-safe; cosmetic, item C did not cover that bullet. (4) TestAgentFrontmatter iterates the roster rather than the agents/ directory, so an agent file absent from agentRoster would go unchecked; pre-existing test design. — commit `fd9d7bc2c5c7432fb1e97ebb6a3b2200a848b8d0` (2026-07-27T01:40:46Z)
- **required-ci** — passing — test (windows-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass — commit `fd9d7bc2c5c7432fb1e97ebb6a3b2200a848b8d0` (2026-07-27T01:40:50Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Give the Claude host an installed agent definition that pins the section 10 safe-downgrade reviewer model exactly, and make orch-delivery step 4 dispatch it by name when the engine routes a reviewer downgrade, so the reviewer recorded in the audit trail is always the reviewer that actually ran.",
  "acceptance_criteria": [
    "adapters/claude/agents/orch-reviewer-safe.md exists with frontmatter name: orch-reviewer-safe, model: claude-sonnet-5, and tools: Read, Grep, Glob, Bash (the same read-only tool set orch-reviewer carries, with no write tool, no Task, and no mcp__ tool).",
    "Its description states that the Architect dispatches it in place of orch-reviewer when DispatchResult.reviewer names the section 10 safe-downgrade profile, and its body states that the downgrade changes which model reviews, not how carefully, while carrying the same review checklist (acceptance criteria, scope, correctness, tests, CI, security, manifest accuracy) and the same one-consolidated-verdict duty as orch-reviewer.",
    "agentRoster in adapters/claude/plugin_test.go includes orch-reviewer-safe with that tool set, writeExcludedAgents includes orch-reviewer-safe, and the comment asserting that Claude 'deliberately does not require a fifth agent to exist' is replaced by the reason the fifth agent now exists (the Task tool's model parameter takes tier aliases, not exact versions, so only frontmatter can pin claude-sonnet-5).",
    "adapters/claude/skills/orch-delivery/SKILL.md step 4 instructs the Architect to spawn orch-reviewer-safe when GateDoc/DispatchResult reports reviewer_downgraded, and orch-reviewer otherwise, with no model override on either spawn so the frontmatter pin is what runs, and states the same stop-and-tell-the-human rule step 2 carries for a routed model the host cannot honor.",
    "The three plugin version sites (.claude-plugin/marketplace.json metadata.version, adapters/claude/.claude-plugin/plugin.json, adapters/codex/.codex-plugin/plugin.json) read 0.5.2, and the hardcoded version pins in adapters/claude/plugin_test.go and adapters/codex/plugin_test.go match, so a version-cached plugin install picks up the new agent."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l .",
    "go vet ./..."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All packages ok (24 packages, 2 with no test files, none failing). Run by the executor against the final committed and pushed state at 5fff705.",
      "commit_oid": "5fff70553faa055cc640364ada986bcebd5ff94d",
      "at": "2026-07-27T01:18:15Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Empty output; no unformatted files. Run by the executor against the final committed and pushed state at 5fff705.",
      "commit_oid": "5fff70553faa055cc640364ada986bcebd5ff94d",
      "at": "2026-07-27T01:18:15Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Clean, no output. Run by the executor against the final committed and pushed state at 5fff705.",
      "commit_oid": "5fff70553faa055cc640364ada986bcebd5ff94d",
      "at": "2026-07-27T01:18:15Z"
    },
    {
      "name": "reviewer-go-test",
      "command": "go test ./... -count=1",
      "result": "pass",
      "detail": "Re-run independently by the reviewer in the worktree at 5fff70553faa055cc640364ada986bcebd5ff94d. No failures. Corrects the pr-open count: 25 packages, 3 with no test files (cmd/orch, internal/adaptertest, internal/execx/execxtest).",
      "commit_oid": "5fff70553faa055cc640364ada986bcebd5ff94d",
      "at": "2026-07-27T01:27:23Z"
    },
    {
      "name": "reviewer-gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Re-run independently by the reviewer at 5fff705. Empty output.",
      "commit_oid": "5fff70553faa055cc640364ada986bcebd5ff94d",
      "at": "2026-07-27T01:27:23Z"
    },
    {
      "name": "reviewer-go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Re-run independently by the reviewer at 5fff705. Clean, no output.",
      "commit_oid": "5fff70553faa055cc640364ada986bcebd5ff94d",
      "at": "2026-07-27T01:27:23Z"
    },
    {
      "name": "reviewer-ci-observed",
      "command": "gh pr checks 66",
      "result": "pass",
      "detail": "All six required checks SUCCESS on workflow run 30229501745 at review time: test (ubuntu-latest), test (macos-latest), test (windows-latest), lint, scripts (ubuntu-latest), scripts (windows-latest). Observed by the reviewer, not the engine's own required-CI record.",
      "commit_oid": "5fff70553faa055cc640364ada986bcebd5ff94d",
      "at": "2026-07-27T01:27:23Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "Core of the change is correct and all five acceptance criteria are met on their own terms, but the PR ships an instruction that another skill in the same session forbids, so the objective is not achieved when installed. Three blocking findings.\n\nBLOCKING 1 - adapters/claude/skills/orch-architect/SKILL.md:88-92 still reads 'You may only spawn the four orch-* agents: orch-scout, orch-implementer, orch-specialist, orch-reviewer ... never spawn a subagent for anything outside these four roles.' orch-delivery's frontmatter says to load it after orch-architect, and the SessionStart hook loads orch-architect before any change, so both are guaranteed in context together. The conservative reading of a 'may only' whitelist beats a step instruction, leaving a downgraded review on orch-reviewer (opus) while the manifest records the sonnet safe profile - the exact audit-trail lie this issue exists to remove. adapters/codex/skills/orch-architect/SKILL.md:88-95 already enumerates five and names orch-reviewer-safe. Claude needs the same at :88-92 and at :37 ('spawning the four orch-* subagents'). Only the enumeration changes; the adjacent 'do not override either' clause is memhub task 52 and stays untouched.\n\nBLOCKING 2 - adapters/claude/skills/orch-delivery/SKILL.md:205-206 keys the choice off a field the wire result does not carry, and off a value escalation invalidates. DispatchResult (internal/run/dispatch.go:32-47) has no reviewer_downgraded field; the same file contradicts itself at :152-154 where DispatchResult is enumerated without it. GateDoc does carry it (internal/run/gate.go:47) but that is the plan-gate snapshot: internal/routing/escalate.go:155-157 and :197 set ReviewerDowngraded=false on an executor reroute or a reviewer-uncertainty escalation, so after escalation a literal reading re-spawns orch-reviewer-safe while the engine has re-routed to the strong reviewer. The new agent file's own description and body already use the correct formulation ('DispatchResult.reviewer names the section 10 safe-downgrade profile'), as does Codex step 4; step 4 here is the only place in the tree using the wrong one.\n\nBLOCKING 3 - adapters/claude/README.md:58-63 enumerates four agent files and calls them 'the four role subagents the Architect spawns during Delivery'; :39 says 'the four-subagent whitelist'. This PR made both false. adapters/codex/README.md:63-71 is the pattern to mirror - it lists five and explains why orch-reviewer-safe exists.\n\nNON-BLOCKING - adapters/claude/plugin_test.go:241-245 TestAgentFrontmatter's doc comment still says 'all four agents exist' and 'scout and reviewer exclude every write tool'; the roster is now five and three roles are write-excluded. Same class of staleness the criteria already had corrected 20 lines above. Minor: the new comment at :215-221 says 'section 10' while the rest of the file uses the section symbol.\n\nVERIFIED GOOD - Criterion 1: frontmatter name matches filename, tools byte-identical to orch-reviewer with no write tool/Task/mcp__, model exactly adaptertest.Profile('claude')['reviewer-safe'].Model; role derivation TrimPrefix gives 'reviewer-safe' and resolves; TestAgentFrontmatter/orch-reviewer-safe passes. Criterion 2: all seven checklist items and the consolidated-verdict duty present; the '(mechanical, low-risk, fully-specified, unsurprising)' parenthetical matches DowngradeFacts.Eligible() exactly. Criterion 3: roster and writeExcludedAgents entries are enforced both directions by the subtest, not decorative. Criterion 5: all three version sites read 0.5.2, both pins updated, no surviving 0.5.1 in the tree, and marketplace_test.go:170 cross-checks each plugin.json against metadata.version. Scope is clean: internal/adaptertest untouched, adapters/codex limited to the version string and its pin, step 2 contradiction untouched. Security: no boundary weakened, read-only by construction now mechanically enforced. All six required CI checks SUCCESS on run 30229501745.\n\nSCOPE CALL AGREED - leaving the stale parenthetical at adapters/codex/plugin_test.go:279-282 ('Claude Code has no equivalent installed-TOML-match concern, since its Task tool takes a per-spawn model override') was the right call given the codex restriction; track as follow-up alongside task 52.\n\nMANIFEST NOTE - the go-test verification detail recorded at pr-open says '24 packages, 2 with no test files'; the actual run reports 25 packages with 3 lacking test files (cmd/orch, internal/adaptertest, internal/execx/execxtest). The pass result is honest and reproducible; the count is corrected here rather than left to stand.",
      "commit_oid": "5fff70553faa055cc640364ada986bcebd5ff94d",
      "at": "2026-07-27T01:27:24Z"
    },
    {
      "name": "fix-round-go-test",
      "command": "go test -count=1 ./...",
      "result": "pass",
      "detail": "Re-run uncached by the cycle-2 reviewer in the worktree at fd9d7bc2c5c7432fb1e97ebb6a3b2200a848b8d0: 25 packages, 0 failures, 3 with no test files (cmd/orch, internal/adaptertest, internal/execx/execxtest). This supersedes the executor's reported '24 packages, 2 with no test files', which was wrong in both rounds.",
      "commit_oid": "fd9d7bc2c5c7432fb1e97ebb6a3b2200a848b8d0",
      "at": "2026-07-27T01:40:44Z"
    },
    {
      "name": "fix-round-go-build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "Re-run by the cycle-2 reviewer at fd9d7bc. OK.",
      "commit_oid": "fd9d7bc2c5c7432fb1e97ebb6a3b2200a848b8d0",
      "at": "2026-07-27T01:40:44Z"
    },
    {
      "name": "fix-round-gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Re-run by the cycle-2 reviewer at fd9d7bc. Empty output.",
      "commit_oid": "fd9d7bc2c5c7432fb1e97ebb6a3b2200a848b8d0",
      "at": "2026-07-27T01:40:44Z"
    },
    {
      "name": "fix-round-go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Re-run by the cycle-2 reviewer at fd9d7bc. Clean, no output.",
      "commit_oid": "fd9d7bc2c5c7432fb1e97ebb6a3b2200a848b8d0",
      "at": "2026-07-27T01:40:44Z"
    },
    {
      "name": "fix-round-ci-observed",
      "command": "gh run view 30229962705",
      "result": "pass",
      "detail": "All six required checks SUCCESS on workflow run 30229962705, whose headSha is fd9d7bc2c5c7432fb1e97ebb6a3b2200a848b8d0: lint, test (ubuntu-latest), test (macos-latest), test (windows-latest), scripts (ubuntu-latest), scripts (windows-latest). PR reported MERGEABLE. Observed by the reviewer, not the engine's own required-CI record.",
      "commit_oid": "fd9d7bc2c5c7432fb1e97ebb6a3b2200a848b8d0",
      "at": "2026-07-27T01:40:44Z"
    },
    {
      "name": "review-cycle-2",
      "result": "approve",
      "detail": "Fresh reviewer, cycle 2, at fd9d7bc (matches the PR live headRefOid and the worktree HEAD; clean, no uncommitted drift). Two commits on the branch, 5fff705 plus the cycle-1 fix round fd9d7bc, nine files changed, +118/-39. All five acceptance criteria pass, all three accepted cycle-1 items pass, and the non-blocking cleanup is done.\n\nCriterion 1 - orch-reviewer-safe.md carries name: orch-reviewer-safe, model: claude-sonnet-5, tools byte-identical to orch-reviewer's line (no write tool, no Task, no mcp__). Frontmatter is four single-line scalars with no embedded colon-space, so plugin_test.go's naive parseFrontmatter parses it exactly. claude-sonnet-5 is exactly adaptertest.Profile('claude')['reviewer-safe'].Model and TrimPrefix yields the resolving role key.\n\nCriterion 2 - description names the dispatch condition on DispatchResult.reviewer; body states the downgrade changes which model reviews, not how carefully, and diff confirms the seven-item checklist, 'How you look', and 'Report' sections are character-identical to orch-reviewer.md rather than paraphrased. The (mechanical, low-risk, fully-specified, unsurprising) parenthetical matches routing.DowngradeFacts.Eligible(). The agent prose says 'section 10' to mirror the Codex sibling TOML, which is host-file convention, distinct from the test-comment convention.\n\nCriterion 3 - agentRoster and writeExcludedAgents both include the new agent and both are load-bearing: TestAgentFrontmatter/orch-reviewer-safe runs and asserts exact tool-set equality both directions, write-tool exclusion, and model equality. The old 'deliberately does not require a fifth agent to exist' comment is replaced by the tier-alias reason.\n\nCriterion 4, judged against the corrected intent - PASS. Step 4 now keys on the routed reviewer selection sourced explicitly to DispatchResult.reviewer (dispatch.go:38); no instruction to read a reviewer_downgraded field off DispatchResult survives. reviewer_downgraded is attributed only to GateDoc, where it genuinely lives (gate.go:47). The 'superseded by any later escalation's new reviewer' clause is correct against escalate.go:155-157 and :196-197. 'No model override on either' and the verbatim step-2 stop-and-tell-the-human sentence are both present.\n\nCriterion 5 - all three sites read 0.5.2, both pins updated, no 0.5.1 survives anywhere in the tree. marketplace_test.go:169-171 cross-checks each plugin.json against metadata.version, so the Codex bump was mechanically required, not incidental.\n\nAccepted item A - word-diff of orch-architect SKILL.md shows exactly four token changes (four-\u003efive at :37, :88 and :93, plus orch-reviewer-safe added to the enumeration at :89-90). The adjacent 'do not override either' clause is preserved verbatim; nothing else moved. Item B is criterion 4 above. Item C - README.md:39 says five-subagent whitelist, :58-71 lists all five files, marks scout/reviewer/reviewer-safe as carrying no write tool, and gives the tier-alias rationale mirroring the Codex README.\n\nCross-file consistency sweep, searched rather than assumed (four|five|fifth, orch-reviewer, reviewer-safe|reviewer_downgraded|ReviewerDowngraded, per-spawn|model override|tier alias, 0.5.x across the tree): no file still describes a four-agent Claude roster. Remaining 'four' hits are unrelated. install.ps1, install.sh, AGENTS.md, ORCH-PRD.md and the root README carry no Claude agent-count claim; ORCH-PRD.md:251 already lists claude-sonnet-5/high as the safe-review-downgrade row, which the new agent now realizes.\n\nScope clean - internal/ and cmd/ have a zero-line diff so adaptertest.Profile is untouched; the Codex diff is exactly the version string plus its test pin; step 2's contradiction and the 'do not override either' clause are untouched.\n\nSecurity - no boundary weakened. The new agent is read-only by construction and all three properties (no write tools, no Task, no mcp__) are mechanically enforced rather than asserted in prose. Widening the spawn whitelist by one read-only agent does not expand the write surface.\n\nManifest accuracy - routed selection, effort_delivery prompt-cue honesty, escalations none, and the review-cycle-1 entry with its request-changes verdict all match what happened.\n\nFOUR NON-BLOCKING OBSERVATIONS, deliberately NOT fixed in this PR and to be tracked as follow-ups: (1) step 5 still says to echo DispatchResult.reviewer verbatim, but review.go:102 compares the submission against issue.Decision.Reviewer, the current decision, so after an escalation the stale dispatch-time value would be refused - pre-existing in BOTH adapters, made visible by step 4's new supersession wording, worth its own cross-host issue. (2) Claude has no frontmatter-match rule: Codex step 2 requires the routed pair to match an installed TOML exactly, but nothing tells the Claude Architect to confirm the frontmatter pin equals DispatchResult.reviewer.model, so a repo overriding hosts.claude.roles.review_downgrade would reintroduce the divergence this issue closes; the new stop-and-tell-the-human sentence is only a partial backstop. (3) README.md:135 still parenthesizes read-only enforcement as '(scout and reviewer must never write)', now also true of reviewer-safe; cosmetic, item C did not cover that bullet. (4) TestAgentFrontmatter iterates the roster rather than the agents/ directory, so an agent file absent from agentRoster would go unchecked; pre-existing test design.",
      "commit_oid": "fd9d7bc2c5c7432fb1e97ebb6a3b2200a848b8d0",
      "at": "2026-07-27T01:40:46Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "fd9d7bc2c5c7432fb1e97ebb6a3b2200a848b8d0",
      "at": "2026-07-27T01:40:50Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->