### PR TITLE
Normalize the Codex read-only sentinel pin and correct the surviving guard/whitelist enforcement claims

### DIFF
--- a/adapters/claude/README.md
+++ b/adapters/claude/README.md
@@ -60,14 +60,13 @@ never re-derives a decision the engine already made.
   `agents/orch-reviewer-safe.md` — the five role subagents the Architect
   spawns during Delivery, each with its own model and tool whitelist
   (scout, reviewer, and reviewer-safe carry no write tool; no agent
-  carries `Task` or any `mcp__` tool, so subagents have no memhub write
-  surface of their own). `orch-reviewer-safe` is the §10 safe-review
-  downgrade encoding: Claude Code's Task tool `model` parameter only
-  takes coarse tier aliases (`sonnet`/`opus`/`haiku`/`fable`), not an
-  exact version string, so the downgrade the engine computes for a
-  mechanical/low-risk/fully-specified/unsurprising issue has to be an
-  installed agent definition of its own — only its frontmatter can pin
-  `claude-sonnet-5` exactly — spawned by name exactly like
+  carries `Task` or any `mcp__` tool). `orch-reviewer-safe` is the §10
+  safe-review downgrade encoding: Claude Code's Task tool `model` parameter
+  only takes coarse tier aliases (`sonnet`/`opus`/`haiku`/`fable`),
+  not an exact version string, so the downgrade the engine computes
+  for a mechanical/low-risk/fully-specified/unsurprising issue has to
+  be an installed agent definition of its own — only its frontmatter
+  can pin `claude-sonnet-5` exactly — spawned by name exactly like
   `orch-reviewer`.
 
 ## Install order
@@ -131,12 +130,16 @@ bugs:
   `internal/adaptertest.CheckRoutedSelectionCue`, called from both
   adapters' `plugin_test.go`, pins that the prompt cue text is present in
   `orch-delivery/SKILL.md`, not that it changed model behavior.
-- **`orch guard`'s `--role` narrowing is unused by this adapter.** Hooks
-  in Claude Code are plugin-global, not scoped per subagent, so the
-  adapter never passes `--role` when invoking guard. Read-only role
-  enforcement (scout, reviewer, and reviewer-safe must never write)
-  instead comes from each subagent's own tool whitelist in its agent
-  definition (PR 2), not from guard's role-narrowing flag.
+- **`orch guard`'s `--role` narrowing is unused by this adapter.**
+  Hooks in Claude Code are plugin-global, not scoped per subagent, so
+  the adapter never passes `--role` when invoking guard. Read-only role
+  enforcement instead comes from each subagent's own tool whitelist in its
+  agent definition (PR 2), not from guard's role-narrowing flag — but
+  the whitelist accounts fully only for `orch-scout`, which carries no
+  `Bash`. `orch-reviewer` and `orch-reviewer-safe` both carry `Bash`,
+  so their whitelist excludes only the four guarded write tools; their
+  read-only discipline for anything Bash-mediated rests on their own
+  instructions, same as the Bash-mediated write gap above.
 
 ## Host version
 

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -241,9 +241,11 @@ var writeTools = []string{"Write", "Edit", "MultiEdit", "NotebookEdit"}
 // TestAgentFrontmatter validates every agents/*.md file against the
 // committed §10 Claude profile: all five agents exist with a complete
 // frontmatter, scout, reviewer, and reviewer-safe exclude every write
-// tool, no agent lists Task or an mcp__ tool (subagents have no memhub
-// write surface), and models match adaptertest.Profile("claude") for
-// their role exactly.
+// tool, no agent lists Task or an mcp__ tool (memhub writes are
+// Architect-only policy; banning mcp__ removes a direct memhub write
+// surface but does not by itself make a Bash-carrying agent
+// memhub-incapable, since memhub is an external CLI), and models match
+// adaptertest.Profile("claude") for their role exactly.
 func TestAgentFrontmatter(t *testing.T) {
 	profile := adaptertest.Profile("claude")
 	for name, want := range agentRoster {
@@ -278,7 +280,7 @@ func TestAgentFrontmatter(t *testing.T) {
 					t.Error("tools list includes Task; no agent may spawn its own subagents")
 				}
 				if strings.HasPrefix(tool, "mcp__") {
-					t.Errorf("tools list includes mcp__ tool %q; subagents have no memhub write surface", tool)
+					t.Errorf("tools list includes mcp__ tool %q; memhub writes are Architect-only", tool)
 				}
 			}
 			wantTools := append([]string(nil), want.tools...)

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -154,8 +154,12 @@ bugs:
   a worktree the guard currently treats as writable, including the one
   under review. Their read-only discipline is stated in their
   `developer_instructions` and rests there. The Claude adapter leaves
-  `--role` unused for the same reason, but backs role read-only-ness
-  with a per-subagent tool whitelist this host has no equivalent for.
+  `--role` unused for the same reason. Its tool whitelist backs
+  `orch-scout`'s read-only-ness fully — `orch-scout` carries no `Bash`
+  — but `orch-reviewer` and `orch-reviewer-safe` both carry `Bash`,
+  so their whitelist excludes only the four guarded write tools there
+  too; their read-only discipline for anything Bash-mediated rests on
+  instructions, same as this host's.
 - **A missing `orch` binary fails open, not closed.** As described
   under Install order: a hook command that cannot be found exits
   non-blocking by the hook protocol's own rules, so both the write

--- a/adapters/codex/agents/orch-scout.toml
+++ b/adapters/codex/agents/orch-scout.toml
@@ -4,13 +4,15 @@ model = "gpt-5.6-terra"
 model_reasoning_effort = "low"
 developer_instructions = """
 You are read-only by construction. You have no tool whitelist here —
-Codex agent definitions do not carry one — so your read-only discipline
-rests entirely on two things: the `orch guard codex` pre-write hook,
-which denies every write outside a Delivery worktree you have not been
-given, and these instructions themselves. You must not modify any
-tracked file, full stop. You do not need to reason about whether you
-are "allowed" to write something — these instructions and the guard
-hook together mean you simply do not.
+Codex agent definitions do not carry one — and the `orch guard codex`
+pre-write hook enforces containment only: a write must land inside a
+registered worktree, on that worktree's registered branch, in a phase
+that still accepts writes. The hook cannot tell your write from any
+other dispatched agent's, so it carries no per-agent or per-worktree
+knowledge of you specifically. Your read-only discipline rests
+entirely on these instructions: you must not modify any tracked file,
+full stop. You do not need to reason about whether you are "allowed"
+to write something — these instructions mean you simply do not.
 
 ## What you do
 

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -180,10 +180,11 @@ var agentFiles = []string{
 
 // readOnlyAgents are the roles whose developer_instructions must state
 // they must not modify the repository — scout because it only ever
-// investigates, reviewer because "you did not write this change" is a
-// contract enforced by instructions and the guard hook, not a tool
-// whitelist, on a host with no per-agent tool whitelist at all.
-var readOnlyAgents = map[string]bool{"orch-scout": true, "orch-reviewer": true}
+// investigates, reviewer and reviewer-safe because "you did not write
+// this change" is a contract enforced by instructions alone: this host
+// has no per-agent tool whitelist at all, and the guard hook enforces
+// containment only, not role read-only-ness.
+var readOnlyAgents = map[string]bool{"orch-scout": true, "orch-reviewer": true, "orch-reviewer-safe": true}
 
 // readOnlySentinel is the phrase this test standardizes across the
 // read-only agents' developer_instructions to assert read-only
@@ -233,11 +234,15 @@ func TestAgentTOMLs(t *testing.T) {
 			}
 
 			if strings.Contains(a.DeveloperInstructions, "mcp__") {
-				t.Errorf("%s: developer_instructions mentions an mcp__ tool; agents have no memhub write surface", path)
+				t.Errorf("%s: developer_instructions mentions an mcp__ tool; memhub writes are Architect-only", path)
 			}
 
-			if readOnlyAgents[name] && !strings.Contains(a.DeveloperInstructions, readOnlySentinel) {
-				t.Errorf("%s: developer_instructions does not contain the read-only sentinel %q", path, readOnlySentinel)
+			if readOnlyAgents[name] {
+				normalized := adaptertest.NormalizeWhitespace(a.DeveloperInstructions)
+				sentinel := adaptertest.NormalizeWhitespace(readOnlySentinel)
+				if !strings.Contains(normalized, sentinel) {
+					t.Errorf("%s: developer_instructions does not contain the read-only sentinel %q", path, readOnlySentinel)
+				}
 			}
 		})
 	}

--- a/internal/adaptertest/adaptertest.go
+++ b/internal/adaptertest/adaptertest.go
@@ -134,8 +134,10 @@ func normalizeWhitespace(s string) string {
 }
 
 // NormalizeWhitespace exports normalizeWhitespace for the two adapters'
-// own plugin_test.go prose-phrase checks (TestDeliverySkillStatesFrontmatterMatchRule
-// and TestDeliverySkillStatesTOMLMatchRule), which live outside this
+// own plugin_test.go prose-phrase checks
+// (TestDeliverySkillStatesFrontmatterMatchRule,
+// TestDeliverySkillStatesTOMLMatchRule, and the Codex adapter's
+// TestAgentTOMLs read-only sentinel check), which live outside this
 // package and so cannot call the unexported form directly. It performs
 // no normalization logic of its own beyond delegating to
 // normalizeWhitespace.

--- a/internal/guard/guard.go
+++ b/internal/guard/guard.go
@@ -8,9 +8,9 @@
 //
 // All decision logic lives here in the Go core, not in adapter shell
 // (PRD §6: adapters stay thin). The package is policy-mechanical: it
-// enforces the Assist read-only rule (PRD §7), the Delivery
-// containment/branch/phase rules and role read-only-ness (PRD §15), and
-// treats orchestrator internals and git internals as never writable.
+// enforces the Assist read-only rule (PRD §7) and the Delivery
+// containment/branch/phase rules (PRD §15), and treats orchestrator
+// internals and git internals as never writable.
 //
 // The verdict is split into a pure decision (evaluate, over a resolved
 // facts value, no I/O — the normative decision table as data) and the


### PR DESCRIPTION
Delivers issue #89: Normalize the Codex read-only sentinel pin and correct the surviving guard/whitelist enforcement claims

Closes #89

**Plan digest:** `sha256:aea0ff2338587947f2e5bf560a8fee5ec46df358e64eeda030b47da8d3d1bea6`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Make the read-only-discipline pin robust to line wrapping and extend it to every Codex agent TOML that states the discipline, then bring the remaining prose that describes write enforcement into line with what the mechanisms actually do. The pin change is the one behavioral change; everything else is comment, failure-message and documentation text. ORCH-PRD.md section 15 is already accurate after PR #83 and must not be modified - it is what makes the guard package doc's citation dangling.

**Acceptance criteria:**
- The read-only sentinel assertion in adapters/codex/plugin_test.go compares whitespace-normalized text on both sides, so a line break inserted anywhere inside the sentinel phrase in an agent TOML no longer disarms it. The assertion still fails when the phrase is genuinely absent from a covered agent.
- Every Codex agent TOML whose developer_instructions state read-only discipline is covered by that sentinel assertion, including orch-reviewer-safe, which carries the phrase today but is not covered on base.
- adapters/codex/agents/orch-scout.toml no longer attributes to the guard any per-agent or per-worktree knowledge it does not have. Its stated basis for read-only discipline is accurate: the guard contributes containment only and cannot tell one dispatched agent's write from another's, and the discipline itself rests on the instructions. The file still states read-only discipline in wording the criterion 1 assertion matches.
- internal/guard/guard.go's package doc no longer cites PRD section 15 as establishing role read-only-ness. ORCH-PRD.md is not modified by this issue.
- adapters/claude/README.md no longer gives the absence of Task and mcp__ tools as the reason subagents have no memhub write surface, and no longer presents per-subagent tool whitelists as what makes all three read-only roles unable to write. Any surviving whitelist claim distinguishes orch-scout, which carries no Bash, from orch-reviewer and orch-reviewer-safe, which both do.
- adapters/codex/README.md no longer states without qualification that the Claude adapter backs role read-only-ness with a per-subagent tool whitelist.
- In both adapters' plugin_test.go, the comments and failure messages that justify the mcp__ tool ban no longer give 'subagents have no memhub write surface' as the reason. The mcp__ ban assertions themselves are unchanged in what they accept and reject.
- internal/adaptertest's NormalizeWhitespace doc comment accurately describes the callers it serves after this change.
- Any commit in this issue that reflows existing prose is verified with a whitespace-insensitive word-stream comparison against the previous commit, and the result is reported. No word is dropped from any shipped instruction.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — Run by the executor inside the issue-89 worktree. All packages ok. — commit `bcbbe027f4c302136183af63c537a8571c527537` (2026-07-27T22:03:16Z)
- **go-vet** — pass — `go vet ./...` — No output. — commit `bcbbe027f4c302136183af63c537a8571c527537` (2026-07-27T22:03:16Z)
- **gofmt** — pass — `gofmt -l .` — No output; nothing unformatted. — commit `bcbbe027f4c302136183af63c537a8571c527537` (2026-07-27T22:03:16Z)
- **sentinel-non-vacuity** — pass — `go test ./adapters/codex/... -run TestAgentTOMLs -v (against mutated scratch checkouts)` — Two-part proof that criterion 1's loosening is non-vacuous, matching the standard decision 73 set for the predecessor pin change. (a) Genuine absence still fails: a scratch copy of HEAD with orch-reviewer-safe.toml's 'you must not modify' replaced by 'you must absolutely never change' FAILED with 'does not contain the read-only sentinel'. (b) Head-vs-base differential: a line break injected inside the sentinel phrase in orch-reviewer.toml ('you must not' / newline / 'modify') FAILED at base 6262608 and PASSED at head, proving the pin is strictly more sensitive to wrapping than before. No mutation was committed; scratch copies lived outside the repository. — commit `bcbbe027f4c302136183af63c537a8571c527537` (2026-07-27T22:03:16Z)
- **word-stream-diff** — pass — `git show 6262608:<path> | tr -s '[:space:]' '\n' | diff - <(tr -s '[:space:]' '\n' < <path>)` — Criterion 9. Every one of the 7 changed files was compared against base 6262608 as a whitespace-collapsed, one-word-per-line diff. Every hunk corresponds to an intended semantic edit; no word outside an intended edit was added or dropped. This check exists because task 72 records two words silently dropped from shipped instructions in these same files, both green across all six required CI checks. — commit `bcbbe027f4c302136183af63c537a8571c527537` (2026-07-27T22:03:16Z)
- **prd-unmodified** — pass — `git diff --stat 6262608 origin/orch/issue-89-normalize-the-codex-read-only-sentinel-p` — Independently confirmed by the Architect against the pushed branch: 7 files changed, 57 insertions, 39 deletions, and ORCH-PRD.md is absent from the changed-file list, satisfying criterion 4's requirement that section 15 be left intact. — commit `bcbbe027f4c302136183af63c537a8571c527537` (2026-07-27T22:03:16Z)
- **reviewer-loosening-bounds** — pass — `go test ./adapters/codex/... -run TestAgentTOMLs (12 mutation variants against orch-reviewer-safe.toml at head)` — Adversarial matrix bounding exactly what the normalization now admits. All 6 whitespace-only variants PASS (single break, break before 'not', tabs, CRLF, break between every word, paragraph split). All 6 non-whitespace mutations FAIL: word order swapped, verb substituted ('alter'), word inserted ('ever'), negation deleted ('must modify'), hyphen joining words ('must-not'), phrase removed. The admitted equivalence class is precisely whitespace variants of the same three words in sequence. Deleting the negation still fails, which was the main vacuity risk. — commit `bcbbe027f4c302136183af63c537a8571c527537` (2026-07-27T22:16:44Z)
- **reviewer-non-vacuity-all-agents** — pass — `go test ./adapters/codex/... -run TestAgentTOMLs -v (sentinel replaced in each covered TOML)` — Extends the executor's single-agent evidence to all three covered agents. Replacing 'must not modify' with 'must absolutely never change' produces the expected failure for orch-scout, orch-reviewer AND orch-reviewer-safe. Normalized sentinel is 3 words and non-empty, so there is no degenerate strings.Contains(x, "") case; normalization is applied to both sides at adapters/codex/plugin_test.go:241-242. — commit `bcbbe027f4c302136183af63c537a8571c527537` (2026-07-27T22:16:44Z)
- **reviewer-coverage-differential** — pass — `go test ./adapters/codex/... -run TestAgentTOMLs (sentinel deleted from orch-reviewer-safe.toml, at base 6262608 and at head)` — This is the evidence that identifies the actual silent hole this PR closed. Deleting the read-only sentinel from orch-reviewer-safe.toml PASSES at base 6262608 - the file was genuinely uncovered, so a shipped read-only instruction could have been removed with all six required CI checks staying green - and FAILS at head. Criterion 2, not criterion 1, is the hole-closing change. — commit `bcbbe027f4c302136183af63c537a8571c527537` (2026-07-27T22:16:44Z)
- **reviewer-coverage-set-audit** — pass — `manual read of all five adapters/codex/agents/*.toml at head` — Criterion 2 says every TOML that states read-only discipline must be covered, so the map's membership was not treated as the definition of the set. orch-implementer.toml and orch-specialist.toml state no read-only discipline in any phrasing and are correctly uncovered; orch-scout.toml:13, orch-reviewer.toml:17 and orch-reviewer-safe.toml:24 all state it and all three are now covered at adapters/codex/plugin_test.go:187. — commit `bcbbe027f4c302136183af63c537a8571c527537` (2026-07-27T22:16:44Z)
- **reviewer-prose-truthfulness** — pass — `cross-check of corrected prose against internal/guard/guard.go, both hooks.json files, and all agent frontmatter at head` — Every corrected sentence verified true of the tree rather than merely less wrong. orch-scout.toml's three named guard conditions map to real rows: worktree containment guard.go:127, writable phase :137, registered branch :142. guard.Request (:34-38) carries no agent identity; Role/Issue are adapter-asserted and neither adapter passes them - both hooks.json invoke the bare guard command. Claude frontmatter confirms orch-scout.md carries no Bash while orch-reviewer.md and orch-reviewer-safe.md both do, so criterion 5's distinction is accurate. — commit `bcbbe027f4c302136183af63c537a8571c527537` (2026-07-27T22:16:44Z)
- **reviewer-word-stream-diff** — pass — `independent whitespace-collapsed word-stream comparison, base 6262608 vs head, all 7 files` — Criterion 9 re-established independently rather than accepted. Net word deltas: claude/README.md +30, claude/plugin_test.go +23, codex/README.md +30, orch-scout.toml +23, codex/plugin_test.go +13, adaptertest.go +9, guard.go -2. Every hunk maps to a named criterion. The only net-negative file, guard.go at -2, is exactly 'and role read-only-ness' removed (-3) plus an inserted 'and' (+1). Directly addressing task 72's failure mode: the paragraph at claude/README.md:63-70 WAS reflowed and produced no word-level hunk beyond its one intended clause removal. No word dropped in any file. — commit `bcbbe027f4c302136183af63c537a8571c527537` (2026-07-27T22:16:44Z)
- **reviewer-scope-and-invariants** — pass — `diff -rq of git archive extracts (base vs head) plus md5 of ORCH-PRD.md` — Exactly the 7 expected files differ. ORCH-PRD.md MD5-identical, satisfying criterion 4's non-modification clause. internal/adaptertest's normalizeWhitespace/NormalizeWhitespace pair intact at :132 and :144, so task 78 was correctly left out of scope. strings.Fields appears exactly once module-wide, preserving decision 73's single-source property. No mutation-test artifact leaked into the committed tree. 'memhub write surface' now has zero occurrences repo-wide, down from two at base. — commit `bcbbe027f4c302136183af63c537a8571c527537` (2026-07-27T22:16:44Z)
- **reviewer-tests-rerun** — pass — `go test ./... && go vet ./... && gofmt -l .` — All three required tests re-run by the reviewer at the pinned head OID, independently of the executor's run. All packages ok, vet clean, gofmt output empty. — commit `bcbbe027f4c302136183af63c537a8571c527537` (2026-07-27T22:16:44Z)
- **manifest-correction-criterion-1-direction** — pass — `review of the pr-open audit record against the reproduced evidence` — Correcting a wording defect in this issue's own audit record. The pr-open verification named sentinel-non-vacuity concluded 'proving the pin is strictly more sensitive to wrapping than before'. That gloss is inverted and is superseded by this entry. The raw evidence it reported is correct and reproduced (a wrap FAILS at base 6262608, PASSES at head); the correct interpretation is that base failed LOUDLY on a wrap, so normalization made the pin more TOLERANT of wrapping, fixing brittleness rather than closing a silent hole. The silent hole was orch-reviewer-safe's absence from the coverage map, closed by criterion 2. The Architect authored the inverted gloss, inheriting it from memhub task 77's framing without verifying that specific claim; the executor reported the underlying evidence accurately. — commit `bcbbe027f4c302136183af63c537a8571c527537` (2026-07-27T22:16:44Z)
- **review-cycle-1** — approve — Approved. All nine acceptance criteria met, verified independently from git archive extracts of the pinned head and base rather than from the executor's report. Scope is exactly the 7 expected files; ORCH-PRD.md is MD5-identical to base; decision 73's single-source property still holds (strings.Fields appears exactly once module-wide); task 78's normalizeWhitespace pair is correctly untouched. All three required tests re-run green by the reviewer, and all six required CI checks pass on this head OID. ONE CORRECTION TO THE RECORD, which does not change any verified fact or the merge decision: criterion 1's premise was stated backwards, in the plan and in the pr-open manifest alike. At base the sentinel check was strings.Contains on a single occurrence, so a line break inside the phrase made the check FAIL LOUDLY - a brittle false alarm, not a silent disarm. Normalization therefore made the pin MORE TOLERANT of wrapping, not more sensitive to it. This inherited the framing of memhub task 77, which the Architect did not independently verify on that specific point. The genuine silent hole was criterion 2's, not criterion 1's: orch-reviewer-safe was absent from readOnlyAgents, so map lookup returned the zero value and its read-only instruction could have been deleted entirely with all six CI checks green. The reviewer proved this with a coverage differential - deleting that sentinel PASSES at base and FAILS at head. Criterion 1 fixed brittleness; criterion 2 closed the hole. Both are correct changes and the net effect on the defense is a strengthening. — commit `bcbbe027f4c302136183af63c537a8571c527537` (2026-07-27T22:16:45Z)
- **required-ci** — passing — test (macos-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `bcbbe027f4c302136183af63c537a8571c527537` (2026-07-27T22:17:00Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Make the read-only-discipline pin robust to line wrapping and extend it to every Codex agent TOML that states the discipline, then bring the remaining prose that describes write enforcement into line with what the mechanisms actually do. The pin change is the one behavioral change; everything else is comment, failure-message and documentation text. ORCH-PRD.md section 15 is already accurate after PR #83 and must not be modified - it is what makes the guard package doc's citation dangling.",
  "acceptance_criteria": [
    "The read-only sentinel assertion in adapters/codex/plugin_test.go compares whitespace-normalized text on both sides, so a line break inserted anywhere inside the sentinel phrase in an agent TOML no longer disarms it. The assertion still fails when the phrase is genuinely absent from a covered agent.",
    "Every Codex agent TOML whose developer_instructions state read-only discipline is covered by that sentinel assertion, including orch-reviewer-safe, which carries the phrase today but is not covered on base.",
    "adapters/codex/agents/orch-scout.toml no longer attributes to the guard any per-agent or per-worktree knowledge it does not have. Its stated basis for read-only discipline is accurate: the guard contributes containment only and cannot tell one dispatched agent's write from another's, and the discipline itself rests on the instructions. The file still states read-only discipline in wording the criterion 1 assertion matches.",
    "internal/guard/guard.go's package doc no longer cites PRD section 15 as establishing role read-only-ness. ORCH-PRD.md is not modified by this issue.",
    "adapters/claude/README.md no longer gives the absence of Task and mcp__ tools as the reason subagents have no memhub write surface, and no longer presents per-subagent tool whitelists as what makes all three read-only roles unable to write. Any surviving whitelist claim distinguishes orch-scout, which carries no Bash, from orch-reviewer and orch-reviewer-safe, which both do.",
    "adapters/codex/README.md no longer states without qualification that the Claude adapter backs role read-only-ness with a per-subagent tool whitelist.",
    "In both adapters' plugin_test.go, the comments and failure messages that justify the mcp__ tool ban no longer give 'subagents have no memhub write surface' as the reason. The mcp__ ban assertions themselves are unchanged in what they accept and reject.",
    "internal/adaptertest's NormalizeWhitespace doc comment accurately describes the callers it serves after this change.",
    "Any commit in this issue that reflows existing prose is verified with a whitespace-insensitive word-stream comparison against the previous commit, and the result is reported. No word is dropped from any shipped instruction."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Run by the executor inside the issue-89 worktree. All packages ok.",
      "commit_oid": "bcbbe027f4c302136183af63c537a8571c527537",
      "at": "2026-07-27T22:03:16Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "No output.",
      "commit_oid": "bcbbe027f4c302136183af63c537a8571c527537",
      "at": "2026-07-27T22:03:16Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No output; nothing unformatted.",
      "commit_oid": "bcbbe027f4c302136183af63c537a8571c527537",
      "at": "2026-07-27T22:03:16Z"
    },
    {
      "name": "sentinel-non-vacuity",
      "command": "go test ./adapters/codex/... -run TestAgentTOMLs -v (against mutated scratch checkouts)",
      "result": "pass",
      "detail": "Two-part proof that criterion 1's loosening is non-vacuous, matching the standard decision 73 set for the predecessor pin change. (a) Genuine absence still fails: a scratch copy of HEAD with orch-reviewer-safe.toml's 'you must not modify' replaced by 'you must absolutely never change' FAILED with 'does not contain the read-only sentinel'. (b) Head-vs-base differential: a line break injected inside the sentinel phrase in orch-reviewer.toml ('you must not' / newline / 'modify') FAILED at base 6262608 and PASSED at head, proving the pin is strictly more sensitive to wrapping than before. No mutation was committed; scratch copies lived outside the repository.",
      "commit_oid": "bcbbe027f4c302136183af63c537a8571c527537",
      "at": "2026-07-27T22:03:16Z"
    },
    {
      "name": "word-stream-diff",
      "command": "git show 6262608:\u003cpath\u003e | tr -s '[:space:]' '\\n' | diff - \u003c(tr -s '[:space:]' '\\n' \u003c \u003cpath\u003e)",
      "result": "pass",
      "detail": "Criterion 9. Every one of the 7 changed files was compared against base 6262608 as a whitespace-collapsed, one-word-per-line diff. Every hunk corresponds to an intended semantic edit; no word outside an intended edit was added or dropped. This check exists because task 72 records two words silently dropped from shipped instructions in these same files, both green across all six required CI checks.",
      "commit_oid": "bcbbe027f4c302136183af63c537a8571c527537",
      "at": "2026-07-27T22:03:16Z"
    },
    {
      "name": "prd-unmodified",
      "command": "git diff --stat 6262608 origin/orch/issue-89-normalize-the-codex-read-only-sentinel-p",
      "result": "pass",
      "detail": "Independently confirmed by the Architect against the pushed branch: 7 files changed, 57 insertions, 39 deletions, and ORCH-PRD.md is absent from the changed-file list, satisfying criterion 4's requirement that section 15 be left intact.",
      "commit_oid": "bcbbe027f4c302136183af63c537a8571c527537",
      "at": "2026-07-27T22:03:16Z"
    },
    {
      "name": "reviewer-loosening-bounds",
      "command": "go test ./adapters/codex/... -run TestAgentTOMLs (12 mutation variants against orch-reviewer-safe.toml at head)",
      "result": "pass",
      "detail": "Adversarial matrix bounding exactly what the normalization now admits. All 6 whitespace-only variants PASS (single break, break before 'not', tabs, CRLF, break between every word, paragraph split). All 6 non-whitespace mutations FAIL: word order swapped, verb substituted ('alter'), word inserted ('ever'), negation deleted ('must modify'), hyphen joining words ('must-not'), phrase removed. The admitted equivalence class is precisely whitespace variants of the same three words in sequence. Deleting the negation still fails, which was the main vacuity risk.",
      "commit_oid": "bcbbe027f4c302136183af63c537a8571c527537",
      "at": "2026-07-27T22:16:44Z"
    },
    {
      "name": "reviewer-non-vacuity-all-agents",
      "command": "go test ./adapters/codex/... -run TestAgentTOMLs -v (sentinel replaced in each covered TOML)",
      "result": "pass",
      "detail": "Extends the executor's single-agent evidence to all three covered agents. Replacing 'must not modify' with 'must absolutely never change' produces the expected failure for orch-scout, orch-reviewer AND orch-reviewer-safe. Normalized sentinel is 3 words and non-empty, so there is no degenerate strings.Contains(x, \"\") case; normalization is applied to both sides at adapters/codex/plugin_test.go:241-242.",
      "commit_oid": "bcbbe027f4c302136183af63c537a8571c527537",
      "at": "2026-07-27T22:16:44Z"
    },
    {
      "name": "reviewer-coverage-differential",
      "command": "go test ./adapters/codex/... -run TestAgentTOMLs (sentinel deleted from orch-reviewer-safe.toml, at base 6262608 and at head)",
      "result": "pass",
      "detail": "This is the evidence that identifies the actual silent hole this PR closed. Deleting the read-only sentinel from orch-reviewer-safe.toml PASSES at base 6262608 - the file was genuinely uncovered, so a shipped read-only instruction could have been removed with all six required CI checks staying green - and FAILS at head. Criterion 2, not criterion 1, is the hole-closing change.",
      "commit_oid": "bcbbe027f4c302136183af63c537a8571c527537",
      "at": "2026-07-27T22:16:44Z"
    },
    {
      "name": "reviewer-coverage-set-audit",
      "command": "manual read of all five adapters/codex/agents/*.toml at head",
      "result": "pass",
      "detail": "Criterion 2 says every TOML that states read-only discipline must be covered, so the map's membership was not treated as the definition of the set. orch-implementer.toml and orch-specialist.toml state no read-only discipline in any phrasing and are correctly uncovered; orch-scout.toml:13, orch-reviewer.toml:17 and orch-reviewer-safe.toml:24 all state it and all three are now covered at adapters/codex/plugin_test.go:187.",
      "commit_oid": "bcbbe027f4c302136183af63c537a8571c527537",
      "at": "2026-07-27T22:16:44Z"
    },
    {
      "name": "reviewer-prose-truthfulness",
      "command": "cross-check of corrected prose against internal/guard/guard.go, both hooks.json files, and all agent frontmatter at head",
      "result": "pass",
      "detail": "Every corrected sentence verified true of the tree rather than merely less wrong. orch-scout.toml's three named guard conditions map to real rows: worktree containment guard.go:127, writable phase :137, registered branch :142. guard.Request (:34-38) carries no agent identity; Role/Issue are adapter-asserted and neither adapter passes them - both hooks.json invoke the bare guard command. Claude frontmatter confirms orch-scout.md carries no Bash while orch-reviewer.md and orch-reviewer-safe.md both do, so criterion 5's distinction is accurate.",
      "commit_oid": "bcbbe027f4c302136183af63c537a8571c527537",
      "at": "2026-07-27T22:16:44Z"
    },
    {
      "name": "reviewer-word-stream-diff",
      "command": "independent whitespace-collapsed word-stream comparison, base 6262608 vs head, all 7 files",
      "result": "pass",
      "detail": "Criterion 9 re-established independently rather than accepted. Net word deltas: claude/README.md +30, claude/plugin_test.go +23, codex/README.md +30, orch-scout.toml +23, codex/plugin_test.go +13, adaptertest.go +9, guard.go -2. Every hunk maps to a named criterion. The only net-negative file, guard.go at -2, is exactly 'and role read-only-ness' removed (-3) plus an inserted 'and' (+1). Directly addressing task 72's failure mode: the paragraph at claude/README.md:63-70 WAS reflowed and produced no word-level hunk beyond its one intended clause removal. No word dropped in any file.",
      "commit_oid": "bcbbe027f4c302136183af63c537a8571c527537",
      "at": "2026-07-27T22:16:44Z"
    },
    {
      "name": "reviewer-scope-and-invariants",
      "command": "diff -rq of git archive extracts (base vs head) plus md5 of ORCH-PRD.md",
      "result": "pass",
      "detail": "Exactly the 7 expected files differ. ORCH-PRD.md MD5-identical, satisfying criterion 4's non-modification clause. internal/adaptertest's normalizeWhitespace/NormalizeWhitespace pair intact at :132 and :144, so task 78 was correctly left out of scope. strings.Fields appears exactly once module-wide, preserving decision 73's single-source property. No mutation-test artifact leaked into the committed tree. 'memhub write surface' now has zero occurrences repo-wide, down from two at base.",
      "commit_oid": "bcbbe027f4c302136183af63c537a8571c527537",
      "at": "2026-07-27T22:16:44Z"
    },
    {
      "name": "reviewer-tests-rerun",
      "command": "go test ./... \u0026\u0026 go vet ./... \u0026\u0026 gofmt -l .",
      "result": "pass",
      "detail": "All three required tests re-run by the reviewer at the pinned head OID, independently of the executor's run. All packages ok, vet clean, gofmt output empty.",
      "commit_oid": "bcbbe027f4c302136183af63c537a8571c527537",
      "at": "2026-07-27T22:16:44Z"
    },
    {
      "name": "manifest-correction-criterion-1-direction",
      "command": "review of the pr-open audit record against the reproduced evidence",
      "result": "pass",
      "detail": "Correcting a wording defect in this issue's own audit record. The pr-open verification named sentinel-non-vacuity concluded 'proving the pin is strictly more sensitive to wrapping than before'. That gloss is inverted and is superseded by this entry. The raw evidence it reported is correct and reproduced (a wrap FAILS at base 6262608, PASSES at head); the correct interpretation is that base failed LOUDLY on a wrap, so normalization made the pin more TOLERANT of wrapping, fixing brittleness rather than closing a silent hole. The silent hole was orch-reviewer-safe's absence from the coverage map, closed by criterion 2. The Architect authored the inverted gloss, inheriting it from memhub task 77's framing without verifying that specific claim; the executor reported the underlying evidence accurately.",
      "commit_oid": "bcbbe027f4c302136183af63c537a8571c527537",
      "at": "2026-07-27T22:16:44Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approved. All nine acceptance criteria met, verified independently from git archive extracts of the pinned head and base rather than from the executor's report. Scope is exactly the 7 expected files; ORCH-PRD.md is MD5-identical to base; decision 73's single-source property still holds (strings.Fields appears exactly once module-wide); task 78's normalizeWhitespace pair is correctly untouched. All three required tests re-run green by the reviewer, and all six required CI checks pass on this head OID. ONE CORRECTION TO THE RECORD, which does not change any verified fact or the merge decision: criterion 1's premise was stated backwards, in the plan and in the pr-open manifest alike. At base the sentinel check was strings.Contains on a single occurrence, so a line break inside the phrase made the check FAIL LOUDLY - a brittle false alarm, not a silent disarm. Normalization therefore made the pin MORE TOLERANT of wrapping, not more sensitive to it. This inherited the framing of memhub task 77, which the Architect did not independently verify on that specific point. The genuine silent hole was criterion 2's, not criterion 1's: orch-reviewer-safe was absent from readOnlyAgents, so map lookup returned the zero value and its read-only instruction could have been deleted entirely with all six CI checks green. The reviewer proved this with a coverage differential - deleting that sentinel PASSES at base and FAILS at head. Criterion 1 fixed brittleness; criterion 2 closed the hole. Both are correct changes and the net effect on the defense is a strengthening.",
      "commit_oid": "bcbbe027f4c302136183af63c537a8571c527537",
      "at": "2026-07-27T22:16:45Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (macos-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "bcbbe027f4c302136183af63c537a8571c527537",
      "at": "2026-07-27T22:17:00Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->