### PR TITLE
State the three criteria-verification duties in both orch-delivery skills' PlanDoc-construction section

### DIFF
--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -88,6 +88,31 @@ as `.memhub/`, `.orchestrator/state.json`, or
 `.orchestrator/config.local.toml` — an executor sees only the committed
 tree inside its worktree, and none of these exist there.
 
+Before submitting a `PlanDoc`, verify every fact an acceptance
+criterion asserts about the repository — a path, a file, a symbol,
+or a count — by running the command that checks it: `git ls-files`,
+`git check-ignore`, or a grep whose output you actually read. A
+count you have not confirmed this way belongs in the criterion as
+"every site", not a specific number like "the five sites" — a form
+an off-by-one cannot falsify. Read one issue's acceptance criteria
+together as a set, not one at a time, and confirm that a single
+implementation can satisfy all of them simultaneously. Symbol
+visibility across a package boundary is a concrete way a set
+becomes contradictory — an unexported symbol one criterion requires
+while another criterion requires a different package to reach it is
+unsatisfiable by construction — so prefer a criterion stating the
+invariant actually wanted ("normalization logic has exactly one
+source in the module") over one prescribing the mechanism you
+imagine delivering it ("a single unexported function"); the
+invariant stays satisfiable however the executor structures the
+code. When a criterion is justified by a claim that something
+currently fails silently or passes while broken, run that failing
+case once yourself and read its actual outcome before writing the
+criterion — a mechanism that looks fragile can fail loudly on
+exactly the change you feared it would miss — and treat a memhub
+note or a prior finding you are relying on as a lead to verify, not
+evidence to inherit.
+
 ## Plan gate
 
 Call `orch run plan` with the `PlanDoc` on stdin. The result is a

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -88,6 +88,31 @@ as `.memhub/`, `.orchestrator/state.json`, or
 `.orchestrator/config.local.toml` — an executor sees only the committed
 tree inside its worktree, and none of these exist there.
 
+Before submitting a `PlanDoc`, verify every fact an acceptance
+criterion asserts about the repository — a path, a file, a symbol,
+or a count — by running the command that checks it: `git ls-files`,
+`git check-ignore`, or a grep whose output you actually read. A
+count you have not confirmed this way belongs in the criterion as
+"every site", not a specific number like "the five sites" — a form
+an off-by-one cannot falsify. Read one issue's acceptance criteria
+together as a set, not one at a time, and confirm that a single
+implementation can satisfy all of them simultaneously. Symbol
+visibility across a package boundary is a concrete way a set
+becomes contradictory — an unexported symbol one criterion requires
+while another criterion requires a different package to reach it is
+unsatisfiable by construction — so prefer a criterion stating the
+invariant actually wanted ("normalization logic has exactly one
+source in the module") over one prescribing the mechanism you
+imagine delivering it ("a single unexported function"); the
+invariant stays satisfiable however the executor structures the
+code. When a criterion is justified by a claim that something
+currently fails silently or passes while broken, run that failing
+case once yourself and read its actual outcome before writing the
+criterion — a mechanism that looks fragile can fail loudly on
+exactly the change you feared it would miss — and treat a memhub
+note or a prior finding you are relying on as a lead to verify, not
+evidence to inherit.
+
 ## Plan gate
 
 Call `orch run plan` with the `PlanDoc` on stdin. The result is a


### PR DESCRIPTION
Delivers issue #91: State the three criteria-verification duties in both orch-delivery skills' PlanDoc-construction section

Closes #91

**Plan digest:** `sha256:09087b6237074170155ac86b1813408dec21325ba16dab6072226a42100cc626`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** The PlanDoc-construction section of both hosts' orch-delivery skill already tells the Architect to write acceptance criteria as a floor rather than a survey, and not to name machine-local or gitignored paths. Nothing there tells the Architect to verify what a criterion asserts before submitting the plan, and three planning errors in three consecutive runs each came from a different unverified assertion: a criterion that restated a checkable fact about the tree (a path's tracked status, a count of sites) without anyone checking it; a set of criteria each individually true of the tree but jointly unsatisfiable across a Go package boundary; and a criterion whose stated failure mechanism was inverted while every site it named was real and correctly located. Add one paragraph covering all three shapes to that section in both adapters/claude/skills/orch-delivery/SKILL.md and adapters/codex/skills/orch-delivery/SKILL.md. Note that no test pins the prose in this section, so a passing test suite is not evidence the paragraph is right; it has to be read.

**Acceptance criteria:**
- The PlanDoc-construction section of both skill files instructs the Architect that, before submitting a PlanDoc, any fact about the repository that an acceptance criterion asserts (a path, a file, a symbol, or a count) is confirmed by running the command that checks it, and that a count which has not been confirmed is written in a form an off-by-one cannot falsify rather than as a specific number.
- That same section in both files instructs the Architect to read one issue's acceptance criteria together as a set and confirm that a single implementation can satisfy all of them simultaneously, naming symbol visibility across package boundaries as a concrete way a set becomes contradictory, and to prefer a criterion stating the invariant that is actually wanted over one prescribing the mechanism that would deliver it.
- That same section in both files instructs the Architect that when a criterion is justified by a claim that something currently fails silently or passes while broken, that failing case is run once and its actual outcome observed before the criterion is written, and that a note or prior finding being relied on is a lead to verify rather than evidence to inherit.
- adapters/claude/skills/orch-delivery/SKILL.md and adapters/codex/skills/orch-delivery/SKILL.md are byte-identical from the '## PlanDoc construction' heading through the last line before the '## Plan gate' heading, except for the host value in the fenced JSON example, which stays 'claude' in the Claude file and 'codex' in the Codex file.
- The change to that section is purely additive: every sentence present in it before the change is still present afterward, unreworded, and the executor's report states how that was confirmed.

**Required tests:**
- `go test ./...`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — All packages ok. Note this is not evidence the new prose is correct: nothing in the module pins the PlanDoc-construction section, so the suite would be green regardless of what the paragraph says. — commit `3548a049f408bbaea8b564817116bbb347f2e95f` (2026-07-27T22:43:55Z)
- **cross-host-section-diff** — pass — `diff <(sed -n '41,115p' adapters/claude/skills/orch-delivery/SKILL.md) <(sed -n '41,115p' adapters/codex/skills/orch-delivery/SKILL.md)` — Exactly one hunk, line 11 of the range: the pre-existing host value in the fenced JSON example (claude vs codex). Same and only hunk that existed before this change, so the two sections remain byte-identical apart from it. — commit `3548a049f408bbaea8b564817116bbb347f2e95f` (2026-07-27T22:43:55Z)
- **identical-patch-both-hosts** — pass — `gh api repos/kninetimmy/orch/commits/3548a04 --jq '.files[N].patch' for N=0,1; diff the two` — Architect-side independent check against the pushed commit rather than the worktree. Both files show +25 -0 and the two patches are byte-identical. Confirms the additive-only property and cross-host parity without relying on the executor's report. — commit `3548a049f408bbaea8b564817116bbb347f2e95f` (2026-07-27T22:43:55Z)
- **word-stream-additive-check** — pass — `tokenize pre-edit and post-edit section text on whitespace; assert the pre-edit token sequence is a contiguous subsequence of the post-edit tokens` — All 303 original words present, unreworded, as one contiguous block at offset 0 of 553 total; 250 new words appended after, 0 inserted before. Identical counts on both hosts. Checks order as well as presence, so a reword or reorder would fail it, not just a dropped word. — commit `3548a049f408bbaea8b564817116bbb347f2e95f` (2026-07-27T22:43:55Z)
- **no-prose-pin-confirmation** — pass — `grep -rn 'PlanDoc construction' --include=*.go .; grep -l 'floor, not a' .` — No Go file references the section; the phrase appears only in the two SKILL.md files. internal/adaptertest pins run-verb tokens, statement literals, gate options, setup terminal forms, hook portability, matcher parity and the routed-selection cue, none of which touch this prose. Establishes that review must read the paragraph; CI cannot judge it. — commit `3548a049f408bbaea8b564817116bbb347f2e95f` (2026-07-27T22:43:55Z)
- **prose-pin-mutation-test** — pass — `in a throwaway clone at 3548a04, replace lines 91-115 of both SKILL.md files with a garbage sentinel string, then go test ./adapters/... ./internal/...` — All packages green with the entire new paragraph replaced by deliberate garbage on both hosts. Empirical proof that no test in the module pins this prose and that a green suite plus 6/6 green CI is zero evidence the paragraph is correct. This is the memhub task 72 failure shape demonstrated on the exact section under review, and it establishes that the reviewer reading the text was the only real gate on this PR. — commit `3548a049f408bbaea8b564817116bbb347f2e95f` (2026-07-27T22:56:20Z)
- **prose-claim-enumeration** — pass — `enumerate every assertion in the added text; check each against the repo or Go semantics` — git ls-files .orchestrator returns .orchestrator/config.toml exit 0; git check-ignore -v distinguishes it (exit 1, tracked) from .memhub/project.sqlite (.gitignore:1) and .orchestrator/state.json (.gitignore:17). The unexported-symbol case is unsatisfiable by construction in Go. The invariant example matches PR #88's shipped adaptertest.NormalizeWhitespace and its doc comment at adaptertest.go:126. The 'can fail loudly' clause is modal and correct: a strings.Count &gt;= 2 pin disarms silently on reflow, a strings.Contains presence check errors. No claim in the paragraph is itself unverified. — commit `3548a049f408bbaea8b564817116bbb347f2e95f` (2026-07-27T22:56:20Z)
- **cross-host-parity-independent** — pass — `diff <(sed -n '41,115p' claude/SKILL.md) <(sed -n '41,115p' codex/SKILL.md); same diff on base range 41,90` — Exactly one hunk at range line 11 (file line 51), the host value in the fenced JSON example. Reviewer ran the same diff against the base sections and got the identical single hunk, confirming it is pre-existing rather than introduced. Reproduced independently of both the executor and the Architect. — commit `3548a049f408bbaea8b564817116bbb347f2e95f` (2026-07-27T22:56:20Z)
- **word-stream-reproduced** — pass — `reviewer's own tokenization of base and head section text; contiguous-subsequence search` — Base 303 tokens, head 553, delta 250, base sequence found contiguous at offset 0 with zero tokens inserted before, identical on both hosts. Line-level diff agrees: 50a51,75, a pure append. Order-preserving, so a reword or reorder would have failed it. — commit `3548a049f408bbaea8b564817116bbb347f2e95f` (2026-07-27T22:56:20Z)
- **byte-level-character-scan** — pass — `scan the added block for line endings, trailing whitespace, double spaces, smart quotes, non-ASCII repertoire` — LF endings, zero trailing whitespace, zero double-space runs, zero smart quotes. The only non-ASCII character is U+2014 em dash, which is also the only non-ASCII character the pre-existing section uses. Character repertoire matches exactly. — commit `3548a049f408bbaea8b564817116bbb347f2e95f` (2026-07-27T22:56:20Z)
- **instruction-actionability** — pass — `check the guard PreToolUse matchers against the commands the new prose tells the Architect to run` — Claude matcher is Write|Edit|MultiEdit|NotebookEdit, Codex is apply_patch; Bash is not intercepted, so git ls-files, git check-ignore and grep are runnable by the Architect in Assist on both hosts. The prose names only read-only commands and does not nudge the Architect toward the unguarded Bash write path. — commit `3548a049f408bbaea8b564817116bbb347f2e95f` (2026-07-27T22:56:20Z)
- **manifest-and-routing-accuracy** — pass — `compare issue and PR manifests against .orchestrator/config.toml and the installed agent frontmatter` — Issue #91 and PR #92 manifests byte-match and the acceptance criteria match the approved plan verbatim. Routing checked against machine truth rather than the shipped fixture: config.toml sets implementer claude-sonnet-5/xhigh and reviewer claude-opus-5/xhigh, config_revision sha256:e6df9bd25185, all three matching the manifest. orch-reviewer.md frontmatter pins claude-opus-5, satisfying the match rule. — commit `3548a049f408bbaea8b564817116bbb347f2e95f` (2026-07-27T22:56:20Z)
- **scope-containment** — pass — `git show --stat 3548a04; gh api repos/kninetimmy/orch/commits/3548a04` — Exactly two files, +25/-0 each, nothing else. No plugin-version bump, matching the precedent of prose-only PR #84 where versions bumped separately in chore PR #86. — commit `3548a049f408bbaea8b564817116bbb347f2e95f` (2026-07-27T22:56:20Z)
- **review-cycle-1** — approve — First-pass approval, no fix cycles. All five acceptance criteria verified independently by the reviewer rather than inherited from the executor's report. The reviewer enumerated every assertion the new paragraph makes and checked each against the repository or against Go semantics: git ls-files and git check-ignore do what the prose implies (and correctly distinguish the tracked .orchestrator/config.toml from the ignored .memhub/ and .orchestrator/state.json, which is exactly the distinction the task-75 error got backwards); the unexported-symbol construction is genuinely unsatisfiable in Go; the invariant-over-mechanism example is the real historical instance from PR #88, matching the shipped normalizeWhitespace doc comment; and the modal 'can fail loudly' clause is accurate for task 81 without overclaiming a universal, since a count-based pin does disarm silently while a presence-based one errors. No claim in the paragraph is itself an unverified assertion, which was the bar for a paragraph about not asserting what you have not checked. No contradictions found against the same section, the orch-architect skill, ORCH-PRD section 8, or the adapter READMEs. The paragraph claims no mechanical enforcement it does not have; every verb is addressed to the Architect. Six non-blocking observations recorded, four cosmetic prose nits, one low-severity follow-up about the guard interaction with duty 3, and one follow-up recommendation about a possible future test pin, which the issue deliberately excluded from scope. — commit `3548a049f408bbaea8b564817116bbb347f2e95f` (2026-07-27T22:56:22Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `3548a049f408bbaea8b564817116bbb347f2e95f` (2026-07-27T22:56:37Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "The PlanDoc-construction section of both hosts' orch-delivery skill already tells the Architect to write acceptance criteria as a floor rather than a survey, and not to name machine-local or gitignored paths. Nothing there tells the Architect to verify what a criterion asserts before submitting the plan, and three planning errors in three consecutive runs each came from a different unverified assertion: a criterion that restated a checkable fact about the tree (a path's tracked status, a count of sites) without anyone checking it; a set of criteria each individually true of the tree but jointly unsatisfiable across a Go package boundary; and a criterion whose stated failure mechanism was inverted while every site it named was real and correctly located. Add one paragraph covering all three shapes to that section in both adapters/claude/skills/orch-delivery/SKILL.md and adapters/codex/skills/orch-delivery/SKILL.md. Note that no test pins the prose in this section, so a passing test suite is not evidence the paragraph is right; it has to be read.",
  "acceptance_criteria": [
    "The PlanDoc-construction section of both skill files instructs the Architect that, before submitting a PlanDoc, any fact about the repository that an acceptance criterion asserts (a path, a file, a symbol, or a count) is confirmed by running the command that checks it, and that a count which has not been confirmed is written in a form an off-by-one cannot falsify rather than as a specific number.",
    "That same section in both files instructs the Architect to read one issue's acceptance criteria together as a set and confirm that a single implementation can satisfy all of them simultaneously, naming symbol visibility across package boundaries as a concrete way a set becomes contradictory, and to prefer a criterion stating the invariant that is actually wanted over one prescribing the mechanism that would deliver it.",
    "That same section in both files instructs the Architect that when a criterion is justified by a claim that something currently fails silently or passes while broken, that failing case is run once and its actual outcome observed before the criterion is written, and that a note or prior finding being relied on is a lead to verify rather than evidence to inherit.",
    "adapters/claude/skills/orch-delivery/SKILL.md and adapters/codex/skills/orch-delivery/SKILL.md are byte-identical from the '## PlanDoc construction' heading through the last line before the '## Plan gate' heading, except for the host value in the fenced JSON example, which stays 'claude' in the Claude file and 'codex' in the Codex file.",
    "The change to that section is purely additive: every sentence present in it before the change is still present afterward, unreworded, and the executor's report states how that was confirmed."
  ],
  "required_tests": [
    "go test ./..."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All packages ok. Note this is not evidence the new prose is correct: nothing in the module pins the PlanDoc-construction section, so the suite would be green regardless of what the paragraph says.",
      "commit_oid": "3548a049f408bbaea8b564817116bbb347f2e95f",
      "at": "2026-07-27T22:43:55Z"
    },
    {
      "name": "cross-host-section-diff",
      "command": "diff \u003c(sed -n '41,115p' adapters/claude/skills/orch-delivery/SKILL.md) \u003c(sed -n '41,115p' adapters/codex/skills/orch-delivery/SKILL.md)",
      "result": "pass",
      "detail": "Exactly one hunk, line 11 of the range: the pre-existing host value in the fenced JSON example (claude vs codex). Same and only hunk that existed before this change, so the two sections remain byte-identical apart from it.",
      "commit_oid": "3548a049f408bbaea8b564817116bbb347f2e95f",
      "at": "2026-07-27T22:43:55Z"
    },
    {
      "name": "identical-patch-both-hosts",
      "command": "gh api repos/kninetimmy/orch/commits/3548a04 --jq '.files[N].patch' for N=0,1; diff the two",
      "result": "pass",
      "detail": "Architect-side independent check against the pushed commit rather than the worktree. Both files show +25 -0 and the two patches are byte-identical. Confirms the additive-only property and cross-host parity without relying on the executor's report.",
      "commit_oid": "3548a049f408bbaea8b564817116bbb347f2e95f",
      "at": "2026-07-27T22:43:55Z"
    },
    {
      "name": "word-stream-additive-check",
      "command": "tokenize pre-edit and post-edit section text on whitespace; assert the pre-edit token sequence is a contiguous subsequence of the post-edit tokens",
      "result": "pass",
      "detail": "All 303 original words present, unreworded, as one contiguous block at offset 0 of 553 total; 250 new words appended after, 0 inserted before. Identical counts on both hosts. Checks order as well as presence, so a reword or reorder would fail it, not just a dropped word.",
      "commit_oid": "3548a049f408bbaea8b564817116bbb347f2e95f",
      "at": "2026-07-27T22:43:55Z"
    },
    {
      "name": "no-prose-pin-confirmation",
      "command": "grep -rn 'PlanDoc construction' --include=*.go .; grep -l 'floor, not a' .",
      "result": "pass",
      "detail": "No Go file references the section; the phrase appears only in the two SKILL.md files. internal/adaptertest pins run-verb tokens, statement literals, gate options, setup terminal forms, hook portability, matcher parity and the routed-selection cue, none of which touch this prose. Establishes that review must read the paragraph; CI cannot judge it.",
      "commit_oid": "3548a049f408bbaea8b564817116bbb347f2e95f",
      "at": "2026-07-27T22:43:55Z"
    },
    {
      "name": "prose-pin-mutation-test",
      "command": "in a throwaway clone at 3548a04, replace lines 91-115 of both SKILL.md files with a garbage sentinel string, then go test ./adapters/... ./internal/...",
      "result": "pass",
      "detail": "All packages green with the entire new paragraph replaced by deliberate garbage on both hosts. Empirical proof that no test in the module pins this prose and that a green suite plus 6/6 green CI is zero evidence the paragraph is correct. This is the memhub task 72 failure shape demonstrated on the exact section under review, and it establishes that the reviewer reading the text was the only real gate on this PR.",
      "commit_oid": "3548a049f408bbaea8b564817116bbb347f2e95f",
      "at": "2026-07-27T22:56:20Z"
    },
    {
      "name": "prose-claim-enumeration",
      "command": "enumerate every assertion in the added text; check each against the repo or Go semantics",
      "result": "pass",
      "detail": "git ls-files .orchestrator returns .orchestrator/config.toml exit 0; git check-ignore -v distinguishes it (exit 1, tracked) from .memhub/project.sqlite (.gitignore:1) and .orchestrator/state.json (.gitignore:17). The unexported-symbol case is unsatisfiable by construction in Go. The invariant example matches PR #88's shipped adaptertest.NormalizeWhitespace and its doc comment at adaptertest.go:126. The 'can fail loudly' clause is modal and correct: a strings.Count \u003e= 2 pin disarms silently on reflow, a strings.Contains presence check errors. No claim in the paragraph is itself unverified.",
      "commit_oid": "3548a049f408bbaea8b564817116bbb347f2e95f",
      "at": "2026-07-27T22:56:20Z"
    },
    {
      "name": "cross-host-parity-independent",
      "command": "diff \u003c(sed -n '41,115p' claude/SKILL.md) \u003c(sed -n '41,115p' codex/SKILL.md); same diff on base range 41,90",
      "result": "pass",
      "detail": "Exactly one hunk at range line 11 (file line 51), the host value in the fenced JSON example. Reviewer ran the same diff against the base sections and got the identical single hunk, confirming it is pre-existing rather than introduced. Reproduced independently of both the executor and the Architect.",
      "commit_oid": "3548a049f408bbaea8b564817116bbb347f2e95f",
      "at": "2026-07-27T22:56:20Z"
    },
    {
      "name": "word-stream-reproduced",
      "command": "reviewer's own tokenization of base and head section text; contiguous-subsequence search",
      "result": "pass",
      "detail": "Base 303 tokens, head 553, delta 250, base sequence found contiguous at offset 0 with zero tokens inserted before, identical on both hosts. Line-level diff agrees: 50a51,75, a pure append. Order-preserving, so a reword or reorder would have failed it.",
      "commit_oid": "3548a049f408bbaea8b564817116bbb347f2e95f",
      "at": "2026-07-27T22:56:20Z"
    },
    {
      "name": "byte-level-character-scan",
      "command": "scan the added block for line endings, trailing whitespace, double spaces, smart quotes, non-ASCII repertoire",
      "result": "pass",
      "detail": "LF endings, zero trailing whitespace, zero double-space runs, zero smart quotes. The only non-ASCII character is U+2014 em dash, which is also the only non-ASCII character the pre-existing section uses. Character repertoire matches exactly.",
      "commit_oid": "3548a049f408bbaea8b564817116bbb347f2e95f",
      "at": "2026-07-27T22:56:20Z"
    },
    {
      "name": "instruction-actionability",
      "command": "check the guard PreToolUse matchers against the commands the new prose tells the Architect to run",
      "result": "pass",
      "detail": "Claude matcher is Write|Edit|MultiEdit|NotebookEdit, Codex is apply_patch; Bash is not intercepted, so git ls-files, git check-ignore and grep are runnable by the Architect in Assist on both hosts. The prose names only read-only commands and does not nudge the Architect toward the unguarded Bash write path.",
      "commit_oid": "3548a049f408bbaea8b564817116bbb347f2e95f",
      "at": "2026-07-27T22:56:20Z"
    },
    {
      "name": "manifest-and-routing-accuracy",
      "command": "compare issue and PR manifests against .orchestrator/config.toml and the installed agent frontmatter",
      "result": "pass",
      "detail": "Issue #91 and PR #92 manifests byte-match and the acceptance criteria match the approved plan verbatim. Routing checked against machine truth rather than the shipped fixture: config.toml sets implementer claude-sonnet-5/xhigh and reviewer claude-opus-5/xhigh, config_revision sha256:e6df9bd25185, all three matching the manifest. orch-reviewer.md frontmatter pins claude-opus-5, satisfying the match rule.",
      "commit_oid": "3548a049f408bbaea8b564817116bbb347f2e95f",
      "at": "2026-07-27T22:56:20Z"
    },
    {
      "name": "scope-containment",
      "command": "git show --stat 3548a04; gh api repos/kninetimmy/orch/commits/3548a04",
      "result": "pass",
      "detail": "Exactly two files, +25/-0 each, nothing else. No plugin-version bump, matching the precedent of prose-only PR #84 where versions bumped separately in chore PR #86.",
      "commit_oid": "3548a049f408bbaea8b564817116bbb347f2e95f",
      "at": "2026-07-27T22:56:20Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "First-pass approval, no fix cycles. All five acceptance criteria verified independently by the reviewer rather than inherited from the executor's report. The reviewer enumerated every assertion the new paragraph makes and checked each against the repository or against Go semantics: git ls-files and git check-ignore do what the prose implies (and correctly distinguish the tracked .orchestrator/config.toml from the ignored .memhub/ and .orchestrator/state.json, which is exactly the distinction the task-75 error got backwards); the unexported-symbol construction is genuinely unsatisfiable in Go; the invariant-over-mechanism example is the real historical instance from PR #88, matching the shipped normalizeWhitespace doc comment; and the modal 'can fail loudly' clause is accurate for task 81 without overclaiming a universal, since a count-based pin does disarm silently while a presence-based one errors. No claim in the paragraph is itself an unverified assertion, which was the bar for a paragraph about not asserting what you have not checked. No contradictions found against the same section, the orch-architect skill, ORCH-PRD section 8, or the adapter READMEs. The paragraph claims no mechanical enforcement it does not have; every verb is addressed to the Architect. Six non-blocking observations recorded, four cosmetic prose nits, one low-severity follow-up about the guard interaction with duty 3, and one follow-up recommendation about a possible future test pin, which the issue deliberately excluded from scope.",
      "commit_oid": "3548a049f408bbaea8b564817116bbb347f2e95f",
      "at": "2026-07-27T22:56:22Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "3548a049f408bbaea8b564817116bbb347f2e95f",
      "at": "2026-07-27T22:56:37Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->