### PR TITLE
Both adapters' review step must echo the reviewer currently in force, not the dispatch-time one

### DIFF
--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -238,8 +238,15 @@ in flight at once. For each issue:
 
 5. **Review** — the reviewer produces **one consolidated report**
    (acceptance criteria, scope, correctness, tests, CI, security,
-   manifest accuracy). Call `orch run review`, echoing
-   `DispatchResult.reviewer` **verbatim**:
+   manifest accuracy). Call `orch run review` with `reviewer` set to
+   the selection **currently in force**: `EscalateResult.reviewer` when
+   an escalation has rerouted the issue since dispatch, or
+   `DispatchResult.reviewer` otherwise. `orch run review` compares the
+   submitted `reviewer` against the issue's current routing decision and
+   refuses a mismatch; `orch run dispatch` cannot be re-run to refresh a
+   stale value — it accepts only the `worktree-ready` phase, which a
+   dispatched issue has already left, so you must track whichever value
+   is current yourself:
 
    ```json
    {"schema_version": 1, "issue_number": N, "reviewed_head_oid": "...",

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -207,17 +207,28 @@ in flight at once. For each issue:
 4. **Dispatch the reviewer** — once the PR stops changing, dispatch
    `orch-reviewer` **fresh** (a new instance, not the executor
    continuing), following the same TOML-match rule as the executor
-   above. If `DispatchResult.reviewer` names the §10 safe-downgrade
-   profile instead of the standard reviewer profile, dispatch
-   `orch-reviewer-safe` by name — it is the installed TOML that encodes
-   that downgrade, since Codex has no per-spawn model override to apply
-   it ad hoc. `reviewed_head_oid` must be the PR's **live** head OID at
-   review time (e.g. via `gh pr view`), never a cached value.
+   above. Base the choice on the reviewer selection **currently in
+   force** — `DispatchResult.reviewer`, superseded by any later
+   escalation's new reviewer (`EscalateResult.reviewer`), never the
+   dispatch-time value once superseded. If that selection names the §10
+   safe-downgrade profile instead of the standard reviewer profile,
+   dispatch `orch-reviewer-safe` by name — it is the installed TOML that
+   encodes that downgrade, since Codex has no per-spawn model override
+   to apply it ad hoc. `reviewed_head_oid` must be the PR's **live**
+   head OID at review time (e.g. via `gh pr view`), never a cached
+   value.
 
 5. **Review** — the reviewer produces **one consolidated report**
    (acceptance criteria, scope, correctness, tests, CI, security,
-   manifest accuracy). Call `orch run review`, echoing
-   `DispatchResult.reviewer` **verbatim**:
+   manifest accuracy). Call `orch run review` with `reviewer` set to
+   the selection **currently in force**: `EscalateResult.reviewer` when
+   an escalation has rerouted the issue since dispatch, or
+   `DispatchResult.reviewer` otherwise. `orch run review` compares the
+   submitted `reviewer` against the issue's current routing decision and
+   refuses a mismatch; `orch run dispatch` cannot be re-run to refresh a
+   stale value — it accepts only the `worktree-ready` phase, which a
+   dispatched issue has already left, so you must track whichever value
+   is current yourself:
 
    ```json
    {"schema_version": 1, "issue_number": N, "reviewed_head_oid": "...",


### PR DESCRIPTION
Delivers issue #68: Both adapters' review step must echo the reviewer currently in force, not the dispatch-time one

Closes #68

**Plan digest:** `sha256:ecd43eeac7c820313624cccf6a7a1c381757b4c05e25330bee318ed0826c13da`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Both adapters' orch-delivery skills tell the Architect to echo DispatchResult.reviewer verbatim into orch run review. internal/run/review.go:102 compares the submitted reviewer against issue.Decision.Reviewer, the CURRENT routing decision, and rejects a mismatch with ErrReviewerMismatch. internal/routing/escalate.go replaces Decision.Reviewer on an executor reroute that restores a downgraded reviewer and on a reviewer-uncertainty escalation, and internal/run/escalate.go persists that new decision and returns it as EscalateResult.reviewer. After any such escalation the dispatch-time value is stale and the engine refuses the review. orch run dispatch cannot be re-run to refresh it: internal/run/dispatch.go:66 accepts only phase worktree-ready, while an escalated issue is in dispatched, pr-open or in-review. The escalation result is therefore the only source for the current value. Correct the instruction in both adapters.

**Acceptance criteria:**
- Step 5 of adapters/claude/skills/orch-delivery/SKILL.md no longer says to echo DispatchResult.reviewer verbatim; it states that the reviewer field must be the selection currently in force, which is EscalateResult.reviewer when an escalation has rerouted the issue since dispatch and DispatchResult.reviewer otherwise.
- Step 5 of adapters/codex/skills/orch-delivery/SKILL.md carries the same corrected instruction.
- Both step 5s state that orch run review compares the submitted reviewer against the issue's current routing decision and refuses a mismatch, and that orch run dispatch cannot be re-run to refresh the value because it accepts only the worktree-ready phase.
- Step 4 of adapters/codex/skills/orch-delivery/SKILL.md gains the escalation-supersession note its Claude counterpart already carries, so the choice between orch-reviewer and orch-reviewer-safe also follows the reviewer currently in force rather than the dispatch-time one.
- Neither adapter's Escalation section contradicts the corrected step 5; the reroute bullet is consistent with the new reviewer selection being the one to echo.

**Required tests:**
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-sonnet-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **build** — pass — `go build ./...` — Exit 0, no output. Run by the executor from the issue-68 worktree root against the final committed state (e38a44c). — commit `e38a44c1dba26c600d56a1b4fa9715a8411ff1d0` (2026-07-27T12:16:29Z)
- **vet** — pass — `go vet ./...` — Exit 0, no output. Run against the final committed state (e38a44c). — commit `e38a44c1dba26c600d56a1b4fa9715a8411ff1d0` (2026-07-27T12:16:29Z)
- **test** — pass — `go test ./...` — Exit 0. All packages ok, including internal/run, adapters/claude and adapters/codex. The adapter plugin_test.go suites pin skill content (run-verb token allowlist and statement literals read live from internal/run), so their passing confirms no verb mention or statement literal was disturbed by the step 4/5 rewrites. — commit `e38a44c1dba26c600d56a1b4fa9715a8411ff1d0` (2026-07-27T12:16:29Z)
- **gofmt** — pass — `gofmt -l .` — Exit 0, no files listed. Run against the final committed state (e38a44c). — commit `e38a44c1dba26c600d56a1b4fa9715a8411ff1d0` (2026-07-27T12:16:29Z)
- **engine-fact-check** — pass — `read internal/run/review.go, internal/routing/escalate.go, internal/run/escalate.go, internal/run/dispatch.go` — The executor re-derived every engine fact the corrected instruction asserts, rather than trusting the issue text. internal/run/review.go Review() compares req.Reviewer against issue.Decision.Reviewer - the current decision reloaded via loadVerb, not a dispatch-time snapshot - and returns ErrReviewerMismatch. internal/routing/escalate.go climbExecutor sets newDecision.Reviewer = p.Reviewer when the prior decision had a downgraded reviewer, and escalateReviewer does the same on the reviewer-uncertainty path. internal/run/escalate.go escalateReroute persists issue.Decision = fromRoutingDecision(outcome.Decision) via c.save() and returns that same reviewer as EscalateResult.Reviewer. internal/run/dispatch.go Dispatch passes a loadVerb phase allowlist of worktree-ready only, confirming orch run dispatch cannot be re-run on a dispatched, pr-open or in-review issue to refresh a stale DispatchResult.reviewer. That last fact is what makes the escalation result the only available source, which is the load-bearing claim of the new text. — commit `e38a44c1dba26c600d56a1b4fa9715a8411ff1d0` (2026-07-27T12:16:29Z)
- **escalation-section-consistency** — pass — `read the Escalation section of both adapters' orch-delivery SKILL.md` — Acceptance criterion 5 checked and found already satisfied without an edit. Both adapters' reroute bullet reads that the result carries a new executor/reviewer and rationale and that the new selection is spawned/dispatched into the same worktree, which is consistent with echoing EscalateResult.reviewer at review time. No contradiction with the corrected step 5, so that section was deliberately left unchanged. — commit `e38a44c1dba26c600d56a1b4fa9715a8411ff1d0` (2026-07-27T12:16:29Z)
- **scope-check** — pass — `git status --porcelain` — Exactly two files changed: adapters/claude/skills/orch-delivery/SKILL.md (step 5 only; step 4 left untouched because it already carried the escalation-supersession clause from PR #70) and adapters/codex/skills/orch-delivery/SKILL.md (steps 4 and 5). No README touched, leaving sibling issue #69 conflict-free; no agent definition, test file, or plugin manifest edited; no version string moved off 0.5.2. No go install was run and the orch binary on PATH was not replaced, so the run continues on the binary that started it. — commit `e38a44c1dba26c600d56a1b4fa9715a8411ff1d0` (2026-07-27T12:16:29Z)
- **review-cycle-1** — approve — Approve. All 5 acceptance criteria satisfied, verified individually against the live diff. Both adapters' step 5 now say reviewer must be the selection currently in force (EscalateResult.reviewer post-escalation, else DispatchResult.reviewer), and both state the review-time comparison and dispatch-cannot-refresh facts identically. Codex step 4 gained the escalation-supersession note in Codex's own idiom (TOML-match, dispatch-by-name), not copied Claude wording about frontmatter or model overrides. Escalation sections in both adapters were independently re-checked and genuinely do not contradict step 5, so the executor's no-edit-needed judgement on criterion 5 holds. All four engine-fact claims the new prose asserts were independently re-derived from internal/run/review.go, internal/routing/escalate.go, internal/run/escalate.go, internal/run/lifecycle.go and internal/run/dispatch.go and match exactly; the reviewer additionally confirmed via lifecycle.go that loadVerb does a fresh state.Load rather than reading a dispatch-time snapshot, which is what makes the current-decision comparison real. Scope is exactly the two declared SKILL.md files, confirmed against origin/main rather than a stale local ref; PR #70's Claude step-4 text is byte-for-byte undisturbed; no README or version string moved off 0.5.2. Build, vet, gofmt and test re-run by the reviewer, including a forced uncached go test -count=1 over adapters, internal/run and internal/routing: all pass. gh pr checks 71: 6/6 required checks SUCCESS, MERGEABLE. Pure Markdown change, no security surface. PR body audit record accurate. One non-blocking, out-of-scope observation: Claude step 4 (untouched here, added by PR #70) still literally says to confirm the agent frontmatter model equals DispatchResult.reviewer.model rather than the currently-in-force selection's model. The surrounding text already says the selection is superseded by any later escalation, so it is not wrong in context, but the sentence reads as checking a stale field after a reviewer escalation. Filed as a follow-up rather than blocking. — commit `e38a44c1dba26c600d56a1b4fa9715a8411ff1d0` (2026-07-27T12:24:22Z)
- **required-ci** — passing — test (macos-latest)=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass — commit `e38a44c1dba26c600d56a1b4fa9715a8411ff1d0` (2026-07-27T12:24:30Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Both adapters' orch-delivery skills tell the Architect to echo DispatchResult.reviewer verbatim into orch run review. internal/run/review.go:102 compares the submitted reviewer against issue.Decision.Reviewer, the CURRENT routing decision, and rejects a mismatch with ErrReviewerMismatch. internal/routing/escalate.go replaces Decision.Reviewer on an executor reroute that restores a downgraded reviewer and on a reviewer-uncertainty escalation, and internal/run/escalate.go persists that new decision and returns it as EscalateResult.reviewer. After any such escalation the dispatch-time value is stale and the engine refuses the review. orch run dispatch cannot be re-run to refresh it: internal/run/dispatch.go:66 accepts only phase worktree-ready, while an escalated issue is in dispatched, pr-open or in-review. The escalation result is therefore the only source for the current value. Correct the instruction in both adapters.",
  "acceptance_criteria": [
    "Step 5 of adapters/claude/skills/orch-delivery/SKILL.md no longer says to echo DispatchResult.reviewer verbatim; it states that the reviewer field must be the selection currently in force, which is EscalateResult.reviewer when an escalation has rerouted the issue since dispatch and DispatchResult.reviewer otherwise.",
    "Step 5 of adapters/codex/skills/orch-delivery/SKILL.md carries the same corrected instruction.",
    "Both step 5s state that orch run review compares the submitted reviewer against the issue's current routing decision and refuses a mismatch, and that orch run dispatch cannot be re-run to refresh the value because it accepts only the worktree-ready phase.",
    "Step 4 of adapters/codex/skills/orch-delivery/SKILL.md gains the escalation-supersession note its Claude counterpart already carries, so the choice between orch-reviewer and orch-reviewer-safe also follows the reviewer currently in force rather than the dispatch-time one.",
    "Neither adapter's Escalation section contradicts the corrected step 5; the reroute bullet is consistent with the new reviewer selection being the one to echo."
  ],
  "required_tests": [
    "go build ./...",
    "go vet ./...",
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "claude-sonnet-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "Exit 0, no output. Run by the executor from the issue-68 worktree root against the final committed state (e38a44c).",
      "commit_oid": "e38a44c1dba26c600d56a1b4fa9715a8411ff1d0",
      "at": "2026-07-27T12:16:29Z"
    },
    {
      "name": "vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Exit 0, no output. Run against the final committed state (e38a44c).",
      "commit_oid": "e38a44c1dba26c600d56a1b4fa9715a8411ff1d0",
      "at": "2026-07-27T12:16:29Z"
    },
    {
      "name": "test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Exit 0. All packages ok, including internal/run, adapters/claude and adapters/codex. The adapter plugin_test.go suites pin skill content (run-verb token allowlist and statement literals read live from internal/run), so their passing confirms no verb mention or statement literal was disturbed by the step 4/5 rewrites.",
      "commit_oid": "e38a44c1dba26c600d56a1b4fa9715a8411ff1d0",
      "at": "2026-07-27T12:16:29Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Exit 0, no files listed. Run against the final committed state (e38a44c).",
      "commit_oid": "e38a44c1dba26c600d56a1b4fa9715a8411ff1d0",
      "at": "2026-07-27T12:16:29Z"
    },
    {
      "name": "engine-fact-check",
      "command": "read internal/run/review.go, internal/routing/escalate.go, internal/run/escalate.go, internal/run/dispatch.go",
      "result": "pass",
      "detail": "The executor re-derived every engine fact the corrected instruction asserts, rather than trusting the issue text. internal/run/review.go Review() compares req.Reviewer against issue.Decision.Reviewer - the current decision reloaded via loadVerb, not a dispatch-time snapshot - and returns ErrReviewerMismatch. internal/routing/escalate.go climbExecutor sets newDecision.Reviewer = p.Reviewer when the prior decision had a downgraded reviewer, and escalateReviewer does the same on the reviewer-uncertainty path. internal/run/escalate.go escalateReroute persists issue.Decision = fromRoutingDecision(outcome.Decision) via c.save() and returns that same reviewer as EscalateResult.Reviewer. internal/run/dispatch.go Dispatch passes a loadVerb phase allowlist of worktree-ready only, confirming orch run dispatch cannot be re-run on a dispatched, pr-open or in-review issue to refresh a stale DispatchResult.reviewer. That last fact is what makes the escalation result the only available source, which is the load-bearing claim of the new text.",
      "commit_oid": "e38a44c1dba26c600d56a1b4fa9715a8411ff1d0",
      "at": "2026-07-27T12:16:29Z"
    },
    {
      "name": "escalation-section-consistency",
      "command": "read the Escalation section of both adapters' orch-delivery SKILL.md",
      "result": "pass",
      "detail": "Acceptance criterion 5 checked and found already satisfied without an edit. Both adapters' reroute bullet reads that the result carries a new executor/reviewer and rationale and that the new selection is spawned/dispatched into the same worktree, which is consistent with echoing EscalateResult.reviewer at review time. No contradiction with the corrected step 5, so that section was deliberately left unchanged.",
      "commit_oid": "e38a44c1dba26c600d56a1b4fa9715a8411ff1d0",
      "at": "2026-07-27T12:16:29Z"
    },
    {
      "name": "scope-check",
      "command": "git status --porcelain",
      "result": "pass",
      "detail": "Exactly two files changed: adapters/claude/skills/orch-delivery/SKILL.md (step 5 only; step 4 left untouched because it already carried the escalation-supersession clause from PR #70) and adapters/codex/skills/orch-delivery/SKILL.md (steps 4 and 5). No README touched, leaving sibling issue #69 conflict-free; no agent definition, test file, or plugin manifest edited; no version string moved off 0.5.2. No go install was run and the orch binary on PATH was not replaced, so the run continues on the binary that started it.",
      "commit_oid": "e38a44c1dba26c600d56a1b4fa9715a8411ff1d0",
      "at": "2026-07-27T12:16:29Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approve. All 5 acceptance criteria satisfied, verified individually against the live diff. Both adapters' step 5 now say reviewer must be the selection currently in force (EscalateResult.reviewer post-escalation, else DispatchResult.reviewer), and both state the review-time comparison and dispatch-cannot-refresh facts identically. Codex step 4 gained the escalation-supersession note in Codex's own idiom (TOML-match, dispatch-by-name), not copied Claude wording about frontmatter or model overrides. Escalation sections in both adapters were independently re-checked and genuinely do not contradict step 5, so the executor's no-edit-needed judgement on criterion 5 holds. All four engine-fact claims the new prose asserts were independently re-derived from internal/run/review.go, internal/routing/escalate.go, internal/run/escalate.go, internal/run/lifecycle.go and internal/run/dispatch.go and match exactly; the reviewer additionally confirmed via lifecycle.go that loadVerb does a fresh state.Load rather than reading a dispatch-time snapshot, which is what makes the current-decision comparison real. Scope is exactly the two declared SKILL.md files, confirmed against origin/main rather than a stale local ref; PR #70's Claude step-4 text is byte-for-byte undisturbed; no README or version string moved off 0.5.2. Build, vet, gofmt and test re-run by the reviewer, including a forced uncached go test -count=1 over adapters, internal/run and internal/routing: all pass. gh pr checks 71: 6/6 required checks SUCCESS, MERGEABLE. Pure Markdown change, no security surface. PR body audit record accurate. One non-blocking, out-of-scope observation: Claude step 4 (untouched here, added by PR #70) still literally says to confirm the agent frontmatter model equals DispatchResult.reviewer.model rather than the currently-in-force selection's model. The surrounding text already says the selection is superseded by any later escalation, so it is not wrong in context, but the sentence reads as checking a stale field after a reviewer escalation. Filed as a follow-up rather than blocking.",
      "commit_oid": "e38a44c1dba26c600d56a1b4fa9715a8411ff1d0",
      "at": "2026-07-27T12:24:22Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (macos-latest)=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "e38a44c1dba26c600d56a1b4fa9715a8411ff1d0",
      "at": "2026-07-27T12:24:30Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->