### PR TITLE
Bump the plugin manifests from 0.5.3 to 0.5.4 as the last content-bearing commit before the next tag

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "kninetimmy" },
   "metadata": {
     "description": "Host adapters for the Orch development orchestrator",
-    "version": "0.5.3"
+    "version": "0.5.4"
   },
   "plugins": [
     {

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Claude Code host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -78,8 +78,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.3" {
-		t.Errorf("version = %q, want 0.5.3", m.Version)
+	if m.Version != "0.5.4" {
+		t.Errorf("version = %q, want 0.5.4", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Codex CLI host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -79,8 +79,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.3" {
-		t.Errorf("version = %q, want 0.5.3", m.Version)
+	if m.Version != "0.5.4" {
+		t.Errorf("version = %q, want 0.5.4", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")


### PR DESCRIPTION
Delivers issue #81: Bump the plugin manifests from 0.5.3 to 0.5.4 as the last content-bearing commit before the next tag

Closes #81

**Plan digest:** `sha256:b03046ccf82f102e66b26266bd43f163d47ec35f5414a79c0645285f991514b0`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Task 69: a version bump is only safe if it is the last content-bearing commit before the tag. Version 0.5.3 shipped twice with different contents (installed 0.5.3 at 4293ec7 versus released 0.5.3 at 0d47213) because PR #76 merged further adapter content at an already-bumped version, and claude plugin update compares version strings only, so it refused to refresh. This issue applies rule (a): bump last, after every prose change in this run has merged, so the released 0.5.4 and the installed 0.5.4 cannot diverge.

**Acceptance criteria:**
- The declared plugin version is 0.5.4 in .claude-plugin/marketplace.json, adapters/claude/.claude-plugin/plugin.json and adapters/codex/.codex-plugin/plugin.json.
- The version assertions in adapters/claude/plugin_test.go and adapters/codex/plugin_test.go expect 0.5.4.
- No tracked file still declares 0.5.3 as the current plugin version; prose that refers to 0.5.3 as a past release is left unchanged.
- No file outside .claude-plugin/marketplace.json, adapters/claude/.claude-plugin/plugin.json, adapters/codex/.codex-plugin/plugin.json, adapters/claude/plugin_test.go and adapters/codex/plugin_test.go is modified.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-sonnet-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **unit-tests** — pass — `go test ./...` — all packages ok including adapters/claude and adapters/codex; two report no test files (cmd/orch, internal/adaptertest) — commit `9446c677339adea56953e3c6e9fcbbd826728c8d` (2026-07-27T16:40:19Z)
- **gofmt** — pass — `gofmt -l .` — empty output — commit `9446c677339adea56953e3c6e9fcbbd826728c8d` (2026-07-27T16:40:19Z)
- **version-declaration-sweep** — pass — `git grep -n '0\.5\.3' over tracked files, cross-checked with a plain recursive grep, plus checks for 0.5.2 remnants and any pre-existing 0.5.4` — every hit was a current-version declaration and all fell inside the five permitted files: marketplace.json line 6, both plugin.json line 4, and the TestPluginManifestStrict expected-value and error-message literals in both plugin_test.go. No hit referred to 0.5.3 as a past release, so nothing needed to be left alone under criterion 3, and no declaration was found outside criterion 4's five files, so no escalation to the Architect was required — commit `9446c677339adea56953e3c6e9fcbbd826728c8d` (2026-07-27T16:40:19Z)
- **scope-check** — pass — `git status --short` — exactly the five permitted files modified, matching acceptance criterion 4 — commit `9446c677339adea56953e3c6e9fcbbd826728c8d` (2026-07-27T16:40:19Z)
- **no-tag-created** — pass — `confirm no git tag and no release-workflow change` — no tag created or pushed and no release workflow touched; tagging v0.5.4 remains a human act after this merges. None of the four already-merged PRs' content was revisited — commit `9446c677339adea56953e3c6e9fcbbd826728c8d` (2026-07-27T16:40:19Z)
- **manifest-versions** — pass — `git show diff of the three JSON manifests at 9446c67` — .claude-plugin/marketplace.json, adapters/claude/.claude-plugin/plugin.json and adapters/codex/.codex-plugin/plugin.json all declare version 0.5.4 — commit `9446c677339adea56953e3c6e9fcbbd826728c8d` (2026-07-27T16:45:58Z)
- **test-assertions-consistent** — pass — `targeted grep of both plugin_test.go files for version literals` — both update the expected-value check and the error-message literal to 0.5.4 with no mismatch between them; only those two lines per file mention a version and nothing stale remains — commit `9446c677339adea56953e3c6e9fcbbd826728c8d` (2026-07-27T16:45:58Z)
- **forward-sweep** — pass — `git grep -n -F '0.5.3' and git grep -n -E '0\.5\.[0-9]' over the full tracked tree at this head` — zero hits for 0.5.3 (exit 1); the version-pattern sweep returns only the seven expected 0.5.4 lines inside the five permitted files — commit `9446c677339adea56953e3c6e9fcbbd826728c8d` (2026-07-27T16:45:58Z)
- **converse-sweep-nothing-rewritten** — pass — `full-tree version-pattern search across all *.md including README.md, both adapter READMEs and ORCH-PRD.md, plus a check for a CHANGELOG` — no CHANGELOG exists and no past-release plugin-version mentions exist anywhere; the only version-like hits are unrelated v0.1.0 install-pinning examples and host versions. The executor's claim that there were no historical references to preserve holds, so criterion 3's leave-alone clause was vacuous rather than violated — commit `9446c677339adea56953e3c6e9fcbbd826728c8d` (2026-07-27T16:45:58Z)
- **missed-declaration-check** — pass — `search for any current-plugin-version declaration outside the five permitted files` — internal/cli/version.go declares the orch binary's ldflag-stamped release version, a different concept, correctly out of scope. marketplace_test.go compares p.Version against m.Metadata.Version dynamically so it hardcodes no literal and needed no edit. No standalone VERSION or package.json. The five-file list in criterion 4 is exhaustive, so criterion 3 and criterion 4 do not conflict here — commit `9446c677339adea56953e3c6e9fcbbd826728c8d` (2026-07-27T16:45:58Z)
- **scope-and-lineage** — pass — `git show --stat, gh pr view --json files, git merge-base f1b870e HEAD, git log ancestry check` — exactly five files, 7 insertions and 7 deletions, one commit. merge-base with f1b870e is f1b870e itself, a clean linear fork with no rebasing. PRs #82, #83, #84 and #85 are all ancestors of the base and untouched by this diff, so the branch adds only the version bump — commit `9446c677339adea56953e3c6e9fcbbd826728c8d` (2026-07-27T16:45:58Z)
- **no-tag-no-workflow** — pass — `git tag -l; git ls-remote --tags origin; git diff f1b870e HEAD -- .github/` — tags run only through v0.5.3 at 0d472136, matching the objective's account of the 0.5.3 release; no v0.5.4 tag exists locally or on origin; the .github/ diff is empty so no release workflow was modified — commit `9446c677339adea56953e3c6e9fcbbd826728c8d` (2026-07-27T16:45:58Z)
- **unit-tests-reproduced** — pass — `go test ./... at 9446c67 in the scratch clone` — all packages pass including adapters/claude, adapters/codex and the root marketplace_test.go package; verbose runs of TestPluginManifestStrict in both adapters and TestMarketplace* in root all PASS — commit `9446c677339adea56953e3c6e9fcbbd826728c8d` (2026-07-27T16:45:58Z)
- **gofmt-reproduced** — pass — `gofmt -l . at 9446c67` — empty output — commit `9446c677339adea56953e3c6e9fcbbd826728c8d` (2026-07-27T16:45:58Z)
- **ci-head-pinned** — pass — `gh run view 30285769767 --json headSha, cross-checked against gh pr checks 86` — all six required checks pass and the run's headSha is exactly 9446c677339adea56953e3c6e9fcbbd826728c8d, confirming the green run is against the reviewed commit and not a stale earlier push — commit `9446c677339adea56953e3c6e9fcbbd826728c8d` (2026-07-27T16:45:58Z)
- **audit-record-accuracy** — pass — `compare the PR body manifest against issue #81's manifest and re-test each recorded verification claim` — the manifest blocks are verbatim identical, and every recorded verification (unit-tests, gofmt, version-declaration-sweep, scope-check, no-tag-created) was independently reproduced and found true, including the hardest claim that no historical 0.5.3 reference existed — commit `9446c677339adea56953e3c6e9fcbbd826728c8d` (2026-07-27T16:45:58Z)
- **review-cycle-1** — approve — Approve, first pass. All four acceptance criteria verified independently in an isolated scratch clone at the exact head OID; the main checkout's HEAD was never touched. Criterion 3 was the one with judgment in it and it was pressed hardest, in all three directions asked for. Forward: git grep -F '0.5.3' over the full tracked tree returns ZERO hits, and git grep -E '0\.5\.[0-9]' returns only the seven expected 0.5.4 lines inside the five permitted files. Converse: the executor's strong claim that no historical 0.5.3 reference existed to preserve was checked rather than accepted - there is no CHANGELOG in this repo, and a full-tree version-pattern sweep across README.md, both adapter READMEs and ORCH-PRD.md finds no past-release plugin-version mentions at all, only unrelated v0.1.0 install-pinning examples and host versions (codex-cli 0.144.1, Claude Code 2.1.207). Nothing was quietly rewritten. Missed-declaration check: internal/cli/version.go declares a DIFFERENT concept, the orch binary's ldflag-stamped release version defaulting to 'dev', correctly out of scope; marketplace_test.go derives its check dynamically (p.Version != m.Metadata.Version) rather than hardcoding a literal, so it needed no edit and is not a missed site; no standalone VERSION or package.json exists. The criteria's five-file list is exhaustive as far as this sweep can determine. Both plugin_test.go edits update the expected value AND the error-message literal consistently, so a future failure message cannot lie. Tags run only through v0.5.3 at 0d472136 and no v0.5.4 tag exists locally or on origin - tagging correctly remains a human act after merge. No .github/ change. The branch is a clean linear fork: merge-base with f1b870e is f1b870e itself, one commit, and all four wave-1 PRs are ancestors and untouched. — commit `9446c677339adea56953e3c6e9fcbbd826728c8d` (2026-07-27T16:45:59Z)
- **required-ci** — passing — test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass — commit `9446c677339adea56953e3c6e9fcbbd826728c8d` (2026-07-27T16:46:03Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Task 69: a version bump is only safe if it is the last content-bearing commit before the tag. Version 0.5.3 shipped twice with different contents (installed 0.5.3 at 4293ec7 versus released 0.5.3 at 0d47213) because PR #76 merged further adapter content at an already-bumped version, and claude plugin update compares version strings only, so it refused to refresh. This issue applies rule (a): bump last, after every prose change in this run has merged, so the released 0.5.4 and the installed 0.5.4 cannot diverge.",
  "acceptance_criteria": [
    "The declared plugin version is 0.5.4 in .claude-plugin/marketplace.json, adapters/claude/.claude-plugin/plugin.json and adapters/codex/.codex-plugin/plugin.json.",
    "The version assertions in adapters/claude/plugin_test.go and adapters/codex/plugin_test.go expect 0.5.4.",
    "No tracked file still declares 0.5.3 as the current plugin version; prose that refers to 0.5.3 as a past release is left unchanged.",
    "No file outside .claude-plugin/marketplace.json, adapters/claude/.claude-plugin/plugin.json, adapters/codex/.codex-plugin/plugin.json, adapters/claude/plugin_test.go and adapters/codex/plugin_test.go is modified."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "claude-sonnet-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "unit-tests",
      "command": "go test ./...",
      "result": "pass",
      "detail": "all packages ok including adapters/claude and adapters/codex; two report no test files (cmd/orch, internal/adaptertest)",
      "commit_oid": "9446c677339adea56953e3c6e9fcbbd826728c8d",
      "at": "2026-07-27T16:40:19Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "empty output",
      "commit_oid": "9446c677339adea56953e3c6e9fcbbd826728c8d",
      "at": "2026-07-27T16:40:19Z"
    },
    {
      "name": "version-declaration-sweep",
      "command": "git grep -n '0\\.5\\.3' over tracked files, cross-checked with a plain recursive grep, plus checks for 0.5.2 remnants and any pre-existing 0.5.4",
      "result": "pass",
      "detail": "every hit was a current-version declaration and all fell inside the five permitted files: marketplace.json line 6, both plugin.json line 4, and the TestPluginManifestStrict expected-value and error-message literals in both plugin_test.go. No hit referred to 0.5.3 as a past release, so nothing needed to be left alone under criterion 3, and no declaration was found outside criterion 4's five files, so no escalation to the Architect was required",
      "commit_oid": "9446c677339adea56953e3c6e9fcbbd826728c8d",
      "at": "2026-07-27T16:40:19Z"
    },
    {
      "name": "scope-check",
      "command": "git status --short",
      "result": "pass",
      "detail": "exactly the five permitted files modified, matching acceptance criterion 4",
      "commit_oid": "9446c677339adea56953e3c6e9fcbbd826728c8d",
      "at": "2026-07-27T16:40:19Z"
    },
    {
      "name": "no-tag-created",
      "command": "confirm no git tag and no release-workflow change",
      "result": "pass",
      "detail": "no tag created or pushed and no release workflow touched; tagging v0.5.4 remains a human act after this merges. None of the four already-merged PRs' content was revisited",
      "commit_oid": "9446c677339adea56953e3c6e9fcbbd826728c8d",
      "at": "2026-07-27T16:40:19Z"
    },
    {
      "name": "manifest-versions",
      "command": "git show diff of the three JSON manifests at 9446c67",
      "result": "pass",
      "detail": ".claude-plugin/marketplace.json, adapters/claude/.claude-plugin/plugin.json and adapters/codex/.codex-plugin/plugin.json all declare version 0.5.4",
      "commit_oid": "9446c677339adea56953e3c6e9fcbbd826728c8d",
      "at": "2026-07-27T16:45:58Z"
    },
    {
      "name": "test-assertions-consistent",
      "command": "targeted grep of both plugin_test.go files for version literals",
      "result": "pass",
      "detail": "both update the expected-value check and the error-message literal to 0.5.4 with no mismatch between them; only those two lines per file mention a version and nothing stale remains",
      "commit_oid": "9446c677339adea56953e3c6e9fcbbd826728c8d",
      "at": "2026-07-27T16:45:58Z"
    },
    {
      "name": "forward-sweep",
      "command": "git grep -n -F '0.5.3' and git grep -n -E '0\\.5\\.[0-9]' over the full tracked tree at this head",
      "result": "pass",
      "detail": "zero hits for 0.5.3 (exit 1); the version-pattern sweep returns only the seven expected 0.5.4 lines inside the five permitted files",
      "commit_oid": "9446c677339adea56953e3c6e9fcbbd826728c8d",
      "at": "2026-07-27T16:45:58Z"
    },
    {
      "name": "converse-sweep-nothing-rewritten",
      "command": "full-tree version-pattern search across all *.md including README.md, both adapter READMEs and ORCH-PRD.md, plus a check for a CHANGELOG",
      "result": "pass",
      "detail": "no CHANGELOG exists and no past-release plugin-version mentions exist anywhere; the only version-like hits are unrelated v0.1.0 install-pinning examples and host versions. The executor's claim that there were no historical references to preserve holds, so criterion 3's leave-alone clause was vacuous rather than violated",
      "commit_oid": "9446c677339adea56953e3c6e9fcbbd826728c8d",
      "at": "2026-07-27T16:45:58Z"
    },
    {
      "name": "missed-declaration-check",
      "command": "search for any current-plugin-version declaration outside the five permitted files",
      "result": "pass",
      "detail": "internal/cli/version.go declares the orch binary's ldflag-stamped release version, a different concept, correctly out of scope. marketplace_test.go compares p.Version against m.Metadata.Version dynamically so it hardcodes no literal and needed no edit. No standalone VERSION or package.json. The five-file list in criterion 4 is exhaustive, so criterion 3 and criterion 4 do not conflict here",
      "commit_oid": "9446c677339adea56953e3c6e9fcbbd826728c8d",
      "at": "2026-07-27T16:45:58Z"
    },
    {
      "name": "scope-and-lineage",
      "command": "git show --stat, gh pr view --json files, git merge-base f1b870e HEAD, git log ancestry check",
      "result": "pass",
      "detail": "exactly five files, 7 insertions and 7 deletions, one commit. merge-base with f1b870e is f1b870e itself, a clean linear fork with no rebasing. PRs #82, #83, #84 and #85 are all ancestors of the base and untouched by this diff, so the branch adds only the version bump",
      "commit_oid": "9446c677339adea56953e3c6e9fcbbd826728c8d",
      "at": "2026-07-27T16:45:58Z"
    },
    {
      "name": "no-tag-no-workflow",
      "command": "git tag -l; git ls-remote --tags origin; git diff f1b870e HEAD -- .github/",
      "result": "pass",
      "detail": "tags run only through v0.5.3 at 0d472136, matching the objective's account of the 0.5.3 release; no v0.5.4 tag exists locally or on origin; the .github/ diff is empty so no release workflow was modified",
      "commit_oid": "9446c677339adea56953e3c6e9fcbbd826728c8d",
      "at": "2026-07-27T16:45:58Z"
    },
    {
      "name": "unit-tests-reproduced",
      "command": "go test ./... at 9446c67 in the scratch clone",
      "result": "pass",
      "detail": "all packages pass including adapters/claude, adapters/codex and the root marketplace_test.go package; verbose runs of TestPluginManifestStrict in both adapters and TestMarketplace* in root all PASS",
      "commit_oid": "9446c677339adea56953e3c6e9fcbbd826728c8d",
      "at": "2026-07-27T16:45:58Z"
    },
    {
      "name": "gofmt-reproduced",
      "command": "gofmt -l . at 9446c67",
      "result": "pass",
      "detail": "empty output",
      "commit_oid": "9446c677339adea56953e3c6e9fcbbd826728c8d",
      "at": "2026-07-27T16:45:58Z"
    },
    {
      "name": "ci-head-pinned",
      "command": "gh run view 30285769767 --json headSha, cross-checked against gh pr checks 86",
      "result": "pass",
      "detail": "all six required checks pass and the run's headSha is exactly 9446c677339adea56953e3c6e9fcbbd826728c8d, confirming the green run is against the reviewed commit and not a stale earlier push",
      "commit_oid": "9446c677339adea56953e3c6e9fcbbd826728c8d",
      "at": "2026-07-27T16:45:58Z"
    },
    {
      "name": "audit-record-accuracy",
      "command": "compare the PR body manifest against issue #81's manifest and re-test each recorded verification claim",
      "result": "pass",
      "detail": "the manifest blocks are verbatim identical, and every recorded verification (unit-tests, gofmt, version-declaration-sweep, scope-check, no-tag-created) was independently reproduced and found true, including the hardest claim that no historical 0.5.3 reference existed",
      "commit_oid": "9446c677339adea56953e3c6e9fcbbd826728c8d",
      "at": "2026-07-27T16:45:58Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approve, first pass. All four acceptance criteria verified independently in an isolated scratch clone at the exact head OID; the main checkout's HEAD was never touched. Criterion 3 was the one with judgment in it and it was pressed hardest, in all three directions asked for. Forward: git grep -F '0.5.3' over the full tracked tree returns ZERO hits, and git grep -E '0\\.5\\.[0-9]' returns only the seven expected 0.5.4 lines inside the five permitted files. Converse: the executor's strong claim that no historical 0.5.3 reference existed to preserve was checked rather than accepted - there is no CHANGELOG in this repo, and a full-tree version-pattern sweep across README.md, both adapter READMEs and ORCH-PRD.md finds no past-release plugin-version mentions at all, only unrelated v0.1.0 install-pinning examples and host versions (codex-cli 0.144.1, Claude Code 2.1.207). Nothing was quietly rewritten. Missed-declaration check: internal/cli/version.go declares a DIFFERENT concept, the orch binary's ldflag-stamped release version defaulting to 'dev', correctly out of scope; marketplace_test.go derives its check dynamically (p.Version != m.Metadata.Version) rather than hardcoding a literal, so it needed no edit and is not a missed site; no standalone VERSION or package.json exists. The criteria's five-file list is exhaustive as far as this sweep can determine. Both plugin_test.go edits update the expected value AND the error-message literal consistently, so a future failure message cannot lie. Tags run only through v0.5.3 at 0d472136 and no v0.5.4 tag exists locally or on origin - tagging correctly remains a human act after merge. No .github/ change. The branch is a clean linear fork: merge-base with f1b870e is f1b870e itself, one commit, and all four wave-1 PRs are ancestors and untouched.",
      "commit_oid": "9446c677339adea56953e3c6e9fcbbd826728c8d",
      "at": "2026-07-27T16:45:59Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "9446c677339adea56953e3c6e9fcbbd826728c8d",
      "at": "2026-07-27T16:46:03Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->