### PR TITLE
Require executors to word-diff any commit that reflows prose

### DIFF
--- a/adapters/claude/agents/orch-implementer.md
+++ b/adapters/claude/agents/orch-implementer.md
@@ -46,6 +46,16 @@ relevant to the change. Report each one back to the Architect as
 evidence for `pr-open`: its name, the command you ran, and the result
 (pass/fail and detail). Do not report a check you did not actually run.
 
+## Check prose reflows for dropped words
+
+Any commit that reflows a paragraph — rewrapping or restructuring prose
+without meaning to change it — gets checked with `git diff --word-diff
+--ignore-all-space` before you push it. The failure signal is a removal
+marker of the form `[-word-]` covering a word you didn't mean to lose;
+a pure reflow that drops nothing produces no such marker, which is what
+makes the check worth running rather than noise. Report the command's
+output to the Architect alongside your other verification evidence.
+
 ## When it's unusually hard
 
 If the task turns out to be substantially harder than the issue

--- a/adapters/claude/agents/orch-specialist.md
+++ b/adapters/claude/agents/orch-specialist.md
@@ -55,5 +55,16 @@ checks. Report each one to the Architect as evidence for `pr-open`: its
 name, the command you ran, and the result. Do not report a check you
 did not actually run.
 
+## Check prose reflows for dropped words
+
+A paragraph reflow can drop a word without the surrounding text ever
+looking wrong, so before pushing any commit that reflows prose, run
+`git diff --word-diff --ignore-all-space` first. Look for a removal
+marker of the form `[-word-]` covering a word you did not intend to
+remove — a pure reflow that drops nothing produces no such marker,
+which is what makes the check usable rather than noisy. Report the
+command's output to the Architect as part of your verification
+evidence.
+
 A write denial from the pre-write guard is policy — report it to the
 Architect; do not work around it.

--- a/adapters/codex/agents/orch-implementer.toml
+++ b/adapters/codex/agents/orch-implementer.toml
@@ -47,6 +47,16 @@ relevant to the change. Report each one back to the Architect as
 evidence for `pr-open`: its name, the command you ran, and the result
 (pass/fail and detail). Do not report a check you did not actually run.
 
+## Check prose reflows for dropped words
+
+Before you push a commit that reflows prose — rewraps or restructures a
+paragraph without changing its meaning — check it with `git diff
+--word-diff --ignore-all-space`. Read the output for a removal marker
+of the form `[-word-]` covering a word you did not intend to drop: a
+pure reflow that drops nothing produces no such marker, which is what
+makes the check usable instead of noisy. Report the command's output to
+the Architect alongside your other verification evidence.
+
 ## When it's unusually hard
 
 If the task turns out to be substantially harder than the issue

--- a/adapters/codex/agents/orch-specialist.toml
+++ b/adapters/codex/agents/orch-specialist.toml
@@ -53,6 +53,17 @@ checks. Report each one to the Architect as evidence for `pr-open`: its
 name, the command you ran, and the result. Do not report a check you
 did not actually run.
 
+## Check prose reflows for dropped words
+
+Reflowing a paragraph can silently lose a word without changing how the
+result reads. Run `git diff --word-diff --ignore-all-space` on any
+commit that reflows prose before you push it, and check for a removal
+marker of the form `[-word-]` covering a word you did not intend to
+remove — a pure reflow that drops nothing produces no such marker,
+which is what makes the check usable rather than noisy. Report the
+command's output to the Architect as part of your verification
+evidence.
+
 A write denial from the pre-write guard is policy — report it to the
 Architect; do not work around it.
 """


### PR DESCRIPTION
Delivers issue #94: Require executors to word-diff any commit that reflows prose

Closes #94

**Plan digest:** `sha256:e2439fafc17830cfce01085362548fbd03188c51a998660f5cf0db6387770096`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Add to both hosts' orch-implementer and orch-specialist agent definitions a duty that any commit which reflows prose is checked with `git diff --word-diff --ignore-all-space` before it is pushed, and that the command's output is reported to the Architect. Two commits in one recent PR each dropped a word while reflowing a paragraph; the full test suite and all six required CI checks were green on the commit that lost one, because the suite pins only literals somebody chose to pin and an ordinary dropped word matches none of them. The named command makes the check reproducible instead of leaving each executor to invent one.

**Acceptance criteria:**
- Both hosts' `orch-implementer` and `orch-specialist` agent definitions state the duty and name `git diff --word-diff --ignore-all-space` as the exact command to run.
- Each of those four definitions names the failure signal concretely: a removal marker of the form `[-word-]` covering a word the executor did not intend to remove. A pure reflow that drops nothing produces no such marker, which is what makes the check usable rather than noisy.
- Each of those four definitions states that the command's output goes to the Architect in the executor's report, so the check's result is visible rather than merely asserted to have been run.
- The four definitions stay parallel in substance without becoming byte-identical: neither host's file adopts the other's vocabulary, and each keeps the formatting conventions already used in the file it is edited into.
- The two Codex definitions remain valid TOML with the instruction body still a single multi-line string, and no text added by this issue mentions an `mcp__` tool, which the Codex adapter's own test rejects.

**Required tests:**
- `go test ./adapters/...`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively unsurprising.

**Escalations:** _none_

**Verification:**
- **go test ./adapters/...** — pass — `go test ./adapters/... -v` — Run by the executor from its worktree root. Both adapters/claude and adapters/codex packages passed, including TestAgentFrontmatter (all five Claude roles) and TestAgentTOMLs (all five Codex roles), the latter exercising the strict TOML decode that rejects unrecognized keys and the mcp__ rejection check. Confirms acceptance criterion 5's TOML-validity and no-mcp__ requirements. — commit `0dbf25d4a04e25c02194e49948db4d188ebc9888` (2026-07-28T01:09:38Z)
- **prose word-diff self-check** — pass — `git diff --word-diff --ignore-all-space --staged` — Run by the executor against its own staged changes before committing, applying the duty this issue adds. Every hunk showed only {+...+} addition markers; no [-...-] removal marker appeared in any of the four files. The change was pure prose addition rather than a reflow, so a removal marker was not structurally possible; the executor ran the command anyway as the duty's own dry run. — commit `0dbf25d4a04e25c02194e49948db4d188ebc9888` (2026-07-28T01:09:38Z)
- **architect scope and deletion audit** — pass — `gh api repos/kninetimmy/orch/compare/main...orch/issue-94-require-executors-to-word-diff-any-commi` — Run independently by the Architect against the pushed branch, not by the executor. One commit (0dbf25d4a04e25c02194e49948db4d188ebc9888). Exactly four files changed, all in scope: adapters/claude/agents/orch-implementer.md +10/-0, adapters/claude/agents/orch-specialist.md +11/-0, adapters/codex/agents/orch-implementer.toml +10/-0, adapters/codex/agents/orch-specialist.toml +11/-0. Zero deletions across the entire branch, which independently confirms no existing word was dropped and no out-of-scope file was touched. — commit `0dbf25d4a04e25c02194e49948db4d188ebc9888` (2026-07-28T01:09:38Z)
- **reviewer independent suite run** — pass — `go test ./... && go vet ./... && gofmt -l .` — Run by the reviewer in a fresh clone made in a scratch directory outside the repository, with HEAD confirmed equal to the pinned OID before use. go test ./adapters/... both packages ok; go test ./... fully green; go vet clean; gofmt -l produced no output. — commit `0dbf25d4a04e25c02194e49948db4d188ebc9888` (2026-07-28T01:21:15Z)
- **reviewer word-diff behaviour reproduction** — pass — `git diff --word-diff --ignore-all-space (throwaway repo, drop-a-word and pure-reflow controls)` — Reviewer re-derived criterion 2's underlying fact rather than inheriting it. Drop-a-word case reduced to exactly [-either-]; pure-reflow control produced zero removal and addition markers but still printed the diff header, index line, ---/+++, hunk header and context lines. Confirms no shipped file may claim empty output as the pass condition, and none does. — commit `0dbf25d4a04e25c02194e49948db4d188ebc9888` (2026-07-28T01:21:15Z)
- **architect post-commit timing reproduction** — fail — `git diff --word-diff --ignore-all-space (bare, --staged, and HEAD~1..HEAD, all after committing a reflow that dropped a word)` — Run by the Architect to verify the reviewer's non-blocking finding rather than inherit it. After the reflow was committed, the bare command produced completely empty output and --staged produced completely empty output; only the range form HEAD~1..HEAD surfaced [-either-]. The shipped instruction names the bare command in the before-you-push window, where it is silent. Recorded as failing because the check as specified does not detect the defect it exists to detect in that window. Defect is in the approved criterion, not this PR's execution. — commit `0dbf25d4a04e25c02194e49948db4d188ebc9888` (2026-07-28T01:21:15Z)
- **review-cycle-1** — approve — Approve. All five acceptance criteria met. Criterion 1: all four bodies contain the literal command (two hard-wrap it inside its backtick span, matching the convention already used for `gh pr diff` in the Codex reviewer files, and consistent with adaptertest's documented position that a hard-wrapped pinned phrase still counts as present). Criterion 2: all four name the [-word-] removal marker and none states or implies the pass condition is empty output, which would have been wrong since the command still prints a diff header and context lines on a clean reflow. Criterion 3: all four route the output to the Architect, adjacent to the pre-existing do-not-report-a-check-you-did-not-run line. Criterion 4: no pair of added paragraphs is byte-identical, and no added paragraph contains any host-specific vocabulary at all (zero occurrences of spawn/dispatch/CLAUDE.md/AGENTS.md/bold), so there is no cross-contamination; each file's maximum body line length is unchanged by the PR. The two specialist paragraphs share 51 of ~80 trailing words, judged as satisfying the criterion rather than violating it because verbatim cross-host sharing is the established baseline in these files (the two base specialist definitions already share 22 identical lines including whole sections) and the new paragraphs diverge more than the sections around them. Criterion 5: both TOMLs keep one triple-quoted developer_instructions string, no added backslash or triple-quote sequence, no mcp__ mention; TestAgentTOMLs passes. Scope clean: one commit, exactly four in-scope files, zero deletions across the entire branch, independently reconfirmed by the reviewer rather than inherited from the Architect. Reviewer-side files and internal/adaptertest correctly untouched per the issue #95 scope note. All six required checks green. No security surface: the only executable text added is a read-only git diff with fixed flags and no interpolation. Manifest accurate on all three recorded verifications and on every routing field. NON-BLOCKING FINDING CARRIED FORWARD, and confirmed by the Architect to be more severe than reported: the bare command compares working tree to index, so in the window the instruction names (before you push, i.e. after commit) it prints nothing. The Architect reproduced this and additionally found --staged is ALSO empty post-commit; only a range form such as HEAD~1..HEAD surfaces the dropped word. This is a defect in the approved acceptance criterion, not in the execution, which was faithful to it. Also carried forward: a mechanical grep for the marker false-positives on this prose itself, and nothing in the suite pins the new text. — commit `0dbf25d4a04e25c02194e49948db4d188ebc9888` (2026-07-28T01:21:16Z)
- **required-ci** — passing — test (windows-latest)=pass, lint=pass, test (ubuntu-latest)=pass, scripts (windows-latest)=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass — commit `0dbf25d4a04e25c02194e49948db4d188ebc9888` (2026-07-28T01:21:35Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Add to both hosts' orch-implementer and orch-specialist agent definitions a duty that any commit which reflows prose is checked with `git diff --word-diff --ignore-all-space` before it is pushed, and that the command's output is reported to the Architect. Two commits in one recent PR each dropped a word while reflowing a paragraph; the full test suite and all six required CI checks were green on the commit that lost one, because the suite pins only literals somebody chose to pin and an ordinary dropped word matches none of them. The named command makes the check reproducible instead of leaving each executor to invent one.",
  "acceptance_criteria": [
    "Both hosts' `orch-implementer` and `orch-specialist` agent definitions state the duty and name `git diff --word-diff --ignore-all-space` as the exact command to run.",
    "Each of those four definitions names the failure signal concretely: a removal marker of the form `[-word-]` covering a word the executor did not intend to remove. A pure reflow that drops nothing produces no such marker, which is what makes the check usable rather than noisy.",
    "Each of those four definitions states that the command's output goes to the Architect in the executor's report, so the check's result is visible rather than merely asserted to have been run.",
    "The four definitions stay parallel in substance without becoming byte-identical: neither host's file adopts the other's vocabulary, and each keeps the formatting conventions already used in the file it is edited into.",
    "The two Codex definitions remain valid TOML with the instruction body still a single multi-line string, and no text added by this issue mentions an `mcp__` tool, which the Codex adapter's own test rejects."
  ],
  "required_tests": [
    "go test ./adapters/..."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively unsurprising.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "go test ./adapters/...",
      "command": "go test ./adapters/... -v",
      "result": "pass",
      "detail": "Run by the executor from its worktree root. Both adapters/claude and adapters/codex packages passed, including TestAgentFrontmatter (all five Claude roles) and TestAgentTOMLs (all five Codex roles), the latter exercising the strict TOML decode that rejects unrecognized keys and the mcp__ rejection check. Confirms acceptance criterion 5's TOML-validity and no-mcp__ requirements.",
      "commit_oid": "0dbf25d4a04e25c02194e49948db4d188ebc9888",
      "at": "2026-07-28T01:09:38Z"
    },
    {
      "name": "prose word-diff self-check",
      "command": "git diff --word-diff --ignore-all-space --staged",
      "result": "pass",
      "detail": "Run by the executor against its own staged changes before committing, applying the duty this issue adds. Every hunk showed only {+...+} addition markers; no [-...-] removal marker appeared in any of the four files. The change was pure prose addition rather than a reflow, so a removal marker was not structurally possible; the executor ran the command anyway as the duty's own dry run.",
      "commit_oid": "0dbf25d4a04e25c02194e49948db4d188ebc9888",
      "at": "2026-07-28T01:09:38Z"
    },
    {
      "name": "architect scope and deletion audit",
      "command": "gh api repos/kninetimmy/orch/compare/main...orch/issue-94-require-executors-to-word-diff-any-commi",
      "result": "pass",
      "detail": "Run independently by the Architect against the pushed branch, not by the executor. One commit (0dbf25d4a04e25c02194e49948db4d188ebc9888). Exactly four files changed, all in scope: adapters/claude/agents/orch-implementer.md +10/-0, adapters/claude/agents/orch-specialist.md +11/-0, adapters/codex/agents/orch-implementer.toml +10/-0, adapters/codex/agents/orch-specialist.toml +11/-0. Zero deletions across the entire branch, which independently confirms no existing word was dropped and no out-of-scope file was touched.",
      "commit_oid": "0dbf25d4a04e25c02194e49948db4d188ebc9888",
      "at": "2026-07-28T01:09:38Z"
    },
    {
      "name": "reviewer independent suite run",
      "command": "go test ./... \u0026\u0026 go vet ./... \u0026\u0026 gofmt -l .",
      "result": "pass",
      "detail": "Run by the reviewer in a fresh clone made in a scratch directory outside the repository, with HEAD confirmed equal to the pinned OID before use. go test ./adapters/... both packages ok; go test ./... fully green; go vet clean; gofmt -l produced no output.",
      "commit_oid": "0dbf25d4a04e25c02194e49948db4d188ebc9888",
      "at": "2026-07-28T01:21:15Z"
    },
    {
      "name": "reviewer word-diff behaviour reproduction",
      "command": "git diff --word-diff --ignore-all-space (throwaway repo, drop-a-word and pure-reflow controls)",
      "result": "pass",
      "detail": "Reviewer re-derived criterion 2's underlying fact rather than inheriting it. Drop-a-word case reduced to exactly [-either-]; pure-reflow control produced zero removal and addition markers but still printed the diff header, index line, ---/+++, hunk header and context lines. Confirms no shipped file may claim empty output as the pass condition, and none does.",
      "commit_oid": "0dbf25d4a04e25c02194e49948db4d188ebc9888",
      "at": "2026-07-28T01:21:15Z"
    },
    {
      "name": "architect post-commit timing reproduction",
      "command": "git diff --word-diff --ignore-all-space (bare, --staged, and HEAD~1..HEAD, all after committing a reflow that dropped a word)",
      "result": "fail",
      "detail": "Run by the Architect to verify the reviewer's non-blocking finding rather than inherit it. After the reflow was committed, the bare command produced completely empty output and --staged produced completely empty output; only the range form HEAD~1..HEAD surfaced [-either-]. The shipped instruction names the bare command in the before-you-push window, where it is silent. Recorded as failing because the check as specified does not detect the defect it exists to detect in that window. Defect is in the approved criterion, not this PR's execution.",
      "commit_oid": "0dbf25d4a04e25c02194e49948db4d188ebc9888",
      "at": "2026-07-28T01:21:15Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approve. All five acceptance criteria met. Criterion 1: all four bodies contain the literal command (two hard-wrap it inside its backtick span, matching the convention already used for `gh pr diff` in the Codex reviewer files, and consistent with adaptertest's documented position that a hard-wrapped pinned phrase still counts as present). Criterion 2: all four name the [-word-] removal marker and none states or implies the pass condition is empty output, which would have been wrong since the command still prints a diff header and context lines on a clean reflow. Criterion 3: all four route the output to the Architect, adjacent to the pre-existing do-not-report-a-check-you-did-not-run line. Criterion 4: no pair of added paragraphs is byte-identical, and no added paragraph contains any host-specific vocabulary at all (zero occurrences of spawn/dispatch/CLAUDE.md/AGENTS.md/bold), so there is no cross-contamination; each file's maximum body line length is unchanged by the PR. The two specialist paragraphs share 51 of ~80 trailing words, judged as satisfying the criterion rather than violating it because verbatim cross-host sharing is the established baseline in these files (the two base specialist definitions already share 22 identical lines including whole sections) and the new paragraphs diverge more than the sections around them. Criterion 5: both TOMLs keep one triple-quoted developer_instructions string, no added backslash or triple-quote sequence, no mcp__ mention; TestAgentTOMLs passes. Scope clean: one commit, exactly four in-scope files, zero deletions across the entire branch, independently reconfirmed by the reviewer rather than inherited from the Architect. Reviewer-side files and internal/adaptertest correctly untouched per the issue #95 scope note. All six required checks green. No security surface: the only executable text added is a read-only git diff with fixed flags and no interpolation. Manifest accurate on all three recorded verifications and on every routing field. NON-BLOCKING FINDING CARRIED FORWARD, and confirmed by the Architect to be more severe than reported: the bare command compares working tree to index, so in the window the instruction names (before you push, i.e. after commit) it prints nothing. The Architect reproduced this and additionally found --staged is ALSO empty post-commit; only a range form such as HEAD~1..HEAD surfaces the dropped word. This is a defect in the approved acceptance criterion, not in the execution, which was faithful to it. Also carried forward: a mechanical grep for the marker false-positives on this prose itself, and nothing in the suite pins the new text.",
      "commit_oid": "0dbf25d4a04e25c02194e49948db4d188ebc9888",
      "at": "2026-07-28T01:21:16Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, lint=pass, test (ubuntu-latest)=pass, scripts (windows-latest)=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "0dbf25d4a04e25c02194e49948db4d188ebc9888",
      "at": "2026-07-28T01:21:35Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->