### PR TITLE
Pin the routed-selection prompt cue in internal/adaptertest and make the Claude README's claim true

### DIFF
--- a/adapters/claude/README.md
+++ b/adapters/claude/README.md
@@ -127,8 +127,10 @@ bugs:
   (low/high/xhigh) is approximated by a prompt cue in the subagent's
   instructions rather than an actual host parameter. The exact routed
   effort is still recorded in the engine's audit trail; only the
-  in-session behavior is an approximation. Parity tests (task 21) assert
-  the prompt cue is present, not that it changed model behavior.
+  in-session behavior is an approximation.
+  `internal/adaptertest.CheckRoutedSelectionCue`, called from both
+  adapters' `plugin_test.go`, pins that the prompt cue text is present in
+  `orch-delivery/SKILL.md`, not that it changed model behavior.
 - **`orch guard`'s `--role` narrowing is unused by this adapter.** Hooks
   in Claude Code are plugin-global, not scoped per subagent, so the
   adapter never passes `--role` when invoking guard. Read-only role

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -334,6 +334,10 @@ func TestSetupSkillHasTerminalForms(t *testing.T) {
 	adaptertest.CheckSetupTerminalForms(t, setupSkillPath)
 }
 
+func TestDeliverySkillHasRoutedSelectionCue(t *testing.T) {
+	adaptertest.CheckRoutedSelectionCue(t, deliverySkillPath)
+}
+
 // frontmatterMatchRuleSentence is the exact phrase
 // orch-delivery/SKILL.md must state: Claude Code's Task tool model
 // parameter is a coarse tier-alias enum (sonnet/opus/haiku/fable), so

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -270,6 +270,10 @@ func TestSetupSkillHasTerminalForms(t *testing.T) {
 	adaptertest.CheckSetupTerminalForms(t, setupSkillPath)
 }
 
+func TestDeliverySkillHasRoutedSelectionCue(t *testing.T) {
+	adaptertest.CheckRoutedSelectionCue(t, deliverySkillPath)
+}
+
 // tomlMatchRuleSentence is the exact phrase orch-delivery/SKILL.md must
 // state: on Codex there is no per-spawn model override, so a routed
 // selection that matches no installed orch-* TOML must stop and tell

--- a/internal/adaptertest/adaptertest.go
+++ b/internal/adaptertest/adaptertest.go
@@ -3,9 +3,9 @@
 // profiles) and assertion helpers (skill/manifest drift pins) so
 // cross-host invariants — the run-verb allowlist, the four
 // anti-forgery statement literals, the plan/merge gate option text, the
-// setup interview's terminal forms, hook command portability, and
-// matcher/guard parity — have exactly one source instead of a copy per
-// adapter that can silently drift apart.
+// setup interview's terminal forms, hook command portability, matcher/
+// guard parity, and the routed-selection prompt cue — have exactly one
+// source instead of a copy per adapter that can silently drift apart.
 //
 // This package carries no Test functions and tests nothing of its own;
 // it is test-support only, imported by adapters/claude/plugin_test.go
@@ -248,6 +248,24 @@ func CheckHookCommandPortability(t *testing.T, commands []string) {
 		if strings.ContainsAny(cmd, portabilityForbidden) {
 			t.Errorf("command %q contains a shell metacharacter", cmd)
 		}
+	}
+}
+
+// routedSelectionCue is the exact opening line every Delivery spawn/
+// dispatch prompt must open with (fenced as its own code block in the
+// skill): the only channel carrying routed effort to a Claude Code
+// subagent, since subagent spawns take no effort parameter, and a plain
+// statement of fact on Codex, where effort is a real host parameter.
+const routedSelectionCue = "Routed selection: <model> @ <effort>"
+
+// CheckRoutedSelectionCue pins skillPath's documented spawn/dispatch
+// prompt against the exact routed-selection opening line every issue's
+// executor (and reviewer) prompt must open with.
+func CheckRoutedSelectionCue(t *testing.T, skillPath string) {
+	t.Helper()
+	content := readFile(t, skillPath)
+	if !strings.Contains(content, routedSelectionCue) {
+		t.Errorf("%s does not contain the routed-selection prompt cue %q", skillPath, routedSelectionCue)
 	}
 }
 


### PR DESCRIPTION
Delivers issue #80: Pin the routed-selection prompt cue in internal/adaptertest and make the Claude README's claim true

Closes #80

**Plan digest:** `sha256:b03046ccf82f102e66b26266bd43f163d47ec35f5414a79c0645285f991514b0`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** adapters/claude/README.md states that parity tests from task 21 assert the routed-selection prompt cue is present. Nothing in the repo asserts that: the literal 'Routed selection' appears only in the two orch-delivery SKILL.md files, in no test and in no internal/adaptertest helper. The cue is the only channel carrying routed effort to a Claude subagent, since Claude Code subagent spawns take no effort parameter, so it should not be silently deletable. Close the gap by adding the pin rather than by deleting the claim: add a cross-host helper in internal/adaptertest (the existing home for shared invariants, alongside CheckRunVerbTokens, CheckStatementLiterals and CheckPlanGateOptions) and call it from both hosts' plugin_test.go.

**Acceptance criteria:**
- internal/adaptertest gains one exported helper following the existing Check* naming and (t *testing.T, path string) signature style that asserts a given orch-delivery skill contains the routed-selection prompt-cue opening line 'Routed selection: &lt;model&gt; @ &lt;effort&gt;'.
- adapters/claude/plugin_test.go calls that helper against adapters/claude/skills/orch-delivery/SKILL.md, and adapters/codex/plugin_test.go calls it against adapters/codex/skills/orch-delivery/SKILL.md.
- The helper is a genuine pin, not a tautology: the executor temporarily removes the cue line from one skill, records that the new test fails, restores the line, and reports the observed failure output in its verification evidence.
- adapters/claude/README.md's reasoning-effort bullet accurately describes the check that now exists instead of attributing it to task 21's parity tests.
- No file outside internal/adaptertest/adaptertest.go, adapters/claude/plugin_test.go, adapters/codex/plugin_test.go and adapters/claude/README.md is modified.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **unit-tests** — pass — `go test ./...` — all packages ok, or no test files where applicable; run on the final committed state — commit `c66efb04aa306732d23ade99b4fdd66a89efa8fb` (2026-07-27T15:43:37Z)
- **gofmt** — pass — `gofmt -l .` — no output; no unformatted files — commit `c66efb04aa306732d23ade99b4fdd66a89efa8fb` (2026-07-27T15:43:37Z)
- **scope-check** — pass — `git diff --name-status against merge base 0d47213` — exactly the four allowed files, single commit, no stray reformatting; every hunk attributable to the objective — commit `c66efb04aa306732d23ade99b4fdd66a89efa8fb` (2026-07-27T16:00:52Z)
- **pin-negative-test** — pass — `go test ./adapters/claude/... -run TestDeliverySkillHasRoutedSelectionCue -v, with the cue line temporarily deleted from adapters/claude/skills/orch-delivery/SKILL.md` — the new check is a genuine pin, not a tautology. Verbatim failure output with the line removed: plugin_test.go:338: skills/orch-delivery/SKILL.md does not contain the routed-selection prompt cue "Routed selection: &lt;model&gt; @ &lt;effort&gt;" --- FAIL: TestDeliverySkillHasRoutedSelectionCue (0.00s). The line was then restored and the file confirmed byte-identical to its committed content before commit; the full suite was re-run green afterwards. Satisfies acceptance criterion 3 — commit `c66efb04aa306732d23ade99b4fdd66a89efa8fb` (2026-07-27T15:43:37Z)
- **unit-tests-reproduced** — pass — `go test ./... at c66efb04 in a private scratch clone` — every package ok or no test files — commit `c66efb04aa306732d23ade99b4fdd66a89efa8fb` (2026-07-27T16:00:52Z)
- **gofmt-reproduced** — pass — `gofmt -l . at c66efb04` — empty — commit `c66efb04aa306732d23ade99b4fdd66a89efa8fb` (2026-07-27T16:00:52Z)
- **vet-reproduced** — pass — `go vet ./...` — clean — commit `c66efb04aa306732d23ade99b4fdd66a89efa8fb` (2026-07-27T16:00:52Z)
- **ci-head-pinned** — pass — `gh run view 30281371890 confirming headSha` — all 6 checks SUCCESS on exactly c66efb04; mergeable MERGEABLE, mergeStateStatus CLEAN — commit `c66efb04aa306732d23ade99b4fdd66a89efa8fb` (2026-07-27T16:00:52Z)
- **cross-pr-pin-survival** — pass — `read both orch-delivery skills at #84's head 0a53e4f4, then merge 0a53e4f4 into c66efb04 in a scratch worktree and run go test ./...` — the cue literal survives byte-identical in both skills at #84's head; the merge is clean (ort, no conflicts) and the suite is green. Merging all four open PRs onto one tree is also green. No merge-order constraint against #82, #83 or #84 — commit `c66efb04aa306732d23ade99b4fdd66a89efa8fb` (2026-07-27T16:00:52Z)
- **pin-negative-test-reproduced** — pass — `delete the cue line from the Claude skill at the PR head and run the new test, then repeat on the Codex skill` — the executor's claimed failure output reproduced byte-for-byte including the line number. The reviewer additionally ran the experiment on the Codex side, which the executor had not, confirming that call site fails identically and is not a no-op — commit `c66efb04aa306732d23ade99b4fdd66a89efa8fb` (2026-07-27T16:00:52Z)
- **removal-residue-check** — pass — `compare blob OIDs of both orch-delivery SKILL.md at the PR head against main` — blob OIDs identical to main (claude 9c67606e, codex bf2b34fa), so the temporary removal left no residue. Stronger evidence than the diff alone, and rules out any collision surface with #84 — commit `c66efb04aa306732d23ade99b4fdd66a89efa8fb` (2026-07-27T16:00:52Z)
- **idiom-conformance** — pass — `compare the new helper against CheckPlanGateOptions, CheckMergeGateOptions and CheckSetupTerminalForms` — matches on every axis: Check* name, (t, path) signature, t.Helper() first, the shared readFile wrapper, strings.Contains, and the same failure-message shape with the path first and the literal %q-quoted. Doc comments present on both the constant and the function — commit `c66efb04aa306732d23ade99b4fdd66a89efa8fb` (2026-07-27T16:00:52Z)
- **readme-no-overclaim** — pass — `read adapters/claude/README.md lines 124-134` — the task-21 attribution is gone; the bullet names the check that exists and preserves the honest half verbatim in substance - pins that the cue text is present, not that it changed model behavior. The remaining task-21 mention at line 147 is a different, unrelated claim — commit `c66efb04aa306732d23ade99b4fdd66a89efa8fb` (2026-07-27T16:00:52Z)
- **doc-order-and-attribution-nits** — noted — `reviewer observations` — non-blocking and deliberately not acted on: the helper is inserted before CheckMatcherEqualsGuardTools while the package doc lists it after, breaking that file's previous doc-order/code-order correspondence; and the constant comment calls the opening line the only channel carrying routed effort, where the skill attributes that role to the following sentence. The line does name effort, so the comment is displaced rather than wrong — commit `c66efb04aa306732d23ade99b4fdd66a89efa8fb` (2026-07-27T16:00:52Z)
- **review-cycle-1** — approve — Approve. All five acceptance criteria pass on evidence the reviewer reproduced rather than accepted. CROSS-PR RULING - the pin holds against sibling #84, on three independent lines of evidence: the cue literal is byte-identical in both of #84's rewritten skills (Claude line 180, Codex line 182, each still in its own fenced block) despite substantial rewriting of the surrounding paragraphs; there is zero file overlap; and the reviewer actually merged #84 into this head in a scratch worktree (clean ort merge) and ran the suite green. It then went further and merged all four open PRs (#82, #83, #84, #85) onto one tree - go test ./... green, gofmt -l . empty. Merge order is unconstrained. PIN CALIBRATION - lands on the right side. The asserted literal carries no indentation, fence or trailing newline and is matched by strings.Contains over the whole file, so reflows and relocation survive, demonstrated empirically by #84 moving the line 4 and 8 lines without disturbing the assertion; deletion or rewording of the cue itself fails, which is correct since that is a change to the contract. Its known looseness (no fencing, position or uniqueness assertion) is exactly the strength of the sibling CheckPlanGateOptions and CheckMergeGateOptions helpers, which criterion 1 asked it to conform to. CRITERION 3 verified beyond what was required: the reviewer reproduced the executor's removal experiment byte-for-byte including the line number, then ran the same experiment on the Codex side, which the executor had not, proving that call site is live rather than a no-op. Removal residue ruled out by blob-OID equality against main, not merely by the diff. — commit `c66efb04aa306732d23ade99b4fdd66a89efa8fb` (2026-07-27T16:00:54Z)
- **required-ci** — passing — test (macos-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `c66efb04aa306732d23ade99b4fdd66a89efa8fb` (2026-07-27T16:01:09Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "adapters/claude/README.md states that parity tests from task 21 assert the routed-selection prompt cue is present. Nothing in the repo asserts that: the literal 'Routed selection' appears only in the two orch-delivery SKILL.md files, in no test and in no internal/adaptertest helper. The cue is the only channel carrying routed effort to a Claude subagent, since Claude Code subagent spawns take no effort parameter, so it should not be silently deletable. Close the gap by adding the pin rather than by deleting the claim: add a cross-host helper in internal/adaptertest (the existing home for shared invariants, alongside CheckRunVerbTokens, CheckStatementLiterals and CheckPlanGateOptions) and call it from both hosts' plugin_test.go.",
  "acceptance_criteria": [
    "internal/adaptertest gains one exported helper following the existing Check* naming and (t *testing.T, path string) signature style that asserts a given orch-delivery skill contains the routed-selection prompt-cue opening line 'Routed selection: \u003cmodel\u003e @ \u003ceffort\u003e'.",
    "adapters/claude/plugin_test.go calls that helper against adapters/claude/skills/orch-delivery/SKILL.md, and adapters/codex/plugin_test.go calls it against adapters/codex/skills/orch-delivery/SKILL.md.",
    "The helper is a genuine pin, not a tautology: the executor temporarily removes the cue line from one skill, records that the new test fails, restores the line, and reports the observed failure output in its verification evidence.",
    "adapters/claude/README.md's reasoning-effort bullet accurately describes the check that now exists instead of attributing it to task 21's parity tests.",
    "No file outside internal/adaptertest/adaptertest.go, adapters/claude/plugin_test.go, adapters/codex/plugin_test.go and adapters/claude/README.md is modified."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "unit-tests",
      "command": "go test ./...",
      "result": "pass",
      "detail": "all packages ok, or no test files where applicable; run on the final committed state",
      "commit_oid": "c66efb04aa306732d23ade99b4fdd66a89efa8fb",
      "at": "2026-07-27T15:43:37Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "no output; no unformatted files",
      "commit_oid": "c66efb04aa306732d23ade99b4fdd66a89efa8fb",
      "at": "2026-07-27T15:43:37Z"
    },
    {
      "name": "scope-check",
      "command": "git diff --name-status against merge base 0d47213",
      "result": "pass",
      "detail": "exactly the four allowed files, single commit, no stray reformatting; every hunk attributable to the objective",
      "commit_oid": "c66efb04aa306732d23ade99b4fdd66a89efa8fb",
      "at": "2026-07-27T16:00:52Z"
    },
    {
      "name": "pin-negative-test",
      "command": "go test ./adapters/claude/... -run TestDeliverySkillHasRoutedSelectionCue -v, with the cue line temporarily deleted from adapters/claude/skills/orch-delivery/SKILL.md",
      "result": "pass",
      "detail": "the new check is a genuine pin, not a tautology. Verbatim failure output with the line removed: plugin_test.go:338: skills/orch-delivery/SKILL.md does not contain the routed-selection prompt cue \"Routed selection: \u003cmodel\u003e @ \u003ceffort\u003e\" --- FAIL: TestDeliverySkillHasRoutedSelectionCue (0.00s). The line was then restored and the file confirmed byte-identical to its committed content before commit; the full suite was re-run green afterwards. Satisfies acceptance criterion 3",
      "commit_oid": "c66efb04aa306732d23ade99b4fdd66a89efa8fb",
      "at": "2026-07-27T15:43:37Z"
    },
    {
      "name": "unit-tests-reproduced",
      "command": "go test ./... at c66efb04 in a private scratch clone",
      "result": "pass",
      "detail": "every package ok or no test files",
      "commit_oid": "c66efb04aa306732d23ade99b4fdd66a89efa8fb",
      "at": "2026-07-27T16:00:52Z"
    },
    {
      "name": "gofmt-reproduced",
      "command": "gofmt -l . at c66efb04",
      "result": "pass",
      "detail": "empty",
      "commit_oid": "c66efb04aa306732d23ade99b4fdd66a89efa8fb",
      "at": "2026-07-27T16:00:52Z"
    },
    {
      "name": "vet-reproduced",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "clean",
      "commit_oid": "c66efb04aa306732d23ade99b4fdd66a89efa8fb",
      "at": "2026-07-27T16:00:52Z"
    },
    {
      "name": "ci-head-pinned",
      "command": "gh run view 30281371890 confirming headSha",
      "result": "pass",
      "detail": "all 6 checks SUCCESS on exactly c66efb04; mergeable MERGEABLE, mergeStateStatus CLEAN",
      "commit_oid": "c66efb04aa306732d23ade99b4fdd66a89efa8fb",
      "at": "2026-07-27T16:00:52Z"
    },
    {
      "name": "cross-pr-pin-survival",
      "command": "read both orch-delivery skills at #84's head 0a53e4f4, then merge 0a53e4f4 into c66efb04 in a scratch worktree and run go test ./...",
      "result": "pass",
      "detail": "the cue literal survives byte-identical in both skills at #84's head; the merge is clean (ort, no conflicts) and the suite is green. Merging all four open PRs onto one tree is also green. No merge-order constraint against #82, #83 or #84",
      "commit_oid": "c66efb04aa306732d23ade99b4fdd66a89efa8fb",
      "at": "2026-07-27T16:00:52Z"
    },
    {
      "name": "pin-negative-test-reproduced",
      "command": "delete the cue line from the Claude skill at the PR head and run the new test, then repeat on the Codex skill",
      "result": "pass",
      "detail": "the executor's claimed failure output reproduced byte-for-byte including the line number. The reviewer additionally ran the experiment on the Codex side, which the executor had not, confirming that call site fails identically and is not a no-op",
      "commit_oid": "c66efb04aa306732d23ade99b4fdd66a89efa8fb",
      "at": "2026-07-27T16:00:52Z"
    },
    {
      "name": "removal-residue-check",
      "command": "compare blob OIDs of both orch-delivery SKILL.md at the PR head against main",
      "result": "pass",
      "detail": "blob OIDs identical to main (claude 9c67606e, codex bf2b34fa), so the temporary removal left no residue. Stronger evidence than the diff alone, and rules out any collision surface with #84",
      "commit_oid": "c66efb04aa306732d23ade99b4fdd66a89efa8fb",
      "at": "2026-07-27T16:00:52Z"
    },
    {
      "name": "idiom-conformance",
      "command": "compare the new helper against CheckPlanGateOptions, CheckMergeGateOptions and CheckSetupTerminalForms",
      "result": "pass",
      "detail": "matches on every axis: Check* name, (t, path) signature, t.Helper() first, the shared readFile wrapper, strings.Contains, and the same failure-message shape with the path first and the literal %q-quoted. Doc comments present on both the constant and the function",
      "commit_oid": "c66efb04aa306732d23ade99b4fdd66a89efa8fb",
      "at": "2026-07-27T16:00:52Z"
    },
    {
      "name": "readme-no-overclaim",
      "command": "read adapters/claude/README.md lines 124-134",
      "result": "pass",
      "detail": "the task-21 attribution is gone; the bullet names the check that exists and preserves the honest half verbatim in substance - pins that the cue text is present, not that it changed model behavior. The remaining task-21 mention at line 147 is a different, unrelated claim",
      "commit_oid": "c66efb04aa306732d23ade99b4fdd66a89efa8fb",
      "at": "2026-07-27T16:00:52Z"
    },
    {
      "name": "doc-order-and-attribution-nits",
      "command": "reviewer observations",
      "result": "noted",
      "detail": "non-blocking and deliberately not acted on: the helper is inserted before CheckMatcherEqualsGuardTools while the package doc lists it after, breaking that file's previous doc-order/code-order correspondence; and the constant comment calls the opening line the only channel carrying routed effort, where the skill attributes that role to the following sentence. The line does name effort, so the comment is displaced rather than wrong",
      "commit_oid": "c66efb04aa306732d23ade99b4fdd66a89efa8fb",
      "at": "2026-07-27T16:00:52Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approve. All five acceptance criteria pass on evidence the reviewer reproduced rather than accepted. CROSS-PR RULING - the pin holds against sibling #84, on three independent lines of evidence: the cue literal is byte-identical in both of #84's rewritten skills (Claude line 180, Codex line 182, each still in its own fenced block) despite substantial rewriting of the surrounding paragraphs; there is zero file overlap; and the reviewer actually merged #84 into this head in a scratch worktree (clean ort merge) and ran the suite green. It then went further and merged all four open PRs (#82, #83, #84, #85) onto one tree - go test ./... green, gofmt -l . empty. Merge order is unconstrained. PIN CALIBRATION - lands on the right side. The asserted literal carries no indentation, fence or trailing newline and is matched by strings.Contains over the whole file, so reflows and relocation survive, demonstrated empirically by #84 moving the line 4 and 8 lines without disturbing the assertion; deletion or rewording of the cue itself fails, which is correct since that is a change to the contract. Its known looseness (no fencing, position or uniqueness assertion) is exactly the strength of the sibling CheckPlanGateOptions and CheckMergeGateOptions helpers, which criterion 1 asked it to conform to. CRITERION 3 verified beyond what was required: the reviewer reproduced the executor's removal experiment byte-for-byte including the line number, then ran the same experiment on the Codex side, which the executor had not, proving that call site is live rather than a no-op. Removal residue ruled out by blob-OID equality against main, not merely by the diff.",
      "commit_oid": "c66efb04aa306732d23ade99b4fdd66a89efa8fb",
      "at": "2026-07-27T16:00:54Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (macos-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "c66efb04aa306732d23ade99b4fdd66a89efa8fb",
      "at": "2026-07-27T16:01:09Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->