### PR TITLE
Say 'most recent EscalateResult' at every site, correct the Codex TOML-match enforcement claim, and forbid machine-local paths in plan text

### DIFF
--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -84,8 +84,9 @@ it is not an invitation for comprehensive coverage, just the check this
 change must pass.
 
 Plan text must never reference machine-local or gitignored paths such
-as `.memhub/` or `.orchestrator/` — an executor sees only the committed
-tree inside its worktree, and neither exists there.
+as `.memhub/`, `.orchestrator/state.json`, or
+`.orchestrator/config.local.toml` — an executor sees only the committed
+tree inside its worktree, and none of these exist there.
 
 ## Plan gate
 
@@ -251,13 +252,11 @@ in flight at once. For each issue:
    the selection **currently in force**: the most recent
    `EscalateResult.reviewer` when an escalation has rerouted the issue
    since dispatch, or `DispatchResult.reviewer` otherwise.
-   `orch run review` compares the submitted `reviewer`
-   against the issue's current routing decision and
-   refuses a mismatch; `orch run dispatch` cannot be
-   re-run to refresh a stale value — it accepts only the
-   `worktree-ready` phase, which a dispatched issue has
-   already left, so you must track whichever value is
-   current yourself:
+   `orch run review` compares the submitted `reviewer` against the
+   issue's current routing decision and refuses a mismatch;
+   `orch run dispatch` cannot be re-run to refresh a stale value — it
+   accepts only the `worktree-ready` phase, which a dispatched issue has
+   already left, so you must track whichever value is current yourself:
 
    ```json
    {"schema_version": 1, "issue_number": N, "reviewed_head_oid": "...",
@@ -338,15 +337,15 @@ Result `kind`:
 
 - `reroute` — carries a new `executor`/`reviewer` and `rationale`; on a
   chain of two or more reroutes on the same issue, each call's result
-  fully replaces the routing decision, so this is now the most recent
-  `EscalateResult` and the only one describing the routing in force,
-  for both roles even if only one changed. Before spawning either into
-  the **same worktree** (never a new one), confirm the new selection's
-  `model` against an installed agent definition's frontmatter under the
-  same match rule as the spawn steps above — **if the new selection
-  matches no installed agent's frontmatter, stop and tell the human —
-  never spawn a mismatched agent, and never report the routed selection
-  as if it ran.**
+  fully replaces the routing decision, so this result is now the most
+  recent `EscalateResult` and the only one describing the routing in
+  force, for both roles even if only one changed. Before spawning
+  either into the **same worktree** (never a new one), confirm the new
+  selection's `model` against an installed agent definition's
+  frontmatter under the same match rule as the spawn steps above — **if
+  the new selection matches no installed agent's frontmatter, stop and
+  tell the human — never spawn a mismatched agent, and never report the
+  routed selection as if it ran.**
 - `return-to-architect` — the issue is blocked for human design work;
   report `reason` and do not push it forward yourself.
 

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -83,6 +83,10 @@ the exact command that gates the change (`go test ./...`, `gofmt -l .`);
 it is not an invitation for comprehensive coverage, just the check this
 change must pass.
 
+Plan text must never reference machine-local or gitignored paths such
+as `.memhub/` or `.orchestrator/` — an executor sees only the committed
+tree inside its worktree, and neither exists there.
+
 ## Plan gate
 
 Call `orch run plan` with the `PlanDoc` on stdin. The result is a
@@ -161,8 +165,8 @@ in flight at once. For each issue:
    an override can never express a routed selection, and is never the
    way to honor routing. Before spawning, confirm that the installed
    executor agent's frontmatter `model` equals the selection
-   **currently in force**: `EscalateResult.executor.model` when an
-   escalation has rerouted the issue since dispatch, or
+   **currently in force**: the most recent `EscalateResult.executor.model`
+   when an escalation has rerouted the issue since dispatch, or
    `DispatchResult.executor.model` otherwise. Compare against the
    **installed** plugin copy under the Claude Code plugin cache
    (`~/.claude/plugins/cache/orch/orch-claude/<version>/agents/`), not
@@ -217,8 +221,9 @@ in flight at once. For each issue:
    `orch-reviewer-safe` when the routed reviewer names the §10
    safe-downgrade profile — the `reviewer_downgraded` routing the
    `GateDoc` showed at the plan gate, carried in
-   `DispatchResult.reviewer` and superseded by any later escalation's
-   new reviewer — `orch-reviewer` otherwise. Spawn whichever of the
+   `DispatchResult.reviewer` and superseded by the most recent
+   `EscalateResult.reviewer` if the issue has been rerouted since
+   dispatch — `orch-reviewer` otherwise. Spawn whichever of the
    two that selection names, by name and with **no model override on
    either**, under the same rule as the executor: the Task tool's
    `model` parameter accepts only the coarse tier aliases `sonnet`,
@@ -227,8 +232,8 @@ in flight at once. For each issue:
    to honor routing — only the installed agent definition's
    frontmatter pins an exact model. Before spawning, confirm that the
    selected reviewer agent's frontmatter `model` equals the selection
-   **currently in force**: `EscalateResult.reviewer.model` when an
-   escalation has rerouted the issue since dispatch, or
+   **currently in force**: the most recent `EscalateResult.reviewer.model`
+   when an escalation has rerouted the issue since dispatch, or
    `DispatchResult.reviewer.model` otherwise. Compare against the
    **installed** plugin copy under the Claude Code plugin cache
    (`~/.claude/plugins/cache/orch/orch-claude/<version>/agents/`), not
@@ -243,14 +248,16 @@ in flight at once. For each issue:
 5. **Review** — the reviewer produces **one consolidated report**
    (acceptance criteria, scope, correctness, tests, CI, security,
    manifest accuracy). Call `orch run review` with `reviewer` set to
-   the selection **currently in force**: `EscalateResult.reviewer` when
-   an escalation has rerouted the issue since dispatch, or
-   `DispatchResult.reviewer` otherwise. `orch run review` compares the
-   submitted `reviewer` against the issue's current routing decision and
-   refuses a mismatch; `orch run dispatch` cannot be re-run to refresh a
-   stale value — it accepts only the `worktree-ready` phase, which a
-   dispatched issue has already left, so you must track whichever value
-   is current yourself:
+   the selection **currently in force**: the most recent
+   `EscalateResult.reviewer` when an escalation has rerouted the issue
+   since dispatch, or `DispatchResult.reviewer` otherwise.
+   `orch run review` compares the submitted `reviewer`
+   against the issue's current routing decision and
+   refuses a mismatch; `orch run dispatch` cannot be
+   re-run to refresh a stale value — it accepts only the
+   `worktree-ready` phase, which a dispatched issue has
+   already left, so you must track whichever value is
+   current yourself:
 
    ```json
    {"schema_version": 1, "issue_number": N, "reviewed_head_oid": "...",
@@ -329,14 +336,17 @@ failure, call `orch run escalate`:
 `weak-model-failure`, `reviewer-uncertainty`, `architectural-ambiguity`.
 Result `kind`:
 
-- `reroute` — carries a new `executor`/`reviewer` and `rationale`;
-  before spawning either into the **same worktree** (never a new
-  one), confirm the new selection's `model` against an installed
-  agent definition's frontmatter under the same match rule as the
-  spawn steps above — **if the new selection matches no installed
-  agent's frontmatter, stop and tell the human — never spawn a
-  mismatched agent, and never report the routed selection as if it
-  ran.**
+- `reroute` — carries a new `executor`/`reviewer` and `rationale`; on a
+  chain of two or more reroutes on the same issue, each call's result
+  fully replaces the routing decision, so this is now the most recent
+  `EscalateResult` and the only one describing the routing in force,
+  for both roles even if only one changed. Before spawning either into
+  the **same worktree** (never a new one), confirm the new selection's
+  `model` against an installed agent definition's frontmatter under the
+  same match rule as the spawn steps above — **if the new selection
+  matches no installed agent's frontmatter, stop and tell the human —
+  never spawn a mismatched agent, and never report the routed selection
+  as if it ran.**
 - `return-to-architect` — the issue is blocked for human design work;
   report `reason` and do not push it forward yourself.
 

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -83,6 +83,10 @@ the exact command that gates the change (`go test ./...`, `gofmt -l .`);
 it is not an invitation for comprehensive coverage, just the check this
 change must pass.
 
+Plan text must never reference machine-local or gitignored paths such
+as `.memhub/` or `.orchestrator/` — an executor sees only the committed
+tree inside its worktree, and neither exists there.
+
 ## Plan gate
 
 Call `orch run plan` with the `PlanDoc` on stdin. The result is a
@@ -159,27 +163,33 @@ in flight at once. For each issue:
    actually runs is whatever its installed TOML (`model`,
    `model_reasoning_effort`) pins. Before dispatching, the selection
    **currently in force** for the routed role — `DispatchResult`'s
-   `(model, effort)`, superseded by any later escalation's new
-   selection (`EscalateResult`'s `(model, effort)`), never the
-   dispatch-time value once superseded — **must match an installed
-   `orch-*` agent TOML exactly** — `orch-scout` gpt-5.6-terra/low,
-   `orch-implementer` gpt-5.6-terra/high, `orch-specialist`
-   gpt-5.6-sol/medium, `orch-reviewer` gpt-5.6-sol/medium,
-   `orch-reviewer-safe` gpt-5.6-terra/high. **If no installed TOML
-   matches the routed selection, stop and tell the human — never
-   dispatch a mismatched agent, and never report the routed selection as
-   if it ran.** Every dispatch prompt opens with:
+   `(model, effort)`, superseded by the most recent `EscalateResult`'s
+   `(model, effort)` if the issue has been rerouted since dispatch,
+   never the dispatch-time value once superseded — **must match an
+   installed `orch-*` agent TOML exactly**. The installed TOMLs are the
+   authority for what that match requires, not this list: by default
+   they pin `orch-scout` gpt-5.6-terra/low, `orch-implementer`
+   gpt-5.6-terra/high, `orch-specialist` gpt-5.6-sol/medium,
+   `orch-reviewer` gpt-5.6-sol/medium, `orch-reviewer-safe`
+   gpt-5.6-terra/high, but a repository that overrides
+   `hosts.codex.roles` and re-renders with `orch render-agents` gets
+   different pins. **If no installed TOML matches the routed selection,
+   stop and tell the human — never dispatch a mismatched agent, and
+   never report the routed selection as if it ran.** Every dispatch
+   prompt opens with:
 
    ```
    Routed selection: <model> @ <effort>
    ```
 
-   Effort is a real host parameter on Codex: the host enforces both the
-   routed model and the routed effort together, through the TOML-match
-   rule above — `model_reasoning_effort` is pinned in the dispatched
-   agent's own installed TOML, not layered on afterward, so there is no
-   prompt cue standing in for it the way there is on Claude. The opening
-   line is a statement of fact, not a behavioral nudge. Transcribe
+   Effort is a real host parameter on Codex: `model_reasoning_effort` is
+   pinned in the dispatched agent's own installed TOML and is what
+   actually runs, not layered on afterward, so there is no prompt cue
+   standing in for it the way there is on Claude. The host enforces
+   whatever TOML was dispatched, not that it matches the routed
+   selection — dispatching the TOML matching the routed selection above
+   is Architect discipline the engine does not verify. The opening line
+   is a statement of fact, not a behavioral nudge. Transcribe
    `DispatchResult.objective`, `.acceptance_criteria`, and
    `.required_tests` into the prompt **verbatim** — this is the text a
    human approved at the plan gate, not the Architect's recollection of
@@ -211,9 +221,10 @@ in flight at once. For each issue:
    `orch-reviewer` **fresh** (a new instance, not the executor
    continuing), following the same TOML-match rule as the executor
    above. Base the choice on the reviewer selection **currently in
-   force** — `DispatchResult.reviewer`, superseded by any later
-   escalation's new reviewer (`EscalateResult.reviewer`), never the
-   dispatch-time value once superseded. If that selection names the §10
+   force** — `DispatchResult.reviewer`, superseded by the most recent
+   `EscalateResult.reviewer` if the issue has been rerouted since
+   dispatch, never the dispatch-time value once superseded. If that
+   selection names the §10
    safe-downgrade profile instead of the standard reviewer profile,
    dispatch `orch-reviewer-safe` by name — it is the installed TOML that
    encodes that downgrade, since Codex has no per-spawn model override
@@ -224,14 +235,16 @@ in flight at once. For each issue:
 5. **Review** — the reviewer produces **one consolidated report**
    (acceptance criteria, scope, correctness, tests, CI, security,
    manifest accuracy). Call `orch run review` with `reviewer` set to
-   the selection **currently in force**: `EscalateResult.reviewer` when
-   an escalation has rerouted the issue since dispatch, or
-   `DispatchResult.reviewer` otherwise. `orch run review` compares the
-   submitted `reviewer` against the issue's current routing decision and
-   refuses a mismatch; `orch run dispatch` cannot be re-run to refresh a
-   stale value — it accepts only the `worktree-ready` phase, which a
-   dispatched issue has already left, so you must track whichever value
-   is current yourself:
+   the selection **currently in force**: the most recent
+   `EscalateResult.reviewer` when an escalation has rerouted the issue
+   since dispatch, or `DispatchResult.reviewer` otherwise.
+   `orch run review` compares the submitted `reviewer`
+   against the issue's current routing decision and
+   refuses a mismatch; `orch run dispatch` cannot be
+   re-run to refresh a stale value — it accepts only the
+   `worktree-ready` phase, which a dispatched issue has
+   already left, so you must track whichever value is
+   current yourself:
 
    ```json
    {"schema_version": 1, "issue_number": N, "reviewed_head_oid": "...",
@@ -311,13 +324,17 @@ failure, call `orch run escalate`:
 `weak-model-failure`, `reviewer-uncertainty`, `architectural-ambiguity`.
 Result `kind`:
 
-- `reroute` — carries a new `executor`/`reviewer` and `rationale`;
-  before dispatching either into the **same worktree** (never a new
-  one), confirm the new selection's `(model, effort)` against an
-  installed `orch-*` agent TOML under the same match rule as the
-  dispatch steps above — **if no installed TOML matches the new
-  selection, stop and tell the human — never dispatch a mismatched
-  agent, and never report the routed selection as if it ran.**
+- `reroute` — carries a new `executor`/`reviewer` and `rationale`; on a
+  chain of two or more reroutes on the same issue, each call's result
+  fully replaces the routing decision, so this is now the most recent
+  `EscalateResult` and the only one describing the routing in force,
+  for both roles even if only one changed. Before dispatching either
+  into the **same worktree** (never a new one), confirm the new
+  selection's `(model, effort)` against an installed `orch-*` agent
+  TOML under the same match rule as the dispatch steps above — **if no
+  installed TOML matches the new selection, stop and tell the human —
+  never dispatch a mismatched agent, and never report the routed
+  selection as if it ran.**
 - `return-to-architect` — the issue is blocked for human design work;
   report `reason` and do not push it forward yourself.
 

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -328,7 +328,7 @@ Result `kind`:
   fully replaces the routing decision, so this result is now the most
   recent `EscalateResult` and the only one describing the routing in
   force, for both roles even if only one changed. Before dispatching
-  into the **same worktree** (never a new one), confirm the new
+  either into the **same worktree** (never a new one), confirm the new
   selection's `(model, effort)` against an installed `orch-*` agent
   TOML under the same match rule as the dispatch steps above — **if no
   installed TOML matches the new selection, stop and tell the human —

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -84,8 +84,9 @@ it is not an invitation for comprehensive coverage, just the check this
 change must pass.
 
 Plan text must never reference machine-local or gitignored paths such
-as `.memhub/` or `.orchestrator/` — an executor sees only the committed
-tree inside its worktree, and neither exists there.
+as `.memhub/`, `.orchestrator/state.json`, or
+`.orchestrator/config.local.toml` — an executor sees only the committed
+tree inside its worktree, and none of these exist there.
 
 ## Plan gate
 
@@ -238,13 +239,11 @@ in flight at once. For each issue:
    the selection **currently in force**: the most recent
    `EscalateResult.reviewer` when an escalation has rerouted the issue
    since dispatch, or `DispatchResult.reviewer` otherwise.
-   `orch run review` compares the submitted `reviewer`
-   against the issue's current routing decision and
-   refuses a mismatch; `orch run dispatch` cannot be
-   re-run to refresh a stale value — it accepts only the
-   `worktree-ready` phase, which a dispatched issue has
-   already left, so you must track whichever value is
-   current yourself:
+   `orch run review` compares the submitted `reviewer` against the
+   issue's current routing decision and refuses a mismatch;
+   `orch run dispatch` cannot be re-run to refresh a stale value — it
+   accepts only the `worktree-ready` phase, which a dispatched issue has
+   already left, so you must track whichever value is current yourself:
 
    ```json
    {"schema_version": 1, "issue_number": N, "reviewed_head_oid": "...",
@@ -326,9 +325,9 @@ Result `kind`:
 
 - `reroute` — carries a new `executor`/`reviewer` and `rationale`; on a
   chain of two or more reroutes on the same issue, each call's result
-  fully replaces the routing decision, so this is now the most recent
-  `EscalateResult` and the only one describing the routing in force,
-  for both roles even if only one changed. Before dispatching either
+  fully replaces the routing decision, so this result is now the most
+  recent `EscalateResult` and the only one describing the routing in
+  force, for both roles even if only one changed. Before dispatching
   into the **same worktree** (never a new one), confirm the new
   selection's `(model, effort)` against an installed `orch-*` agent
   TOML under the same match rule as the dispatch steps above — **if no


### PR DESCRIPTION
Delivers issue #79: Say 'most recent EscalateResult' at every site, correct the Codex TOML-match enforcement claim, and forbid machine-local paths in plan text

Closes #79

**Plan digest:** `sha256:b03046ccf82f102e66b26266bd43f163d47ec35f5414a79c0645285f991514b0`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Three prose defects in both orch-delivery skills. First, five sites per host resolve the selection currently in force from an unqualified EscalateResult; on a chain of two or more reroutes on the same issue that does not say which one governs. Engine truth: internal/run/escalate.go sets issue.Decision = fromRoutingDecision(outcome.Decision) on every reroute, so each reroute overwrites the whole Decision and only the latest EscalateResult describes the routing in force; escalateReroute populates both Executor and Reviewer from the full new Decision, so both roles are authoritative after any reroute even when only one changed. Second, the Codex skill's step 2 claims the host enforces both the routed model and the routed effort through the TOML-match rule; the host runs whatever TOML was dispatched, and dispatching the matching one is unverified Architect discipline. That step also hardcodes the five shipped default (model, effort) pairs as if they were the required set, which misleads a repo overriding hosts.codex.roles. Third, a Delivery worktree contains no .memhub/ or .orchestrator/state.json (both gitignored or machine-local) and PlanDoc acceptance criteria are free text validated only structurally, so plan text can name paths an executor can never reach.

**Acceptance criteria:**
- In adapters/claude/skills/orch-delivery/SKILL.md, every site that resolves the selection currently in force from an escalation says the most recent EscalateResult rather than an unqualified EscalateResult: the executor spawn step, the reviewer spawn step's superseded-by sentence, the reviewer frontmatter check, the review verb's reviewer field, and the Escalation section's reroute bullet.
- In adapters/codex/skills/orch-delivery/SKILL.md, the corresponding five sites carry the same qualification, worded to match the Claude skill wherever the two hosts' sentences were previously parallel.
- adapters/codex/skills/orch-delivery/SKILL.md step 2 no longer claims that the host enforces both the routed model and the routed effort together through the TOML-match rule; it states that the host runs whatever TOML was dispatched and that dispatching the TOML matching the routed selection is Architect discipline the engine does not verify.
- That same step presents the five (model, effort) pairs as the shipped defaults rather than the required set, and names the installed agent TOMLs as the authority, so a repo overriding hosts.codex.roles via orch render-agents is not misled.
- Both orch-delivery SKILL.md files' PlanDoc construction section gains one sentence stating that plan text must never reference machine-local or gitignored paths such as .memhub/ or .orchestrator/, because an executor sees only the committed tree inside its worktree.
- No file outside adapters/claude/skills/orch-delivery/SKILL.md and adapters/codex/skills/orch-delivery/SKILL.md is modified.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **unit-tests** — pass — `go test ./...` — commit `0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108` (2026-07-27T15:41:51Z)
- **gofmt** — pass — `gofmt -l .` — commit `0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108` (2026-07-27T15:41:51Z)
- **scope-check** — pass — `gh pr diff --name-only across all three commits` — commit `659c59b93c2886cd68edb79f4d19a146c8153c76` (2026-07-27T16:30:33Z)
- **engine-truth-check** — pass — `read internal/run/escalate.go escalateReroute` — commit `0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108` (2026-07-27T15:41:51Z)
- **shipped-defaults-check** — pass — `compare the five (model, effort) pairs in the Codex skill against adapters/codex/agents/*.toml` — the enumerated pairs match the shipped agent TOMLs; they are now framed as defaults with the installed TOMLs named as authority — commit `0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108` (2026-07-27T15:41:51Z)
- **site-count-check** — partial — `direct read of both orch-delivery SKILL.md files to locate every ambiguous EscalateResult reference` — acceptance criterion 2 says 'the corresponding five sites' on Codex; direct reading found only 4 distinct textual locations there, because the Codex step-4 paragraph combines what the Claude skill splits into two sentences. The qualification was applied at all 4 real Codex locations and all 5 Claude locations; no paragraph was split to manufacture a fifth. Flagged for reviewer judgment. — commit `0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108` (2026-07-27T15:41:51Z)
- **unit-tests-reproduced** — pass — `go test ./... at 1fd0e46 in an isolated scratch clone` — all packages ok; three report no test files (cmd/orch, internal/adaptertest, internal/execx/execxtest) — commit `1fd0e460b4db6b4583322649bec847744d003e0d` (2026-07-27T16:15:52Z)
- **gofmt-reproduced** — pass — `gofmt -l . at 1fd0e46` — no output — commit `1fd0e460b4db6b4583322649bec847744d003e0d` (2026-07-27T16:15:52Z)
- **vet-reproduced** — pass — `go vet ./... at 1fd0e46` — clean — commit `1fd0e460b4db6b4583322649bec847744d003e0d` (2026-07-27T16:15:52Z)
- **ci-head-pinned** — pass — `gh check-runs API pinned to 659c59b` — 6/6 required contexts SUCCESS; strict false, mergeable MERGEABLE, mergeStateStatus CLEAN — commit `659c59b93c2886cd68edb79f4d19a146c8153c76` (2026-07-27T16:30:33Z)
- **planpath-sentence-truth** — fail — `git ls-files .orchestrator; inspect .orchestrator/worktrees/issue-79/.orchestrator/; read .gitignore, internal/guard/guard.go rows 9-15 and internal/guard/resolve_test.go` — BLOCKING. .orchestrator/config.toml is tracked and present inside the worktree, and Delivery guard rules permit writing it. The clause 'and neither exists there' is false for .orchestrator/. Required fix: either narrow the examples to paths that really are machine-local or gitignored (.memhub/, .orchestrator/state.json, .orchestrator/config.local.toml), matching the objective's own wording, or drop the 'and neither exists there' clause and rest the rule on 'machine-local or gitignored', which is correct as stated. Apply the identical edit to both files, which are currently byte-identical here — commit `0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108` (2026-07-27T15:53:09Z)
- **site-count-ruling** — pass — `independent count of every EscalateResult resolution site in both skills at this commit, plus comparison against main's pre-change text` — 5 Claude sites and 4 Codex sites, all qualified. The Codex asymmetry is structural and predates this PR: its step 4 delegates the frontmatter match by reference rather than stating it as a second sentence. Splitting that paragraph to manufacture a fifth site would have been padding. Criterion 2's 'five' was an Architect miscount — commit `0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108` (2026-07-27T15:53:09Z)
- **engine-truth-escalate** — pass — `read internal/run/escalate.go and internal/routing/escalate.go at this commit` — issue.Decision = fromRoutingDecision(outcome.Decision) is a whole-struct overwrite; EscalateResult.Executor and .Reviewer both come from outcome.Decision; and in routing, escalateReviewer copies the full Decision before overwriting reviewer fields while climbExecutor carries Reviewer forward. The 'both roles even if only one changed' claim is correct — commit `0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108` (2026-07-27T15:53:09Z)
- **no-overcorrection-check** — pass — `read the reframed Codex step 2` — the mandatory TOML-match rule survives in bold and unweakened, including the stop-and-tell-the-human imperative. The change reassigns who enforces it without touching whether it matters — commit `0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108` (2026-07-27T15:53:09Z)
- **cross-pr-pin-survival** — pass — `byte-compare the cue line against main in both files and inspect the now-merged CheckRoutedSelectionCue` — the cue line is byte-identical to main in both files and still fenced as its own block, so the merged #85 pin survives this PR. Existing stop-and-tell-the-human pins also survive: Claude requires at least 2 and head has 3, Codex requires at least 1 and head has 2 — commit `1fd0e460b4db6b4583322649bec847744d003e0d` (2026-07-27T16:15:52Z)
- **scope-and-conflict** — pass — `git diff --name-only main... plus a sweep of every origin/orch/* branch for edits to either orch-delivery skill` — exactly the two named files, one commit; only this branch touches them. No overlap with #77, #78 or #80 — commit `0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108` (2026-07-27T15:53:09Z)
- **rewrap-diff-noise** — noted — `compare wrap widths of the reflowed review-verb paragraph against the rest of both files` — non-blocking. The review-verb paragraph was re-wrapped to 51-58 columns while both files otherwise wrap at roughly 68-71. Words unchanged; only wrapping. Re-wrapping to the files' normal width would cut diff noise and keep the two hosts byte-identical — commit `0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108` (2026-07-27T15:53:09Z)
- **review-cycle-1** — request-changes — Request changes on one blocking falsehood; everything else passes. BLOCKER: the new PlanDoc sentence, identical in both files, ends 'an executor sees only the committed tree inside its worktree, and neither exists there'. That is false for .orchestrator/. git ls-files .orchestrator returns .orchestrator/config.toml - the directory is tracked, and .gitignore excludes only config.local.toml, state.json, delivery.lock and worktrees/. The reviewer confirmed empirically that .orchestrator/config.toml is present inside this issue's own worktree, and internal/guard/resolve_test.go carries the comment 'The worktree carries a committed .orchestrator/ of its own'. Worse, guard.go rows 9-15 have no underOrch denial in Delivery, so an executor can both see and write that file - the very file this repo's CLAUDE.md directs people to edit. The issue objective stated the truth precisely (.orchestrator/state.json); the acceptance criterion loosened it to .orchestrator/, and the executor then appended an 'and neither exists there' clause the criterion never asked for. The Architect owns the criterion's imprecision; the added clause is the defect. SITE-COUNT RULING: resolved in the executor's favour. The reviewer counted independently - 5 qualified Claude sites, 4 on Codex - and confirmed the asymmetry is structural and pre-existing, because Codex's step 4 delegates the match check by reference where Claude states it as a second sentence. Three near-miss candidates were checked and all anchor to already-qualified sites. No reader is left with a bare EscalateResult beside a qualified one. Criterion 2's 'five' was an Architect miscount, not a coverage gap. ENGINE TRUTH: verified one level deeper than the executor went - routing/escalate.go's escalateReviewer copies the whole Decision before overwriting reviewer fields, and climbExecutor carries Reviewer forward, so 'both roles even if only one changed' genuinely holds. CROSS-PR: the reviewer built the post-merge tree of this PR plus sibling #80 and ran both adapter packages green, so #80's new cue pin survives this rewrite. — commit `0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108` (2026-07-27T15:53:10Z)
- **blocker-fix-truth** — pass — `git ls-files .orchestrator; git check-ignore -v on each named path; inspect .orchestrator/worktrees/issue-79 directly` — at 1fd0e46 only .orchestrator/config.toml is tracked; .memhub/, .orchestrator/state.json and .orchestrator/config.local.toml are all ignored at .gitignore lines 1, 17 and 14; .orchestrator/config.toml produces no ignore match and is correctly no longer named. The live worktree's .orchestrator/ contains only config.toml and has no .memhub/. Blocker resolved without substituting a new falsehood — commit `1fd0e460b4db6b4583322649bec847744d003e0d` (2026-07-27T16:15:52Z)
- **planpath-sentence-parity** — pass — `sha256 of the extracted sentence in both files` — byte-identical across hosts, both sha256 18ad8abf, at lines 86-89 under PlanDoc construction — commit `659c59b93c2886cd68edb79f4d19a146c8153c76` (2026-07-27T16:30:33Z)
- **reflow-word-stream-diff** — fail — `whitespace-insensitive word-stream diff of main to head and of 0a53e4f to 1fd0e46, per file` — BLOCKING. The reflow is word-preserving everywhere except one place: on Codex only, [delete] 'either' from the reroute bullet. Cycle 1 and main both had 'Before dispatching either into the same worktree'; head reads 'Before dispatching into the same worktree'. Required fix: restore the word so it reads 'Before dispatching either into the **same worktree** (never a new one), confirm the new selection's (model, effort)', matching the Claude file's surviving 'Before spawning either into the same worktree'. Re-wrap only the lines that word displaces — commit `1fd0e460b4db6b4583322649bec847744d003e0d` (2026-07-27T16:15:52Z)
- **proofread-remainder** — pass — `adjacent-duplicate scan, inline code-span split check, CRLF and trailing-whitespace check on both files` — no duplicated words, no new inline code span split across a line break (the odd-backtick prose lines in each file are pre-existing and untouched), no CRLF, no trailing whitespace, trailing newline present — commit `1fd0e460b4db6b4583322649bec847744d003e0d` (2026-07-27T16:15:52Z)
- **site-count-re-ruling** — pass — `independent recount at this head plus comparison against main` — Claude EscalateResult mentions went 3 to 5 and all five named sites are qualified with none left bare; Codex has 4 distinct sites, all qualified. The asymmetry is structural and pre-existing - Codex step 4 delegates the frontmatter match by reference where Claude states it as a second sentence. Criterion 2's 'five' remains an Architect miscount, not a coverage gap — commit `1fd0e460b4db6b4583322649bec847744d003e0d` (2026-07-27T16:15:52Z)
- **engine-truth-re-verified** — pass — `read internal/run/escalate.go and internal/routing/escalate.go at 1fd0e46` — whole-Decision overwrite on reroute confirmed; EscalateResult sets both Executor and Reviewer from outcome.Decision; escalateReviewer copies the full Decision before overwriting reviewer fields and climbExecutor carries Reviewer forward, so 'both roles even if only one changed' holds literally. escalateReturnToArchitect does not overwrite issue.Decision, so scoping the new sentence to the reroute bullet is correct — commit `1fd0e460b4db6b4583322649bec847744d003e0d` (2026-07-27T16:15:52Z)
- **ac3-engine-check** — pass — `search internal/run for any verb validating the executor's actual selection` — no verb validates which TOML actually ran; review.go compares only the submitted req.Reviewer against issue.Decision.Reviewer, a self-reported field. The new claim that dispatching the matching TOML is Architect discipline the engine does not verify is accurate, and the mandatory stop-and-tell-the-human imperative survives unweakened in bold — commit `1fd0e460b4db6b4583322649bec847744d003e0d` (2026-07-27T16:15:52Z)
- **ac5-criterion-deviation** — noted — `compare the shipped sentence against acceptance criterion 5's literal example list` — the reviewer endorses a deliberate deviation from the criterion's letter. Criterion 5's example list said '.memhub/ or .orchestrator/', but .orchestrator/ is tracked, so the criterion as written is factually wrong. The executor narrowed to three genuinely machine-local paths, matching the objective's own wording. Recorded here so a future reader does not restore the criterion's literal phrasing and reintroduce the falsehood — commit `1fd0e460b4db6b4583322649bec847744d003e0d` (2026-07-27T16:15:52Z)
- **wrap-width-nits** — noted — `column-width scan of both files` — non-blocking and deliberately not required: Codex line 228 is a 26-column orphan left by a partially reflowed paragraph, and Claude lines 169 and 236 are 74 columns against the files' 72-column norm. Cosmetic diff noise only — commit `1fd0e460b4db6b4583322649bec847744d003e0d` (2026-07-27T16:15:52Z)
- **review-cycle-2** — request-changes — Cycle 2. The cycle-1 blocker is FIXED and fixed truthfully - a fresh reviewer re-derived the evidence itself rather than trusting the report: git ls-files .orchestrator at this head returns only .orchestrator/config.toml, git check-ignore -v confirms .memhub/ (gitignore:1), .orchestrator/state.json (:17) and .orchestrator/config.local.toml (:14) are all ignored, and an empirical check of this run's live worktree confirms its .orchestrator/ holds only config.toml with .memhub/ absent. All three named examples are genuinely gitignored and genuinely absent, so the 'none of these exist there' clause is true; the false .orchestrator/ claim is gone and nothing false replaced it. The sentence is byte-identical in both files. All six criteria were re-checked from scratch at this head rather than only the delta, the site-count ruling was independently re-derived and again lands in the executor's favour (5 Claude sites, 4 Codex, structural and pre-existing on main), the engine claims were re-verified in both internal/run/escalate.go and internal/routing/escalate.go including that escalateReturnToArchitect does not overwrite issue.Decision so the reroute-only scoping is right, and the #85 cue pin is confirmed byte-identical to main in both files so it survives in either merge order. BLOCKING, one item: a whitespace-insensitive word-stream diff of 0a53e4f to 1fd0e46 found the cycle-2 reflow commit silently deleted the word 'either' from the Codex reroute bullet. The word survives in the Claude counterpart, was present on main and in cycle 1, and its loss leaves the imperative object-less exactly where the bullet's subject is a new executor/reviewer - so the two hosts now instruct differently at one of the sites this issue exists to keep parallel. It was neither requested nor reported. This is the second consecutive commit in which a reflow altered words; the first was self-caught, this one was not. — commit `1fd0e460b4db6b4583322649bec847744d003e0d` (2026-07-27T16:15:53Z)
- **one-word-fix-confirmed** — pass — `raw line diff and whitespace-insensitive word-stream diff of 1fd0e46 to 659c59b, per file, at head 659c59b` — Claude word streams identical at 2369 words both sides, zero deltas. Codex 2251 to 2252 words: exactly one insertion, +either between dispatching and into, zero removals. The Codex reroute bullet now reads 'Before dispatching either into the same worktree (never a new one)', restoring parallel with Claude's 'Before spawning either into the same worktree'. Supersedes the cycle-2 BLOCKING finding — commit `659c59b93c2886cd68edb79f4d19a146c8153c76` (2026-07-27T16:30:33Z)
- **whole-pr-word-attribution** — pass — `word-stream diff of main 0d47213 to 659c59b per file, enumerating every removed word` — Claude +100/-6 words, Codex +178/-36. All 42 removals individually attributed: the reviewer superseded-by rewrites (criteria 1 and 2), the defaults reframe (criterion 4), and the 18-word false host-enforcement claim (criterion 3). No word-level change in the PR is unattributable to a criterion — commit `659c59b93c2886cd68edb79f4d19a146c8153c76` (2026-07-27T16:30:33Z)
- **blocker-re-verified-at-head** — pass — `git ls-files .orchestrator; git ls-files .memhub; git check-ignore -v on each named path, at 659c59b` — only .orchestrator/config.toml tracked, nothing under .memhub tracked; .memhub/ (.gitignore:1), .orchestrator/state.json (:17) and .orchestrator/config.local.toml (:14) all ignored; .orchestrator/config.toml correctly not ignored and correctly not named by the sentence. Re-derived at this head, not carried forward from cycle 2 — commit `659c59b93c2886cd68edb79f4d19a146c8153c76` (2026-07-27T16:30:33Z)
- **site-coverage-sweep** — pass — `sweep both files for EscalateResult, 'currently in force', superseded and escalat` — five qualified Claude sites (169, 225-226, 236, 252-253, 341) and four qualified Codex sites (167, 226, 240, 329), with no bare site left in either file. The five-versus-four question was re-derived independently a third time: Codex step 4 delegates the match check by reference where Claude states it as a separate sentence, so Claude's fifth site has no Codex counterpart. Architect miscount confirmed — commit `659c59b93c2886cd68edb79f4d19a146c8153c76` (2026-07-27T16:30:33Z)
- **shipped-defaults-verified** — pass — `compare the five (model, effort) pairs against the shipped adapters/codex/agents/*.toml` — exact match: scout terra/low, implementer terra/high, specialist sol/medium, reviewer sol/medium, reviewer-safe terra/high. orch render-agents confirmed real at internal/cli/cli.go:77 and hosts.codex.roles confirmed a real config path — commit `659c59b93c2886cd68edb79f4d19a146c8153c76` (2026-07-27T16:30:33Z)
- **merged-with-main-suite** — pass — `git merge origin/main into 659c59b in a scratch clone, then go test ./... and gofmt -l .` — clean merge, zero conflicts; main's post-base changes touch ORCH-PRD.md, both READMEs, both plugin_test.go, both orch-architect skills, two agent TOMLs and adaptertest.go, none overlapping the two orch-delivery skills. Merged tree keeps this PR's blobs verbatim. go test ./... exit 0, gofmt empty — commit `659c59b93c2886cd68edb79f4d19a146c8153c76` (2026-07-27T16:30:33Z)
- **live-cue-pin-survival** — pass — `targeted verbose run of TestDeliverySkillHasRoutedSelectionCue for both adapters on the merged tree` — the cue literal is present exactly once per file with LF endings and no trailing whitespace (Claude 181, Codex 183). Sibling #85's pin, now live on main, PASSES for both adapters against this PR's files. TestDeliverySkillStatesFrontmatterMatchRule, TestDeliverySkillStatesTOMLMatchRule and TestSkillStatementLiteralsPinnedToRunConstants also pass on the merged tree — commit `659c59b93c2886cd68edb79f4d19a146c8153c76` (2026-07-27T16:30:33Z)
- **statement-literal-margin** — noted — `count unbroken occurrences of the stop-and-tell-the-human phrase in both files` — NON-BLOCKING but the Architect should own this. Claude's unbroken count fell from 3 on main to 2 at this head, and TestDeliverySkillStatesFrontmatterMatchRule requires at least 2, so the margin is now exactly zero. Cause: criterion 1's required chain-sentence insertion reflowed the reroute bullet so the third instance now wraps across a line break at Claude 346-347, invisible to a raw-byte strings.Count. The test's stated intent is intact - both spawn steps carry the phrase verbatim at unbroken lines 176 and 243 - and the third instance is still present in the prose and renders identically in markdown. Deliberately not raised as a blocker because the only remedy is another reflow, the operation that produced the last two defects and that the Architect prohibited. Codex is unchanged at 2 — commit `659c59b93c2886cd68edb79f4d19a146c8153c76` (2026-07-27T16:30:33Z)
- **unit-tests-at-head** — pass — `go test ./... at 659c59b` — exit 0, all packages ok. Pinned to the current head, repairing the audit gap where no verification referenced this commit — commit `659c59b93c2886cd68edb79f4d19a146c8153c76` (2026-07-27T16:30:33Z)
- **gofmt-at-head** — pass — `gofmt -l . at 659c59b` — empty — commit `659c59b93c2886cd68edb79f4d19a146c8153c76` (2026-07-27T16:30:33Z)
- **vet-at-head** — pass — `go vet ./... at 659c59b` — clean — commit `659c59b93c2886cd68edb79f4d19a146c8153c76` (2026-07-27T16:30:33Z)
- **proofread-at-head** — pass — `CRLF, trailing-whitespace, duplicate-word and code-span-split scan of both files` — no CRLF, no trailing whitespace, trailing newline present, no duplicated words including no 'either either', no inline code span split across a line break — commit `659c59b93c2886cd68edb79f4d19a146c8153c76` (2026-07-27T16:30:33Z)
- **prior-cycle-manifest-correction** — noted — `recount the cross-pr-pin-survival claim recorded in cycle 2` — cycle 2's entry stated 'Claude requires at least 2 and head has 3'. The countable unbroken value is 2, not 3 - that entry counted line mentions rather than unbroken literals. Corrected here for the record — commit `659c59b93c2886cd68edb79f4d19a146c8153c76` (2026-07-27T16:30:33Z)
- **review-cycle-3** — approve — Cycle 3, approve. This entry supersedes cycle 2's reflow-word-stream-diff FAIL, which was pinned to the now-superseded 1fd0e46: the dropped word is restored and independently confirmed. A fresh reviewer ran its own whitespace-insensitive word-stream diff of 1fd0e46 to 659c59b and found zero deltas in the Claude file and exactly one insertion in Codex, +either between dispatching and into, with zero removals. It then ran a second word-stream diff of main 0d47213 to 659c59b across all three commits and enumerated every one of the 42 removed words, attributing each to a specific acceptance criterion; no word-level change anywhere in the PR is unattributable. All six criteria pass. The cycle-1 blocker was re-verified at this head rather than carried forward: git ls-files .orchestrator returns only config.toml, and check-ignore confirms all three named paths ignored while config.toml is correctly not named. The PlanDoc sentence is byte-identical across hosts (both sha256 18ad8abf). The site-count question was re-derived a third time and again resolves as an Architect miscount, not a coverage gap. Critically, main has moved since this branch's base, so the reviewer merged origin/main into this head - clean, zero conflicts - and ran the suite on the merged tree: go test ./... exit 0, gofmt clean, and the now-live TestDeliverySkillHasRoutedSelectionCue from merged sibling #85 passes for both adapters against this PR's files. Main will not break when this lands. — commit `659c59b93c2886cd68edb79f4d19a146c8153c76` (2026-07-27T16:30:34Z)
- **required-ci** — passing — test (windows-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass — commit `659c59b93c2886cd68edb79f4d19a146c8153c76` (2026-07-27T16:30:39Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Three prose defects in both orch-delivery skills. First, five sites per host resolve the selection currently in force from an unqualified EscalateResult; on a chain of two or more reroutes on the same issue that does not say which one governs. Engine truth: internal/run/escalate.go sets issue.Decision = fromRoutingDecision(outcome.Decision) on every reroute, so each reroute overwrites the whole Decision and only the latest EscalateResult describes the routing in force; escalateReroute populates both Executor and Reviewer from the full new Decision, so both roles are authoritative after any reroute even when only one changed. Second, the Codex skill's step 2 claims the host enforces both the routed model and the routed effort through the TOML-match rule; the host runs whatever TOML was dispatched, and dispatching the matching one is unverified Architect discipline. That step also hardcodes the five shipped default (model, effort) pairs as if they were the required set, which misleads a repo overriding hosts.codex.roles. Third, a Delivery worktree contains no .memhub/ or .orchestrator/state.json (both gitignored or machine-local) and PlanDoc acceptance criteria are free text validated only structurally, so plan text can name paths an executor can never reach.",
  "acceptance_criteria": [
    "In adapters/claude/skills/orch-delivery/SKILL.md, every site that resolves the selection currently in force from an escalation says the most recent EscalateResult rather than an unqualified EscalateResult: the executor spawn step, the reviewer spawn step's superseded-by sentence, the reviewer frontmatter check, the review verb's reviewer field, and the Escalation section's reroute bullet.",
    "In adapters/codex/skills/orch-delivery/SKILL.md, the corresponding five sites carry the same qualification, worded to match the Claude skill wherever the two hosts' sentences were previously parallel.",
    "adapters/codex/skills/orch-delivery/SKILL.md step 2 no longer claims that the host enforces both the routed model and the routed effort together through the TOML-match rule; it states that the host runs whatever TOML was dispatched and that dispatching the TOML matching the routed selection is Architect discipline the engine does not verify.",
    "That same step presents the five (model, effort) pairs as the shipped defaults rather than the required set, and names the installed agent TOMLs as the authority, so a repo overriding hosts.codex.roles via orch render-agents is not misled.",
    "Both orch-delivery SKILL.md files' PlanDoc construction section gains one sentence stating that plan text must never reference machine-local or gitignored paths such as .memhub/ or .orchestrator/, because an executor sees only the committed tree inside its worktree.",
    "No file outside adapters/claude/skills/orch-delivery/SKILL.md and adapters/codex/skills/orch-delivery/SKILL.md is modified."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "unit-tests",
      "command": "go test ./...",
      "result": "pass",
      "commit_oid": "0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108",
      "at": "2026-07-27T15:41:51Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "commit_oid": "0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108",
      "at": "2026-07-27T15:41:51Z"
    },
    {
      "name": "scope-check",
      "command": "gh pr diff --name-only across all three commits",
      "result": "pass",
      "commit_oid": "659c59b93c2886cd68edb79f4d19a146c8153c76",
      "at": "2026-07-27T16:30:33Z"
    },
    {
      "name": "engine-truth-check",
      "command": "read internal/run/escalate.go escalateReroute",
      "result": "pass",
      "commit_oid": "0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108",
      "at": "2026-07-27T15:41:51Z"
    },
    {
      "name": "shipped-defaults-check",
      "command": "compare the five (model, effort) pairs in the Codex skill against adapters/codex/agents/*.toml",
      "result": "pass",
      "detail": "the enumerated pairs match the shipped agent TOMLs; they are now framed as defaults with the installed TOMLs named as authority",
      "commit_oid": "0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108",
      "at": "2026-07-27T15:41:51Z"
    },
    {
      "name": "site-count-check",
      "command": "direct read of both orch-delivery SKILL.md files to locate every ambiguous EscalateResult reference",
      "result": "partial",
      "detail": "acceptance criterion 2 says 'the corresponding five sites' on Codex; direct reading found only 4 distinct textual locations there, because the Codex step-4 paragraph combines what the Claude skill splits into two sentences. The qualification was applied at all 4 real Codex locations and all 5 Claude locations; no paragraph was split to manufacture a fifth. Flagged for reviewer judgment.",
      "commit_oid": "0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108",
      "at": "2026-07-27T15:41:51Z"
    },
    {
      "name": "unit-tests-reproduced",
      "command": "go test ./... at 1fd0e46 in an isolated scratch clone",
      "result": "pass",
      "detail": "all packages ok; three report no test files (cmd/orch, internal/adaptertest, internal/execx/execxtest)",
      "commit_oid": "1fd0e460b4db6b4583322649bec847744d003e0d",
      "at": "2026-07-27T16:15:52Z"
    },
    {
      "name": "gofmt-reproduced",
      "command": "gofmt -l . at 1fd0e46",
      "result": "pass",
      "detail": "no output",
      "commit_oid": "1fd0e460b4db6b4583322649bec847744d003e0d",
      "at": "2026-07-27T16:15:52Z"
    },
    {
      "name": "vet-reproduced",
      "command": "go vet ./... at 1fd0e46",
      "result": "pass",
      "detail": "clean",
      "commit_oid": "1fd0e460b4db6b4583322649bec847744d003e0d",
      "at": "2026-07-27T16:15:52Z"
    },
    {
      "name": "ci-head-pinned",
      "command": "gh check-runs API pinned to 659c59b",
      "result": "pass",
      "detail": "6/6 required contexts SUCCESS; strict false, mergeable MERGEABLE, mergeStateStatus CLEAN",
      "commit_oid": "659c59b93c2886cd68edb79f4d19a146c8153c76",
      "at": "2026-07-27T16:30:33Z"
    },
    {
      "name": "planpath-sentence-truth",
      "command": "git ls-files .orchestrator; inspect .orchestrator/worktrees/issue-79/.orchestrator/; read .gitignore, internal/guard/guard.go rows 9-15 and internal/guard/resolve_test.go",
      "result": "fail",
      "detail": "BLOCKING. .orchestrator/config.toml is tracked and present inside the worktree, and Delivery guard rules permit writing it. The clause 'and neither exists there' is false for .orchestrator/. Required fix: either narrow the examples to paths that really are machine-local or gitignored (.memhub/, .orchestrator/state.json, .orchestrator/config.local.toml), matching the objective's own wording, or drop the 'and neither exists there' clause and rest the rule on 'machine-local or gitignored', which is correct as stated. Apply the identical edit to both files, which are currently byte-identical here",
      "commit_oid": "0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108",
      "at": "2026-07-27T15:53:09Z"
    },
    {
      "name": "site-count-ruling",
      "command": "independent count of every EscalateResult resolution site in both skills at this commit, plus comparison against main's pre-change text",
      "result": "pass",
      "detail": "5 Claude sites and 4 Codex sites, all qualified. The Codex asymmetry is structural and predates this PR: its step 4 delegates the frontmatter match by reference rather than stating it as a second sentence. Splitting that paragraph to manufacture a fifth site would have been padding. Criterion 2's 'five' was an Architect miscount",
      "commit_oid": "0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108",
      "at": "2026-07-27T15:53:09Z"
    },
    {
      "name": "engine-truth-escalate",
      "command": "read internal/run/escalate.go and internal/routing/escalate.go at this commit",
      "result": "pass",
      "detail": "issue.Decision = fromRoutingDecision(outcome.Decision) is a whole-struct overwrite; EscalateResult.Executor and .Reviewer both come from outcome.Decision; and in routing, escalateReviewer copies the full Decision before overwriting reviewer fields while climbExecutor carries Reviewer forward. The 'both roles even if only one changed' claim is correct",
      "commit_oid": "0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108",
      "at": "2026-07-27T15:53:09Z"
    },
    {
      "name": "no-overcorrection-check",
      "command": "read the reframed Codex step 2",
      "result": "pass",
      "detail": "the mandatory TOML-match rule survives in bold and unweakened, including the stop-and-tell-the-human imperative. The change reassigns who enforces it without touching whether it matters",
      "commit_oid": "0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108",
      "at": "2026-07-27T15:53:09Z"
    },
    {
      "name": "cross-pr-pin-survival",
      "command": "byte-compare the cue line against main in both files and inspect the now-merged CheckRoutedSelectionCue",
      "result": "pass",
      "detail": "the cue line is byte-identical to main in both files and still fenced as its own block, so the merged #85 pin survives this PR. Existing stop-and-tell-the-human pins also survive: Claude requires at least 2 and head has 3, Codex requires at least 1 and head has 2",
      "commit_oid": "1fd0e460b4db6b4583322649bec847744d003e0d",
      "at": "2026-07-27T16:15:52Z"
    },
    {
      "name": "scope-and-conflict",
      "command": "git diff --name-only main... plus a sweep of every origin/orch/* branch for edits to either orch-delivery skill",
      "result": "pass",
      "detail": "exactly the two named files, one commit; only this branch touches them. No overlap with #77, #78 or #80",
      "commit_oid": "0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108",
      "at": "2026-07-27T15:53:09Z"
    },
    {
      "name": "rewrap-diff-noise",
      "command": "compare wrap widths of the reflowed review-verb paragraph against the rest of both files",
      "result": "noted",
      "detail": "non-blocking. The review-verb paragraph was re-wrapped to 51-58 columns while both files otherwise wrap at roughly 68-71. Words unchanged; only wrapping. Re-wrapping to the files' normal width would cut diff noise and keep the two hosts byte-identical",
      "commit_oid": "0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108",
      "at": "2026-07-27T15:53:09Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "Request changes on one blocking falsehood; everything else passes. BLOCKER: the new PlanDoc sentence, identical in both files, ends 'an executor sees only the committed tree inside its worktree, and neither exists there'. That is false for .orchestrator/. git ls-files .orchestrator returns .orchestrator/config.toml - the directory is tracked, and .gitignore excludes only config.local.toml, state.json, delivery.lock and worktrees/. The reviewer confirmed empirically that .orchestrator/config.toml is present inside this issue's own worktree, and internal/guard/resolve_test.go carries the comment 'The worktree carries a committed .orchestrator/ of its own'. Worse, guard.go rows 9-15 have no underOrch denial in Delivery, so an executor can both see and write that file - the very file this repo's CLAUDE.md directs people to edit. The issue objective stated the truth precisely (.orchestrator/state.json); the acceptance criterion loosened it to .orchestrator/, and the executor then appended an 'and neither exists there' clause the criterion never asked for. The Architect owns the criterion's imprecision; the added clause is the defect. SITE-COUNT RULING: resolved in the executor's favour. The reviewer counted independently - 5 qualified Claude sites, 4 on Codex - and confirmed the asymmetry is structural and pre-existing, because Codex's step 4 delegates the match check by reference where Claude states it as a second sentence. Three near-miss candidates were checked and all anchor to already-qualified sites. No reader is left with a bare EscalateResult beside a qualified one. Criterion 2's 'five' was an Architect miscount, not a coverage gap. ENGINE TRUTH: verified one level deeper than the executor went - routing/escalate.go's escalateReviewer copies the whole Decision before overwriting reviewer fields, and climbExecutor carries Reviewer forward, so 'both roles even if only one changed' genuinely holds. CROSS-PR: the reviewer built the post-merge tree of this PR plus sibling #80 and ran both adapter packages green, so #80's new cue pin survives this rewrite.",
      "commit_oid": "0a53e4f4dcd1051d1e10f57d2a0f3b107ed4a108",
      "at": "2026-07-27T15:53:10Z"
    },
    {
      "name": "blocker-fix-truth",
      "command": "git ls-files .orchestrator; git check-ignore -v on each named path; inspect .orchestrator/worktrees/issue-79 directly",
      "result": "pass",
      "detail": "at 1fd0e46 only .orchestrator/config.toml is tracked; .memhub/, .orchestrator/state.json and .orchestrator/config.local.toml are all ignored at .gitignore lines 1, 17 and 14; .orchestrator/config.toml produces no ignore match and is correctly no longer named. The live worktree's .orchestrator/ contains only config.toml and has no .memhub/. Blocker resolved without substituting a new falsehood",
      "commit_oid": "1fd0e460b4db6b4583322649bec847744d003e0d",
      "at": "2026-07-27T16:15:52Z"
    },
    {
      "name": "planpath-sentence-parity",
      "command": "sha256 of the extracted sentence in both files",
      "result": "pass",
      "detail": "byte-identical across hosts, both sha256 18ad8abf, at lines 86-89 under PlanDoc construction",
      "commit_oid": "659c59b93c2886cd68edb79f4d19a146c8153c76",
      "at": "2026-07-27T16:30:33Z"
    },
    {
      "name": "reflow-word-stream-diff",
      "command": "whitespace-insensitive word-stream diff of main to head and of 0a53e4f to 1fd0e46, per file",
      "result": "fail",
      "detail": "BLOCKING. The reflow is word-preserving everywhere except one place: on Codex only, [delete] 'either' from the reroute bullet. Cycle 1 and main both had 'Before dispatching either into the same worktree'; head reads 'Before dispatching into the same worktree'. Required fix: restore the word so it reads 'Before dispatching either into the **same worktree** (never a new one), confirm the new selection's (model, effort)', matching the Claude file's surviving 'Before spawning either into the same worktree'. Re-wrap only the lines that word displaces",
      "commit_oid": "1fd0e460b4db6b4583322649bec847744d003e0d",
      "at": "2026-07-27T16:15:52Z"
    },
    {
      "name": "proofread-remainder",
      "command": "adjacent-duplicate scan, inline code-span split check, CRLF and trailing-whitespace check on both files",
      "result": "pass",
      "detail": "no duplicated words, no new inline code span split across a line break (the odd-backtick prose lines in each file are pre-existing and untouched), no CRLF, no trailing whitespace, trailing newline present",
      "commit_oid": "1fd0e460b4db6b4583322649bec847744d003e0d",
      "at": "2026-07-27T16:15:52Z"
    },
    {
      "name": "site-count-re-ruling",
      "command": "independent recount at this head plus comparison against main",
      "result": "pass",
      "detail": "Claude EscalateResult mentions went 3 to 5 and all five named sites are qualified with none left bare; Codex has 4 distinct sites, all qualified. The asymmetry is structural and pre-existing - Codex step 4 delegates the frontmatter match by reference where Claude states it as a second sentence. Criterion 2's 'five' remains an Architect miscount, not a coverage gap",
      "commit_oid": "1fd0e460b4db6b4583322649bec847744d003e0d",
      "at": "2026-07-27T16:15:52Z"
    },
    {
      "name": "engine-truth-re-verified",
      "command": "read internal/run/escalate.go and internal/routing/escalate.go at 1fd0e46",
      "result": "pass",
      "detail": "whole-Decision overwrite on reroute confirmed; EscalateResult sets both Executor and Reviewer from outcome.Decision; escalateReviewer copies the full Decision before overwriting reviewer fields and climbExecutor carries Reviewer forward, so 'both roles even if only one changed' holds literally. escalateReturnToArchitect does not overwrite issue.Decision, so scoping the new sentence to the reroute bullet is correct",
      "commit_oid": "1fd0e460b4db6b4583322649bec847744d003e0d",
      "at": "2026-07-27T16:15:52Z"
    },
    {
      "name": "ac3-engine-check",
      "command": "search internal/run for any verb validating the executor's actual selection",
      "result": "pass",
      "detail": "no verb validates which TOML actually ran; review.go compares only the submitted req.Reviewer against issue.Decision.Reviewer, a self-reported field. The new claim that dispatching the matching TOML is Architect discipline the engine does not verify is accurate, and the mandatory stop-and-tell-the-human imperative survives unweakened in bold",
      "commit_oid": "1fd0e460b4db6b4583322649bec847744d003e0d",
      "at": "2026-07-27T16:15:52Z"
    },
    {
      "name": "ac5-criterion-deviation",
      "command": "compare the shipped sentence against acceptance criterion 5's literal example list",
      "result": "noted",
      "detail": "the reviewer endorses a deliberate deviation from the criterion's letter. Criterion 5's example list said '.memhub/ or .orchestrator/', but .orchestrator/ is tracked, so the criterion as written is factually wrong. The executor narrowed to three genuinely machine-local paths, matching the objective's own wording. Recorded here so a future reader does not restore the criterion's literal phrasing and reintroduce the falsehood",
      "commit_oid": "1fd0e460b4db6b4583322649bec847744d003e0d",
      "at": "2026-07-27T16:15:52Z"
    },
    {
      "name": "wrap-width-nits",
      "command": "column-width scan of both files",
      "result": "noted",
      "detail": "non-blocking and deliberately not required: Codex line 228 is a 26-column orphan left by a partially reflowed paragraph, and Claude lines 169 and 236 are 74 columns against the files' 72-column norm. Cosmetic diff noise only",
      "commit_oid": "1fd0e460b4db6b4583322649bec847744d003e0d",
      "at": "2026-07-27T16:15:52Z"
    },
    {
      "name": "review-cycle-2",
      "result": "request-changes",
      "detail": "Cycle 2. The cycle-1 blocker is FIXED and fixed truthfully - a fresh reviewer re-derived the evidence itself rather than trusting the report: git ls-files .orchestrator at this head returns only .orchestrator/config.toml, git check-ignore -v confirms .memhub/ (gitignore:1), .orchestrator/state.json (:17) and .orchestrator/config.local.toml (:14) are all ignored, and an empirical check of this run's live worktree confirms its .orchestrator/ holds only config.toml with .memhub/ absent. All three named examples are genuinely gitignored and genuinely absent, so the 'none of these exist there' clause is true; the false .orchestrator/ claim is gone and nothing false replaced it. The sentence is byte-identical in both files. All six criteria were re-checked from scratch at this head rather than only the delta, the site-count ruling was independently re-derived and again lands in the executor's favour (5 Claude sites, 4 Codex, structural and pre-existing on main), the engine claims were re-verified in both internal/run/escalate.go and internal/routing/escalate.go including that escalateReturnToArchitect does not overwrite issue.Decision so the reroute-only scoping is right, and the #85 cue pin is confirmed byte-identical to main in both files so it survives in either merge order. BLOCKING, one item: a whitespace-insensitive word-stream diff of 0a53e4f to 1fd0e46 found the cycle-2 reflow commit silently deleted the word 'either' from the Codex reroute bullet. The word survives in the Claude counterpart, was present on main and in cycle 1, and its loss leaves the imperative object-less exactly where the bullet's subject is a new executor/reviewer - so the two hosts now instruct differently at one of the sites this issue exists to keep parallel. It was neither requested nor reported. This is the second consecutive commit in which a reflow altered words; the first was self-caught, this one was not.",
      "commit_oid": "1fd0e460b4db6b4583322649bec847744d003e0d",
      "at": "2026-07-27T16:15:53Z"
    },
    {
      "name": "one-word-fix-confirmed",
      "command": "raw line diff and whitespace-insensitive word-stream diff of 1fd0e46 to 659c59b, per file, at head 659c59b",
      "result": "pass",
      "detail": "Claude word streams identical at 2369 words both sides, zero deltas. Codex 2251 to 2252 words: exactly one insertion, +either between dispatching and into, zero removals. The Codex reroute bullet now reads 'Before dispatching either into the same worktree (never a new one)', restoring parallel with Claude's 'Before spawning either into the same worktree'. Supersedes the cycle-2 BLOCKING finding",
      "commit_oid": "659c59b93c2886cd68edb79f4d19a146c8153c76",
      "at": "2026-07-27T16:30:33Z"
    },
    {
      "name": "whole-pr-word-attribution",
      "command": "word-stream diff of main 0d47213 to 659c59b per file, enumerating every removed word",
      "result": "pass",
      "detail": "Claude +100/-6 words, Codex +178/-36. All 42 removals individually attributed: the reviewer superseded-by rewrites (criteria 1 and 2), the defaults reframe (criterion 4), and the 18-word false host-enforcement claim (criterion 3). No word-level change in the PR is unattributable to a criterion",
      "commit_oid": "659c59b93c2886cd68edb79f4d19a146c8153c76",
      "at": "2026-07-27T16:30:33Z"
    },
    {
      "name": "blocker-re-verified-at-head",
      "command": "git ls-files .orchestrator; git ls-files .memhub; git check-ignore -v on each named path, at 659c59b",
      "result": "pass",
      "detail": "only .orchestrator/config.toml tracked, nothing under .memhub tracked; .memhub/ (.gitignore:1), .orchestrator/state.json (:17) and .orchestrator/config.local.toml (:14) all ignored; .orchestrator/config.toml correctly not ignored and correctly not named by the sentence. Re-derived at this head, not carried forward from cycle 2",
      "commit_oid": "659c59b93c2886cd68edb79f4d19a146c8153c76",
      "at": "2026-07-27T16:30:33Z"
    },
    {
      "name": "site-coverage-sweep",
      "command": "sweep both files for EscalateResult, 'currently in force', superseded and escalat",
      "result": "pass",
      "detail": "five qualified Claude sites (169, 225-226, 236, 252-253, 341) and four qualified Codex sites (167, 226, 240, 329), with no bare site left in either file. The five-versus-four question was re-derived independently a third time: Codex step 4 delegates the match check by reference where Claude states it as a separate sentence, so Claude's fifth site has no Codex counterpart. Architect miscount confirmed",
      "commit_oid": "659c59b93c2886cd68edb79f4d19a146c8153c76",
      "at": "2026-07-27T16:30:33Z"
    },
    {
      "name": "shipped-defaults-verified",
      "command": "compare the five (model, effort) pairs against the shipped adapters/codex/agents/*.toml",
      "result": "pass",
      "detail": "exact match: scout terra/low, implementer terra/high, specialist sol/medium, reviewer sol/medium, reviewer-safe terra/high. orch render-agents confirmed real at internal/cli/cli.go:77 and hosts.codex.roles confirmed a real config path",
      "commit_oid": "659c59b93c2886cd68edb79f4d19a146c8153c76",
      "at": "2026-07-27T16:30:33Z"
    },
    {
      "name": "merged-with-main-suite",
      "command": "git merge origin/main into 659c59b in a scratch clone, then go test ./... and gofmt -l .",
      "result": "pass",
      "detail": "clean merge, zero conflicts; main's post-base changes touch ORCH-PRD.md, both READMEs, both plugin_test.go, both orch-architect skills, two agent TOMLs and adaptertest.go, none overlapping the two orch-delivery skills. Merged tree keeps this PR's blobs verbatim. go test ./... exit 0, gofmt empty",
      "commit_oid": "659c59b93c2886cd68edb79f4d19a146c8153c76",
      "at": "2026-07-27T16:30:33Z"
    },
    {
      "name": "live-cue-pin-survival",
      "command": "targeted verbose run of TestDeliverySkillHasRoutedSelectionCue for both adapters on the merged tree",
      "result": "pass",
      "detail": "the cue literal is present exactly once per file with LF endings and no trailing whitespace (Claude 181, Codex 183). Sibling #85's pin, now live on main, PASSES for both adapters against this PR's files. TestDeliverySkillStatesFrontmatterMatchRule, TestDeliverySkillStatesTOMLMatchRule and TestSkillStatementLiteralsPinnedToRunConstants also pass on the merged tree",
      "commit_oid": "659c59b93c2886cd68edb79f4d19a146c8153c76",
      "at": "2026-07-27T16:30:33Z"
    },
    {
      "name": "statement-literal-margin",
      "command": "count unbroken occurrences of the stop-and-tell-the-human phrase in both files",
      "result": "noted",
      "detail": "NON-BLOCKING but the Architect should own this. Claude's unbroken count fell from 3 on main to 2 at this head, and TestDeliverySkillStatesFrontmatterMatchRule requires at least 2, so the margin is now exactly zero. Cause: criterion 1's required chain-sentence insertion reflowed the reroute bullet so the third instance now wraps across a line break at Claude 346-347, invisible to a raw-byte strings.Count. The test's stated intent is intact - both spawn steps carry the phrase verbatim at unbroken lines 176 and 243 - and the third instance is still present in the prose and renders identically in markdown. Deliberately not raised as a blocker because the only remedy is another reflow, the operation that produced the last two defects and that the Architect prohibited. Codex is unchanged at 2",
      "commit_oid": "659c59b93c2886cd68edb79f4d19a146c8153c76",
      "at": "2026-07-27T16:30:33Z"
    },
    {
      "name": "unit-tests-at-head",
      "command": "go test ./... at 659c59b",
      "result": "pass",
      "detail": "exit 0, all packages ok. Pinned to the current head, repairing the audit gap where no verification referenced this commit",
      "commit_oid": "659c59b93c2886cd68edb79f4d19a146c8153c76",
      "at": "2026-07-27T16:30:33Z"
    },
    {
      "name": "gofmt-at-head",
      "command": "gofmt -l . at 659c59b",
      "result": "pass",
      "detail": "empty",
      "commit_oid": "659c59b93c2886cd68edb79f4d19a146c8153c76",
      "at": "2026-07-27T16:30:33Z"
    },
    {
      "name": "vet-at-head",
      "command": "go vet ./... at 659c59b",
      "result": "pass",
      "detail": "clean",
      "commit_oid": "659c59b93c2886cd68edb79f4d19a146c8153c76",
      "at": "2026-07-27T16:30:33Z"
    },
    {
      "name": "proofread-at-head",
      "command": "CRLF, trailing-whitespace, duplicate-word and code-span-split scan of both files",
      "result": "pass",
      "detail": "no CRLF, no trailing whitespace, trailing newline present, no duplicated words including no 'either either', no inline code span split across a line break",
      "commit_oid": "659c59b93c2886cd68edb79f4d19a146c8153c76",
      "at": "2026-07-27T16:30:33Z"
    },
    {
      "name": "prior-cycle-manifest-correction",
      "command": "recount the cross-pr-pin-survival claim recorded in cycle 2",
      "result": "noted",
      "detail": "cycle 2's entry stated 'Claude requires at least 2 and head has 3'. The countable unbroken value is 2, not 3 - that entry counted line mentions rather than unbroken literals. Corrected here for the record",
      "commit_oid": "659c59b93c2886cd68edb79f4d19a146c8153c76",
      "at": "2026-07-27T16:30:33Z"
    },
    {
      "name": "review-cycle-3",
      "result": "approve",
      "detail": "Cycle 3, approve. This entry supersedes cycle 2's reflow-word-stream-diff FAIL, which was pinned to the now-superseded 1fd0e46: the dropped word is restored and independently confirmed. A fresh reviewer ran its own whitespace-insensitive word-stream diff of 1fd0e46 to 659c59b and found zero deltas in the Claude file and exactly one insertion in Codex, +either between dispatching and into, with zero removals. It then ran a second word-stream diff of main 0d47213 to 659c59b across all three commits and enumerated every one of the 42 removed words, attributing each to a specific acceptance criterion; no word-level change anywhere in the PR is unattributable. All six criteria pass. The cycle-1 blocker was re-verified at this head rather than carried forward: git ls-files .orchestrator returns only config.toml, and check-ignore confirms all three named paths ignored while config.toml is correctly not named. The PlanDoc sentence is byte-identical across hosts (both sha256 18ad8abf). The site-count question was re-derived a third time and again resolves as an Architect miscount, not a coverage gap. Critically, main has moved since this branch's base, so the reviewer merged origin/main into this head - clean, zero conflicts - and ran the suite on the merged tree: go test ./... exit 0, gofmt clean, and the now-live TestDeliverySkillHasRoutedSelectionCue from merged sibling #85 passes for both adapters against this PR's files. Main will not break when this lands.",
      "commit_oid": "659c59b93c2886cd68edb79f4d19a146c8153c76",
      "at": "2026-07-27T16:30:34Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "659c59b93c2886cd68edb79f4d19a146c8153c76",
      "at": "2026-07-27T16:30:39Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->