### PR TITLE
Replace the Claude model-override rule with a frontmatter match-or-stop rule at both spawn steps

### DIFF
--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -333,3 +333,28 @@ func TestDeliverySkillHasMergeGateOptions(t *testing.T) {
 func TestSetupSkillHasTerminalForms(t *testing.T) {
 	adaptertest.CheckSetupTerminalForms(t, setupSkillPath)
 }
+
+// frontmatterMatchRuleSentence is the exact phrase
+// orch-delivery/SKILL.md must state: Claude Code's Task tool model
+// parameter is a coarse tier-alias enum (sonnet/opus/haiku/fable), so
+// no per-spawn override can express an exact routed version — only an
+// installed agent definition's frontmatter pins one — and a routed
+// selection matching no installed frontmatter must stop and tell the
+// human rather than silently spawning a mismatched agent.
+const frontmatterMatchRuleSentence = "stop and tell the human"
+
+// TestDeliverySkillStatesFrontmatterMatchRule is this adapter's twin of
+// the Codex adapter's TestDeliverySkillStatesTOMLMatchRule: the no-match
+// escalation rule must be stated verbatim, not just implied. Both spawn
+// steps carry it — the executor spawn and the reviewer spawn — so the
+// phrase is required at least twice, not merely present somewhere.
+func TestDeliverySkillStatesFrontmatterMatchRule(t *testing.T) {
+	data, err := os.ReadFile(deliverySkillPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", deliverySkillPath, err)
+	}
+	if got := strings.Count(string(data), frontmatterMatchRuleSentence); got < 2 {
+		t.Errorf("%s contains the verbatim phrase %q %d time(s), want it at both the executor and reviewer spawn steps",
+			deliverySkillPath, frontmatterMatchRuleSentence, got)
+	}
+}

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -153,12 +153,22 @@ in flight at once. For each issue:
    `rationale`, `objective`, `acceptance_criteria`, `required_tests`.
 
 2. **Spawn the executor** — spawn `orch-implementer` or
-   `orch-specialist` (per the routed role) via the Task tool, passing
-   `DispatchResult.executor.model` as the model override; the agent
-   frontmatter `model` is only the fallback if the Task tool gives no
-   override for this spawn. **If the host cannot honor the routed
-   model, stop and tell the human — never spawn a different model and
-   report the routed one as if it ran.** Every spawn prompt opens with:
+   `orch-specialist` (per the routed role) via the Task tool **by
+   name, with no model override**, so the installed agent definition's
+   frontmatter `model` is what runs. The Task tool's `model` parameter
+   accepts only the coarse tier aliases `sonnet`, `opus`, `haiku` and
+   `fable` — never an exact version string like `claude-sonnet-5` — so
+   an override can never express a routed selection, and is never the
+   way to honor routing. Before spawning, confirm that the installed
+   executor agent's frontmatter `model` equals
+   `DispatchResult.executor.model`. Compare against the **installed**
+   plugin copy under the Claude Code plugin cache
+   (`~/.claude/plugins/cache/orch/orch-claude/<version>/agents/`), not
+   this repository's `adapters/claude/agents/` copy — a plugin version
+   behind head can still carry an older pin. **If the routed model
+   matches no installed agent's frontmatter, stop and tell the human —
+   never spawn a mismatched agent, and never report the routed
+   selection as if it ran.** Every spawn prompt opens with:
 
    ```
    Routed selection: <model> @ <effort>
@@ -168,10 +178,10 @@ in flight at once. For each issue:
    depth for this task."; `low` → "Work fast and economically; this
    task does not need deep reasoning." Claude Code subagent spawns take
    no effort parameter, so this sentence is the only way the routed
-   effort reaches the executor: the host enforces the routed *model*
-   (via the Task tool override above, or by refusing to spawn) but only
-   *conveys* the routed effort as this prompt cue — nothing checks that
-   the executor actually reasoned at that depth. Transcribe
+   effort reaches the executor: the routed *model* is pinned by the
+   installed agent definition the match rule above checks, but the
+   routed *effort* is only *conveyed* as this prompt cue — nothing
+   checks that the executor actually reasoned at that depth. Transcribe
    `DispatchResult.objective`, `.acceptance_criteria`, and
    `.required_tests` into the prompt **verbatim** — this is the text a
    human approved at the plan gate, not the Architect's recollection of
@@ -206,13 +216,25 @@ in flight at once. For each issue:
    safe-downgrade profile — the `reviewer_downgraded` routing the
    `GateDoc` showed at the plan gate, carried in
    `DispatchResult.reviewer` and superseded by any later escalation's
-   new reviewer — `orch-reviewer` otherwise. Spawn with **no model
-   override on either** — each agent's frontmatter pins its exact
-   model, so that pin is what runs. **If the host cannot honor the
-   routed model, stop and tell the human — never spawn a different
-   model and report the routed one as if it ran.** `reviewed_head_oid`
-   must be the PR's **live** head OID at review time (e.g. via `gh pr
-   view`), never a cached value.
+   new reviewer — `orch-reviewer` otherwise. Spawn whichever of the
+   two that selection names, by name and with **no model override on
+   either**, under the same rule as the executor: the Task tool's
+   `model` parameter accepts only the coarse tier aliases `sonnet`,
+   `opus`, `haiku` and `fable`, never an exact version string, so it
+   cannot express a routed selection and an override is never the way
+   to honor routing — only the installed agent definition's
+   frontmatter pins an exact model. Before spawning, confirm that the
+   selected reviewer agent's frontmatter `model` equals
+   `DispatchResult.reviewer.model`. Compare against the **installed**
+   plugin copy under the Claude Code plugin cache
+   (`~/.claude/plugins/cache/orch/orch-claude/<version>/agents/`), not
+   this repository's `adapters/claude/agents/` copy — a plugin version
+   behind head can still carry an older pin. **If the routed model
+   matches no installed agent's frontmatter, stop and tell the human —
+   never spawn a mismatched agent, and never report the routed
+   selection as if it ran.** `reviewed_head_oid` must be the PR's
+   **live** head OID at review time (e.g. via `gh pr view`), never a
+   cached value.
 
 5. **Review** — the reviewer produces **one consolidated report**
    (acceptance criteria, scope, correctness, tests, CI, security,

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -276,10 +276,14 @@ func TestSetupSkillHasTerminalForms(t *testing.T) {
 // the human rather than silently dispatching a mismatched agent.
 const tomlMatchRuleSentence = "stop and tell the human"
 
-// TestDeliverySkillStatesTOMLMatchRule is a Codex-only pin (Claude Code
-// has no equivalent installed-TOML-match concern, since its Task tool
-// takes a per-spawn model override): orch-delivery/SKILL.md must state
-// the no-match escalation rule verbatim, not just imply it.
+// TestDeliverySkillStatesTOMLMatchRule pins the Codex half of a rule
+// both hosts carry: orch-delivery/SKILL.md must state the no-match
+// escalation rule verbatim, not just imply it. Claude Code's twin is
+// TestDeliverySkillStatesFrontmatterMatchRule in
+// adapters/claude/plugin_test.go — its Task tool's model parameter is a
+// coarse tier-alias enum, so a per-spawn override cannot express an
+// exact routed version there either, and only an installed agent
+// definition's frontmatter pins one.
 func TestDeliverySkillStatesTOMLMatchRule(t *testing.T) {
 	data, err := os.ReadFile(deliverySkillPath)
 	if err != nil {


### PR DESCRIPTION
Delivers issue #67: Replace the Claude model-override rule with a frontmatter match-or-stop rule at both spawn steps

Closes #67

**Plan digest:** `sha256:ecd43eeac7c820313624cccf6a7a1c381757b4c05e25330bee318ed0826c13da`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** In adapters/claude/skills/orch-delivery/SKILL.md, replace the instruction to pass a Task-tool model override with the same match-or-stop discipline the Codex adapter already uses, keyed on the installed agent definition's frontmatter model, and apply it to BOTH the executor spawn (step 2) and the reviewer spawn (step 4). The Task tool's model parameter accepts only the coarse tier aliases sonnet, opus, haiku and fable, never an exact version string such as claude-sonnet-5, while the audit record's contract is written in exact selections and internal/run/review.go rejects a mismatch. An override can therefore only ever make a weaker claim than the engine routed, so only an installed agent's frontmatter can honor routing. This is the executor-path twin of the reviewer-path fix delivered as PR #66, and it governs every executor dispatch rather than only downgraded reviews.

**Acceptance criteria:**
- Step 2 of adapters/claude/skills/orch-delivery/SKILL.md no longer instructs passing DispatchResult.executor.model as a Task-tool model override, and instead states that the executor agent is spawned by name with no model override so the installed agent definition's frontmatter model is what runs.
- Step 2 requires the Architect, before spawning, to confirm that the installed executor agent's frontmatter model equals DispatchResult.executor.model.
- Step 4 carries the same explicit requirement to confirm that the installed reviewer agent's frontmatter model equals DispatchResult.reviewer.model, for whichever of orch-reviewer or orch-reviewer-safe that step selects.
- Both steps state that the file to compare against is the installed plugin copy under the Claude Code plugin cache (~/.claude/plugins/cache/orch/orch-claude/&lt;version&gt;/agents/), not the repository's adapters/claude/agents/ copy, because a plugin version behind head can still carry an older pin.
- Both steps state that the Task tool's model parameter accepts only the coarse tier aliases sonnet, opus, haiku and fable and therefore cannot express an exact routed version, so a model override is never the way to honor routing.
- Both steps retain the verbatim phrase "stop and tell the human" for the case where the routed model matches no installed agent frontmatter.
- Step 2's effort paragraph still states that Claude Code subagent spawns take no effort parameter and that the prompt sentence is the only way routed effort reaches the executor, with no remaining claim that the host enforces the routed model through a Task-tool override.
- adapters/claude/plugin_test.go gains a test pinning the verbatim phrase "stop and tell the human" in adapters/claude/skills/orch-delivery/SKILL.md, mirroring the Codex adapter's TestDeliverySkillStatesTOMLMatchRule.
- The doc comment on TestDeliverySkillStatesTOMLMatchRule in adapters/codex/plugin_test.go no longer claims that Claude Code has no equivalent installed-match concern because its Task tool takes a per-spawn model override.

**Required tests:**
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `specialist` |
| Executor | `claude-opus-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to a specialist with a strong reviewer because the task is unusually difficult.

**Escalations:** _none_

**Verification:**
- **build** — pass — `go build ./...` — Exit 0, no output. Run by the executor from the issue-67 worktree root against the final committed state (fd9856a). — commit `fd9856af5a70833d02435d32ac9683fac7dfaa1b` (2026-07-27T11:59:34Z)
- **vet** — pass — `go vet ./...` — Exit 0, no output. Run against the final committed state (fd9856a). — commit `fd9856af5a70833d02435d32ac9683fac7dfaa1b` (2026-07-27T11:59:34Z)
- **test** — pass — `go test ./...` — Exit 0. All 22 packages ok, including adapters/claude (which now carries the new TestDeliverySkillStatesFrontmatterMatchRule) and adapters/codex. Run against the final committed state (fd9856a). — commit `fd9856af5a70833d02435d32ac9683fac7dfaa1b` (2026-07-27T11:59:34Z)
- **gofmt** — pass — `gofmt -l .` — Exit 0, no files listed. Run against the final committed state (fd9856a). — commit `fd9856af5a70833d02435d32ac9683fac7dfaa1b` (2026-07-27T11:59:34Z)
- **pin-mutation-check** — pass — `sha256sum adapters/claude/skills/orch-delivery/SKILL.md; git cat-file blob HEAD:adapters/claude/skills/orch-delivery/SKILL.md | sha256sum` — CORRECTED at review. The pr-open entry cited SHA-256 27b4f78dcaa0f0d6383aa56a2f3c4a3074f9885a06a4ed42cec87397247d662b, which identifies nothing in this PR. The committed file's actual SHA-256 is 77c00e69e7c248402f0d9a405c9e0c37fe7140139526b6b6566c680349fd3561, identical on disk and as the git blob at HEAD (fd9856af5a70833d02435d32ac9683fac7dfaa1b), working tree clean. Confirmed by the reviewer via sha256sum, PowerShell Get-FileHash and git cat-file, and re-confirmed independently by the Architect; CRLF, BOM and pre-change renderings were all ruled out as explanations. The substantive claim the entry carries is true and was independently reproduced: the skill file is not left mutated, and TestDeliverySkillStatesFrontmatterMatchRule is not vacuous - removing the step-2 occurrence on a scratchpad copy produced the failure 'contains the verbatim phrase "stop and tell the human" 1 time(s), want it at both the executor and reviewer spawn steps'. Only the hash was wrong; this entry replaces it by name so the merged record's evidence is reproducible. — commit `fd9856af5a70833d02435d32ac9683fac7dfaa1b` (2026-07-27T12:08:58Z)
- **scope-check** — pass — `git status --porcelain` — Exactly three files changed: adapters/claude/skills/orch-delivery/SKILL.md, adapters/claude/plugin_test.go, adapters/codex/plugin_test.go (doc comment only). No version string touched anywhere (plugin manifests stay at 0.5.2 and TestPluginManifestStrict still passes); adapters/codex/skills/orch-delivery/SKILL.md left untouched for sibling issue #68; no README, agent definition, or manifest edited. No go install was run and the orch binary on PATH was not replaced, so the run continues on the binary that started it. — commit `fd9856af5a70833d02435d32ac9683fac7dfaa1b` (2026-07-27T11:59:34Z)
- **review-cycle-1** — approve — Approve. All nine acceptance criteria hold, verified individually against the file. Step 2 (SKILL.md 155-171) and step 4 (219-237) now carry the same rule: spawn by name with no model override; before spawning confirm the installed agent's frontmatter model equals DispatchResult.executor.model / .reviewer.model; compare the installed copy under ~/.claude/plugins/cache/orch/orch-claude/&lt;version&gt;/agents/, not the repo copy; the Task tool's model takes only sonnet/opus/haiku/fable so an override can never honor routing; 'stop and tell the human' appears verbatim at both (lines 169, 233). The effort paragraph keeps the no-effort-parameter statement with the override-enforcement claim removed. No contradiction remains in the Claude adapter: orch-architect already said 'do not override either', the Escalation section has no override language, and README.md 64-71 agrees. Scope is exactly the three declared files; codex SKILL.md untouched; all versions stay 0.5.2. Reviewer re-ran everything: build, vet, gofmt -l . and go test ./... all exit 0 (22 packages). CI green 6/6. The new test uses strings.Count(...) &lt; 2, not Contains, as claimed; non-vacuity independently reproduced on a scratchpad copy, yielding the exact quoted failure when the step-2 occurrence was removed. The skill file is not left mutated. No security impact. One manifest defect found and corrected here: the pin-mutation-check entry as supplied at pr-open cited SHA-256 27b4f78d..., but the committed file hashes to 77c00e69e7c248402f0d9a405c9e0c37fe7140139526b6b6566c680349fd3561. The reviewer confirmed this via sha256sum, Get-FileHash and the git blob, ruling out CRLF, BOM and pre-change artifacts; the Architect then independently re-confirmed it against both the working file and git cat-file blob HEAD. The underlying evidence was true, only the hash was unreproducible, so this was corrected by re-supplying pin-mutation-check at review rather than by a commit. Non-blocking follow-ups the reviewer raised: &lt;version&gt; in the cache path is ambiguous (six version dirs exist; 0.1.0 still pins claude-opus-4-8 and has no orch-reviewer-safe) and installed_plugins.json is the authoritative resolver; step 2's comparison keys on the dispatch-time executor and is not escalation-aware the way step 4 is (pre-existing); adapters/codex/README.md:152 still reads as though Claude has a usable per-spawn model override; and the now-duplicated match-phrase consts could move to internal/adaptertest. — commit `fd9856af5a70833d02435d32ac9683fac7dfaa1b` (2026-07-27T12:08:59Z)
- **required-ci** — passing — scripts (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass — commit `fd9856af5a70833d02435d32ac9683fac7dfaa1b` (2026-07-27T12:09:19Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "In adapters/claude/skills/orch-delivery/SKILL.md, replace the instruction to pass a Task-tool model override with the same match-or-stop discipline the Codex adapter already uses, keyed on the installed agent definition's frontmatter model, and apply it to BOTH the executor spawn (step 2) and the reviewer spawn (step 4). The Task tool's model parameter accepts only the coarse tier aliases sonnet, opus, haiku and fable, never an exact version string such as claude-sonnet-5, while the audit record's contract is written in exact selections and internal/run/review.go rejects a mismatch. An override can therefore only ever make a weaker claim than the engine routed, so only an installed agent's frontmatter can honor routing. This is the executor-path twin of the reviewer-path fix delivered as PR #66, and it governs every executor dispatch rather than only downgraded reviews.",
  "acceptance_criteria": [
    "Step 2 of adapters/claude/skills/orch-delivery/SKILL.md no longer instructs passing DispatchResult.executor.model as a Task-tool model override, and instead states that the executor agent is spawned by name with no model override so the installed agent definition's frontmatter model is what runs.",
    "Step 2 requires the Architect, before spawning, to confirm that the installed executor agent's frontmatter model equals DispatchResult.executor.model.",
    "Step 4 carries the same explicit requirement to confirm that the installed reviewer agent's frontmatter model equals DispatchResult.reviewer.model, for whichever of orch-reviewer or orch-reviewer-safe that step selects.",
    "Both steps state that the file to compare against is the installed plugin copy under the Claude Code plugin cache (~/.claude/plugins/cache/orch/orch-claude/\u003cversion\u003e/agents/), not the repository's adapters/claude/agents/ copy, because a plugin version behind head can still carry an older pin.",
    "Both steps state that the Task tool's model parameter accepts only the coarse tier aliases sonnet, opus, haiku and fable and therefore cannot express an exact routed version, so a model override is never the way to honor routing.",
    "Both steps retain the verbatim phrase \"stop and tell the human\" for the case where the routed model matches no installed agent frontmatter.",
    "Step 2's effort paragraph still states that Claude Code subagent spawns take no effort parameter and that the prompt sentence is the only way routed effort reaches the executor, with no remaining claim that the host enforces the routed model through a Task-tool override.",
    "adapters/claude/plugin_test.go gains a test pinning the verbatim phrase \"stop and tell the human\" in adapters/claude/skills/orch-delivery/SKILL.md, mirroring the Codex adapter's TestDeliverySkillStatesTOMLMatchRule.",
    "The doc comment on TestDeliverySkillStatesTOMLMatchRule in adapters/codex/plugin_test.go no longer claims that Claude Code has no equivalent installed-match concern because its Task tool takes a per-spawn model override."
  ],
  "required_tests": [
    "go build ./...",
    "go vet ./...",
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "specialist",
  "executor": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to a specialist with a strong reviewer because the task is unusually difficult.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "Exit 0, no output. Run by the executor from the issue-67 worktree root against the final committed state (fd9856a).",
      "commit_oid": "fd9856af5a70833d02435d32ac9683fac7dfaa1b",
      "at": "2026-07-27T11:59:34Z"
    },
    {
      "name": "vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Exit 0, no output. Run against the final committed state (fd9856a).",
      "commit_oid": "fd9856af5a70833d02435d32ac9683fac7dfaa1b",
      "at": "2026-07-27T11:59:34Z"
    },
    {
      "name": "test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Exit 0. All 22 packages ok, including adapters/claude (which now carries the new TestDeliverySkillStatesFrontmatterMatchRule) and adapters/codex. Run against the final committed state (fd9856a).",
      "commit_oid": "fd9856af5a70833d02435d32ac9683fac7dfaa1b",
      "at": "2026-07-27T11:59:34Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Exit 0, no files listed. Run against the final committed state (fd9856a).",
      "commit_oid": "fd9856af5a70833d02435d32ac9683fac7dfaa1b",
      "at": "2026-07-27T11:59:34Z"
    },
    {
      "name": "pin-mutation-check",
      "command": "sha256sum adapters/claude/skills/orch-delivery/SKILL.md; git cat-file blob HEAD:adapters/claude/skills/orch-delivery/SKILL.md | sha256sum",
      "result": "pass",
      "detail": "CORRECTED at review. The pr-open entry cited SHA-256 27b4f78dcaa0f0d6383aa56a2f3c4a3074f9885a06a4ed42cec87397247d662b, which identifies nothing in this PR. The committed file's actual SHA-256 is 77c00e69e7c248402f0d9a405c9e0c37fe7140139526b6b6566c680349fd3561, identical on disk and as the git blob at HEAD (fd9856af5a70833d02435d32ac9683fac7dfaa1b), working tree clean. Confirmed by the reviewer via sha256sum, PowerShell Get-FileHash and git cat-file, and re-confirmed independently by the Architect; CRLF, BOM and pre-change renderings were all ruled out as explanations. The substantive claim the entry carries is true and was independently reproduced: the skill file is not left mutated, and TestDeliverySkillStatesFrontmatterMatchRule is not vacuous - removing the step-2 occurrence on a scratchpad copy produced the failure 'contains the verbatim phrase \"stop and tell the human\" 1 time(s), want it at both the executor and reviewer spawn steps'. Only the hash was wrong; this entry replaces it by name so the merged record's evidence is reproducible.",
      "commit_oid": "fd9856af5a70833d02435d32ac9683fac7dfaa1b",
      "at": "2026-07-27T12:08:58Z"
    },
    {
      "name": "scope-check",
      "command": "git status --porcelain",
      "result": "pass",
      "detail": "Exactly three files changed: adapters/claude/skills/orch-delivery/SKILL.md, adapters/claude/plugin_test.go, adapters/codex/plugin_test.go (doc comment only). No version string touched anywhere (plugin manifests stay at 0.5.2 and TestPluginManifestStrict still passes); adapters/codex/skills/orch-delivery/SKILL.md left untouched for sibling issue #68; no README, agent definition, or manifest edited. No go install was run and the orch binary on PATH was not replaced, so the run continues on the binary that started it.",
      "commit_oid": "fd9856af5a70833d02435d32ac9683fac7dfaa1b",
      "at": "2026-07-27T11:59:34Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approve. All nine acceptance criteria hold, verified individually against the file. Step 2 (SKILL.md 155-171) and step 4 (219-237) now carry the same rule: spawn by name with no model override; before spawning confirm the installed agent's frontmatter model equals DispatchResult.executor.model / .reviewer.model; compare the installed copy under ~/.claude/plugins/cache/orch/orch-claude/\u003cversion\u003e/agents/, not the repo copy; the Task tool's model takes only sonnet/opus/haiku/fable so an override can never honor routing; 'stop and tell the human' appears verbatim at both (lines 169, 233). The effort paragraph keeps the no-effort-parameter statement with the override-enforcement claim removed. No contradiction remains in the Claude adapter: orch-architect already said 'do not override either', the Escalation section has no override language, and README.md 64-71 agrees. Scope is exactly the three declared files; codex SKILL.md untouched; all versions stay 0.5.2. Reviewer re-ran everything: build, vet, gofmt -l . and go test ./... all exit 0 (22 packages). CI green 6/6. The new test uses strings.Count(...) \u003c 2, not Contains, as claimed; non-vacuity independently reproduced on a scratchpad copy, yielding the exact quoted failure when the step-2 occurrence was removed. The skill file is not left mutated. No security impact. One manifest defect found and corrected here: the pin-mutation-check entry as supplied at pr-open cited SHA-256 27b4f78d..., but the committed file hashes to 77c00e69e7c248402f0d9a405c9e0c37fe7140139526b6b6566c680349fd3561. The reviewer confirmed this via sha256sum, Get-FileHash and the git blob, ruling out CRLF, BOM and pre-change artifacts; the Architect then independently re-confirmed it against both the working file and git cat-file blob HEAD. The underlying evidence was true, only the hash was unreproducible, so this was corrected by re-supplying pin-mutation-check at review rather than by a commit. Non-blocking follow-ups the reviewer raised: \u003cversion\u003e in the cache path is ambiguous (six version dirs exist; 0.1.0 still pins claude-opus-4-8 and has no orch-reviewer-safe) and installed_plugins.json is the authoritative resolver; step 2's comparison keys on the dispatch-time executor and is not escalation-aware the way step 4 is (pre-existing); adapters/codex/README.md:152 still reads as though Claude has a usable per-spawn model override; and the now-duplicated match-phrase consts could move to internal/adaptertest.",
      "commit_oid": "fd9856af5a70833d02435d32ac9683fac7dfaa1b",
      "at": "2026-07-27T12:08:59Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "scripts (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "fd9856af5a70833d02435d32ac9683fac7dfaa1b",
      "at": "2026-07-27T12:09:19Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->