### PR TITLE
Clear the two README bullets still describing the pre-PR-#66 override world

### DIFF
--- a/adapters/claude/README.md
+++ b/adapters/claude/README.md
@@ -132,9 +132,9 @@ bugs:
 - **`orch guard`'s `--role` narrowing is unused by this adapter.** Hooks
   in Claude Code are plugin-global, not scoped per subagent, so the
   adapter never passes `--role` when invoking guard. Read-only role
-  enforcement (scout and reviewer must never write) instead comes from
-  each subagent's own tool whitelist in its agent definition (PR 2), not
-  from guard's role-narrowing flag.
+  enforcement (scout, reviewer, and reviewer-safe must never write)
+  instead comes from each subagent's own tool whitelist in its agent
+  definition (PR 2), not from guard's role-narrowing flag.
 
 ## Host version
 

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -149,17 +149,24 @@ bugs:
   approval is outstanding. Install order, `orch doctor`, and the visible
   absence of session-start context are the mitigations; there is no way
   to make either gap fail closed from inside the hook itself.
-- **No per-spawn model override.** Unlike Claude Code (which can at
-  least prompt-cue an effort it cannot enforce), Codex CLI dispatches an
-  agent with whatever `model`/`model_reasoning_effort` its installed
-  TOML pins — there is no host mechanism to override either per
-  dispatch. `orch-delivery`'s spawn step therefore requires the routed
-  `(model, effort)` to match an installed `orch-*` TOML exactly, and
-  stops and tells the human rather than silently substituting a
-  mismatched agent or reporting the routed selection as if it ran.
-  `orch-reviewer-safe` exists specifically so the §10 safe-downgrade row
-  has a real installed TOML to dispatch, instead of dead-ending at that
-  same stop-and-tell-human rule on every routine downgrade.
+- **No per-spawn model override.** Codex CLI dispatches an agent with
+  whatever `model`/`model_reasoning_effort` its installed TOML pins —
+  there is no host mechanism to override either per dispatch. This is
+  not a Codex-specific constraint relative to Claude Code: both hosts
+  require the routed selection to match an installed agent definition
+  exactly, because Claude Code's Task tool `model` parameter only
+  accepts coarse tier aliases (`sonnet`/`opus`/`haiku`/`fable`), never
+  an exact version string, so a per-spawn override cannot express a
+  routed selection there either. `orch-delivery`'s spawn step therefore
+  stops and tells the human on a mismatch, on either host, rather than
+  silently substituting a mismatched agent or reporting the routed
+  selection as if it ran. The genuine Codex-specific piece is effort:
+  it is pinned in the installed TOML and enforced by the host, whereas
+  Claude Code subagent spawns take no effort parameter at all and the
+  routed effort is only conveyed as a prompt cue. `orch-reviewer-safe`
+  exists specifically so the §10 safe-downgrade row has a real
+  installed TOML to dispatch, instead of dead-ending at that same
+  stop-and-tell-human rule on every routine downgrade.
 - **A configured non-default model is applied by `orch render-agents`,
   not automatically.** A repository that overrides the §10 defaults
   must run `orch render-agents` (PRD §22) itself — install and upgrade


### PR DESCRIPTION
Delivers issue #69: Clear the two README bullets still describing the pre-PR-#66 override world

Closes #69

**Plan digest:** `sha256:ecd43eeac7c820313624cccf6a7a1c381757b4c05e25330bee318ed0826c13da`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Two README bullets still describe the world before PR #66 shipped orch-reviewer-safe for the Claude adapter and before the executor path moved to the same match-or-stop rule. adapters/claude/README.md:135 parenthesizes read-only role enforcement as covering scout and reviewer, omitting orch-reviewer-safe, which is also write-excluded; the artifact map at :58-71 was corrected in PR #66 but this bullet was not. adapters/codex/README.md:152 frames the absence of a per-spawn model override as a Codex-specific limitation relative to Claude Code, which stops being the distinction once the sibling issue in this plan lands and both hosts require the routed selection to match an installed agent definition. Cosmetic only: no behavior, no test, no engine claim depends on either sentence.

**Acceptance criteria:**
- The --role narrowing bullet in adapters/claude/README.md no longer names only scout and reviewer as the read-only roles; it also names orch-reviewer-safe, consistent with the artifact map earlier in the same file.
- The "No per-spawn model override" bullet in adapters/codex/README.md no longer frames the match-or-stop rule as a Codex limitation relative to Claude Code, and instead states that both hosts require the routed selection to match the installed agent definition, with the Codex-specific part being that effort is pinned in the TOML rather than conveyed as a prompt cue.
- Neither adapter README states or implies that Claude Code honors a routed model through a per-spawn Task-tool model override.

**Required tests:**
- `go build ./...`
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-sonnet-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **build** — pass — `go build ./...` — Exit 0, no output. Run by the executor from the issue-69 worktree root against the final committed state (3a57ec3). — commit `3a57ec35346127764274704666801d389508302f` (2026-07-27T12:16:35Z)
- **test** — pass — `go test ./...` — Exit 0. All packages ok, including adapters/claude and adapters/codex. Run against the final committed state (3a57ec3). — commit `3a57ec35346127764274704666801d389508302f` (2026-07-27T12:16:35Z)
- **gofmt** — pass — `gofmt -l .` — Exit 0, no files listed. Both changed files are Markdown so the check is a no-op on them specifically, but it ran clean across the whole tree. — commit `3a57ec35346127764274704666801d389508302f` (2026-07-27T12:16:35Z)
- **post-67-source-check** — pass — `read adapters/claude/skills/orch-delivery/SKILL.md in the issue-69 worktree (post-PR-#70)` — Criterion 2 required the new Codex README text to describe a rule that is genuinely true on both hosts, so the executor read the Claude skill as it stands after sibling issue #67 merged rather than writing from the issue description. Confirmed that its step 2 now states the executor is spawned by name with no model override, that the Task tool's model parameter accepts only coarse tier aliases and can never express an exact routed version, and that before spawning the Architect must confirm the installed agent definition's frontmatter model equals the routed model, stopping and telling the human on a mismatch - the same rule step 4 already applied to the reviewer. The rewritten bullet describes that symmetry and isolates the remaining genuine Codex-vs-Claude difference to effort: TOML-pinned and host-enforced on Codex, prompt-cue only on Claude. — commit `3a57ec35346127764274704666801d389508302f` (2026-07-27T12:16:35Z)
- **scope-check** — pass — `git status --porcelain` — Exactly two files changed: adapters/claude/README.md (the --role narrowing bullet, now naming scout, reviewer and reviewer-safe) and adapters/codex/README.md (the No per-spawn model override bullet). No skill file touched, leaving sibling issue #68 conflict-free; no agent definition, test file, or plugin manifest edited; no version string moved off 0.5.2. Edits were kept to the two existing Known limitations bullets, matching each README's voice, bullet structure and wrap width, with no surrounding restructuring. No go install was run and the orch binary on PATH was not replaced. — commit `3a57ec35346127764274704666801d389508302f` (2026-07-27T12:16:35Z)
- **review-cycle-1** — approve — Approve. All 3 acceptance criteria hold. (1) The Claude README --role bullet now names scout, reviewer and reviewer-safe, matching the artifact map earlier in the same file; the reviewer verified the claim is literally true by reading adapters/claude/agents/orch-reviewer-safe.md's frontmatter tools list (Read, Grep, Glob, Bash - no write tool). (2) The Codex README No per-spawn model override bullet no longer frames the match-or-stop rule as a Codex limitation relative to Claude; it states the rule is symmetric across hosts and isolates the remaining genuine difference to effort, TOML-pinned and host-enforced on Codex versus no effort parameter at all on Claude where it is conveyed only as a prompt cue. The reviewer cross-checked that sentence by sentence against the CURRENT adapters/claude/skills/orch-delivery/SKILL.md steps 2 and 4 as they read after sibling PR #70 merged, not against the pre-run framing, and confirmed the README claims match what the skill now says. Both overstatement risks were checked and cleared: the bullet does not claim remediation parity (it never suggests Claude has an orch render-agents equivalent, asserting symmetry only in the match-or-stop detection rule, which the reviewer confirmed exists verbatim in the Codex skill too), and the effort isolation is corroborated by the Claude README's own reasoning-effort limitation bullet and the Claude skill's effort paragraph. (3) Grepping both READMEs for override, Task tool and model parameter found no surviving claim that Claude honors a routed model through a per-spawn override. Scope clean: diffed against the correct base (origin/main including merged PR #70) rather than a stale local ref, exactly the two declared README files, plugin versions still 0.5.2, no skill file touched so issue #68 stayed conflict-free. Required tests re-run by the reviewer: go build, go test and gofmt -l . all clean. gh pr checks 72: 6/6 required checks pass. Documentation-only diff, no security surface. PR body audit record accurate and stamped at the reviewed head with no drift. The executor's one out-of-scope finding - adapters/codex/README.md's artifact-map sentence near line 68 still saying Codex has no per-spawn model override - was judged defensible to leave: it makes no comparative claim about Claude, is true standalone, and mirrors the Claude README's own host-native artifact-map explanation. — commit `3a57ec35346127764274704666801d389508302f` (2026-07-27T12:24:25Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, test (macos-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `3a57ec35346127764274704666801d389508302f` (2026-07-27T12:24:34Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Two README bullets still describe the world before PR #66 shipped orch-reviewer-safe for the Claude adapter and before the executor path moved to the same match-or-stop rule. adapters/claude/README.md:135 parenthesizes read-only role enforcement as covering scout and reviewer, omitting orch-reviewer-safe, which is also write-excluded; the artifact map at :58-71 was corrected in PR #66 but this bullet was not. adapters/codex/README.md:152 frames the absence of a per-spawn model override as a Codex-specific limitation relative to Claude Code, which stops being the distinction once the sibling issue in this plan lands and both hosts require the routed selection to match an installed agent definition. Cosmetic only: no behavior, no test, no engine claim depends on either sentence.",
  "acceptance_criteria": [
    "The --role narrowing bullet in adapters/claude/README.md no longer names only scout and reviewer as the read-only roles; it also names orch-reviewer-safe, consistent with the artifact map earlier in the same file.",
    "The \"No per-spawn model override\" bullet in adapters/codex/README.md no longer frames the match-or-stop rule as a Codex limitation relative to Claude Code, and instead states that both hosts require the routed selection to match the installed agent definition, with the Codex-specific part being that effort is pinned in the TOML rather than conveyed as a prompt cue.",
    "Neither adapter README states or implies that Claude Code honors a routed model through a per-spawn Task-tool model override."
  ],
  "required_tests": [
    "go build ./...",
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "claude-sonnet-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "Exit 0, no output. Run by the executor from the issue-69 worktree root against the final committed state (3a57ec3).",
      "commit_oid": "3a57ec35346127764274704666801d389508302f",
      "at": "2026-07-27T12:16:35Z"
    },
    {
      "name": "test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Exit 0. All packages ok, including adapters/claude and adapters/codex. Run against the final committed state (3a57ec3).",
      "commit_oid": "3a57ec35346127764274704666801d389508302f",
      "at": "2026-07-27T12:16:35Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Exit 0, no files listed. Both changed files are Markdown so the check is a no-op on them specifically, but it ran clean across the whole tree.",
      "commit_oid": "3a57ec35346127764274704666801d389508302f",
      "at": "2026-07-27T12:16:35Z"
    },
    {
      "name": "post-67-source-check",
      "command": "read adapters/claude/skills/orch-delivery/SKILL.md in the issue-69 worktree (post-PR-#70)",
      "result": "pass",
      "detail": "Criterion 2 required the new Codex README text to describe a rule that is genuinely true on both hosts, so the executor read the Claude skill as it stands after sibling issue #67 merged rather than writing from the issue description. Confirmed that its step 2 now states the executor is spawned by name with no model override, that the Task tool's model parameter accepts only coarse tier aliases and can never express an exact routed version, and that before spawning the Architect must confirm the installed agent definition's frontmatter model equals the routed model, stopping and telling the human on a mismatch - the same rule step 4 already applied to the reviewer. The rewritten bullet describes that symmetry and isolates the remaining genuine Codex-vs-Claude difference to effort: TOML-pinned and host-enforced on Codex, prompt-cue only on Claude.",
      "commit_oid": "3a57ec35346127764274704666801d389508302f",
      "at": "2026-07-27T12:16:35Z"
    },
    {
      "name": "scope-check",
      "command": "git status --porcelain",
      "result": "pass",
      "detail": "Exactly two files changed: adapters/claude/README.md (the --role narrowing bullet, now naming scout, reviewer and reviewer-safe) and adapters/codex/README.md (the No per-spawn model override bullet). No skill file touched, leaving sibling issue #68 conflict-free; no agent definition, test file, or plugin manifest edited; no version string moved off 0.5.2. Edits were kept to the two existing Known limitations bullets, matching each README's voice, bullet structure and wrap width, with no surrounding restructuring. No go install was run and the orch binary on PATH was not replaced.",
      "commit_oid": "3a57ec35346127764274704666801d389508302f",
      "at": "2026-07-27T12:16:35Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approve. All 3 acceptance criteria hold. (1) The Claude README --role bullet now names scout, reviewer and reviewer-safe, matching the artifact map earlier in the same file; the reviewer verified the claim is literally true by reading adapters/claude/agents/orch-reviewer-safe.md's frontmatter tools list (Read, Grep, Glob, Bash - no write tool). (2) The Codex README No per-spawn model override bullet no longer frames the match-or-stop rule as a Codex limitation relative to Claude; it states the rule is symmetric across hosts and isolates the remaining genuine difference to effort, TOML-pinned and host-enforced on Codex versus no effort parameter at all on Claude where it is conveyed only as a prompt cue. The reviewer cross-checked that sentence by sentence against the CURRENT adapters/claude/skills/orch-delivery/SKILL.md steps 2 and 4 as they read after sibling PR #70 merged, not against the pre-run framing, and confirmed the README claims match what the skill now says. Both overstatement risks were checked and cleared: the bullet does not claim remediation parity (it never suggests Claude has an orch render-agents equivalent, asserting symmetry only in the match-or-stop detection rule, which the reviewer confirmed exists verbatim in the Codex skill too), and the effort isolation is corroborated by the Claude README's own reasoning-effort limitation bullet and the Claude skill's effort paragraph. (3) Grepping both READMEs for override, Task tool and model parameter found no surviving claim that Claude honors a routed model through a per-spawn override. Scope clean: diffed against the correct base (origin/main including merged PR #70) rather than a stale local ref, exactly the two declared README files, plugin versions still 0.5.2, no skill file touched so issue #68 stayed conflict-free. Required tests re-run by the reviewer: go build, go test and gofmt -l . all clean. gh pr checks 72: 6/6 required checks pass. Documentation-only diff, no security surface. PR body audit record accurate and stamped at the reviewed head with no drift. The executor's one out-of-scope finding - adapters/codex/README.md's artifact-map sentence near line 68 still saying Codex has no per-spawn model override - was judged defensible to leave: it makes no comparative claim about Claude, is true standalone, and mirrors the Claude README's own host-native artifact-map explanation.",
      "commit_oid": "3a57ec35346127764274704666801d389508302f",
      "at": "2026-07-27T12:24:25Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, test (macos-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "3a57ec35346127764274704666801d389508302f",
      "at": "2026-07-27T12:24:34Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->