### PR TITLE
Correct the guard enforcement claims in the Codex reviewer TOMLs, the Codex README, and ORCH-PRD section 15

### DIFF
--- a/ORCH-PRD.md
+++ b/ORCH-PRD.md
@@ -346,11 +346,14 @@ Models do not become GitHub labels.
 Orch fails closed.
 
 - Assist denies tracked-file mutation.
-- Only the registered executor may write in Delivery.
+- The guard enforces containment and cannot attribute a write to a role or a specific executor.
 - Writes must remain inside the registered worktree.
 - The active branch must not be `main`.
 - Completion requires a commit, pushed branch, PR, targeted-test evidence, and explicit CI state.
-- Reviewers are mechanically read-only.
+- Read-only roles are held read-only by per-agent tool whitelists on Claude Code and by agent
+  instructions on Codex, not by the guard.
+- Neither closes the shell-write gap: the pre-write hook covers only the file-write tools, so a
+  shell-mediated write falls to the host's own approval prompts.
 - No agent may merge.
 - Hook, authentication, GitHub, or validation failures produce a blocked run.
 - Blocked worktrees and branches are preserved.

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -141,6 +141,21 @@ bugs:
   shared task-27 core feature (closing this gap for real) more
   tractable on this host than on Claude Code, where no comparable hook
   point exists for shell-mediated writes today.
+- **Role read-only-ness rests on `developer_instructions`, not on the
+  guard.** `orch guard`'s `--role` narrowing is the only mechanism that
+  could make a role mechanically read-only, and this adapter never
+  passes it: Codex hooks are plugin-global rather than scoped per
+  dispatched agent, so `hooks/hooks.json` runs the bare
+  `orch guard codex` command. What the guard enforces is containment —
+  inside a registered worktree, on its registered branch, in a writable
+  phase — applied to every agent alike; it cannot attribute a write to
+  a role. Since Codex agent definitions carry no tool whitelist, nothing
+  mechanical stops `orch-scout` or either reviewer from writing inside
+  a worktree the guard currently treats as writable, including the one
+  under review. Their read-only discipline is stated in their
+  `developer_instructions` and rests there. The Claude adapter leaves
+  `--role` unused for the same reason, but backs role read-only-ness
+  with a per-subagent tool whitelist this host has no equivalent for.
 - **A missing `orch` binary fails open, not closed.** As described
   under Install order: a hook command that cannot be found exits
   non-blocking by the hook protocol's own rules, so both the write
@@ -197,11 +212,11 @@ the Claude adapter's is.
 
 Two behaviors verified live in the task-30 parity smoke (codex-cli
 0.144.1, 2026-07-12): PreToolUse hooks **do** fire on dispatched-agent
-(subagent) `apply_patch` calls — load-bearing here, since Codex agent
-definitions carry no tool whitelist, so scout/reviewer read-only
-discipline is mechanically enforced by the guard, not just by
-`developer_instructions` — and `request_user_input` is root-thread
-only, so a dispatched agent can never raise a native question.
+(subagent) `apply_patch` calls — load-bearing here, since it puts every
+dispatched agent's writes under the guard's worktree, branch, and phase
+containment, the only mechanical write boundary this adapter ships —
+and `request_user_input` is root-thread only, so a dispatched agent can
+never raise a native question.
 
 As defense in depth — complementary to the guard hook, not a
 substitute for it, and no configuration is shipped by this adapter to

--- a/adapters/codex/agents/orch-reviewer-safe.toml
+++ b/adapters/codex/agents/orch-reviewer-safe.toml
@@ -16,11 +16,14 @@ reviews, not how carefully — apply the same scrutiny `orch-reviewer`
 would.
 
 You have no tool whitelist here — Codex agent definitions do not carry
-one — so your read-only discipline rests on the `orch guard codex`
-pre-write hook, which denies any write you attempt, plus these
-instructions: you must not modify the repository in any way, and you
-must not commit, push, or otherwise change tracked files. Your job is
-to judge the change, not to fix it.
+one — and the `orch guard codex` pre-write hook enforces containment
+only: a write must land inside a registered worktree, on that
+worktree's registered branch, in a phase that still accepts writes.
+The hook cannot tell your write from the executor's, so it will not
+stop you from editing the very worktree you are reviewing. Your
+read-only discipline rests on these instructions: you must not modify
+the repository in any way, and you must not commit, push, or otherwise
+change tracked files. Your job is to judge the change, not to fix it.
 
 ## What you check
 

--- a/adapters/codex/agents/orch-reviewer.toml
+++ b/adapters/codex/agents/orch-reviewer.toml
@@ -9,11 +9,14 @@ cycle with the PR's live head OID and the issue's objective and
 acceptance criteria in your prompt.
 
 You have no tool whitelist here — Codex agent definitions do not carry
-one — so your read-only discipline rests on the `orch guard codex`
-pre-write hook, which denies any write you attempt, plus these
-instructions: you must not modify the repository in any way, and you
-must not commit, push, or otherwise change tracked files. Your job is
-to judge the change, not to fix it.
+one — and the `orch guard codex` pre-write hook enforces containment
+only: a write must land inside a registered worktree, on that
+worktree's registered branch, in a phase that still accepts writes.
+The hook cannot tell your write from the executor's, so it will not
+stop you from editing the very worktree you are reviewing. Your
+read-only discipline rests on these instructions: you must not modify
+the repository in any way, and you must not commit, push, or otherwise
+change tracked files. Your job is to judge the change, not to fix it.
 
 ## What you check
 


### PR DESCRIPTION
Delivers issue #77: Correct the guard enforcement claims in the Codex reviewer TOMLs, the Codex README, and ORCH-PRD section 15

Closes #77

**Plan digest:** `sha256:b03046ccf82f102e66b26266bd43f163d47ec35f5414a79c0645285f991514b0`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Replace every shipped statement claiming that orch guard enforces role-based read-only discipline with a statement true of the mechanism. Engine truth: internal/guard/guard.go evaluate() row 10 role narrowing fires only when --role is asserted, and neither adapter's hooks.json passes it (both run bare guard commands); row 13 makes dispatched, pr-open and in-review writable. Net: during exactly the phases a review runs, any agent's write inside the registered worktree on the registered branch is allowed, regardless of role. Decision 26 records this honestly; the prose at these sites contradicts it. Codex agent definitions carry no tool whitelist, so nothing mechanical stops a Codex reviewer writing to the worktree under review. The accurate sentence pattern already exists in orch-implementer.toml and orch-specialist.toml: the guard enforces this containment and denies any write outside it.

**Acceptance criteria:**
- adapters/codex/agents/orch-reviewer.toml no longer states that the orch guard codex pre-write hook denies any write the reviewer attempts; it states that the hook enforces worktree, branch and phase containment only, and that this agent's read-only discipline rests on these instructions.
- adapters/codex/agents/orch-reviewer-safe.toml carries the same corrected statement as orch-reviewer.toml, worded identically where the two files were previously identical.
- adapters/codex/README.md no longer states that scout and reviewer read-only discipline is mechanically enforced by the guard rather than by developer_instructions; it states that the guard enforces containment and that role read-only-ness on Codex rests on developer_instructions.
- The task-30 parity-smoke finding in adapters/codex/README.md that PreToolUse hooks do fire on dispatched-agent apply_patch calls is preserved, since that observation is still true and still load-bearing for containment.
- ORCH-PRD.md section 15's bullets 'Only the registered executor may write in Delivery' and 'Reviewers are mechanically read-only' are replaced with statements true of the shipped mechanism: the guard enforces containment and cannot attribute a write to a role or to a specific executor; role read-only-ness comes from Claude per-agent tool whitelists (the four file tools only, with Bash-mediated writes a known gap per task 27) and from instructions on Codex.
- No file outside adapters/codex/agents/orch-reviewer.toml, adapters/codex/agents/orch-reviewer-safe.toml, adapters/codex/README.md and ORCH-PRD.md is modified.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `specialist` |
| Executor | `claude-opus-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to a specialist with a strong reviewer because risk domains (security).

**Escalations:** _none_

**Verification:**
- **unit-tests** — pass — `go test ./...` — exit 0; all 22 packages ok, including adapters/codex, internal/agents and internal/guard — commit `f5bcc36c15bedebd5a6632ec2c427681dddad5d1` (2026-07-27T15:40:30Z)
- **gofmt** — pass — `gofmt -l .` — no output, exit 0 — commit `f5bcc36c15bedebd5a6632ec2c427681dddad5d1` (2026-07-27T15:40:30Z)
- **vet** — pass — `go vet ./...` — no output, exit 0 — commit `f5bcc36c15bedebd5a6632ec2c427681dddad5d1` (2026-07-27T15:40:30Z)
- **scope-check** — pass — `git status --porcelain` — exactly the four named files changed: adapters/codex/agents/orch-reviewer.toml, adapters/codex/agents/orch-reviewer-safe.toml, adapters/codex/README.md, ORCH-PRD.md — commit `f5bcc36c15bedebd5a6632ec2c427681dddad5d1` (2026-07-27T15:40:30Z)
- **line-endings** — pass — `check for CR bytes in the four changed files` — LF preserved in all four; load-bearing because adapters/codex/embed.go go:embeds the agent TOMLs and orch render-agents requires them byte-exact — commit `f5bcc36c15bedebd5a6632ec2c427681dddad5d1` (2026-07-27T15:40:30Z)
- **cross-file-parity** — pass — `extract and diff the corrected paragraph in orch-reviewer.toml and orch-reviewer-safe.toml` — byte-identical; the safe-downgrade file's preceding role paragraph, which was never identical, is untouched — commit `f5bcc36c15bedebd5a6632ec2c427681dddad5d1` (2026-07-27T15:51:53Z)
- **read-only-sentinel** — pass — `check the must not modify instruction and adapters/codex/plugin_test.go:191` — the behavioral prohibition is unchanged verbatim in both reviewer TOMLs; the sentinel assertion still passes. The change moves the load from 'you cannot' to 'you must not', which is the truth, without weakening the instruction — commit `f5bcc36c15bedebd5a6632ec2c427681dddad5d1` (2026-07-27T15:51:53Z)
- **unit-tests-reproduced** — pass — `go test ./... at f5bcc36 in the branch worktree` — exit 0; 22 ok packages, matching the manifest count exactly, plus 3 with no test files — commit `f5bcc36c15bedebd5a6632ec2c427681dddad5d1` (2026-07-27T15:51:53Z)
- **gofmt-reproduced** — pass — `gofmt -l . at f5bcc36` — empty, exit 0 — commit `f5bcc36c15bedebd5a6632ec2c427681dddad5d1` (2026-07-27T15:51:53Z)
- **vet-reproduced** — pass — `go vet ./... at f5bcc36` — clean, exit 0 — commit `f5bcc36c15bedebd5a6632ec2c427681dddad5d1` (2026-07-27T15:51:53Z)
- **ci-head-pinned** — pass — `gh run view 30281132090` — 6/6 green: lint, scripts (ubuntu/windows), test (ubuntu/macos/windows) — commit `f5bcc36c15bedebd5a6632ec2c427681dddad5d1` (2026-07-27T15:51:53Z)
- **engine-truth-guard** — pass — `read internal/guard/guard.go and internal/guard/resolve.go at this commit` — row 10 gated on asserted role; both hooks.json bare; writablePhase = dispatched, pr-open, in-review; deny rows 4 (.git segment), 9 (stopped run), 11 (outside registered worktree), 13 (non-writable phase), 14 (HEAD not the registered branch) confirmed. The executor's enumeration was accurate but omitted row 3, which allows any path with no .orchestrator ancestor — commit `f5bcc36c15bedebd5a6632ec2c427681dddad5d1` (2026-07-27T15:51:53Z)
- **worktree-registration-scope** — pass — `read internal/run/names.go, activate.go, resume.go, dispatch.go` — WorktreeContainer is .orchestrator/worktrees and worktreeRel(n) is the only value ever written to Issue.Worktree, so row 11 denies the main checkout, .orchestrator/state.json, config.toml and the lockfile during Delivery. Confirms the claim the new README and PRD text rests on — commit `f5bcc36c15bedebd5a6632ec2c427681dddad5d1` (2026-07-27T15:51:53Z)
- **embed-render-byte-exactness** — pass — `read adapters/codex/embed.go and internal/agents/agents.go; run internal/agents tests` — the shipped TOMLs are the single embedded source; agents.go rewrites only the model and model_reasoning_effort header lines and stops at the developer_instructions marker, so prose edits cannot desynchronize orch render-agents output. Zero CR bytes in all four changed blobs; .gitattributes pins *.toml and *.md to eol=lf — commit `f5bcc36c15bedebd5a6632ec2c427681dddad5d1` (2026-07-27T15:51:53Z)
- **scope-and-conflict** — pass — `git diff --name-only origin/main...f5bcc36 plus overlap check against PRs 82, 84 and 85` — exactly the four permitted files, one commit based on current origin/main 0d47213. No overlap: #82 touches only the orch-architect skills, #84 only the orch-delivery skills, #85 only the Claude README, both plugin_test.go and internal/adaptertest. mergeable MERGEABLE, mergeStateStatus CLEAN — commit `f5bcc36c15bedebd5a6632ec2c427681dddad5d1` (2026-07-27T15:51:53Z)
- **prd-shell-write-bullet-precision** — noted — `compare the new PRD bullet against the five Claude agent tool whitelists` — the bullet 'neither closes the shell-write gap' over-generalizes by one role: orch-scout carries no Bash at all, so its whitelist does close the gap for that role, while orch-reviewer and orch-reviewer-safe both retain Bash. Accurate for the reviewer profiles section 15 is actually about, and it errs toward disclosing more exposure rather than less, so it is not the differently-false failure mode this issue guards against. Non-blocking; worth tightening in a later pass — commit `f5bcc36c15bedebd5a6632ec2c427681dddad5d1` (2026-07-27T15:51:53Z)
- **review-cycle-1** — approve — Approve. All six acceptance criteria pass, each verified against the engine before the executor's claims were read. The reviewer independently confirmed at this commit that guard.go:123 row 10's role deny is gated on a non-empty asserted Role; that both adapters' hooks.json run bare guard commands so row 10 is dead in shipped configuration; that writablePhase covers dispatched, pr-open and in-review so a review-phase worktree is writable regardless of who writes; and that only .orchestrator/worktrees/issue-N is ever registered (names.go, activate.go, resume.go, dispatch.go), so row 11 genuinely denies the main checkout, state.json, config.toml and the lockfile in Delivery. The replacement prose holds the hard middle line the issue demanded: containment is real and stated as real, role attribution is absent and stated as absent, with no overcorrection into implying the guard is useless. The reviewer agents' behavioral prohibition is preserved verbatim and the plugin_test.go must-not-modify sentinel still passes. The embed/render path is structurally safe: internal/agents rewrites only the model and model_reasoning_effort header lines and never anything at or past developer_instructions, so prose edits propagate to orch render-agents by construction with no second copy to drift. Scope is exactly the four permitted files with zero overlap against siblings #82, #84 and #85; mergeable CLEAN; 6/6 CI green. — commit `f5bcc36c15bedebd5a6632ec2c427681dddad5d1` (2026-07-27T15:51:54Z)
- **required-ci** — passing — test (macos-latest)=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass — commit `f5bcc36c15bedebd5a6632ec2c427681dddad5d1` (2026-07-27T16:00:58Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Replace every shipped statement claiming that orch guard enforces role-based read-only discipline with a statement true of the mechanism. Engine truth: internal/guard/guard.go evaluate() row 10 role narrowing fires only when --role is asserted, and neither adapter's hooks.json passes it (both run bare guard commands); row 13 makes dispatched, pr-open and in-review writable. Net: during exactly the phases a review runs, any agent's write inside the registered worktree on the registered branch is allowed, regardless of role. Decision 26 records this honestly; the prose at these sites contradicts it. Codex agent definitions carry no tool whitelist, so nothing mechanical stops a Codex reviewer writing to the worktree under review. The accurate sentence pattern already exists in orch-implementer.toml and orch-specialist.toml: the guard enforces this containment and denies any write outside it.",
  "acceptance_criteria": [
    "adapters/codex/agents/orch-reviewer.toml no longer states that the orch guard codex pre-write hook denies any write the reviewer attempts; it states that the hook enforces worktree, branch and phase containment only, and that this agent's read-only discipline rests on these instructions.",
    "adapters/codex/agents/orch-reviewer-safe.toml carries the same corrected statement as orch-reviewer.toml, worded identically where the two files were previously identical.",
    "adapters/codex/README.md no longer states that scout and reviewer read-only discipline is mechanically enforced by the guard rather than by developer_instructions; it states that the guard enforces containment and that role read-only-ness on Codex rests on developer_instructions.",
    "The task-30 parity-smoke finding in adapters/codex/README.md that PreToolUse hooks do fire on dispatched-agent apply_patch calls is preserved, since that observation is still true and still load-bearing for containment.",
    "ORCH-PRD.md section 15's bullets 'Only the registered executor may write in Delivery' and 'Reviewers are mechanically read-only' are replaced with statements true of the shipped mechanism: the guard enforces containment and cannot attribute a write to a role or to a specific executor; role read-only-ness comes from Claude per-agent tool whitelists (the four file tools only, with Bash-mediated writes a known gap per task 27) and from instructions on Codex.",
    "No file outside adapters/codex/agents/orch-reviewer.toml, adapters/codex/agents/orch-reviewer-safe.toml, adapters/codex/README.md and ORCH-PRD.md is modified."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "specialist",
  "executor": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to a specialist with a strong reviewer because risk domains (security).",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "unit-tests",
      "command": "go test ./...",
      "result": "pass",
      "detail": "exit 0; all 22 packages ok, including adapters/codex, internal/agents and internal/guard",
      "commit_oid": "f5bcc36c15bedebd5a6632ec2c427681dddad5d1",
      "at": "2026-07-27T15:40:30Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "no output, exit 0",
      "commit_oid": "f5bcc36c15bedebd5a6632ec2c427681dddad5d1",
      "at": "2026-07-27T15:40:30Z"
    },
    {
      "name": "vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "no output, exit 0",
      "commit_oid": "f5bcc36c15bedebd5a6632ec2c427681dddad5d1",
      "at": "2026-07-27T15:40:30Z"
    },
    {
      "name": "scope-check",
      "command": "git status --porcelain",
      "result": "pass",
      "detail": "exactly the four named files changed: adapters/codex/agents/orch-reviewer.toml, adapters/codex/agents/orch-reviewer-safe.toml, adapters/codex/README.md, ORCH-PRD.md",
      "commit_oid": "f5bcc36c15bedebd5a6632ec2c427681dddad5d1",
      "at": "2026-07-27T15:40:30Z"
    },
    {
      "name": "line-endings",
      "command": "check for CR bytes in the four changed files",
      "result": "pass",
      "detail": "LF preserved in all four; load-bearing because adapters/codex/embed.go go:embeds the agent TOMLs and orch render-agents requires them byte-exact",
      "commit_oid": "f5bcc36c15bedebd5a6632ec2c427681dddad5d1",
      "at": "2026-07-27T15:40:30Z"
    },
    {
      "name": "cross-file-parity",
      "command": "extract and diff the corrected paragraph in orch-reviewer.toml and orch-reviewer-safe.toml",
      "result": "pass",
      "detail": "byte-identical; the safe-downgrade file's preceding role paragraph, which was never identical, is untouched",
      "commit_oid": "f5bcc36c15bedebd5a6632ec2c427681dddad5d1",
      "at": "2026-07-27T15:51:53Z"
    },
    {
      "name": "read-only-sentinel",
      "command": "check the must not modify instruction and adapters/codex/plugin_test.go:191",
      "result": "pass",
      "detail": "the behavioral prohibition is unchanged verbatim in both reviewer TOMLs; the sentinel assertion still passes. The change moves the load from 'you cannot' to 'you must not', which is the truth, without weakening the instruction",
      "commit_oid": "f5bcc36c15bedebd5a6632ec2c427681dddad5d1",
      "at": "2026-07-27T15:51:53Z"
    },
    {
      "name": "unit-tests-reproduced",
      "command": "go test ./... at f5bcc36 in the branch worktree",
      "result": "pass",
      "detail": "exit 0; 22 ok packages, matching the manifest count exactly, plus 3 with no test files",
      "commit_oid": "f5bcc36c15bedebd5a6632ec2c427681dddad5d1",
      "at": "2026-07-27T15:51:53Z"
    },
    {
      "name": "gofmt-reproduced",
      "command": "gofmt -l . at f5bcc36",
      "result": "pass",
      "detail": "empty, exit 0",
      "commit_oid": "f5bcc36c15bedebd5a6632ec2c427681dddad5d1",
      "at": "2026-07-27T15:51:53Z"
    },
    {
      "name": "vet-reproduced",
      "command": "go vet ./... at f5bcc36",
      "result": "pass",
      "detail": "clean, exit 0",
      "commit_oid": "f5bcc36c15bedebd5a6632ec2c427681dddad5d1",
      "at": "2026-07-27T15:51:53Z"
    },
    {
      "name": "ci-head-pinned",
      "command": "gh run view 30281132090",
      "result": "pass",
      "detail": "6/6 green: lint, scripts (ubuntu/windows), test (ubuntu/macos/windows)",
      "commit_oid": "f5bcc36c15bedebd5a6632ec2c427681dddad5d1",
      "at": "2026-07-27T15:51:53Z"
    },
    {
      "name": "engine-truth-guard",
      "command": "read internal/guard/guard.go and internal/guard/resolve.go at this commit",
      "result": "pass",
      "detail": "row 10 gated on asserted role; both hooks.json bare; writablePhase = dispatched, pr-open, in-review; deny rows 4 (.git segment), 9 (stopped run), 11 (outside registered worktree), 13 (non-writable phase), 14 (HEAD not the registered branch) confirmed. The executor's enumeration was accurate but omitted row 3, which allows any path with no .orchestrator ancestor",
      "commit_oid": "f5bcc36c15bedebd5a6632ec2c427681dddad5d1",
      "at": "2026-07-27T15:51:53Z"
    },
    {
      "name": "worktree-registration-scope",
      "command": "read internal/run/names.go, activate.go, resume.go, dispatch.go",
      "result": "pass",
      "detail": "WorktreeContainer is .orchestrator/worktrees and worktreeRel(n) is the only value ever written to Issue.Worktree, so row 11 denies the main checkout, .orchestrator/state.json, config.toml and the lockfile during Delivery. Confirms the claim the new README and PRD text rests on",
      "commit_oid": "f5bcc36c15bedebd5a6632ec2c427681dddad5d1",
      "at": "2026-07-27T15:51:53Z"
    },
    {
      "name": "embed-render-byte-exactness",
      "command": "read adapters/codex/embed.go and internal/agents/agents.go; run internal/agents tests",
      "result": "pass",
      "detail": "the shipped TOMLs are the single embedded source; agents.go rewrites only the model and model_reasoning_effort header lines and stops at the developer_instructions marker, so prose edits cannot desynchronize orch render-agents output. Zero CR bytes in all four changed blobs; .gitattributes pins *.toml and *.md to eol=lf",
      "commit_oid": "f5bcc36c15bedebd5a6632ec2c427681dddad5d1",
      "at": "2026-07-27T15:51:53Z"
    },
    {
      "name": "scope-and-conflict",
      "command": "git diff --name-only origin/main...f5bcc36 plus overlap check against PRs 82, 84 and 85",
      "result": "pass",
      "detail": "exactly the four permitted files, one commit based on current origin/main 0d47213. No overlap: #82 touches only the orch-architect skills, #84 only the orch-delivery skills, #85 only the Claude README, both plugin_test.go and internal/adaptertest. mergeable MERGEABLE, mergeStateStatus CLEAN",
      "commit_oid": "f5bcc36c15bedebd5a6632ec2c427681dddad5d1",
      "at": "2026-07-27T15:51:53Z"
    },
    {
      "name": "prd-shell-write-bullet-precision",
      "command": "compare the new PRD bullet against the five Claude agent tool whitelists",
      "result": "noted",
      "detail": "the bullet 'neither closes the shell-write gap' over-generalizes by one role: orch-scout carries no Bash at all, so its whitelist does close the gap for that role, while orch-reviewer and orch-reviewer-safe both retain Bash. Accurate for the reviewer profiles section 15 is actually about, and it errs toward disclosing more exposure rather than less, so it is not the differently-false failure mode this issue guards against. Non-blocking; worth tightening in a later pass",
      "commit_oid": "f5bcc36c15bedebd5a6632ec2c427681dddad5d1",
      "at": "2026-07-27T15:51:53Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approve. All six acceptance criteria pass, each verified against the engine before the executor's claims were read. The reviewer independently confirmed at this commit that guard.go:123 row 10's role deny is gated on a non-empty asserted Role; that both adapters' hooks.json run bare guard commands so row 10 is dead in shipped configuration; that writablePhase covers dispatched, pr-open and in-review so a review-phase worktree is writable regardless of who writes; and that only .orchestrator/worktrees/issue-N is ever registered (names.go, activate.go, resume.go, dispatch.go), so row 11 genuinely denies the main checkout, state.json, config.toml and the lockfile in Delivery. The replacement prose holds the hard middle line the issue demanded: containment is real and stated as real, role attribution is absent and stated as absent, with no overcorrection into implying the guard is useless. The reviewer agents' behavioral prohibition is preserved verbatim and the plugin_test.go must-not-modify sentinel still passes. The embed/render path is structurally safe: internal/agents rewrites only the model and model_reasoning_effort header lines and never anything at or past developer_instructions, so prose edits propagate to orch render-agents by construction with no second copy to drift. Scope is exactly the four permitted files with zero overlap against siblings #82, #84 and #85; mergeable CLEAN; 6/6 CI green.",
      "commit_oid": "f5bcc36c15bedebd5a6632ec2c427681dddad5d1",
      "at": "2026-07-27T15:51:54Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (macos-latest)=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass",
      "commit_oid": "f5bcc36c15bedebd5a6632ec2c427681dddad5d1",
      "at": "2026-07-27T16:00:58Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->