### PR TITLE
Key both adapters' agent-definition match rule on the selection currently in force

### DIFF
--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -160,9 +160,11 @@ in flight at once. For each issue:
    `fable` — never an exact version string like `claude-sonnet-5` — so
    an override can never express a routed selection, and is never the
    way to honor routing. Before spawning, confirm that the installed
-   executor agent's frontmatter `model` equals
-   `DispatchResult.executor.model`. Compare against the **installed**
-   plugin copy under the Claude Code plugin cache
+   executor agent's frontmatter `model` equals the selection
+   **currently in force**: `EscalateResult.executor.model` when an
+   escalation has rerouted the issue since dispatch, or
+   `DispatchResult.executor.model` otherwise. Compare against the
+   **installed** plugin copy under the Claude Code plugin cache
    (`~/.claude/plugins/cache/orch/orch-claude/<version>/agents/`), not
    this repository's `adapters/claude/agents/` copy — a plugin version
    behind head can still carry an older pin. **If the routed model
@@ -224,9 +226,11 @@ in flight at once. For each issue:
    cannot express a routed selection and an override is never the way
    to honor routing — only the installed agent definition's
    frontmatter pins an exact model. Before spawning, confirm that the
-   selected reviewer agent's frontmatter `model` equals
-   `DispatchResult.reviewer.model`. Compare against the **installed**
-   plugin copy under the Claude Code plugin cache
+   selected reviewer agent's frontmatter `model` equals the selection
+   **currently in force**: `EscalateResult.reviewer.model` when an
+   escalation has rerouted the issue since dispatch, or
+   `DispatchResult.reviewer.model` otherwise. Compare against the
+   **installed** plugin copy under the Claude Code plugin cache
    (`~/.claude/plugins/cache/orch/orch-claude/<version>/agents/`), not
    this repository's `adapters/claude/agents/` copy — a plugin version
    behind head can still carry an older pin. **If the routed model
@@ -326,7 +330,13 @@ failure, call `orch run escalate`:
 Result `kind`:
 
 - `reroute` — carries a new `executor`/`reviewer` and `rationale`;
-  spawn the new selection into the **same worktree**, never a new one.
+  before spawning either into the **same worktree** (never a new
+  one), confirm the new selection's `model` against an installed
+  agent definition's frontmatter under the same match rule as the
+  spawn steps above — **if the new selection matches no installed
+  agent's frontmatter, stop and tell the human — never spawn a
+  mismatched agent, and never report the routed selection as if it
+  ran.**
 - `return-to-architect` — the issue is blocked for human design work;
   report `reason` and do not push it forward yourself.
 

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -157,8 +157,11 @@ in flight at once. For each issue:
    `orch-specialist` (per the routed role) by naming the agent in your
    prompt; Codex has no per-spawn model override, so the agent that
    actually runs is whatever its installed TOML (`model`,
-   `model_reasoning_effort`) pins. Before dispatching, `DispatchResult`'s
-   `(model, effort)` for the routed role **must match an installed
+   `model_reasoning_effort`) pins. Before dispatching, the selection
+   **currently in force** for the routed role — `DispatchResult`'s
+   `(model, effort)`, superseded by any later escalation's new
+   selection (`EscalateResult`'s `(model, effort)`), never the
+   dispatch-time value once superseded — **must match an installed
    `orch-*` agent TOML exactly** — `orch-scout` gpt-5.6-terra/low,
    `orch-implementer` gpt-5.6-terra/high, `orch-specialist`
    gpt-5.6-sol/medium, `orch-reviewer` gpt-5.6-sol/medium,
@@ -309,8 +312,12 @@ failure, call `orch run escalate`:
 Result `kind`:
 
 - `reroute` — carries a new `executor`/`reviewer` and `rationale`;
-  dispatch the new selection into the **same worktree**, never a new
-  one.
+  before dispatching either into the **same worktree** (never a new
+  one), confirm the new selection's `(model, effort)` against an
+  installed `orch-*` agent TOML under the same match rule as the
+  dispatch steps above — **if no installed TOML matches the new
+  selection, stop and tell the human — never dispatch a mismatched
+  agent, and never report the routed selection as if it ran.**
 - `return-to-architect` — the issue is blocked for human design work;
   report `reason` and do not push it forward yourself.
 


### PR DESCRIPTION
Delivers issue #75: Key both adapters' agent-definition match rule on the selection currently in force

Closes #75

**Plan digest:** `sha256:95757cb468185db424c504199de82f92ef37c2a250ca0709ae77d6a4dc0200c2`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Both adapters' orch-delivery skills must tell the Architect to compare an installed agent definition against the routing selection currently in force, not the dispatch-time value, at every spawn step and in the Escalation section. Today Claude step 2 names DispatchResult.executor.model and Codex step 2 names DispatchResult's (model, effort), each with no note that an escalation supersedes them; Claude step 4 names DispatchResult.reviewer.model even though its own surrounding sentence already says the selection is superseded by any later escalation. Neither Escalation section restates the match rule, so an Architect spawning a rerouted agent has no instruction to re-check the pin. Use the phrasing already present at Claude step 5 and Codex step 4 so all spawn steps read consistently across both hosts.

**Acceptance criteria:**
- In adapters/claude/skills/orch-delivery/SKILL.md step 2, the sentence mandating the executor frontmatter comparison names the selection currently in force - EscalateResult.executor when an escalation has rerouted the issue since dispatch, DispatchResult.executor otherwise - rather than naming DispatchResult.executor.model unconditionally.
- In adapters/claude/skills/orch-delivery/SKILL.md step 4, the sentence mandating the reviewer frontmatter comparison uses that same two-source phrasing, naming EscalateResult.reviewer after a reroute and DispatchResult.reviewer otherwise.
- In adapters/codex/skills/orch-delivery/SKILL.md step 2, the TOML-match rule names the selection currently in force using the same two-source phrasing, so it carries the supersession note that the same file's step 4 already has.
- The Escalation section of both adapters' orch-delivery SKILL.md files states, on the reroute outcome, that the new selection must be checked against an installed agent definition before the agent is spawned or dispatched, with the same stop-and-tell-the-human consequence the spawn steps state.
- go test ./... passes, including adapters/claude's TestDeliverySkillStatesFrontmatterMatchRule, which fails unless the exact phrase 'stop and tell the human' appears at least twice in the Claude skill, and adapters/codex's TestDeliverySkillStatesTOMLMatchRule.
- No file outside the two orch-delivery SKILL.md files is modified: no Go source, no test, no agent definition, no README, and no plugin manifest version change.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — Executor reported all packages passing, including adapters/claude (0.642s) and adapters/codex (0.671s). Architect did not independently re-run the full suite; the six required CI checks on the PR are the authoritative gate and are recorded separately by orch run ci. — commit `9903eace4228cfa16527b0c164febd595a95e258` (2026-07-27T14:47:30Z)
- **gofmt** — pass — `gofmt -l .` — No output, no unformatted files. Vacuous for this change: the diff touches only two markdown files and no Go source. Reported because it is a declared required test and a CI lint gate. — commit `9903eace4228cfa16527b0c164febd595a95e258` (2026-07-27T14:47:30Z)
- **skill-pin-counts** — pass — `git show <branch>:<skill> | grep -o 'stop and tell the human' | wc -l` — Architect-run, independent of the executor. Counted the exact phrase in each SKILL.md blob on the pushed branch: adapters/claude 3 occurrences (TestDeliverySkillStatesFrontmatterMatchRule requires &gt;= 2), adapters/codex 2 occurrences (TestDeliverySkillStatesTOMLMatchRule requires &gt;= 1). Both pins hold with margin. This confirms the executor's reported counts of 3 and 2. — commit `9903eace4228cfa16527b0c164febd595a95e258` (2026-07-27T14:47:30Z)
- **scope-and-diff-audit** — pass — `git diff --numstat main...origin/orch/issue-75-key-both-adapters-agent-definition-match` — Architect-run. Exactly two files changed, satisfying AC 6: adapters/claude/skills/orch-delivery/SKILL.md 17 added / 7 deleted, adapters/codex/skills/orch-delivery/SKILL.md 11 added / 4 deleted. No Go source, test, agent definition, README, or plugin manifest touched; plugin version remains 0.5.3. CORRECTION TO THE EXECUTOR REPORT: it stated 24 insertions / 11 deletions for the Claude file and 15 insertions / 4 deletions for the Codex file, apparently reading git diff --stat's total-changed-lines column as an insertion count. The numbers above are from --numstat and are the accurate ones. The error is cosmetic and does not affect the change itself, which was reviewed line by line against all six acceptance criteria. — commit `9903eace4228cfa16527b0c164febd595a95e258` (2026-07-27T14:47:30Z)
- **acceptance-criteria-walkthrough** — pass — `git diff main...origin/orch/issue-75-key-both-adapters-agent-definition-match` — Architect read the full diff against each criterion. AC1: Claude step 2 now reads 'equals the selection currently in force: EscalateResult.executor.model when an escalation has rerouted the issue since dispatch, or DispatchResult.executor.model otherwise'. AC2: Claude step 4 carries the identical two-source shape for the reviewer. AC3: Codex step 2 now reads 'the selection currently in force for the routed role - DispatchResult's (model, effort), superseded by any later escalation's new selection (EscalateResult's (model, effort)), never the dispatch-time value once superseded'. AC4: both Escalation reroute bullets now require confirming the new selection against an installed agent definition before spawn/dispatch, each carrying the verbatim stop-and-tell-the-human consequence. AC5 and AC6 covered by the two verifications above. Codex step 4, which already carried the clause correctly, was left untouched as instructed. — commit `9903eace4228cfa16527b0c164febd595a95e258` (2026-07-27T14:47:30Z)
- **reviewer-independent-test-run** — pass — `go test ./... && gofmt -l . && go vet ./...` — Run by the reviewer in a separate clone at head 9903eac, independent of the executor's worktree and of the Architect. All packages pass including TestDeliverySkillStatesFrontmatterMatchRule and TestDeliverySkillStatesTOMLMatchRule; gofmt -l . produced no output; go vet clean. This is a second independent confirmation of AC5 rather than a restatement of the executor's evidence. — commit `9903eace4228cfa16527b0c164febd595a95e258` (2026-07-27T14:54:38Z)
- **reviewer-engine-truth-check** — pass — `read internal/run/escalate.go, internal/routing/escalate.go, internal/run/dispatch.go` — The reviewer re-derived the engine behavior the new prose asserts, instead of trusting the Architect's dispatch-prompt summary. Confirmed: escalate.go:106 replaces the entire Decision; escalateReroute populates both EscalateResult.Executor and .Reviewer from the full new Decision, so both are authoritative after any reroute even when only one role actually changed; routing/escalate.go restores the strong reviewer on an executor reroute that had a downgraded reviewer, which is precisely the case the old step 4 wording got wrong; dispatch.go:66 accepts only the worktree-ready phase, so EscalateResult is the sole refresh source. Also confirmed the wording 'an escalation has rerouted' correctly excludes the return-to-architect outcome. — commit `9903eace4228cfa16527b0c164febd595a95e258` (2026-07-27T14:54:38Z)
- **review-cycle-1** — approve — Approve. Reviewer verified engine truth independently rather than adopting the Architect's: escalate.go:106 replaces the whole Decision, and escalateReroute fills EscalateResult.Executor AND .Reviewer from the full new Decision, so both roles are authoritative on any reroute even when one was unchanged - the new prose is true for both. routing/escalate.go restores the strong reviewer on an executor reroute when downgraded, exactly the case old step 4 got wrong. dispatch.go:66 accepts only worktree-ready, confirming EscalateResult is the only refresh source. 'has rerouted' correctly excludes return-to-architect. AC1-4 judged by reading the prose, not word-matching: Claude steps 2/4 key the check to the selection currently in force using step 5's template; Codex step 2 adopts its own step 4's supersession shape; both Escalation reroute bullets require confirming the new selection under the same match rule with the verbatim stop-and-tell-the-human consequence, while keeping 'same worktree, never a new one'. AC5: at 9903eac in a separate clone, go test ./... passes including both pins, gofmt -l . empty, go vet clean. AC6: exactly two files (17/7, 11/4), plugin version still 0.5.3 in all three manifests, no stale duplicate wording elsewhere. CI 6/6 SUCCESS, MERGEABLE. Security: prose-only, and it fails closed at a point previously unguarded. Reviewer confirmed the Architect's line-count correction (24=17+7, 15=11+4; the executor read --stat's changed-lines column) and the pin counts 3 and 2. Non-blocking nits: Codex step 2 is now a dense three-dash sentence; 'an escalation has rerouted' does not say 'most recent' on a reroute chain, inherited from the shipped template and not a regression; the Architect's recorded audit commands used main... rather than origin/main..., equivalent here since local main is at origin/main 4293ec7, but less reproducible. — commit `9903eace4228cfa16527b0c164febd595a95e258` (2026-07-27T14:54:39Z)
- **required-ci** — passing — scripts (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass — commit `9903eace4228cfa16527b0c164febd595a95e258` (2026-07-27T14:54:43Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Both adapters' orch-delivery skills must tell the Architect to compare an installed agent definition against the routing selection currently in force, not the dispatch-time value, at every spawn step and in the Escalation section. Today Claude step 2 names DispatchResult.executor.model and Codex step 2 names DispatchResult's (model, effort), each with no note that an escalation supersedes them; Claude step 4 names DispatchResult.reviewer.model even though its own surrounding sentence already says the selection is superseded by any later escalation. Neither Escalation section restates the match rule, so an Architect spawning a rerouted agent has no instruction to re-check the pin. Use the phrasing already present at Claude step 5 and Codex step 4 so all spawn steps read consistently across both hosts.",
  "acceptance_criteria": [
    "In adapters/claude/skills/orch-delivery/SKILL.md step 2, the sentence mandating the executor frontmatter comparison names the selection currently in force - EscalateResult.executor when an escalation has rerouted the issue since dispatch, DispatchResult.executor otherwise - rather than naming DispatchResult.executor.model unconditionally.",
    "In adapters/claude/skills/orch-delivery/SKILL.md step 4, the sentence mandating the reviewer frontmatter comparison uses that same two-source phrasing, naming EscalateResult.reviewer after a reroute and DispatchResult.reviewer otherwise.",
    "In adapters/codex/skills/orch-delivery/SKILL.md step 2, the TOML-match rule names the selection currently in force using the same two-source phrasing, so it carries the supersession note that the same file's step 4 already has.",
    "The Escalation section of both adapters' orch-delivery SKILL.md files states, on the reroute outcome, that the new selection must be checked against an installed agent definition before the agent is spawned or dispatched, with the same stop-and-tell-the-human consequence the spawn steps state.",
    "go test ./... passes, including adapters/claude's TestDeliverySkillStatesFrontmatterMatchRule, which fails unless the exact phrase 'stop and tell the human' appears at least twice in the Claude skill, and adapters/codex's TestDeliverySkillStatesTOMLMatchRule.",
    "No file outside the two orch-delivery SKILL.md files is modified: no Go source, no test, no agent definition, no README, and no plugin manifest version change."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Executor reported all packages passing, including adapters/claude (0.642s) and adapters/codex (0.671s). Architect did not independently re-run the full suite; the six required CI checks on the PR are the authoritative gate and are recorded separately by orch run ci.",
      "commit_oid": "9903eace4228cfa16527b0c164febd595a95e258",
      "at": "2026-07-27T14:47:30Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No output, no unformatted files. Vacuous for this change: the diff touches only two markdown files and no Go source. Reported because it is a declared required test and a CI lint gate.",
      "commit_oid": "9903eace4228cfa16527b0c164febd595a95e258",
      "at": "2026-07-27T14:47:30Z"
    },
    {
      "name": "skill-pin-counts",
      "command": "git show \u003cbranch\u003e:\u003cskill\u003e | grep -o 'stop and tell the human' | wc -l",
      "result": "pass",
      "detail": "Architect-run, independent of the executor. Counted the exact phrase in each SKILL.md blob on the pushed branch: adapters/claude 3 occurrences (TestDeliverySkillStatesFrontmatterMatchRule requires \u003e= 2), adapters/codex 2 occurrences (TestDeliverySkillStatesTOMLMatchRule requires \u003e= 1). Both pins hold with margin. This confirms the executor's reported counts of 3 and 2.",
      "commit_oid": "9903eace4228cfa16527b0c164febd595a95e258",
      "at": "2026-07-27T14:47:30Z"
    },
    {
      "name": "scope-and-diff-audit",
      "command": "git diff --numstat main...origin/orch/issue-75-key-both-adapters-agent-definition-match",
      "result": "pass",
      "detail": "Architect-run. Exactly two files changed, satisfying AC 6: adapters/claude/skills/orch-delivery/SKILL.md 17 added / 7 deleted, adapters/codex/skills/orch-delivery/SKILL.md 11 added / 4 deleted. No Go source, test, agent definition, README, or plugin manifest touched; plugin version remains 0.5.3. CORRECTION TO THE EXECUTOR REPORT: it stated 24 insertions / 11 deletions for the Claude file and 15 insertions / 4 deletions for the Codex file, apparently reading git diff --stat's total-changed-lines column as an insertion count. The numbers above are from --numstat and are the accurate ones. The error is cosmetic and does not affect the change itself, which was reviewed line by line against all six acceptance criteria.",
      "commit_oid": "9903eace4228cfa16527b0c164febd595a95e258",
      "at": "2026-07-27T14:47:30Z"
    },
    {
      "name": "acceptance-criteria-walkthrough",
      "command": "git diff main...origin/orch/issue-75-key-both-adapters-agent-definition-match",
      "result": "pass",
      "detail": "Architect read the full diff against each criterion. AC1: Claude step 2 now reads 'equals the selection currently in force: EscalateResult.executor.model when an escalation has rerouted the issue since dispatch, or DispatchResult.executor.model otherwise'. AC2: Claude step 4 carries the identical two-source shape for the reviewer. AC3: Codex step 2 now reads 'the selection currently in force for the routed role - DispatchResult's (model, effort), superseded by any later escalation's new selection (EscalateResult's (model, effort)), never the dispatch-time value once superseded'. AC4: both Escalation reroute bullets now require confirming the new selection against an installed agent definition before spawn/dispatch, each carrying the verbatim stop-and-tell-the-human consequence. AC5 and AC6 covered by the two verifications above. Codex step 4, which already carried the clause correctly, was left untouched as instructed.",
      "commit_oid": "9903eace4228cfa16527b0c164febd595a95e258",
      "at": "2026-07-27T14:47:30Z"
    },
    {
      "name": "reviewer-independent-test-run",
      "command": "go test ./... \u0026\u0026 gofmt -l . \u0026\u0026 go vet ./...",
      "result": "pass",
      "detail": "Run by the reviewer in a separate clone at head 9903eac, independent of the executor's worktree and of the Architect. All packages pass including TestDeliverySkillStatesFrontmatterMatchRule and TestDeliverySkillStatesTOMLMatchRule; gofmt -l . produced no output; go vet clean. This is a second independent confirmation of AC5 rather than a restatement of the executor's evidence.",
      "commit_oid": "9903eace4228cfa16527b0c164febd595a95e258",
      "at": "2026-07-27T14:54:38Z"
    },
    {
      "name": "reviewer-engine-truth-check",
      "command": "read internal/run/escalate.go, internal/routing/escalate.go, internal/run/dispatch.go",
      "result": "pass",
      "detail": "The reviewer re-derived the engine behavior the new prose asserts, instead of trusting the Architect's dispatch-prompt summary. Confirmed: escalate.go:106 replaces the entire Decision; escalateReroute populates both EscalateResult.Executor and .Reviewer from the full new Decision, so both are authoritative after any reroute even when only one role actually changed; routing/escalate.go restores the strong reviewer on an executor reroute that had a downgraded reviewer, which is precisely the case the old step 4 wording got wrong; dispatch.go:66 accepts only the worktree-ready phase, so EscalateResult is the sole refresh source. Also confirmed the wording 'an escalation has rerouted' correctly excludes the return-to-architect outcome.",
      "commit_oid": "9903eace4228cfa16527b0c164febd595a95e258",
      "at": "2026-07-27T14:54:38Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approve. Reviewer verified engine truth independently rather than adopting the Architect's: escalate.go:106 replaces the whole Decision, and escalateReroute fills EscalateResult.Executor AND .Reviewer from the full new Decision, so both roles are authoritative on any reroute even when one was unchanged - the new prose is true for both. routing/escalate.go restores the strong reviewer on an executor reroute when downgraded, exactly the case old step 4 got wrong. dispatch.go:66 accepts only worktree-ready, confirming EscalateResult is the only refresh source. 'has rerouted' correctly excludes return-to-architect. AC1-4 judged by reading the prose, not word-matching: Claude steps 2/4 key the check to the selection currently in force using step 5's template; Codex step 2 adopts its own step 4's supersession shape; both Escalation reroute bullets require confirming the new selection under the same match rule with the verbatim stop-and-tell-the-human consequence, while keeping 'same worktree, never a new one'. AC5: at 9903eac in a separate clone, go test ./... passes including both pins, gofmt -l . empty, go vet clean. AC6: exactly two files (17/7, 11/4), plugin version still 0.5.3 in all three manifests, no stale duplicate wording elsewhere. CI 6/6 SUCCESS, MERGEABLE. Security: prose-only, and it fails closed at a point previously unguarded. Reviewer confirmed the Architect's line-count correction (24=17+7, 15=11+4; the executor read --stat's changed-lines column) and the pin counts 3 and 2. Non-blocking nits: Codex step 2 is now a dense three-dash sentence; 'an escalation has rerouted' does not say 'most recent' on a reroute chain, inherited from the shipped template and not a regression; the Architect's recorded audit commands used main... rather than origin/main..., equivalent here since local main is at origin/main 4293ec7, but less reproducible.",
      "commit_oid": "9903eace4228cfa16527b0c164febd595a95e258",
      "at": "2026-07-27T14:54:39Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "scripts (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "9903eace4228cfa16527b0c164febd595a95e258",
      "at": "2026-07-27T14:54:43Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->