### PR TITLE
Bump adapter plugin version from 0.5.2 to 0.5.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "kninetimmy" },
   "metadata": {
     "description": "Host adapters for the Orch development orchestrator",
-    "version": "0.5.2"
+    "version": "0.5.3"
   },
   "plugins": [
     {

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Claude Code host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -78,8 +78,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.2" {
-		t.Errorf("version = %q, want 0.5.2", m.Version)
+	if m.Version != "0.5.3" {
+		t.Errorf("version = %q, want 0.5.3", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Codex CLI host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -79,8 +79,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.2" {
-		t.Errorf("version = %q, want 0.5.2", m.Version)
+	if m.Version != "0.5.3" {
+		t.Errorf("version = %q, want 0.5.3", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")


### PR DESCRIPTION
Delivers issue #73: Bump adapter plugin version from 0.5.2 to 0.5.3

Closes #73

**Plan digest:** `sha256:f9dbd21de27f84468ac0ac91e371d661b372766c7423d1751242e38eb3efcf66`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Move the adapter plugin version from 0.5.2 to 0.5.3 across the three plugin manifests and the two Go tests that pin the literal. Release preparation only: no adapter skill text, agent definition, prose, or Go behavior changes in this issue. Context: version 0.5.2 was released from an earlier commit and head has since merged three adapter-text PRs without a bump, so two different plugin contents both declare 0.5.2. Bumping restores the invariant that a plugin version identifies plugin content.

**Acceptance criteria:**
- In .claude-plugin/marketplace.json, metadata.version is the string 0.5.3.
- In adapters/claude/.claude-plugin/plugin.json, version is the string 0.5.3.
- In adapters/codex/.codex-plugin/plugin.json, version is the string 0.5.3.
- In adapters/claude/plugin_test.go, TestPluginManifestStrict compares m.Version against 0.5.3 and its Errorf message says want 0.5.3.
- In adapters/codex/plugin_test.go, the equivalent manifest test compares m.Version against 0.5.3 and its Errorf message says want 0.5.3.
- A repository-wide search for the literal string 0.5.2 returns no matches.
- Exactly these five files are modified; no other tracked file changes.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-sonnet-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — All packages ok. Includes adapters/claude (0.506s) and adapters/codex (0.463s), which carry the version-pinning manifest tests, and the marketplace cross-check asserting each host plugin.json version equals marketplace metadata.version. — commit `9666b41b31f8c194346411fc8d182c28cb93c108` (2026-07-27T14:03:03Z)
- **go-vet** — pass — `go vet ./...` — No output, exit code 0. — commit `9666b41b31f8c194346411fc8d182c28cb93c108` (2026-07-27T14:03:03Z)
- **gofmt** — pass — `gofmt -l .` — No output; no files listed as needing formatting. — commit `9666b41b31f8c194346411fc8d182c28cb93c108` (2026-07-27T14:03:03Z)
- **no-stale-version-literal** — pass — Acceptance criterion 6. Executor ran a repository-wide regex search for the literal 0.5.2 across the worktree root and reported 0 matches. — commit `9666b41b31f8c194346411fc8d182c28cb93c108` (2026-07-27T14:03:03Z)
- **scope-five-files** — pass — `git status --short` — Acceptance criterion 7. Exactly the five planned files reported modified: .claude-plugin/marketplace.json, adapters/claude/.claude-plugin/plugin.json, adapters/claude/plugin_test.go, adapters/codex/.codex-plugin/plugin.json, adapters/codex/plugin_test.go. No others. — commit `9666b41b31f8c194346411fc8d182c28cb93c108` (2026-07-27T14:03:03Z)
- **reviewer-go-test** — pass — `go test -count=1 ./...` — Reviewer re-ran independently in the worktree. All packages ok, including adapters/claude (0.460s), adapters/codex (0.470s), and the root package carrying marketplace_test.go's cross-check. No failures, no skips. — commit `9666b41b31f8c194346411fc8d182c28cb93c108` (2026-07-27T14:06:10Z)
- **reviewer-go-vet** — pass — `go vet ./...` — Reviewer re-ran independently in the worktree. Exit 0, no output. — commit `9666b41b31f8c194346411fc8d182c28cb93c108` (2026-07-27T14:06:10Z)
- **reviewer-gofmt** — pass — `gofmt -l .` — Reviewer re-ran independently in the worktree. Exit 0, no output; no files need formatting. — commit `9666b41b31f8c194346411fc8d182c28cb93c108` (2026-07-27T14:06:10Z)
- **reviewer-diff-parity** — pass — `gh pr diff 74` — Reviewer confirmed the PR diff on GitHub is byte-identical to git diff in the worktree at head 9666b41b, and that worktree git status --short is clean with no uncommitted residue. — commit `9666b41b31f8c194346411fc8d182c28cb93c108` (2026-07-27T14:06:10Z)
- **review-cycle-1** — approve — PR #74 (head 9666b41b) makes exactly the five planned edits - bumping the literal plugin version from 0.5.2 to 0.5.3 in .claude-plugin/marketplace.json, both adapters' plugin.json files, and the matching literal/error-message pairs in both adapters' plugin_test.go - with no other tracked-file changes, no stray 0.5.2 literal left anywhere in the repo, and all three required commands (go test ./..., go vet ./..., gofmt -l .) independently re-run clean by the reviewer. The pre-existing marketplace_test.go cross-check (TestMarketplaceEntryConsistency) further confirms the three manifests agree with each other post-bump. The reviewer also confirmed gh pr diff 74 is byte-identical to the worktree diff, so GitHub and disk agree. Five of six required CI checks were green at review time and one (test (windows-latest)) was still pending with no failures observed; this is to be confirmed complete before merge but does not change the verdict on this fully-verified, low-risk release-prep change. Approved. — commit `9666b41b31f8c194346411fc8d182c28cb93c108` (2026-07-27T14:06:12Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `9666b41b31f8c194346411fc8d182c28cb93c108` (2026-07-27T14:06:33Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Move the adapter plugin version from 0.5.2 to 0.5.3 across the three plugin manifests and the two Go tests that pin the literal. Release preparation only: no adapter skill text, agent definition, prose, or Go behavior changes in this issue. Context: version 0.5.2 was released from an earlier commit and head has since merged three adapter-text PRs without a bump, so two different plugin contents both declare 0.5.2. Bumping restores the invariant that a plugin version identifies plugin content.",
  "acceptance_criteria": [
    "In .claude-plugin/marketplace.json, metadata.version is the string 0.5.3.",
    "In adapters/claude/.claude-plugin/plugin.json, version is the string 0.5.3.",
    "In adapters/codex/.codex-plugin/plugin.json, version is the string 0.5.3.",
    "In adapters/claude/plugin_test.go, TestPluginManifestStrict compares m.Version against 0.5.3 and its Errorf message says want 0.5.3.",
    "In adapters/codex/plugin_test.go, the equivalent manifest test compares m.Version against 0.5.3 and its Errorf message says want 0.5.3.",
    "A repository-wide search for the literal string 0.5.2 returns no matches.",
    "Exactly these five files are modified; no other tracked file changes."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "claude-sonnet-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All packages ok. Includes adapters/claude (0.506s) and adapters/codex (0.463s), which carry the version-pinning manifest tests, and the marketplace cross-check asserting each host plugin.json version equals marketplace metadata.version.",
      "commit_oid": "9666b41b31f8c194346411fc8d182c28cb93c108",
      "at": "2026-07-27T14:03:03Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "No output, exit code 0.",
      "commit_oid": "9666b41b31f8c194346411fc8d182c28cb93c108",
      "at": "2026-07-27T14:03:03Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No output; no files listed as needing formatting.",
      "commit_oid": "9666b41b31f8c194346411fc8d182c28cb93c108",
      "at": "2026-07-27T14:03:03Z"
    },
    {
      "name": "no-stale-version-literal",
      "result": "pass",
      "detail": "Acceptance criterion 6. Executor ran a repository-wide regex search for the literal 0.5.2 across the worktree root and reported 0 matches.",
      "commit_oid": "9666b41b31f8c194346411fc8d182c28cb93c108",
      "at": "2026-07-27T14:03:03Z"
    },
    {
      "name": "scope-five-files",
      "command": "git status --short",
      "result": "pass",
      "detail": "Acceptance criterion 7. Exactly the five planned files reported modified: .claude-plugin/marketplace.json, adapters/claude/.claude-plugin/plugin.json, adapters/claude/plugin_test.go, adapters/codex/.codex-plugin/plugin.json, adapters/codex/plugin_test.go. No others.",
      "commit_oid": "9666b41b31f8c194346411fc8d182c28cb93c108",
      "at": "2026-07-27T14:03:03Z"
    },
    {
      "name": "reviewer-go-test",
      "command": "go test -count=1 ./...",
      "result": "pass",
      "detail": "Reviewer re-ran independently in the worktree. All packages ok, including adapters/claude (0.460s), adapters/codex (0.470s), and the root package carrying marketplace_test.go's cross-check. No failures, no skips.",
      "commit_oid": "9666b41b31f8c194346411fc8d182c28cb93c108",
      "at": "2026-07-27T14:06:10Z"
    },
    {
      "name": "reviewer-go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Reviewer re-ran independently in the worktree. Exit 0, no output.",
      "commit_oid": "9666b41b31f8c194346411fc8d182c28cb93c108",
      "at": "2026-07-27T14:06:10Z"
    },
    {
      "name": "reviewer-gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Reviewer re-ran independently in the worktree. Exit 0, no output; no files need formatting.",
      "commit_oid": "9666b41b31f8c194346411fc8d182c28cb93c108",
      "at": "2026-07-27T14:06:10Z"
    },
    {
      "name": "reviewer-diff-parity",
      "command": "gh pr diff 74",
      "result": "pass",
      "detail": "Reviewer confirmed the PR diff on GitHub is byte-identical to git diff in the worktree at head 9666b41b, and that worktree git status --short is clean with no uncommitted residue.",
      "commit_oid": "9666b41b31f8c194346411fc8d182c28cb93c108",
      "at": "2026-07-27T14:06:10Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "PR #74 (head 9666b41b) makes exactly the five planned edits - bumping the literal plugin version from 0.5.2 to 0.5.3 in .claude-plugin/marketplace.json, both adapters' plugin.json files, and the matching literal/error-message pairs in both adapters' plugin_test.go - with no other tracked-file changes, no stray 0.5.2 literal left anywhere in the repo, and all three required commands (go test ./..., go vet ./..., gofmt -l .) independently re-run clean by the reviewer. The pre-existing marketplace_test.go cross-check (TestMarketplaceEntryConsistency) further confirms the three manifests agree with each other post-bump. The reviewer also confirmed gh pr diff 74 is byte-identical to the worktree diff, so GitHub and disk agree. Five of six required CI checks were green at review time and one (test (windows-latest)) was still pending with no failures observed; this is to be confirmed complete before merge but does not change the verdict on this fully-verified, low-risk release-prep change. Approved.",
      "commit_oid": "9666b41b31f8c194346411fc8d182c28cb93c108",
      "at": "2026-07-27T14:06:12Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "9666b41b31f8c194346411fc8d182c28cb93c108",
      "at": "2026-07-27T14:06:33Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->