### PR TITLE
Correct both orch-architect skills' enforcement and memhub-isolation claims, and name memhub review accept at wrap-up

### DIFF
--- a/adapters/claude/skills/orch-architect/SKILL.md
+++ b/adapters/claude/skills/orch-architect/SKILL.md
@@ -100,10 +100,12 @@ comes back through the engine's own output, e.g. `DispatchResult`,
 
 ## Memhub discipline
 
-- **Only the Architect writes to memhub.** Subagents never do — they
-  have no memhub tools, and even if they could reach one they must not
-  write it. Anything a subagent needs remembered comes back to you in
-  its report, and you decide whether and how to record it.
+- **Only the Architect writes to memhub.** Subagents never do — that
+  boundary is enforced by these instructions, not by the absence of
+  memhub tools. Because memhub is an external CLI, any subagent
+  carrying `Bash` can reach it and must still not write it. Anything a
+  subagent needs remembered comes back to you in its report, and you
+  decide whether and how to record it.
 - **Always run memhub commands with the main checkout as the process
   working directory — never a worktree.** A Delivery worktree is a
   separate git working tree for one issue's branch; memhub's project
@@ -114,7 +116,12 @@ comes back through the engine's own output, e.g. `DispatchResult`,
   result carries `memhub_wrapup_due: true` when a wrap-up is owed (i.e.
   memhub mode is not "off"). When you see that flag, do the wrap-up
   before announcing the return to Assist — do not skip it, and do not
-  run it speculatively when the flag is absent or false.
+  run it speculatively when the flag is absent or false. Staged
+  decisions and facts sit in memhub's pending writes until a human
+  accepts them, so once the wrap-up is staged, report the staged count
+  to the human and name `memhub review accept` as the command that
+  makes them durable — running it is the human's approval gate, never
+  yours.
 
 ## Handoff
 

--- a/adapters/codex/skills/orch-architect/SKILL.md
+++ b/adapters/codex/skills/orch-architect/SKILL.md
@@ -95,9 +95,12 @@ and you do not override it. Never dispatch a general-purpose agent, and
 never dispatch an agent outside these five roles.
 
 Codex agent definitions carry no tool whitelist (unlike Claude Code's
-per-agent `tools:` frontmatter): scout and reviewer's read-only
-discipline rests entirely on the `orch guard codex` hook plus their own
-developer instructions, not on a mechanically enforced tool list.
+per-agent `tools:` frontmatter), and the `orch guard codex` hook
+contributes containment only: it confines a write to a registered
+worktree in a writable phase, and this adapter never passes guard's
+`--role` narrowing, so it cannot tell a scout or reviewer from an
+implementer. Scout and reviewer read-only-ness rests on their own
+developer instructions.
 
 Respect the concurrency cap. `concurrency.max_subagents` in
 `.orchestrator/config.toml` is the **one** configuration key this
@@ -108,9 +111,12 @@ comes back through the engine's own output, e.g. `DispatchResult`,
 ## Memhub discipline
 
 - **Only the Architect writes to memhub.** Dispatched agents never do —
-  they have no memhub tools, and even if they could reach one they must
-  not write it. Anything a dispatched agent needs remembered comes back
-  to you in its report, and you decide whether and how to record it.
+  that boundary is enforced by these instructions, not by the absence
+  of memhub tools. Because memhub is an external CLI and Codex agent
+  definitions carry no tool whitelist, any dispatched agent can reach
+  it and must still not write it. Anything a dispatched agent needs
+  remembered comes back to you in its report, and you decide whether
+  and how to record it.
 - **Always run memhub commands with the main checkout as the process
   working directory — never a worktree.** A Delivery worktree is a
   separate git working tree for one issue's branch; memhub's project
@@ -121,7 +127,12 @@ comes back through the engine's own output, e.g. `DispatchResult`,
   result carries `memhub_wrapup_due: true` when a wrap-up is owed (i.e.
   memhub mode is not "off"). When you see that flag, do the wrap-up
   before announcing the return to Assist — do not skip it, and do not
-  run it speculatively when the flag is absent or false.
+  run it speculatively when the flag is absent or false. Staged
+  decisions and facts sit in memhub's pending writes until a human
+  accepts them, so once the wrap-up is staged, report the staged count
+  to the human and name `memhub review accept` as the command that
+  makes them durable — running it is the human's approval gate, never
+  yours.
 
 ## Handoff
 


### PR DESCRIPTION
Delivers issue #78: Correct both orch-architect skills' enforcement and memhub-isolation claims, and name memhub review accept at wrap-up

Closes #78

**Plan digest:** `sha256:b03046ccf82f102e66b26266bd43f163d47ec35f5414a79c0645285f991514b0`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Both orch-architect skills assert two mechanisms that do not exist, and omit the step that makes a run's curated memhub record durable. First, the Codex skill says scout and reviewer read-only discipline rests entirely on the orch guard codex hook plus developer instructions; the hook contributes containment only. Second, both skills say subagents have no memhub tools; memhub is an external CLI, and the Claude orch-reviewer, orch-implementer and orch-specialist all carry Bash while Codex agents have no whitelist at all, so the Architect-only-writes boundary is instruction-enforced (decision 67 supersedes decisions 37 and 49 on this premise; the policy itself stands). Third, staged memhub writes sit in pending_writes until a human runs memhub review accept, and nothing in the wrap-up bullet says so.

**Acceptance criteria:**
- adapters/codex/skills/orch-architect/SKILL.md no longer says scout and reviewer read-only discipline rests entirely on the orch guard codex hook plus their own developer instructions; it says the hook contributes containment only and that role read-only-ness rests on developer instructions.
- Both adapters/codex/skills/orch-architect/SKILL.md and adapters/claude/skills/orch-architect/SKILL.md state in the Memhub discipline section that the Architect-only-writes boundary is enforced by these instructions, not by the absence of memhub tools, and no longer claim that subagents have no memhub tools.
- Both orch-architect SKILL.md files' wrap-up bullet gains a sentence directing the Architect, after staging memhub writes, to report the staged count to the human and to name memhub review accept as the command that makes them durable.
- Wording shared between the two hosts' orch-architect skills stays parallel: any sentence that exists in both files is worded identically except where a host difference is real (for example Codex's absent tool whitelist).
- No file outside adapters/codex/skills/orch-architect/SKILL.md and adapters/claude/skills/orch-architect/SKILL.md is modified.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `specialist` |
| Executor | `claude-opus-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to a specialist with a strong reviewer because risk domains (security).

**Escalations:** _none_

**Verification:**
- **unit-tests** — pass — `go test ./...` — exit 0; all 21 packages ok, including adapters/claude, adapters/codex and internal/guard — commit `4da02aa714132f11768816de3659b07a9040d559` (2026-07-27T15:39:22Z)
- **gofmt** — pass — `gofmt -l .` — empty output — commit `4da02aa714132f11768816de3659b07a9040d559` (2026-07-27T15:39:22Z)
- **vet** — pass — `go vet ./...` — exit 0 — commit `4da02aa714132f11768816de3659b07a9040d559` (2026-07-27T15:39:22Z)
- **scope-check** — pass — `git status --porcelain` — exactly the two target orch-architect SKILL.md files modified; no file outside acceptance criterion 5 — commit `4da02aa714132f11768816de3659b07a9040d559` (2026-07-27T15:39:22Z)
- **stale-claim-sweep** — pass — `grep over both orch-architect SKILL.md files for the phrases 'have no memhub tools' and 'rests entirely on'` — no matches; both superseded claims removed — commit `4da02aa714132f11768816de3659b07a9040d559` (2026-07-27T15:39:22Z)
- **cross-host-parallelism** — pass — `diff of the extracted wrap-up bullets across hosts` — wrap-up bullets byte-identical across hosts; memhub bullet differs only by the subagent/dispatched-agent lexicon and the one real host difference — commit `4da02aa714132f11768816de3659b07a9040d559` (2026-07-27T15:39:22Z)
- **unit-tests-reproduced** — pass — `go test ./... at 4da02aa in an isolated clone` — exit 0; all packages ok including adapters/claude, adapters/codex and internal/guard. Note: the executor's audit entry said 21 packages, actual is 22 ok plus 3 with no test files - the substantive claim holds, the count was off by one — commit `4da02aa714132f11768816de3659b07a9040d559` (2026-07-27T15:51:11Z)
- **gofmt-reproduced** — pass — `gofmt -l . at 4da02aa` — empty output — commit `4da02aa714132f11768816de3659b07a9040d559` (2026-07-27T15:51:11Z)
- **vet-reproduced** — pass — `go vet ./... at 4da02aa` — exit 0 — commit `4da02aa714132f11768816de3659b07a9040d559` (2026-07-27T15:51:11Z)
- **ci-head-pinned** — pass — `gh run view 30281040733 checking headSha rather than trusting gh pr checks` — headSha 4da02aa714132f11768816de3659b07a9040d559, conclusion success, all six required checks passing (lint, scripts x2, test x3) — commit `4da02aa714132f11768816de3659b07a9040d559` (2026-07-27T15:51:11Z)
- **engine-truth-guard** — pass — `read internal/guard/guard.go evaluate() and adapters/codex/hooks/hooks.json at this commit` — guard.go:123 row 10 reads req.Role != "" &amp;&amp; req.Role != RoleImplementer &amp;&amp; req.Role != RoleSpecialist, so an empty Role falls through to pure containment; the Codex hook passes no --role. The new prose is true, not differently false — commit `4da02aa714132f11768816de3659b07a9040d559` (2026-07-27T15:51:11Z)
- **bash-roster-check** — pass — `read tools: frontmatter of all five adapters/claude/agents/*.md` — four of five carry Bash (implementer, specialist, reviewer, reviewer-safe); only orch-scout is memhub-incapable. Decision 67's stored premise names only three and should be corrected in the memhub record; the shipped prose is generic and needs no change — commit `4da02aa714132f11768816de3659b07a9040d559` (2026-07-27T15:51:11Z)
- **scope-and-conflict** — pass — `git diff --name-only merge-base..4da02aa, plus overlap check against sibling branches` — exactly the two named orch-architect SKILL.md files; merge-base is 0d47213, the current main tip; zero file overlap with #77 (f5bcc36), #79 (0a53e4f) or #80 — commit `4da02aa714132f11768816de3659b07a9040d559` (2026-07-27T15:51:11Z)
- **reviewer-main-checkout-incident** — noted — `git status --short --branch; git rev-parse HEAD main origin/main; git stash list` — The reviewer disclosed that a failed cd caused a chained git checkout to run in the main checkout, detaching HEAD at 4da02aa, and reported restoring main. The Architect independently verified afterwards: branch main, HEAD 0d472136 equal to origin/main, clean tree, no stashes, not detached. No repository content was written or committed and no review finding depended on the detached state - every finding is pinned to the explicit OID. Root cause is task 27's Bash-bypass class: git checkout is shell-mediated, so the guard's PreToolUse hook, which matches only the four file tools, could not intercept it. This is the same gap the run's own prose corrections describe, observed live — commit `4da02aa714132f11768816de3659b07a9040d559` (2026-07-27T15:51:11Z)
- **shared-checkout-fetch-head-hazard** — noted — `observation during concurrent sibling reviews` — The reviewer observed .git/FETCH_HEAD in the shared main checkout being overwritten mid-review by concurrent sibling reviews in this run, briefly flipping from issue-78's head to issue-77's head. Any reviewer resolving FETCH_HEAD symbolically in the shared checkout can silently review the wrong commit. This review pinned every finding to an explicit OID and was unaffected — commit `4da02aa714132f11768816de3659b07a9040d559` (2026-07-27T15:51:11Z)
- **review-cycle-1** — approve — Approve. All five acceptance criteria pass, verified against the engine rather than the executor's summary. Criterion 1: the replacement Codex prose is true of internal/guard/guard.go at this commit - row 10's role deny is gated on a non-empty asserted Role, adapters/codex/hooks/hooks.json invokes orch guard codex bare, so the hook genuinely cannot distinguish a reviewer from an implementer; the sentence understates the hook slightly (omits run-stop, off-branch, git-internals denials) but in the restrictive-to-permissive direction, never falsely. Criterion 2: both files drop the superseded no-memhub-tools premise; the executor's four-of-five Bash claim was independently confirmed against adapters/claude/agents/*.md frontmatter - orch-reviewer-safe also carries Bash, so decision 67's stored three-agent premise undercounts, and the shipped prose correctly avoids enumerating a roster at all. Criterion 3: the wrap-up sentence is byte-identical across hosts and assigns memhub review accept to the human unambiguously. Criterion 4: a normalized cross-host diff found only the pre-existing subagent/dispatched-agent lexicon and one load-bearing host difference. Criterion 5: exactly the two named files, merge-base is current main, zero file overlap with siblings #77/#79/#80, GitHub reports MERGEABLE. Policy strength is preserved or increased: the change converts a false mechanical guarantee into an explicit instruction-level obligation. Tests and CI reproduced independently in an isolated clone at the pinned OID. — commit `4da02aa714132f11768816de3659b07a9040d559` (2026-07-27T15:51:12Z)
- **required-ci** — passing — test (macos-latest)=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (windows-latest)=pass — commit `4da02aa714132f11768816de3659b07a9040d559` (2026-07-27T16:01:04Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Both orch-architect skills assert two mechanisms that do not exist, and omit the step that makes a run's curated memhub record durable. First, the Codex skill says scout and reviewer read-only discipline rests entirely on the orch guard codex hook plus developer instructions; the hook contributes containment only. Second, both skills say subagents have no memhub tools; memhub is an external CLI, and the Claude orch-reviewer, orch-implementer and orch-specialist all carry Bash while Codex agents have no whitelist at all, so the Architect-only-writes boundary is instruction-enforced (decision 67 supersedes decisions 37 and 49 on this premise; the policy itself stands). Third, staged memhub writes sit in pending_writes until a human runs memhub review accept, and nothing in the wrap-up bullet says so.",
  "acceptance_criteria": [
    "adapters/codex/skills/orch-architect/SKILL.md no longer says scout and reviewer read-only discipline rests entirely on the orch guard codex hook plus their own developer instructions; it says the hook contributes containment only and that role read-only-ness rests on developer instructions.",
    "Both adapters/codex/skills/orch-architect/SKILL.md and adapters/claude/skills/orch-architect/SKILL.md state in the Memhub discipline section that the Architect-only-writes boundary is enforced by these instructions, not by the absence of memhub tools, and no longer claim that subagents have no memhub tools.",
    "Both orch-architect SKILL.md files' wrap-up bullet gains a sentence directing the Architect, after staging memhub writes, to report the staged count to the human and to name memhub review accept as the command that makes them durable.",
    "Wording shared between the two hosts' orch-architect skills stays parallel: any sentence that exists in both files is worded identically except where a host difference is real (for example Codex's absent tool whitelist).",
    "No file outside adapters/codex/skills/orch-architect/SKILL.md and adapters/claude/skills/orch-architect/SKILL.md is modified."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "specialist",
  "executor": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to a specialist with a strong reviewer because risk domains (security).",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "unit-tests",
      "command": "go test ./...",
      "result": "pass",
      "detail": "exit 0; all 21 packages ok, including adapters/claude, adapters/codex and internal/guard",
      "commit_oid": "4da02aa714132f11768816de3659b07a9040d559",
      "at": "2026-07-27T15:39:22Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "empty output",
      "commit_oid": "4da02aa714132f11768816de3659b07a9040d559",
      "at": "2026-07-27T15:39:22Z"
    },
    {
      "name": "vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "exit 0",
      "commit_oid": "4da02aa714132f11768816de3659b07a9040d559",
      "at": "2026-07-27T15:39:22Z"
    },
    {
      "name": "scope-check",
      "command": "git status --porcelain",
      "result": "pass",
      "detail": "exactly the two target orch-architect SKILL.md files modified; no file outside acceptance criterion 5",
      "commit_oid": "4da02aa714132f11768816de3659b07a9040d559",
      "at": "2026-07-27T15:39:22Z"
    },
    {
      "name": "stale-claim-sweep",
      "command": "grep over both orch-architect SKILL.md files for the phrases 'have no memhub tools' and 'rests entirely on'",
      "result": "pass",
      "detail": "no matches; both superseded claims removed",
      "commit_oid": "4da02aa714132f11768816de3659b07a9040d559",
      "at": "2026-07-27T15:39:22Z"
    },
    {
      "name": "cross-host-parallelism",
      "command": "diff of the extracted wrap-up bullets across hosts",
      "result": "pass",
      "detail": "wrap-up bullets byte-identical across hosts; memhub bullet differs only by the subagent/dispatched-agent lexicon and the one real host difference",
      "commit_oid": "4da02aa714132f11768816de3659b07a9040d559",
      "at": "2026-07-27T15:39:22Z"
    },
    {
      "name": "unit-tests-reproduced",
      "command": "go test ./... at 4da02aa in an isolated clone",
      "result": "pass",
      "detail": "exit 0; all packages ok including adapters/claude, adapters/codex and internal/guard. Note: the executor's audit entry said 21 packages, actual is 22 ok plus 3 with no test files - the substantive claim holds, the count was off by one",
      "commit_oid": "4da02aa714132f11768816de3659b07a9040d559",
      "at": "2026-07-27T15:51:11Z"
    },
    {
      "name": "gofmt-reproduced",
      "command": "gofmt -l . at 4da02aa",
      "result": "pass",
      "detail": "empty output",
      "commit_oid": "4da02aa714132f11768816de3659b07a9040d559",
      "at": "2026-07-27T15:51:11Z"
    },
    {
      "name": "vet-reproduced",
      "command": "go vet ./... at 4da02aa",
      "result": "pass",
      "detail": "exit 0",
      "commit_oid": "4da02aa714132f11768816de3659b07a9040d559",
      "at": "2026-07-27T15:51:11Z"
    },
    {
      "name": "ci-head-pinned",
      "command": "gh run view 30281040733 checking headSha rather than trusting gh pr checks",
      "result": "pass",
      "detail": "headSha 4da02aa714132f11768816de3659b07a9040d559, conclusion success, all six required checks passing (lint, scripts x2, test x3)",
      "commit_oid": "4da02aa714132f11768816de3659b07a9040d559",
      "at": "2026-07-27T15:51:11Z"
    },
    {
      "name": "engine-truth-guard",
      "command": "read internal/guard/guard.go evaluate() and adapters/codex/hooks/hooks.json at this commit",
      "result": "pass",
      "detail": "guard.go:123 row 10 reads req.Role != \"\" \u0026\u0026 req.Role != RoleImplementer \u0026\u0026 req.Role != RoleSpecialist, so an empty Role falls through to pure containment; the Codex hook passes no --role. The new prose is true, not differently false",
      "commit_oid": "4da02aa714132f11768816de3659b07a9040d559",
      "at": "2026-07-27T15:51:11Z"
    },
    {
      "name": "bash-roster-check",
      "command": "read tools: frontmatter of all five adapters/claude/agents/*.md",
      "result": "pass",
      "detail": "four of five carry Bash (implementer, specialist, reviewer, reviewer-safe); only orch-scout is memhub-incapable. Decision 67's stored premise names only three and should be corrected in the memhub record; the shipped prose is generic and needs no change",
      "commit_oid": "4da02aa714132f11768816de3659b07a9040d559",
      "at": "2026-07-27T15:51:11Z"
    },
    {
      "name": "scope-and-conflict",
      "command": "git diff --name-only merge-base..4da02aa, plus overlap check against sibling branches",
      "result": "pass",
      "detail": "exactly the two named orch-architect SKILL.md files; merge-base is 0d47213, the current main tip; zero file overlap with #77 (f5bcc36), #79 (0a53e4f) or #80",
      "commit_oid": "4da02aa714132f11768816de3659b07a9040d559",
      "at": "2026-07-27T15:51:11Z"
    },
    {
      "name": "reviewer-main-checkout-incident",
      "command": "git status --short --branch; git rev-parse HEAD main origin/main; git stash list",
      "result": "noted",
      "detail": "The reviewer disclosed that a failed cd caused a chained git checkout to run in the main checkout, detaching HEAD at 4da02aa, and reported restoring main. The Architect independently verified afterwards: branch main, HEAD 0d472136 equal to origin/main, clean tree, no stashes, not detached. No repository content was written or committed and no review finding depended on the detached state - every finding is pinned to the explicit OID. Root cause is task 27's Bash-bypass class: git checkout is shell-mediated, so the guard's PreToolUse hook, which matches only the four file tools, could not intercept it. This is the same gap the run's own prose corrections describe, observed live",
      "commit_oid": "4da02aa714132f11768816de3659b07a9040d559",
      "at": "2026-07-27T15:51:11Z"
    },
    {
      "name": "shared-checkout-fetch-head-hazard",
      "command": "observation during concurrent sibling reviews",
      "result": "noted",
      "detail": "The reviewer observed .git/FETCH_HEAD in the shared main checkout being overwritten mid-review by concurrent sibling reviews in this run, briefly flipping from issue-78's head to issue-77's head. Any reviewer resolving FETCH_HEAD symbolically in the shared checkout can silently review the wrong commit. This review pinned every finding to an explicit OID and was unaffected",
      "commit_oid": "4da02aa714132f11768816de3659b07a9040d559",
      "at": "2026-07-27T15:51:11Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approve. All five acceptance criteria pass, verified against the engine rather than the executor's summary. Criterion 1: the replacement Codex prose is true of internal/guard/guard.go at this commit - row 10's role deny is gated on a non-empty asserted Role, adapters/codex/hooks/hooks.json invokes orch guard codex bare, so the hook genuinely cannot distinguish a reviewer from an implementer; the sentence understates the hook slightly (omits run-stop, off-branch, git-internals denials) but in the restrictive-to-permissive direction, never falsely. Criterion 2: both files drop the superseded no-memhub-tools premise; the executor's four-of-five Bash claim was independently confirmed against adapters/claude/agents/*.md frontmatter - orch-reviewer-safe also carries Bash, so decision 67's stored three-agent premise undercounts, and the shipped prose correctly avoids enumerating a roster at all. Criterion 3: the wrap-up sentence is byte-identical across hosts and assigns memhub review accept to the human unambiguously. Criterion 4: a normalized cross-host diff found only the pre-existing subagent/dispatched-agent lexicon and one load-bearing host difference. Criterion 5: exactly the two named files, merge-base is current main, zero file overlap with siblings #77/#79/#80, GitHub reports MERGEABLE. Policy strength is preserved or increased: the change converts a false mechanical guarantee into an explicit instruction-level obligation. Tests and CI reproduced independently in an isolated clone at the pinned OID.",
      "commit_oid": "4da02aa714132f11768816de3659b07a9040d559",
      "at": "2026-07-27T15:51:12Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (macos-latest)=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (windows-latest)=pass",
      "commit_oid": "4da02aa714132f11768816de3659b07a9040d559",
      "at": "2026-07-27T16:01:04Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->