### PR TITLE
Compare prose pins on normalized whitespace in internal/adaptertest and both plugin tests

### DIFF
--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -351,13 +351,18 @@ const frontmatterMatchRuleSentence = "stop and tell the human"
 // the Codex adapter's TestDeliverySkillStatesTOMLMatchRule: the no-match
 // escalation rule must be stated verbatim, not just implied. Both spawn
 // steps carry it — the executor spawn and the reviewer spawn — so the
-// phrase is required at least twice, not merely present somewhere.
+// phrase is required at least twice, not merely present somewhere. The
+// count runs on whitespace-normalized text on both sides (via
+// adaptertest.NormalizeWhitespace), so a site the markdown hard-wraps
+// across a line break still counts.
 func TestDeliverySkillStatesFrontmatterMatchRule(t *testing.T) {
 	data, err := os.ReadFile(deliverySkillPath)
 	if err != nil {
 		t.Fatalf("read %s: %v", deliverySkillPath, err)
 	}
-	if got := strings.Count(string(data), frontmatterMatchRuleSentence); got < 2 {
+	content := adaptertest.NormalizeWhitespace(string(data))
+	phrase := adaptertest.NormalizeWhitespace(frontmatterMatchRuleSentence)
+	if got := strings.Count(content, phrase); got < 2 {
 		t.Errorf("%s contains the verbatim phrase %q %d time(s), want it at both the executor and reviewer spawn steps",
 			deliverySkillPath, frontmatterMatchRuleSentence, got)
 	}

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -287,13 +287,18 @@ const tomlMatchRuleSentence = "stop and tell the human"
 // adapters/claude/plugin_test.go — its Task tool's model parameter is a
 // coarse tier-alias enum, so a per-spawn override cannot express an
 // exact routed version there either, and only an installed agent
-// definition's frontmatter pins one.
+// definition's frontmatter pins one. The containment check runs on
+// whitespace-normalized text on both sides (via
+// adaptertest.NormalizeWhitespace), so a site the markdown hard-wraps
+// across a line break still counts.
 func TestDeliverySkillStatesTOMLMatchRule(t *testing.T) {
 	data, err := os.ReadFile(deliverySkillPath)
 	if err != nil {
 		t.Fatalf("read %s: %v", deliverySkillPath, err)
 	}
-	if !strings.Contains(string(data), tomlMatchRuleSentence) {
+	content := adaptertest.NormalizeWhitespace(string(data))
+	phrase := adaptertest.NormalizeWhitespace(tomlMatchRuleSentence)
+	if !strings.Contains(content, phrase) {
 		t.Errorf("%s does not contain the verbatim phrase %q", deliverySkillPath, tomlMatchRuleSentence)
 	}
 }

--- a/internal/adaptertest/adaptertest.go
+++ b/internal/adaptertest/adaptertest.go
@@ -15,6 +15,13 @@
 // plugin_test.go already makes, since `go test` runs a package's tests
 // with that package's directory as the process cwd.
 //
+// These helpers pin the presence of instruction text in shipped skill
+// markdown; they cannot pin its meaning. Every prose-phrase comparison
+// runs through NormalizeWhitespace on both sides deliberately, so a
+// pinned phrase that a markdown reflow happens to hard-wrap across a
+// line break still counts as present — the pins track whether the
+// words are there, not how the file happens to be line-wrapped.
+//
 // It may import internal/run (the four statement constants) and
 // internal/guard (a caller may pass guard.ClaudeTools()/CodexTools()
 // into CheckMatcherEqualsGuardTools) and nothing else in this module —
@@ -114,6 +121,28 @@ func globFiles(t *testing.T, pattern string) []string {
 	return matches
 }
 
+// normalizeWhitespace collapses every run of whitespace in s — including
+// a hard-wrapped line break — to a single space, and trims leading and
+// trailing whitespace. It is the only place this normalization logic is
+// written; every prose-phrase comparison in this package, and the two
+// adapters' own prose-phrase checks via NormalizeWhitespace, is written
+// in terms of it, so a pinned phrase a markdown reflow happens to split
+// across a line break still compares equal to the same phrase read from
+// the reflowed file.
+func normalizeWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// NormalizeWhitespace exports normalizeWhitespace for the two adapters'
+// own plugin_test.go prose-phrase checks (TestDeliverySkillStatesFrontmatterMatchRule
+// and TestDeliverySkillStatesTOMLMatchRule), which live outside this
+// package and so cannot call the unexported form directly. It performs
+// no normalization logic of its own beyond delegating to
+// normalizeWhitespace.
+func NormalizeWhitespace(s string) string {
+	return normalizeWhitespace(s)
+}
+
 // CheckRunVerbTokens drift-pins every `orch run <verb>` token mentioned
 // in a skill (found by skillGlob, e.g. "skills/*/SKILL.md") against the
 // real verb set: a renamed or removed verb that a skill still mentions
@@ -185,12 +214,15 @@ var planGateOptions = []string{
 }
 
 // CheckPlanGateOptions pins deliverySkillPath's documented plan-gate
-// question options against the exact PRD §8 four-option set.
+// question options against the exact PRD §8 four-option set. The
+// comparison runs on whitespace-normalized text on both sides, so an
+// option string a markdown reflow happens to hard-wrap across a line
+// break still counts as present.
 func CheckPlanGateOptions(t *testing.T, deliverySkillPath string) {
 	t.Helper()
-	content := readFile(t, deliverySkillPath)
+	content := normalizeWhitespace(readFile(t, deliverySkillPath))
 	for _, opt := range planGateOptions {
-		if !strings.Contains(content, opt) {
+		if !strings.Contains(content, normalizeWhitespace(opt)) {
 			t.Errorf("%s does not contain plan-gate option %q", deliverySkillPath, opt)
 		}
 	}
@@ -204,12 +236,15 @@ var mergeGateOptions = []string{
 }
 
 // CheckMergeGateOptions pins deliverySkillPath's documented merge-gate
-// question options against the exact two-option set.
+// question options against the exact two-option set. The comparison
+// runs on whitespace-normalized text on both sides, so an option string
+// a markdown reflow happens to hard-wrap across a line break still
+// counts as present.
 func CheckMergeGateOptions(t *testing.T, deliverySkillPath string) {
 	t.Helper()
-	content := readFile(t, deliverySkillPath)
+	content := normalizeWhitespace(readFile(t, deliverySkillPath))
 	for _, opt := range mergeGateOptions {
-		if !strings.Contains(content, opt) {
+		if !strings.Contains(content, normalizeWhitespace(opt)) {
 			t.Errorf("%s does not contain merge-gate option %q", deliverySkillPath, opt)
 		}
 	}
@@ -224,12 +259,15 @@ var setupTerminalForms = []string{
 }
 
 // CheckSetupTerminalForms pins setupSkillPath's documented terminal
-// forms against the exact three commands each interview ends with.
+// forms against the exact three commands each interview ends with. The
+// comparison runs on whitespace-normalized text on both sides, so a
+// terminal form a markdown reflow happens to hard-wrap across a line
+// break still counts as present.
 func CheckSetupTerminalForms(t *testing.T, setupSkillPath string) {
 	t.Helper()
-	content := readFile(t, setupSkillPath)
+	content := normalizeWhitespace(readFile(t, setupSkillPath))
 	for _, form := range setupTerminalForms {
-		if !strings.Contains(content, form) {
+		if !strings.Contains(content, normalizeWhitespace(form)) {
 			t.Errorf("%s does not contain terminal form %q", setupSkillPath, form)
 		}
 	}
@@ -260,11 +298,14 @@ const routedSelectionCue = "Routed selection: <model> @ <effort>"
 
 // CheckRoutedSelectionCue pins skillPath's documented spawn/dispatch
 // prompt against the exact routed-selection opening line every issue's
-// executor (and reviewer) prompt must open with.
+// executor (and reviewer) prompt must open with. The comparison runs on
+// whitespace-normalized text on both sides, so the cue would still count
+// as present even if a markdown reflow hard-wrapped it across a line
+// break.
 func CheckRoutedSelectionCue(t *testing.T, skillPath string) {
 	t.Helper()
-	content := readFile(t, skillPath)
-	if !strings.Contains(content, routedSelectionCue) {
+	content := normalizeWhitespace(readFile(t, skillPath))
+	if !strings.Contains(content, normalizeWhitespace(routedSelectionCue)) {
 		t.Errorf("%s does not contain the routed-selection prompt cue %q", skillPath, routedSelectionCue)
 	}
 }


### PR DESCRIPTION
Delivers issue #87: Compare prose pins on normalized whitespace in internal/adaptertest and both plugin tests

Closes #87

**Plan digest:** `sha256:d943d90aaf1fe1703c39cc54bb8f1d386c5c76d320e1b6cd74b485d4baebd371`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** internal/adaptertest/adaptertest.go and the two adapters' plugin tests assert that specific instruction phrases appear in shipped skill markdown, and every one of those assertions compares raw file bytes. Markdown is hard-wrapped, so any reflow that moves a line break into the middle of a pinned phrase makes the assertion stop seeing a phrase that is still present and still renders correctly. This has already happened: adapters/claude/skills/orch-delivery/SKILL.md states the no-match escalation rule at three sites, but the third wraps as 'stop and' / 'tell the human', so adapters/claude/plugin_test.go's strings.Count sees 2 against a floor of 2 and the next reflow of that file turns CI red for a formatting reason. Introduce one whitespace-normalizing comparison in internal/adaptertest (collapse each run of whitespace to a single space, applied to both the file content and the pinned phrase) and route every prose-phrase assertion through it, on both hosts. Do not change any skill markdown: reflowing prose to restore the byte match is explicitly the wrong fix here, because reflowing is what injected the problem and has twice silently dropped words from these same files. The assertions are the thing being corrected, not the prose.

**Acceptance criteria:**
- internal/adaptertest/adaptertest.go defines a single unexported whitespace-normalizing function that collapses every run of whitespace in a string to one space and trims leading and trailing whitespace, and it is the only place that normalization logic is written.
- internal/adaptertest's CheckPlanGateOptions, CheckMergeGateOptions, CheckSetupTerminalForms, and CheckRoutedSelectionCue each compare the normalized file content against the normalized pinned string, so a pinned phrase split across a line break still satisfies them.
- adapters/claude/plugin_test.go's TestDeliverySkillStatesFrontmatterMatchRule counts occurrences of the normalized frontmatterMatchRuleSentence in the normalized file content, keeping its existing floor of 2 and its existing failure message.
- adapters/codex/plugin_test.go's TestDeliverySkillStatesTOMLMatchRule tests containment of the normalized tomlMatchRuleSentence in the normalized file content, keeping its existing failure message.
- The executor's report states the observed normalized occurrence count of 'stop and tell the human' for each host's skills/orch-delivery/SKILL.md; the Claude count must be 3, confirming the previously line-wrapped third site is now seen.
- internal/adaptertest's CheckStatementLiterals and CheckRunVerbTokens are left unchanged, because both match via regular expressions rather than fixed prose phrases.
- internal/adaptertest's package doc gains a sentence recording that these helpers pin the presence of instruction text and cannot pin its meaning, and that normalization deliberately ignores line wrapping so the pins are not hostage to formatting.
- No file under adapters/claude/skills/ or adapters/codex/skills/ is modified by this change.
- No file outside internal/adaptertest/ and the two adapters' plugin_test.go files is modified by this change.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively low-risk.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — All 22 packages with tests ok; adapters/claude 0.679s, adapters/codex 0.743s, internal/run 19.308s. internal/adaptertest has no test files of its own (test-support package). — commit `af9ca5fe89c6b2623bd601f9b4972b696b11764b` (2026-07-27T17:55:02Z)
- **go-vet** — pass — `go vet ./...` — Exit 0, no output. — commit `af9ca5fe89c6b2623bd601f9b4972b696b11764b` (2026-07-27T17:55:02Z)
- **gofmt** — pass — `gofmt -l .` — Exit 0, no output; no unformatted files. — commit `af9ca5fe89c6b2623bd601f9b4972b696b11764b` (2026-07-27T17:55:02Z)
- **scope-boundary** — pass — `git diff --name-only HEAD` — Changed files are exactly adapters/claude/plugin_test.go, adapters/codex/plugin_test.go, internal/adaptertest/adaptertest.go. No file under adapters/claude/skills/ or adapters/codex/skills/ modified (acceptance criteria 8 and 9). — commit `af9ca5fe89c6b2623bd601f9b4972b696b11764b` (2026-07-27T17:55:02Z)
- **normalized-occurrence-count** — pass — `strings.Join(strings.Fields(content), " ") occurrence count of the pinned phrase per host SKILL.md` — Claude skills/orch-delivery/SKILL.md normalized count = 3 (was 2 by raw byte count; the line-wrapped third site at ~346-347 is now seen, restoring margin above the floor of 2). Codex skills/orch-delivery/SKILL.md normalized count = 2 against a floor of 1. Acceptance criterion 5. — commit `af9ca5fe89c6b2623bd601f9b4972b696b11764b` (2026-07-27T17:55:02Z)
- **reviewer-go-test** — pass — `go test ./... (re-run by reviewer on scratch export of af9ca5f, go1.26.5 windows/amd64)` — 22 ok packages, 0 failures; independently counted and matched against the manifest's claim. — commit `af9ca5fe89c6b2623bd601f9b4972b696b11764b` (2026-07-27T18:06:24Z)
- **reviewer-go-vet** — pass — `go vet ./... (re-run by reviewer)` — Exit 0, no output. — commit `af9ca5fe89c6b2623bd601f9b4972b696b11764b` (2026-07-27T18:06:24Z)
- **reviewer-gofmt** — pass — `gofmt -l . (re-run by reviewer)` — No output. — commit `af9ca5fe89c6b2623bd601f9b4972b696b11764b` (2026-07-27T18:06:24Z)
- **both-sides-normalized** — pass — `read every prose-pin comparison site and confirm normalization of haystack and needle` — internal/adaptertest/adaptertest.go:223+225, :245+247, :268+270, :307+308; adapters/claude/plugin_test.go:363-365; adapters/codex/plugin_test.go:299-301. All six normalize both sides. No pinned constant normalizes to the empty string. — commit `af9ca5fe89c6b2623bd601f9b4972b696b11764b` (2026-07-27T18:06:24Z)
- **raw-vs-normalized-counts** — pass — `offset-preserving normalizer measuring raw and normalized occurrence counts across all pin/file combinations` — 24 combinations measured; normalization changed exactly one count, the intended one. Claude match-rule phrase raw 2 to normalized 3; its third site (adapters/claude/skills/orch-delivery/SKILL.md:346-347) is the only match in the entire set whose raw span crosses a newline. Codex unchanged at 2. — commit `af9ca5fe89c6b2623bd601f9b4972b696b11764b` (2026-07-27T18:06:24Z)
- **mutation-matrix** — pass — `break each pinned phrase in a scratch copy outside the repo and run the real tests` — Six mutations, six failures with correct messages: plan-gate option, merge-gate option, setup terminal form, routed-selection cue, Claude match-rule floor (reported 1 time(s), floor still bites), Codex match-rule. No pin was disarmed by normalization. — commit `af9ca5fe89c6b2623bd601f9b4972b696b11764b` (2026-07-27T18:06:24Z)
- **head-vs-base-differential** — pass — `inject a hard wrap into a pinned phrase and run the tests at head and at base` — Hard wrap inside a plan-gate option: passes at af9ca5f, fails on base main. One unwrapped match-rule site removed: passes at head, fails on base. Confirms the pins are strictly more sensitive after this change, not less. — commit `af9ca5fe89c6b2623bd601f9b4972b696b11764b` (2026-07-27T18:06:24Z)
- **scope-boundary-independent** — pass — `reviewer's own diff inspection against merge-base` — Exactly three files, one commit, merge-base equals current main. Nothing under either skills/ tree touched. No dependency, logging, or config changes. — commit `af9ca5fe89c6b2623bd601f9b4972b696b11764b` (2026-07-27T18:06:24Z)
- **manifest-accuracy** — pass — `compare issue-body and PR-body audit records against independently measured values` — Issue and PR manifests identical; every verification entry checks out, including the 22-package count, the 346-347 line reference, and the Claude-3/Codex-2 counts. Routing record matches the committed config. Reviewer notes it did not independently verify config_revision sha256:e6df9bd25185. — commit `af9ca5fe89c6b2623bd601f9b4972b696b11764b` (2026-07-27T18:06:24Z)
- **review-cycle-1** — approve — Approve. All nine acceptance criteria met; the loosening is provably non-vacuous. Reviewer re-ran all three required tests itself on a scratch git-archive export of af9ca5f (never writing to the main checkout, which stayed clean on main at 0d079a0 throughout) and confirmed 22 ok packages, clean vet, clean gofmt, and 6/6 CI checks green. Normalization is applied to both the haystack and the needle at all six call sites; no pinned constant normalizes to empty, which was the one real vacuity vector. Across 24 pin/file combinations normalization changed exactly one count, the intended one: the Claude match-rule phrase goes from raw 2 to normalized 3, and its third site is the only match in the whole set whose raw span crosses a newline. Mutation testing broke each of the six pinned phrases in a scratch copy and confirmed every corresponding test fails with the correct message, so no pin was disarmed. Positive proof the fix works: a hard wrap injected into a pinned phrase passes at head and fails on base. Criterion 1's 'unexported' wording was unsatisfiable alongside criteria 3 and 4 (the adapters' tests are in different packages); the executor's unexported helper plus a pure delegating exported wrapper preserves the criterion's intent, and strings.Fields appears exactly once in the module. False-positive risk from collapsing newlines assessed as negligible for these six pins, since markdown structural markers survive normalization and break any cross-boundary span; the one genuine loosening named honestly is that a cue hard-wrapped inside a fenced code block would now be accepted. Scope discipline clean: exactly three files, one commit, no skill markdown touched. Non-blocking nits recorded: the commit message does not disclose the new exported symbol, the package doc slightly over-generalizes about which helpers read markdown, and both failure messages still say 'verbatim phrase' though the comparison is now normalized (kept deliberately because criteria 3 and 4 mandated preserving them). — commit `af9ca5fe89c6b2623bd601f9b4972b696b11764b` (2026-07-27T18:06:25Z)
- **required-ci** — passing — test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, test (ubuntu-latest)=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `af9ca5fe89c6b2623bd601f9b4972b696b11764b` (2026-07-27T18:06:37Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "internal/adaptertest/adaptertest.go and the two adapters' plugin tests assert that specific instruction phrases appear in shipped skill markdown, and every one of those assertions compares raw file bytes. Markdown is hard-wrapped, so any reflow that moves a line break into the middle of a pinned phrase makes the assertion stop seeing a phrase that is still present and still renders correctly. This has already happened: adapters/claude/skills/orch-delivery/SKILL.md states the no-match escalation rule at three sites, but the third wraps as 'stop and' / 'tell the human', so adapters/claude/plugin_test.go's strings.Count sees 2 against a floor of 2 and the next reflow of that file turns CI red for a formatting reason. Introduce one whitespace-normalizing comparison in internal/adaptertest (collapse each run of whitespace to a single space, applied to both the file content and the pinned phrase) and route every prose-phrase assertion through it, on both hosts. Do not change any skill markdown: reflowing prose to restore the byte match is explicitly the wrong fix here, because reflowing is what injected the problem and has twice silently dropped words from these same files. The assertions are the thing being corrected, not the prose.",
  "acceptance_criteria": [
    "internal/adaptertest/adaptertest.go defines a single unexported whitespace-normalizing function that collapses every run of whitespace in a string to one space and trims leading and trailing whitespace, and it is the only place that normalization logic is written.",
    "internal/adaptertest's CheckPlanGateOptions, CheckMergeGateOptions, CheckSetupTerminalForms, and CheckRoutedSelectionCue each compare the normalized file content against the normalized pinned string, so a pinned phrase split across a line break still satisfies them.",
    "adapters/claude/plugin_test.go's TestDeliverySkillStatesFrontmatterMatchRule counts occurrences of the normalized frontmatterMatchRuleSentence in the normalized file content, keeping its existing floor of 2 and its existing failure message.",
    "adapters/codex/plugin_test.go's TestDeliverySkillStatesTOMLMatchRule tests containment of the normalized tomlMatchRuleSentence in the normalized file content, keeping its existing failure message.",
    "The executor's report states the observed normalized occurrence count of 'stop and tell the human' for each host's skills/orch-delivery/SKILL.md; the Claude count must be 3, confirming the previously line-wrapped third site is now seen.",
    "internal/adaptertest's CheckStatementLiterals and CheckRunVerbTokens are left unchanged, because both match via regular expressions rather than fixed prose phrases.",
    "internal/adaptertest's package doc gains a sentence recording that these helpers pin the presence of instruction text and cannot pin its meaning, and that normalization deliberately ignores line wrapping so the pins are not hostage to formatting.",
    "No file under adapters/claude/skills/ or adapters/codex/skills/ is modified by this change.",
    "No file outside internal/adaptertest/ and the two adapters' plugin_test.go files is modified by this change."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively low-risk.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All 22 packages with tests ok; adapters/claude 0.679s, adapters/codex 0.743s, internal/run 19.308s. internal/adaptertest has no test files of its own (test-support package).",
      "commit_oid": "af9ca5fe89c6b2623bd601f9b4972b696b11764b",
      "at": "2026-07-27T17:55:02Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Exit 0, no output.",
      "commit_oid": "af9ca5fe89c6b2623bd601f9b4972b696b11764b",
      "at": "2026-07-27T17:55:02Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Exit 0, no output; no unformatted files.",
      "commit_oid": "af9ca5fe89c6b2623bd601f9b4972b696b11764b",
      "at": "2026-07-27T17:55:02Z"
    },
    {
      "name": "scope-boundary",
      "command": "git diff --name-only HEAD",
      "result": "pass",
      "detail": "Changed files are exactly adapters/claude/plugin_test.go, adapters/codex/plugin_test.go, internal/adaptertest/adaptertest.go. No file under adapters/claude/skills/ or adapters/codex/skills/ modified (acceptance criteria 8 and 9).",
      "commit_oid": "af9ca5fe89c6b2623bd601f9b4972b696b11764b",
      "at": "2026-07-27T17:55:02Z"
    },
    {
      "name": "normalized-occurrence-count",
      "command": "strings.Join(strings.Fields(content), \" \") occurrence count of the pinned phrase per host SKILL.md",
      "result": "pass",
      "detail": "Claude skills/orch-delivery/SKILL.md normalized count = 3 (was 2 by raw byte count; the line-wrapped third site at ~346-347 is now seen, restoring margin above the floor of 2). Codex skills/orch-delivery/SKILL.md normalized count = 2 against a floor of 1. Acceptance criterion 5.",
      "commit_oid": "af9ca5fe89c6b2623bd601f9b4972b696b11764b",
      "at": "2026-07-27T17:55:02Z"
    },
    {
      "name": "reviewer-go-test",
      "command": "go test ./... (re-run by reviewer on scratch export of af9ca5f, go1.26.5 windows/amd64)",
      "result": "pass",
      "detail": "22 ok packages, 0 failures; independently counted and matched against the manifest's claim.",
      "commit_oid": "af9ca5fe89c6b2623bd601f9b4972b696b11764b",
      "at": "2026-07-27T18:06:24Z"
    },
    {
      "name": "reviewer-go-vet",
      "command": "go vet ./... (re-run by reviewer)",
      "result": "pass",
      "detail": "Exit 0, no output.",
      "commit_oid": "af9ca5fe89c6b2623bd601f9b4972b696b11764b",
      "at": "2026-07-27T18:06:24Z"
    },
    {
      "name": "reviewer-gofmt",
      "command": "gofmt -l . (re-run by reviewer)",
      "result": "pass",
      "detail": "No output.",
      "commit_oid": "af9ca5fe89c6b2623bd601f9b4972b696b11764b",
      "at": "2026-07-27T18:06:24Z"
    },
    {
      "name": "both-sides-normalized",
      "command": "read every prose-pin comparison site and confirm normalization of haystack and needle",
      "result": "pass",
      "detail": "internal/adaptertest/adaptertest.go:223+225, :245+247, :268+270, :307+308; adapters/claude/plugin_test.go:363-365; adapters/codex/plugin_test.go:299-301. All six normalize both sides. No pinned constant normalizes to the empty string.",
      "commit_oid": "af9ca5fe89c6b2623bd601f9b4972b696b11764b",
      "at": "2026-07-27T18:06:24Z"
    },
    {
      "name": "raw-vs-normalized-counts",
      "command": "offset-preserving normalizer measuring raw and normalized occurrence counts across all pin/file combinations",
      "result": "pass",
      "detail": "24 combinations measured; normalization changed exactly one count, the intended one. Claude match-rule phrase raw 2 to normalized 3; its third site (adapters/claude/skills/orch-delivery/SKILL.md:346-347) is the only match in the entire set whose raw span crosses a newline. Codex unchanged at 2.",
      "commit_oid": "af9ca5fe89c6b2623bd601f9b4972b696b11764b",
      "at": "2026-07-27T18:06:24Z"
    },
    {
      "name": "mutation-matrix",
      "command": "break each pinned phrase in a scratch copy outside the repo and run the real tests",
      "result": "pass",
      "detail": "Six mutations, six failures with correct messages: plan-gate option, merge-gate option, setup terminal form, routed-selection cue, Claude match-rule floor (reported 1 time(s), floor still bites), Codex match-rule. No pin was disarmed by normalization.",
      "commit_oid": "af9ca5fe89c6b2623bd601f9b4972b696b11764b",
      "at": "2026-07-27T18:06:24Z"
    },
    {
      "name": "head-vs-base-differential",
      "command": "inject a hard wrap into a pinned phrase and run the tests at head and at base",
      "result": "pass",
      "detail": "Hard wrap inside a plan-gate option: passes at af9ca5f, fails on base main. One unwrapped match-rule site removed: passes at head, fails on base. Confirms the pins are strictly more sensitive after this change, not less.",
      "commit_oid": "af9ca5fe89c6b2623bd601f9b4972b696b11764b",
      "at": "2026-07-27T18:06:24Z"
    },
    {
      "name": "scope-boundary-independent",
      "command": "reviewer's own diff inspection against merge-base",
      "result": "pass",
      "detail": "Exactly three files, one commit, merge-base equals current main. Nothing under either skills/ tree touched. No dependency, logging, or config changes.",
      "commit_oid": "af9ca5fe89c6b2623bd601f9b4972b696b11764b",
      "at": "2026-07-27T18:06:24Z"
    },
    {
      "name": "manifest-accuracy",
      "command": "compare issue-body and PR-body audit records against independently measured values",
      "result": "pass",
      "detail": "Issue and PR manifests identical; every verification entry checks out, including the 22-package count, the 346-347 line reference, and the Claude-3/Codex-2 counts. Routing record matches the committed config. Reviewer notes it did not independently verify config_revision sha256:e6df9bd25185.",
      "commit_oid": "af9ca5fe89c6b2623bd601f9b4972b696b11764b",
      "at": "2026-07-27T18:06:24Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approve. All nine acceptance criteria met; the loosening is provably non-vacuous. Reviewer re-ran all three required tests itself on a scratch git-archive export of af9ca5f (never writing to the main checkout, which stayed clean on main at 0d079a0 throughout) and confirmed 22 ok packages, clean vet, clean gofmt, and 6/6 CI checks green. Normalization is applied to both the haystack and the needle at all six call sites; no pinned constant normalizes to empty, which was the one real vacuity vector. Across 24 pin/file combinations normalization changed exactly one count, the intended one: the Claude match-rule phrase goes from raw 2 to normalized 3, and its third site is the only match in the whole set whose raw span crosses a newline. Mutation testing broke each of the six pinned phrases in a scratch copy and confirmed every corresponding test fails with the correct message, so no pin was disarmed. Positive proof the fix works: a hard wrap injected into a pinned phrase passes at head and fails on base. Criterion 1's 'unexported' wording was unsatisfiable alongside criteria 3 and 4 (the adapters' tests are in different packages); the executor's unexported helper plus a pure delegating exported wrapper preserves the criterion's intent, and strings.Fields appears exactly once in the module. False-positive risk from collapsing newlines assessed as negligible for these six pins, since markdown structural markers survive normalization and break any cross-boundary span; the one genuine loosening named honestly is that a cue hard-wrapped inside a fenced code block would now be accepted. Scope discipline clean: exactly three files, one commit, no skill markdown touched. Non-blocking nits recorded: the commit message does not disclose the new exported symbol, the package doc slightly over-generalizes about which helpers read markdown, and both failure messages still say 'verbatim phrase' though the comparison is now normalized (kept deliberately because criteria 3 and 4 mandated preserving them).",
      "commit_oid": "af9ca5fe89c6b2623bd601f9b4972b696b11764b",
      "at": "2026-07-27T18:06:25Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, test (ubuntu-latest)=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "af9ca5fe89c6b2623bd601f9b4972b696b11764b",
      "at": "2026-07-27T18:06:37Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->