### PR TITLE
Provision a disposable unregistered review worktree and tear it down in cleanup

### DIFF
--- a/internal/adaptertest/adaptertest.go
+++ b/internal/adaptertest/adaptertest.go
@@ -81,15 +81,15 @@ func Profile(host string) map[string]RoleSpec {
 }
 
 // runVerbTokens is the closed set every `orch run <word>` token found in
-// a skill must belong to: the 13 document-taking verbs internal/cli/run.go
+// a skill must belong to: the 14 document-taking verbs internal/cli/run.go
 // dispatches, plus "status" (orch run status --json, dispatched
 // separately but still spelled "orch run status"). Moved verbatim from
 // adapters/claude/plugin_test.go so both hosts pin against the same set.
 var runVerbTokens = map[string]bool{
 	"plan": true, "activate": true, "dispatch": true, "pr-open": true,
-	"review": true, "escalate": true, "ci": true, "merge-report": true,
-	"merge": true, "block": true, "abandon": true, "cleanup": true,
-	"complete": true, "status": true,
+	"review-worktree": true, "review": true, "escalate": true, "ci": true,
+	"merge-report": true, "merge": true, "block": true, "abandon": true,
+	"cleanup": true, "complete": true, "status": true,
 }
 
 var orchRunTokenPattern = regexp.MustCompile(`orch run ([a-z-]+)`)
@@ -156,7 +156,7 @@ func CheckRunVerbTokens(t *testing.T, skillGlob string) {
 		for _, m := range orchRunTokenPattern.FindAllStringSubmatch(content, -1) {
 			verb := m[1]
 			if !runVerbTokens[verb] {
-				t.Errorf("%s: mentions `orch run %s`, which is not one of the 13 verbs or status", path, verb)
+				t.Errorf("%s: mentions `orch run %s`, which is not one of the 14 verbs or status", path, verb)
 			}
 		}
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -12,25 +12,26 @@ import (
 )
 
 // runUsage is the one-line usage for the adapter plumbing surface.
-const runUsage = "orch run: usage: orch run plan|activate|dispatch|pr-open|review|escalate|ci|merge-report|merge|block|abandon|cleanup|complete (JSON document on stdin) | orch run status --json"
+const runUsage = "orch run: usage: orch run plan|activate|dispatch|pr-open|review-worktree|review|escalate|ci|merge-report|merge|block|abandon|cleanup|complete (JSON document on stdin) | orch run status --json"
 
 // runVerbs maps each document-taking verb to its run-engine entry point.
 // Every one reads a JSON request on stdin and writes a JSON result on
 // stdout; status is handled separately because it must never read stdin.
 var runVerbs = map[string]func(context.Context, run.Env, []byte) (any, error){
-	"plan":         adaptRunVerb(run.Plan),
-	"activate":     adaptRunVerb(run.Activate),
-	"dispatch":     adaptRunVerb(run.Dispatch),
-	"pr-open":      adaptRunVerb(run.PROpen),
-	"review":       adaptRunVerb(run.Review),
-	"escalate":     adaptRunVerb(run.Escalate),
-	"ci":           adaptRunVerb(run.CI),
-	"merge-report": adaptRunVerb(run.MergeReport),
-	"merge":        adaptRunVerb(run.Merge),
-	"block":        adaptRunVerb(run.Block),
-	"abandon":      adaptRunVerb(run.Abandon),
-	"cleanup":      adaptRunVerb(run.Cleanup),
-	"complete":     adaptRunVerb(run.Complete),
+	"plan":            adaptRunVerb(run.Plan),
+	"activate":        adaptRunVerb(run.Activate),
+	"dispatch":        adaptRunVerb(run.Dispatch),
+	"pr-open":         adaptRunVerb(run.PROpen),
+	"review-worktree": adaptRunVerb(run.ReviewWorktree),
+	"review":          adaptRunVerb(run.Review),
+	"escalate":        adaptRunVerb(run.Escalate),
+	"ci":              adaptRunVerb(run.CI),
+	"merge-report":    adaptRunVerb(run.MergeReport),
+	"merge":           adaptRunVerb(run.Merge),
+	"block":           adaptRunVerb(run.Block),
+	"abandon":         adaptRunVerb(run.Abandon),
+	"cleanup":         adaptRunVerb(run.Cleanup),
+	"complete":        adaptRunVerb(run.Complete),
 }
 
 // adaptRunVerb erases a verb's concrete result type so every document

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -122,17 +122,18 @@ func TestRunStatusNeverReadsStdin(t *testing.T) {
 // valid document yields ExitError, never ExitUsage.
 func TestRunLifecycleVerbsAreRouted(t *testing.T) {
 	verbs := map[string]string{
-		"dispatch":     `{"schema_version":2,"issue_number":1}`,
-		"pr-open":      `{"schema_version":1,"issue_number":1,"verifications":[{"name":"t","result":"pass"}]}`,
-		"review":       `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"h","verdict":"approve","summary":"s","reviewer":{"model":"m","effort":"e"}}`,
-		"escalate":     `{"schema_version":1,"issue_number":1,"trigger":"architectural-ambiguity","detail":"x"}`,
-		"ci":           `{"schema_version":1,"issue_number":1}`,
-		"merge-report": `{"schema_version":1,"issue_number":1}`,
-		"merge":        `{"schema_version":1,"issue_number":1,"approval":{"pr_number":1,"head_oid":"h","approved_by":"a","approved_at":"2026-07-11T12:00:00Z","statement":"approve-merge"}}`,
-		"block":        `{"schema_version":1,"issue_number":1,"class":"other","detail":"x"}`,
-		"abandon":      `{"schema_version":1,"issue_number":1,"reason":"x","statement":"abandon-issue"}`,
-		"cleanup":      `{"schema_version":1,"issue_number":1,"statement":"cleanup-issue"}`,
-		"complete":     `{"schema_version":1}`,
+		"dispatch":        `{"schema_version":2,"issue_number":1}`,
+		"pr-open":         `{"schema_version":1,"issue_number":1,"verifications":[{"name":"t","result":"pass"}]}`,
+		"review-worktree": `{"schema_version":1,"issue_number":1,"head_oid":"0123456789abcdef0123456789abcdef01234567"}`,
+		"review":          `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"h","verdict":"approve","summary":"s","reviewer":{"model":"m","effort":"e"}}`,
+		"escalate":        `{"schema_version":1,"issue_number":1,"trigger":"architectural-ambiguity","detail":"x"}`,
+		"ci":              `{"schema_version":1,"issue_number":1}`,
+		"merge-report":    `{"schema_version":1,"issue_number":1}`,
+		"merge":           `{"schema_version":1,"issue_number":1,"approval":{"pr_number":1,"head_oid":"h","approved_by":"a","approved_at":"2026-07-11T12:00:00Z","statement":"approve-merge"}}`,
+		"block":           `{"schema_version":1,"issue_number":1,"class":"other","detail":"x"}`,
+		"abandon":         `{"schema_version":1,"issue_number":1,"reason":"x","statement":"abandon-issue"}`,
+		"cleanup":         `{"schema_version":1,"issue_number":1,"statement":"cleanup-issue"}`,
+		"complete":        `{"schema_version":1}`,
 	}
 	for verb, doc := range verbs {
 		t.Run(verb, func(t *testing.T) {

--- a/internal/gitops/gitops.go
+++ b/internal/gitops/gitops.go
@@ -6,9 +6,13 @@
 // The package is policy-free: callers supply branch names, worktree
 // paths, remotes, and protected-branch lists — naming and placement
 // policy belongs to the run engine. Every operation fails closed: any
-// git error propagates, destructive operations require an explicit
-// Confirmation (PRD §15: blocked worktrees and branches are
-// preserved), and --force never touches user work.
+// git error propagates, and a destructive operation that can reach
+// committed work requires an explicit Confirmation (PRD §15: blocked
+// worktrees and branches are preserved). The two removals that pass
+// --force differ only in mechanism: WithBaseWorktree force-removes the
+// detached checkout it created itself, and RemoveDetachedWorktree
+// refuses any worktree that is not detached, so neither can reach a
+// branch or the commits on it.
 //
 // Operations that pre-check and then act (for example AddWorktree)
 // are not atomic; the run engine serializes potentially conflicting

--- a/internal/gitops/worktree.go
+++ b/internal/gitops/worktree.go
@@ -73,34 +73,47 @@ func (g *Git) ListWorktrees(ctx context.Context) ([]Worktree, error) {
 	return list, nil
 }
 
+// prepareWorktreePath canonicalizes path and applies the two placement
+// pre-checks every worktree creation shares, in order: path must not
+// already exist (never clobber), and a path inside the primary
+// checkout must be git-ignored (F1: worktrees must be isolated from
+// the primary checkout's tracked tree, PRD §5 — an ignored
+// inside-primary path is safe because it never appears in
+// `status --porcelain`, so RequireClean and isolation guarantees still
+// hold). It touches nothing; the caller creates the worktree.
+func (g *Git) prepareWorktreePath(ctx context.Context, path string) (string, error) {
+	canon, err := paths.Canonical(path)
+	if err != nil {
+		return "", err
+	}
+	switch _, err := os.Lstat(canon); {
+	case err == nil:
+		return "", fmt.Errorf("worktree path %s already exists; refusing to clobber it", canon)
+	case !errors.Is(err, fs.ErrNotExist):
+		return "", fmt.Errorf("check worktree path %s: %w", canon, err)
+	}
+	inside, err := paths.Inside(g.root, canon)
+	if err != nil {
+		return "", err
+	}
+	if inside {
+		if err := g.RequireIgnored(ctx, canon); err != nil {
+			return "", fmt.Errorf("worktree path %s is inside the primary checkout and not git-ignored: %w", canon, err)
+		}
+	}
+	return canon, nil
+}
+
 // AddWorktree creates branch at startPoint together with a new
 // worktree at path (PRD §12 step 7: one branch/worktree per issue).
 // It fails closed before touching git when path already exists (never
 // clobber), when the branch already exists (ErrBranchExists), or when
-// path lies inside the primary checkout and is not git-ignored (F1:
-// worktrees must be isolated from the primary checkout's tracked tree,
-// PRD §5 — an ignored inside-primary path is safe because it never
-// appears in `status --porcelain`, so RequireClean and isolation
-// guarantees still hold). Never uses --force.
+// path lies inside the primary checkout and is not git-ignored
+// (prepareWorktreePath). Never uses --force.
 func (g *Git) AddWorktree(ctx context.Context, path, branch, startPoint string) (*Worktree, error) {
-	canon, err := paths.Canonical(path)
+	canon, err := g.prepareWorktreePath(ctx, path)
 	if err != nil {
 		return nil, err
-	}
-	switch _, err := os.Lstat(canon); {
-	case err == nil:
-		return nil, fmt.Errorf("worktree path %s already exists; refusing to clobber it", canon)
-	case !errors.Is(err, fs.ErrNotExist):
-		return nil, fmt.Errorf("check worktree path %s: %w", canon, err)
-	}
-	inside, err := paths.Inside(g.root, canon)
-	if err != nil {
-		return nil, err
-	}
-	if inside {
-		if err := g.RequireIgnored(ctx, canon); err != nil {
-			return nil, fmt.Errorf("worktree path %s is inside the primary checkout and not git-ignored: %w", canon, err)
-		}
 	}
 	res, err := g.run(ctx, g.root, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch)
 	if err != nil {
@@ -119,6 +132,32 @@ func (g *Git) AddWorktree(ctx context.Context, path, branch, startPoint string) 
 	return &Worktree{Path: canon, Branch: branch, Head: head}, nil
 }
 
+// AddDetachedWorktree checks commit out into a new worktree at path
+// with a detached HEAD: it creates no branch and checks none out, so
+// the checkout holds no ref that another worktree could contend for or
+// move under it. It runs prepareWorktreePath's clobber and
+// inside-primary checks first and never uses --force, exactly as
+// AddWorktree does; only the branch handling differs.
+//
+// The returned Worktree carries the commit HEAD actually resolved to,
+// read back from the new checkout rather than echoed from commit, so
+// an abbreviated commit-ish is reported in full and the caller can
+// report what it got rather than what it asked for.
+func (g *Git) AddDetachedWorktree(ctx context.Context, path, commit string) (*Worktree, error) {
+	canon, err := g.prepareWorktreePath(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := g.git(ctx, g.root, "worktree", "add", "--detach", canon, commit); err != nil {
+		return nil, err
+	}
+	head, err := g.git(ctx, canon, "rev-parse", "--verify", "HEAD^{commit}")
+	if err != nil {
+		return nil, err
+	}
+	return &Worktree{Path: canon, Head: head, Detached: true}, nil
+}
+
 // Confirmation proves the caller obtained explicit human approval for
 // a destructive operation (PRD §15). The zero value fails closed;
 // only ExplicitConfirmation constructs a valid token. gitops never
@@ -130,6 +169,29 @@ type Confirmation struct{ ok bool }
 // specific deletion (PRD §15: cleanup or abandonment deletion
 // requires explicit confirmation).
 func ExplicitConfirmation() Confirmation { return Confirmation{ok: true} }
+
+// findWorktree returns the registered worktree whose path is the
+// canonical path canon, or ErrUnknownWorktree when git knows no
+// worktree there — the check that keeps every removal path from
+// deleting an arbitrary directory. The primary checkout matches like
+// any other entry; refusing it belongs to the caller, and every
+// removal path does refuse it.
+func (g *Git) findWorktree(ctx context.Context, canon string) (*Worktree, error) {
+	worktrees, err := g.ListWorktrees(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range worktrees {
+		same, err := samePath(worktrees[i].Path, canon)
+		if err != nil {
+			return nil, err
+		}
+		if same {
+			return &worktrees[i], nil
+		}
+	}
+	return nil, fmt.Errorf("%w: %s", ErrUnknownWorktree, canon)
+}
 
 // RemoveWorktree removes the registered worktree at path and prunes
 // stale metadata (PRD §12 step 19). Fail-closed gates, in order: the
@@ -146,32 +208,55 @@ func (g *Git) RemoveWorktree(ctx context.Context, path string, c Confirmation) e
 	if err != nil {
 		return err
 	}
-	worktrees, err := g.ListWorktrees(ctx)
+	wt, err := g.findWorktree(ctx, canon)
 	if err != nil {
 		return err
 	}
-	found := false
-	for _, wt := range worktrees {
-		same, err := samePath(wt.Path, canon)
-		if err != nil {
-			return err
-		}
-		if !same {
-			continue
-		}
-		if wt.Primary {
-			return fmt.Errorf("%s is the primary checkout; refusing to remove it", canon)
-		}
-		found = true
-		break
-	}
-	if !found {
-		return fmt.Errorf("%w: %s", ErrUnknownWorktree, canon)
+	if wt.Primary {
+		return fmt.Errorf("%s is the primary checkout; refusing to remove it", canon)
 	}
 	if err := g.RequireClean(ctx, canon); err != nil {
 		return err
 	}
 	if _, err := g.git(ctx, g.root, "worktree", "remove", canon); err != nil {
+		return err
+	}
+	return g.PruneWorktrees(ctx)
+}
+
+// RemoveDetachedWorktree removes the registered detached worktree at
+// path, discarding whatever modified or untracked files it holds, and
+// prunes stale metadata. Fail-closed gates, in order: the canonical
+// path must match a registered worktree (ErrUnknownWorktree — the same
+// "never delete an arbitrary directory" rule RemoveWorktree obeys); it
+// must not be the primary checkout, which is refused even when its own
+// HEAD happens to be detached; and it must be detached, so a worktree
+// holding a branch is refused by name.
+//
+// It takes no Confirmation, for the reason WithBaseWorktree's forced
+// removal takes none: what PRD §15 protects from a forced removal is
+// committed work, which lives on a branch, and the detached gate above
+// makes "holds no branch" a checked precondition rather than a promise
+// — a branch worktree can never reach the removal below. What is lost
+// is uncommitted scratch inside a disposable checkout, which is what
+// disposable means. A caller removing a worktree that may hold work
+// must use RemoveWorktree, which is confirmed and refuses a dirty tree.
+func (g *Git) RemoveDetachedWorktree(ctx context.Context, path string) error {
+	canon, err := paths.Canonical(path)
+	if err != nil {
+		return err
+	}
+	wt, err := g.findWorktree(ctx, canon)
+	if err != nil {
+		return err
+	}
+	if wt.Primary {
+		return fmt.Errorf("%s is the primary checkout; refusing to remove it", canon)
+	}
+	if !wt.Detached {
+		return fmt.Errorf("%s is checked out on branch %s, not detached; refusing to force-remove a worktree holding a branch", canon, wt.Branch)
+	}
+	if _, err := g.git(ctx, g.root, "worktree", "remove", "--force", canon); err != nil {
 		return err
 	}
 	return g.PruneWorktrees(ctx)

--- a/internal/gitops/worktree_test.go
+++ b/internal/gitops/worktree_test.go
@@ -157,6 +157,127 @@ func TestAddWorktreeExistingPathFailsClosed(t *testing.T) {
 	}
 }
 
+func TestAddDetachedWorktree(t *testing.T) {
+	root := tempRoot(t)
+	path := canon(t, filepath.Join(root, ".orchestrator", "worktrees", "review-issue-4"))
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const head = "6666666666666666666666666666666666666666"
+	g, script := openScripted(t, root,
+		execxtest.Call{Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/"}, Dir: root},
+		execxtest.Call{Name: "git", Args: []string{"worktree", "add", "--detach", path, "6666666"}, Dir: root},
+		// The resolved HEAD is read back inside the new checkout, so an
+		// abbreviated commit-ish comes back in full.
+		execxtest.Call{Name: "git", Args: []string{"rev-parse", "--verify", "HEAD^{commit}"}, Dir: path, Stdout: head + "\n"},
+	)
+	wt, err := g.AddDetachedWorktree(context.Background(), path, "6666666")
+	script.AssertExhausted()
+	if err != nil {
+		t.Fatalf("AddDetachedWorktree: %v", err)
+	}
+	want := Worktree{Path: path, Head: head, Detached: true}
+	if *wt != want {
+		t.Errorf("worktree = %+v, want %+v", *wt, want)
+	}
+}
+
+func TestAddDetachedWorktreeExistingPathFailsClosed(t *testing.T) {
+	g, script := openScripted(t, tempRoot(t))
+	existing := t.TempDir()
+	_, err := g.AddDetachedWorktree(context.Background(), existing, "6666666666666666666666666666666666666666")
+	script.AssertExhausted() // fail closed before any git call
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("err = %v, want clobber refusal", err)
+	}
+}
+
+func TestAddDetachedWorktreeInsidePrimaryNotIgnoredFailsClosed(t *testing.T) {
+	root := tempRoot(t)
+	path := filepath.Join(root, "review")
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/"}, Dir: root, Exit: 1,
+	})
+	_, err = g.AddDetachedWorktree(context.Background(), path, "6666666666666666666666666666666666666666")
+	script.AssertExhausted() // no `worktree add` followed
+	if !errors.Is(err, ErrNotIgnored) {
+		t.Fatalf("err = %v, want ErrNotIgnored", err)
+	}
+}
+
+func TestRemoveDetachedWorktree(t *testing.T) {
+	root := tempRoot(t)
+	wt := tempRoot(t)
+	g, script := openScripted(t, root,
+		execxtest.Call{Name: "git", Args: listArgs, Stdout: porcelain(
+			"worktree "+root, "HEAD 1111", "branch refs/heads/main", "",
+			"worktree "+wt, "HEAD 2222", "detached",
+		)},
+		// No cleanliness check: the checkout is disposable, and a reviewer
+		// legitimately leaves test output in it.
+		execxtest.Call{Name: "git", Args: []string{"worktree", "remove", "--force", wt}, Dir: root},
+		execxtest.Call{Name: "git", Args: []string{"worktree", "prune"}, Dir: root},
+	)
+	if err := g.RemoveDetachedWorktree(context.Background(), wt); err != nil {
+		t.Fatalf("RemoveDetachedWorktree: %v", err)
+	}
+	script.AssertExhausted()
+}
+
+func TestRemoveDetachedWorktreeUnknownPath(t *testing.T) {
+	root := tempRoot(t)
+	stray := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "git", Args: listArgs,
+		Stdout: porcelain("worktree "+root, "HEAD 1111", "branch refs/heads/main"),
+	})
+	err := g.RemoveDetachedWorktree(context.Background(), stray)
+	script.AssertExhausted() // no forced removal of a directory git does not know
+	if !errors.Is(err, ErrUnknownWorktree) {
+		t.Fatalf("err = %v, want ErrUnknownWorktree", err)
+	}
+}
+
+// TestRemoveDetachedWorktreeBranchRefused proves the gate that stands in
+// for RemoveWorktree's Confirmation: a worktree holding a branch — where
+// committed work lives — never reaches the forced removal.
+func TestRemoveDetachedWorktreeBranchRefused(t *testing.T) {
+	root := tempRoot(t)
+	wt := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "git", Args: listArgs, Stdout: porcelain(
+			"worktree "+root, "HEAD 1111", "branch refs/heads/main", "",
+			"worktree "+wt, "HEAD 2222", "branch refs/heads/orch/issue-4",
+		),
+	})
+	err := g.RemoveDetachedWorktree(context.Background(), wt)
+	script.AssertExhausted()
+	if err == nil || !strings.Contains(err.Error(), "orch/issue-4") {
+		t.Fatalf("err = %v, want a refusal naming the branch", err)
+	}
+}
+
+// TestRemoveDetachedWorktreePrimaryRefused pins the primary check ahead
+// of the detached check: a primary checkout left on a detached HEAD (the
+// shape a mis-targeted checkout leaves behind) is still refused.
+func TestRemoveDetachedWorktreePrimaryRefused(t *testing.T) {
+	root := tempRoot(t)
+	g, script := openScripted(t, root, execxtest.Call{
+		Name: "git", Args: listArgs,
+		Stdout: porcelain("worktree "+root, "HEAD 1111", "detached"),
+	})
+	err := g.RemoveDetachedWorktree(context.Background(), root)
+	script.AssertExhausted()
+	if err == nil || !strings.Contains(err.Error(), "primary checkout") {
+		t.Fatalf("err = %v, want primary-checkout refusal", err)
+	}
+}
+
 func TestRemoveWorktreeUnconfirmed(t *testing.T) {
 	g, script := openScripted(t, tempRoot(t))
 	err := g.RemoveWorktree(context.Background(), t.TempDir(), Confirmation{})

--- a/internal/run/cleanup.go
+++ b/internal/run/cleanup.go
@@ -15,8 +15,12 @@ import (
 const CleanupSchemaVersion = 1
 
 // CleanupStatement is the exact confirmation cleanup requires: one
-// statement covers the verb's three deletions — remote branch, worktree,
-// and local branch — because they are one act (PRD §15).
+// statement covers the verb's three confirmed deletions — remote
+// branch, worktree, and local branch — because they are one act
+// (PRD §15). The disposable review checkout cleanup also removes needs
+// no confirmation of its own: it is detached, so it holds no branch
+// and none of the committed work a confirmation protects
+// (gitops.RemoveDetachedWorktree).
 const CleanupStatement = "cleanup-issue"
 
 // CleanupRequest removes a merged or abandoned issue's git artifacts.
@@ -34,11 +38,12 @@ type CleanupResult struct {
 }
 
 // Cleanup deletes a merged or abandoned issue's remote branch, worktree,
-// and local branch (PRD §12 steps 18-19), then marks the issue cleaned
-// (terminal). Each deletion is pre-checked so a crashed cleanup re-runs
-// cleanly; the only state write is the final Save. A failure mid-cleanup
-// leaves the run incomplete (PRD §16) — the phase stays put and cleanup
-// re-runs.
+// and local branch (PRD §12 steps 18-19) along with any disposable
+// review checkout a review cycle left behind, then marks the issue
+// cleaned (terminal). Each deletion is pre-checked so a crashed cleanup
+// re-runs cleanly; the only state write is the final Save. A failure
+// mid-cleanup leaves the run incomplete (PRD §16) — the phase stays put
+// and cleanup re-runs.
 func Cleanup(ctx context.Context, env Env, reqJSON []byte) (*CleanupResult, error) {
 	var req CleanupRequest
 	if err := decodeRequest(reqJSON, &req); err != nil {
@@ -81,7 +86,17 @@ func Cleanup(ctx context.Context, env Env, reqJSON []byte) (*CleanupResult, erro
 		return nil, err
 	}
 
-	// 3. Local branch (idempotent: only force-delete when it still
+	// 3. Review worktree, when a review cycle provisioned one
+	// (idempotent the same way, and tolerant of the same
+	// ErrUnknownWorktree). No field of the run state names it — see
+	// ReviewWorktree for why that absence is deliberate — so cleanup
+	// derives its path exactly as the verb that created it does rather
+	// than reading state that was never written.
+	if err := git.RemoveDetachedWorktree(ctx, reviewWorktreeAbs(env.RepoRoot, issue.Number)); err != nil && !errors.Is(err, gitops.ErrUnknownWorktree) {
+		return nil, err
+	}
+
+	// 4. Local branch (idempotent: only force-delete when it still
 	// resolves — a squash merge leaves it unmerged by design).
 	if _, err := git.RevParse(ctx, issue.Branch); err == nil {
 		if err := git.ForceDeleteBranch(ctx, issue.Branch, confirm); err != nil {

--- a/internal/run/cleanup.go
+++ b/internal/run/cleanup.go
@@ -17,9 +17,9 @@ const CleanupSchemaVersion = 1
 // CleanupStatement is the exact confirmation cleanup requires: one
 // statement covers the verb's three confirmed deletions — remote
 // branch, worktree, and local branch — because they are one act
-// (PRD §15). The disposable review checkout cleanup also removes needs
-// no confirmation of its own: it is detached, so it holds no branch
-// and none of the committed work a confirmation protects
+// (PRD §15). Cleanup also removes the disposable review checkout; that
+// removal needs no confirmation of its own: it is detached, so it holds
+// no branch and none of the committed work a confirmation protects
 // (gitops.RemoveDetachedWorktree).
 const CleanupStatement = "cleanup-issue"
 

--- a/internal/run/lifecycle.go
+++ b/internal/run/lifecycle.go
@@ -1,17 +1,18 @@
 // This file holds the shared infrastructure for the per-issue Delivery
 // lifecycle verbs (PRD §12 steps 8-22), each in its own file:
 //
-//	dispatch      worktree-ready → dispatched
-//	pr-open       dispatched     → pr-open
-//	review        pr-open/in-review → in-review
-//	escalate      dispatched/pr-open/in-review → reroute (same) or blocked
-//	ci            pr-open/in-review/awaiting-merge → same (manifest only)
-//	merge-report  in-review      → awaiting-merge
-//	merge         awaiting-merge → merged
-//	block         any non-terminal → blocked
-//	abandon       any non-terminal → abandoned
-//	cleanup       merged/abandoned → cleaned
-//	complete      run-level; requires every issue cleaned
+//	dispatch         worktree-ready → dispatched
+//	pr-open          dispatched     → pr-open
+//	review-worktree  pr-open/in-review → same (git only, no state write)
+//	review           pr-open/in-review → in-review
+//	escalate         dispatched/pr-open/in-review → reroute (same) or blocked
+//	ci               pr-open/in-review/awaiting-merge → same (manifest only)
+//	merge-report     in-review      → awaiting-merge
+//	merge            awaiting-merge → merged
+//	block            any non-terminal → blocked
+//	abandon          any non-terminal → abandoned
+//	cleanup          merged/abandoned → cleaned
+//	complete         run-level; requires every issue cleaned
 //
 // Failure semantics are pure (PRD §15, resolved 2026-07-11): no verb
 // mutates phase, state, GitHub, or git as a side effect of failing.

--- a/internal/run/names.go
+++ b/internal/run/names.go
@@ -46,3 +46,26 @@ func worktreeRel(number int) string {
 func worktreeAbs(repoRoot string, number int) string {
 	return filepath.Join(repoRoot, filepath.FromSlash(worktreeRel(number)))
 }
+
+// reviewWorktreeRel is the repo-relative, slash-separated path of issue
+// number's disposable review checkout (see ReviewWorktree). It shares
+// the git-ignored container with the executor worktrees but carries a
+// "review-" prefix, so it cannot equal worktreeRel's output for this
+// issue or any other: worktreeRel always yields "issue-<n>", which
+// never begins with "review-". Nor can either path contain the other,
+// since they are siblings — which is what keeps the review checkout
+// outside every registered worktree rather than nested inside one.
+//
+// Nothing persists this path. Both callers — the verb that creates the
+// checkout and the cleanup that removes it — derive it here, which is
+// what keeps the review checkout absent from the worktree set the
+// guard reads out of state.
+func reviewWorktreeRel(number int) string {
+	return WorktreeContainer + "/" + fmt.Sprintf("review-issue-%d", number)
+}
+
+// reviewWorktreeAbs is the canonical filesystem path for issue
+// number's review checkout under repoRoot.
+func reviewWorktreeAbs(repoRoot string, number int) string {
+	return filepath.Join(repoRoot, filepath.FromSlash(reviewWorktreeRel(number)))
+}

--- a/internal/run/reviewworktree.go
+++ b/internal/run/reviewworktree.go
@@ -14,16 +14,27 @@ import (
 // schema this build accepts and emits.
 const ReviewWorktreeSchemaVersion = 1
 
-// headOIDPattern is the shape head_oid must have: hexadecimal only,
-// between an abbreviation git can resolve and a full SHA-256 hash. The
-// field is an object id and nothing else, so a symbolic name — a
-// branch, HEAD, FETCH_HEAD, a revision expression — is a bad request
-// rather than something to resolve. That is not pedantry: a name is
-// resolved when git reads it, and a concurrently running verb can move
-// what it points at between the moment a reviewer chose it and that
-// read, which is exactly how a review ends up reporting findings
+// headOIDPattern is the shape head_oid must have: a full hexadecimal
+// hash, 40 characters under SHA-1 or 64 under SHA-256, in upper or
+// lower case. The field is an object id and nothing else, so a symbolic
+// name — a branch, HEAD, FETCH_HEAD, a revision expression — is a bad
+// request rather than something to resolve. That is not pedantry: a
+// name is resolved when git reads it, and a concurrently running verb
+// can move what it points at between the moment a reviewer chose it and
+// that read, which is exactly how a review ends up reporting findings
 // against a commit it never meant to read. An OID cannot move.
-var headOIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{7,64}$`)
+//
+// An abbreviation is rejected for the same reason rather than accepted
+// as a convenience. Git resolves a name as a ref before it resolves it
+// as a short object, so a short all-hex string can be a branch — a
+// branch named "deadbeef" wins over any object whose id starts that
+// way — and even an unambiguous abbreviation is only resolved against
+// the object database at read time, growing ambiguous as that database
+// grows. The full hash is the one spelling with neither problem: git
+// deliberately ignores a ref spelled as a full hash, so the object
+// always wins there. Nothing is lost by requiring it, either — every
+// caller has the full hash from the PR's headRefOid.
+var headOIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{40}$|^[0-9a-fA-F]{64}$`)
 
 // ReviewWorktreeRequest asks for a disposable checkout of one reviewed
 // commit.
@@ -88,7 +99,7 @@ func ReviewWorktree(ctx context.Context, env Env, reqJSON []byte) (*ReviewWorktr
 		return nil, fmt.Errorf("%w: schema_version %d is unsupported (this build supports %d)", ErrBadRequest, req.SchemaVersion, ReviewWorktreeSchemaVersion)
 	}
 	if !headOIDPattern.MatchString(req.HeadOID) {
-		return nil, fmt.Errorf("%w: head_oid %q is not an object id; pass the commit's hash, never a ref name a concurrent verb could move", ErrBadRequest, req.HeadOID)
+		return nil, fmt.Errorf("%w: head_oid %q is not a full object id; pass the commit's complete hash, never an abbreviation or a ref name a concurrent verb could move", ErrBadRequest, req.HeadOID)
 	}
 
 	// The phase gate is loadVerb's, not this verb's: a review checkout

--- a/internal/run/reviewworktree.go
+++ b/internal/run/reviewworktree.go
@@ -1,0 +1,130 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/kninetimmy/orch/internal/gitops"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// ReviewWorktreeSchemaVersion is the review-worktree request/result
+// schema this build accepts and emits.
+const ReviewWorktreeSchemaVersion = 1
+
+// headOIDPattern is the shape head_oid must have: hexadecimal only,
+// between an abbreviation git can resolve and a full SHA-256 hash. The
+// field is an object id and nothing else, so a symbolic name — a
+// branch, HEAD, FETCH_HEAD, a revision expression — is a bad request
+// rather than something to resolve. That is not pedantry: a name is
+// resolved when git reads it, and a concurrently running verb can move
+// what it points at between the moment a reviewer chose it and that
+// read, which is exactly how a review ends up reporting findings
+// against a commit it never meant to read. An OID cannot move.
+var headOIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{7,64}$`)
+
+// ReviewWorktreeRequest asks for a disposable checkout of one reviewed
+// commit.
+type ReviewWorktreeRequest struct {
+	SchemaVersion int    `json:"schema_version"`
+	IssueNumber   int    `json:"issue_number"`
+	HeadOID       string `json:"head_oid"`
+}
+
+// ReviewWorktreeResult reports the provisioned checkout: where it is,
+// repo-relative and slash-separated like every other worktree path
+// this engine emits, and the commit its HEAD actually resolved to.
+type ReviewWorktreeResult struct {
+	SchemaVersion int    `json:"schema_version"`
+	IssueNumber   int    `json:"issue_number"`
+	Worktree      string `json:"worktree"`
+	HeadOID       string `json:"head_oid"`
+}
+
+// ReviewWorktree checks the reviewed commit out into a disposable
+// worktree with a detached HEAD, under the same git-ignored container
+// the executor worktrees live in, and reports its repo-relative path.
+// A reviewer reads the code there instead of in the primary checkout.
+//
+// Nothing about that worktree is persisted, and that absence is the
+// feature rather than an omission. internal/guard resolves a Delivery
+// write against the worktrees run state registers and denies any
+// in-repository target that lies inside none of them, so a worktree
+// inside the repository that state does not register is read-only to
+// the guarded tools with no guard code of its own. Registering it here
+// would make it writable and invert the point. Putting it outside the
+// repository would be worse still: the guard allows any path with no
+// .orchestrator ancestor, so a temp-directory checkout would carry no
+// enforcement at all.
+//
+// What that buys is exactly as wide as the PreToolUse hooks the guard
+// sits behind — Claude's Write, Edit, MultiEdit and NotebookEdit, and
+// Codex's apply_patch. A write a reviewer performs through a shell
+// command is not mediated by those hooks and is not denied by any of
+// this. The verb makes a reviewer's tool-mediated writes fail closed;
+// it does not make a reviewer read-only.
+//
+// Two hazards of reviewing in the primary checkout motivate it, both
+// observed live: a shell command whose directory change failed ran a
+// state-changing git command in the primary checkout instead, and
+// concurrent reviewers raced on a shared fetched-ref name there. The
+// checkout here is detached at one requested OID, so it holds no
+// branch and no ref another reviewer or verb can move under it.
+//
+// Re-running for the same issue replaces the previous cycle's checkout
+// instead of accumulating one per cycle, so a request-changes cycle
+// re-provisions at the new head; cleanup removes whatever is left,
+// finding it by the same derivation, since state never held it. The
+// verb writes no state at all: there is no phase transition, and no
+// metrics event, because nothing in the issue's lifecycle advanced.
+func ReviewWorktree(ctx context.Context, env Env, reqJSON []byte) (*ReviewWorktreeResult, error) {
+	var req ReviewWorktreeRequest
+	if err := decodeRequest(reqJSON, &req); err != nil {
+		return nil, err
+	}
+	if req.SchemaVersion != ReviewWorktreeSchemaVersion {
+		return nil, fmt.Errorf("%w: schema_version %d is unsupported (this build supports %d)", ErrBadRequest, req.SchemaVersion, ReviewWorktreeSchemaVersion)
+	}
+	if !headOIDPattern.MatchString(req.HeadOID) {
+		return nil, fmt.Errorf("%w: head_oid %q is not an object id; pass the commit's hash, never a ref name a concurrent verb could move", ErrBadRequest, req.HeadOID)
+	}
+
+	// The phase gate is loadVerb's, not this verb's: a review checkout
+	// only makes sense for an issue whose PR is open and under review,
+	// the same pair the review verb accepts.
+	c, err := loadVerb(env, req.IssueNumber, []state.Phase{state.PhasePROpen, state.PhaseInReview}, false)
+	if err != nil {
+		return nil, err
+	}
+	issue := c.issue()
+
+	git, err := gitops.Open(ctx, env.Runner, env.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	// Replace an earlier cycle's checkout (idempotent the way cleanup's
+	// deletions are: nothing left behind is not registered, so
+	// ErrUnknownWorktree is the expected answer, not a failure). The
+	// removal is forced because a reviewer legitimately leaves untracked
+	// files — test output, build artifacts — in a checkout that exists to
+	// be thrown away; gitops refuses to force-remove anything holding a
+	// branch, so no work can be reached this way.
+	abs := reviewWorktreeAbs(env.RepoRoot, issue.Number)
+	if err := git.RemoveDetachedWorktree(ctx, abs); err != nil && !errors.Is(err, gitops.ErrUnknownWorktree) {
+		return nil, err
+	}
+	wt, err := git.AddDetachedWorktree(ctx, abs, req.HeadOID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ReviewWorktreeResult{
+		SchemaVersion: ReviewWorktreeSchemaVersion,
+		IssueNumber:   issue.Number,
+		Worktree:      reviewWorktreeRel(issue.Number),
+		HeadOID:       wt.Head,
+	}, nil
+}

--- a/internal/run/reviewworktree_test.go
+++ b/internal/run/reviewworktree_test.go
@@ -163,6 +163,10 @@ func TestReviewWorktreeBadRequestBeforeMutation(t *testing.T) {
 		"fetch head":          reviewWorktreeJSON(1, "FETCH_HEAD"),
 		"branch name":         reviewWorktreeJSON(1, "main"),
 		"revision expression": reviewWorktreeJSON(1, "HEAD~1"),
+		// An abbreviation is rejected too: git resolves a name as a ref
+		// before it resolves it as a short object, so a short all-hex
+		// string is a possible branch name, not a pinned commit.
+		"abbreviated oid": reviewWorktreeJSON(1, "0123456"),
 	}
 	for name, doc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/run/reviewworktree_test.go
+++ b/internal/run/reviewworktree_test.go
@@ -1,0 +1,291 @@
+package run
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+	"github.com/kninetimmy/orch/internal/paths"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// seedReviewRun adds a second commit to the git sandbox at root and
+// enters Delivery with one issue (#1) in phase, returning the two
+// commit OIDs on main (oldest first) a review can be pinned to. The
+// issue's own worktree is named in state but never created on disk: no
+// code path under test needs it, and leaving it out keeps the review
+// checkout the only worktree these tests can be observing.
+func seedReviewRun(t *testing.T, root string, phase state.Phase) (string, string) {
+	t.Helper()
+	first := strings.TrimSpace(rawGit(t, root, "rev-parse", "HEAD"))
+	if err := os.WriteFile(filepath.Join(root, "second.txt"), []byte("second\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rawGit(t, root, "add", "-A")
+	rawGit(t, root, "commit", "-m", "second")
+	second := strings.TrimSpace(rawGit(t, root, "rev-parse", "HEAD"))
+
+	enterDeliveryAt(t, root, "r1", []state.Issue{fixtureIssue("a", 1, phase)})
+	return first, second
+}
+
+// reviewEnv is an Env whose git calls run for real and whose gh script
+// is empty: any GitHub call the verb under test makes fails the test,
+// which is itself an assertion — provisioning a review checkout is a
+// purely local act.
+func reviewEnv(t *testing.T, root string) (Env, *execxtest.Script) {
+	t.Helper()
+	script := &execxtest.Script{T: t}
+	return Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}, script
+}
+
+func reviewWorktreeJSON(number int, headOID string) string {
+	return fmt.Sprintf(`{"schema_version":1,"issue_number":%d,"head_oid":%q}`, number, headOID)
+}
+
+// detachedHeadAt fails the test unless dir is a checkout with a detached
+// HEAD sitting on oid.
+func detachedHeadAt(t *testing.T, dir, oid string) {
+	t.Helper()
+	if head := strings.TrimSpace(rawGit(t, dir, "rev-parse", "HEAD")); head != oid {
+		t.Errorf("%s HEAD = %s, want %s", dir, head, oid)
+	}
+	if ref := strings.TrimSpace(rawGit(t, dir, "rev-parse", "--abbrev-ref", "HEAD")); ref != "HEAD" {
+		t.Errorf("%s is on branch %s, want a detached HEAD (a branch is a name a concurrent verb can move)", dir, ref)
+	}
+}
+
+// TestReviewWorktreeCheckoutIsDetachedAndUnregistered covers the shape
+// of the created checkout and the invariant the whole feature rests on:
+// persisted state must not refer to it. A change that registers the
+// review worktree makes it a worktree the guard matches, and therefore
+// writable by the guarded tools — the exact inversion of the point — so
+// this test asserts the absence directly rather than through any
+// downstream behavior.
+func TestReviewWorktreeCheckoutIsDetachedAndUnregistered(t *testing.T) {
+	root := newActivateRepo(t)
+	_, second := seedReviewRun(t, root, state.PhaseInReview)
+	before := stateBytes(t, root)
+
+	res := runVerb(t, root, ReviewWorktree, reviewWorktreeJSON(1, second))
+
+	if want := WorktreeContainer + "/review-issue-1"; res.Worktree != want {
+		t.Errorf("worktree = %q, want %q", res.Worktree, want)
+	}
+	if res.Worktree == worktreeRel(1) {
+		t.Fatalf("review worktree %q collides with issue #1's executor worktree", res.Worktree)
+	}
+	if res.HeadOID != second {
+		t.Errorf("head_oid = %q, want the requested %q", res.HeadOID, second)
+	}
+	abs := reviewWorktreeAbs(root, 1)
+	detachedHeadAt(t, abs, second)
+
+	// Criterion: no issue's Worktree field equals the review path.
+	st := loadRun(t, root)
+	for i := range st.Run.Issues {
+		if st.Run.Issues[i].Worktree == res.Worktree {
+			t.Fatalf("issue #%d registers the review worktree %q in state; leaving it unregistered is what makes it read-only to the guarded tools", st.Run.Issues[i].Number, res.Worktree)
+		}
+	}
+	// The same invariant over the whole document, so a future field that
+	// records the path under another name fails here too.
+	after := stateBytes(t, root)
+	if bytes.Contains(after, []byte("review-issue-1")) {
+		t.Fatalf("persisted state names the review worktree:\n%s", after)
+	}
+	// Stronger still, and true today: the verb persists nothing at all.
+	if !bytes.Equal(before, after) {
+		t.Errorf("state changed; the verb advances no phase and records nothing\nbefore %s\nafter  %s", before, after)
+	}
+
+	// The containment fact the guard's Delivery rule turns into a denial:
+	// the review checkout lies inside no registered worktree, so a write
+	// targeting it matches none of them.
+	for i := range st.Run.Issues {
+		registered := filepath.Join(root, filepath.FromSlash(st.Run.Issues[i].Worktree))
+		inside, err := paths.Inside(registered, abs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if inside {
+			t.Errorf("review checkout %s lies inside registered worktree %s", abs, registered)
+		}
+	}
+}
+
+// TestReviewWorktreeReplacesPreviousCycle covers a request-changes
+// cycle: the second call re-provisions at the new head instead of
+// failing on the leftover checkout or accumulating a second one, and it
+// does so even though the reviewer left untracked files behind.
+func TestReviewWorktreeReplacesPreviousCycle(t *testing.T) {
+	root := newActivateRepo(t)
+	first, second := seedReviewRun(t, root, state.PhaseInReview)
+	abs := reviewWorktreeAbs(root, 1)
+
+	if res := runVerb(t, root, ReviewWorktree, reviewWorktreeJSON(1, first)); res.HeadOID != first {
+		t.Fatalf("first cycle head = %q, want %q", res.HeadOID, first)
+	}
+	detachedHeadAt(t, abs, first)
+	scratch := filepath.Join(abs, "reviewer-notes.txt")
+	if err := os.WriteFile(scratch, []byte("test output\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if res := runVerb(t, root, ReviewWorktree, reviewWorktreeJSON(1, second)); res.HeadOID != second {
+		t.Fatalf("second cycle head = %q, want the new head %q", res.HeadOID, second)
+	}
+	detachedHeadAt(t, abs, second)
+	if _, err := os.Stat(scratch); err == nil {
+		t.Error("the replaced checkout kept the previous cycle's untracked file")
+	}
+	if n := strings.Count(rawGit(t, root, "worktree", "list", "--porcelain"), "review-issue-1"); n != 1 {
+		t.Errorf("git registers %d review worktrees for issue #1, want exactly 1", n)
+	}
+}
+
+// TestReviewWorktreeBadRequestBeforeMutation pins the pre-mutation
+// rejections. The head_oid cases matter beyond schema hygiene: a ref
+// name resolves when git reads it, so accepting one would reintroduce
+// the race the pinned checkout exists to remove.
+func TestReviewWorktreeBadRequestBeforeMutation(t *testing.T) {
+	cases := map[string]string{
+		"unsupported schema":  `{"schema_version":2,"issue_number":1,"head_oid":"0123456789abcdef0123456789abcdef01234567"}`,
+		"unknown field":       `{"schema_version":1,"issue_number":1,"head_oid":"0123456789abcdef0123456789abcdef01234567","ref":"main"}`,
+		"empty head_oid":      reviewWorktreeJSON(1, ""),
+		"fetch head":          reviewWorktreeJSON(1, "FETCH_HEAD"),
+		"branch name":         reviewWorktreeJSON(1, "main"),
+		"revision expression": reviewWorktreeJSON(1, "HEAD~1"),
+	}
+	for name, doc := range cases {
+		t.Run(name, func(t *testing.T) {
+			root := newActivateRepo(t)
+			seedReviewRun(t, root, state.PhaseInReview)
+			before := stateBytes(t, root)
+
+			env, script := reviewEnv(t, root)
+			_, err := ReviewWorktree(context.Background(), env, []byte(doc))
+			if !errors.Is(err, ErrBadRequest) {
+				t.Fatalf("err = %v, want ErrBadRequest", err)
+			}
+			script.AssertExhausted()
+			if _, err := os.Stat(reviewWorktreeAbs(root, 1)); err == nil {
+				t.Error("a rejected request still created a checkout")
+			}
+			if !bytes.Equal(stateBytes(t, root), before) {
+				t.Error("a rejected request changed state")
+			}
+		})
+	}
+}
+
+// TestReviewWorktreeUnknownOIDFailsAndRetries covers the OID that is
+// well-formed but absent from the repository — a head never fetched, or
+// one that has since gone away. git's failure propagates rather than
+// being swallowed into some fallback commit, it leaves no half-created
+// checkout, and the next request with a real OID therefore succeeds
+// instead of colliding with wreckage.
+func TestReviewWorktreeUnknownOIDFailsAndRetries(t *testing.T) {
+	root := newActivateRepo(t)
+	_, second := seedReviewRun(t, root, state.PhaseInReview)
+
+	env, script := reviewEnv(t, root)
+	_, err := ReviewWorktree(context.Background(), env, []byte(reviewWorktreeJSON(1, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")))
+	if err == nil {
+		t.Fatal("an OID the repository does not have was accepted")
+	}
+	script.AssertExhausted()
+	if _, statErr := os.Stat(reviewWorktreeAbs(root, 1)); !os.IsNotExist(statErr) {
+		t.Errorf("a failed provision left a checkout behind (stat err = %v)", statErr)
+	}
+
+	if res := runVerb(t, root, ReviewWorktree, reviewWorktreeJSON(1, second)); res.HeadOID != second {
+		t.Fatalf("retry head = %q, want %q", res.HeadOID, second)
+	}
+}
+
+// TestReviewWorktreePreconditions covers the two refusals the verb
+// inherits from loadVerb rather than implementing itself: a phase
+// outside {pr-open, in-review}, and no active Delivery run at all.
+func TestReviewWorktreePreconditions(t *testing.T) {
+	oidOf := func(t *testing.T, root string) string {
+		t.Helper()
+		return strings.TrimSpace(rawGit(t, root, "rev-parse", "HEAD"))
+	}
+
+	for _, phase := range []state.Phase{state.PhaseWorktreeReady, state.PhaseDispatched, state.PhaseAwaitingMerge, state.PhaseMerged} {
+		t.Run(string(phase), func(t *testing.T) {
+			root := newActivateRepo(t)
+			_, second := seedReviewRun(t, root, phase)
+
+			env, script := reviewEnv(t, root)
+			_, err := ReviewWorktree(context.Background(), env, []byte(reviewWorktreeJSON(1, second)))
+			if !errors.Is(err, ErrWrongPhase) {
+				t.Fatalf("err = %v, want ErrWrongPhase", err)
+			}
+			script.AssertExhausted()
+			if _, err := os.Stat(reviewWorktreeAbs(root, 1)); err == nil {
+				t.Error("a refused request still created a checkout")
+			}
+		})
+	}
+
+	t.Run("assist", func(t *testing.T) {
+		root := newActivateRepo(t) // no Delivery run entered
+		env, script := reviewEnv(t, root)
+		_, err := ReviewWorktree(context.Background(), env, []byte(reviewWorktreeJSON(1, oidOf(t, root))))
+		if !errors.Is(err, ErrNoDeliveryRun) {
+			t.Fatalf("err = %v, want ErrNoDeliveryRun", err)
+		}
+		script.AssertExhausted()
+	})
+}
+
+// TestCleanupRemovesReviewWorktree covers cleanup's teardown from both
+// sides: it removes a checkout a review cycle left behind — locating it
+// by the same derivation, since state never held the path — and it stays
+// the idempotent success it already was when there is none.
+func TestCleanupRemovesReviewWorktree(t *testing.T) {
+	for _, provision := range []bool{true, false} {
+		name := "with a review worktree"
+		if !provision {
+			name = "without one"
+		}
+		t.Run(name, func(t *testing.T) {
+			root := newLifecycleRepo(t)
+			_, second := seedReviewRun(t, root, state.PhaseInReview)
+			abs := reviewWorktreeAbs(root, 1)
+
+			if provision {
+				runVerb(t, root, ReviewWorktree, reviewWorktreeJSON(1, second))
+				if _, err := os.Stat(abs); err != nil {
+					t.Fatalf("review checkout was not created: %v", err)
+				}
+			}
+
+			// The issue reaches cleanup's phase the way a real run does.
+			st := loadRun(t, root)
+			st.Run.Issues[0].Phase = state.PhaseMerged
+			st.Run.Issues[0].ApprovedHeadOID = second
+			if err := state.Save(root, st); err != nil {
+				t.Fatal(err)
+			}
+
+			runVerb(t, root, Cleanup, `{"schema_version":1,"issue_number":1,"statement":"cleanup-issue"}`)
+			wantPhase(t, root, 1, state.PhaseCleaned)
+			if _, err := os.Stat(abs); !os.IsNotExist(err) {
+				t.Errorf("review checkout still present after cleanup (stat err = %v)", err)
+			}
+			if strings.Contains(rawGit(t, root, "worktree", "list", "--porcelain"), "review-issue-1") {
+				t.Error("git still registers the review worktree after cleanup")
+			}
+		})
+	}
+}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -12,10 +12,10 @@
 //	orch run status --json   # run-state JSON on stdout
 //
 // The per-issue lifecycle verbs (see lifecycle.go) extend the surface —
-// dispatch, pr-open, review, escalate, ci, merge-report, merge, block,
-// abandon, cleanup — plus the run-level complete. Each reads a
-// schema-versioned request document on stdin and writes a
-// schema-versioned result on stdout.
+// dispatch, pr-open, review-worktree, review, escalate, ci,
+// merge-report, merge, block, abandon, cleanup — plus the run-level
+// complete. Each reads a schema-versioned request document on stdin and
+// writes a schema-versioned result on stdout.
 //
 // Concurrency invariant: plan and status are read-only. Every mutating
 // verb acquires or re-verifies the cross-host Delivery lock: activate

--- a/internal/run/verb_unit_test.go
+++ b/internal/run/verb_unit_test.go
@@ -80,6 +80,14 @@ func fixtureIssue(planID string, number int, phase state.Phase) state.Issue {
 func setupDeliveryRepo(t *testing.T, planRev string, issues []state.Issue) string {
 	t.Helper()
 	root := setupRepo(t, testConfigTOML)
+	enterDeliveryAt(t, root, planRev, issues)
+	return root
+}
+
+// enterDeliveryAt is setupDeliveryRepo's state half, split out for the
+// tests whose root is a real git sandbox built elsewhere.
+func enterDeliveryAt(t *testing.T, root, planRev string, issues []state.Issue) {
+	t.Helper()
 	planned := make([]state.Issue, len(issues))
 	for i := range issues {
 		planned[i] = state.Issue{PlanID: issues[i].PlanID, Phase: state.PhasePlanned}
@@ -92,7 +100,6 @@ func setupDeliveryRepo(t *testing.T, planRev string, issues []state.Issue) strin
 	if err := state.Save(root, st); err != nil {
 		t.Fatal(err)
 	}
-	return root
 }
 
 func ghEnv(root string, script *execxtest.Script) Env {


### PR DESCRIPTION
Delivers issue #93: Provision a disposable unregistered review worktree and tear it down in cleanup

Closes #93

**Plan digest:** `sha256:e2439fafc17830cfce01085362548fbd03188c51a998660f5cf0db6387770096`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Add an `orch run review-worktree` plumbing verb that checks a reviewed commit out into a disposable detached worktree under `run.WorktreeContainer`, deliberately absent from persisted run state, and fold its teardown into `orch run cleanup`. The point of leaving it unregistered is containment: `internal/guard`'s Delivery evaluation denies a write whose target lies outside every registered worktree, so an unregistered worktree is read-only to the four guarded file tools with no new guard code. Placing it inside the repository is what makes that rule apply at all, since the guard allows any path outside an orch repository. Two live incidents motivate the feature: a reviewer's chained directory change failed and left a state-changing git command running in the primary checkout, and concurrent reviewers raced on a fetched-ref name there, which lets a review report findings against a commit it did not intend to read.

**Acceptance criteria:**
- A new `orch run review-worktree` verb decodes `{schema_version, issue_number, head_oid}` from stdin and emits a JSON result carrying the created worktree's repo-relative path and the head OID it was checked out at; an unsupported `schema_version` is rejected with `ErrBadRequest` before any mutation, the way the existing verbs reject one.
- The worktree is created detached at the requested `head_oid` under `run.WorktreeContainer`, at a path derived from the issue number that cannot collide with the per-issue executor worktree path `worktreeRel` returns for the same issue.
- No field of the persisted run state refers to the review worktree: after the verb succeeds, no issue's `Worktree` field equals its path. Leaving it unregistered is what makes it read-only, so registering it would invert the feature.
- Running the verb a second time for the same issue replaces any existing review worktree at that path rather than failing or accumulating one per review cycle, so a `request-changes` cycle can re-provision at the new head.
- `orch run cleanup` removes the issue's review worktree when one exists and still succeeds unchanged when none does, preserving the idempotence it already has, and locates it by the same derivation the verb uses rather than by reading persisted state.
- The verb refuses an issue that is not in phase `pr-open` or `in-review` through the package's existing `loadVerb` precondition path rather than a bespoke check, and is refused outside an active Delivery run.
- A test asserts the third criterion's invariant directly, so a later change that registers the review worktree in persisted state fails the suite rather than silently making it writable.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `specialist` |
| Executor | `claude-opus-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to a specialist with a strong reviewer because risk domains (authorization, destructive-operations) and the task is unusually difficult.

**Escalations:** _none_

**Verification:**
- **go test ./...** — pass — `go test -count=1 ./...` — Re-run by the cycle-2 reviewer at the head OID in a fresh clone outside the repository, clean tree, Go 1.26.5. All 22 packages ok. Verbose run of the review tests: 6 top-level tests and 12 subtests, all executed, none skipped, including the newly added abbreviated_oid case. This entry supersedes the parent-pinned result recorded at pr-open. — commit `3db03edf808b8027414b1646e1dace5ee0b1bb9d` (2026-07-28T02:01:36Z)
- **go vet ./...** — pass — `go vet ./...` — Re-run by the cycle-2 reviewer at the head OID in a fresh clone. No output. go build ./... additionally clean. This entry supersedes the parent-pinned result recorded at pr-open. — commit `3db03edf808b8027414b1646e1dace5ee0b1bb9d` (2026-07-28T02:01:36Z)
- **gofmt -l .** — pass — `gofmt -l .` — Re-run by the cycle-2 reviewer at the head OID in a fresh clone. No output. This entry supersedes the parent-pinned result recorded at pr-open. — commit `3db03edf808b8027414b1646e1dace5ee0b1bb9d` (2026-07-28T02:01:36Z)
- **guard containment observed end to end** — pass — `guard.NewChecker(execx.Local{}).Check against a real review checkout in a real Delivery sandbox` — Run by the executor via a throwaway test that was deleted before committing, so this evidence is NOT reproducible from the committed tree. Results observed: executor worktree allow=true; review worktree allow=false reason 'outside every registered worktree'; a deep path inside the review worktree allow=false same reason; primary checkout allow=false same reason. This confirms the objective's central claim, including that root discovery resolves to the primary root via FindOutermostRoot even though the review checkout carries a committed .orchestrator/ of its own, so guard row 11 is what fires. — commit `7cf918c04b783357351bc1495cee5bf6d33580c3` (2026-07-28T01:28:02Z)
- **architect prose audit of the branch** — pass — `git -C <scratch clone> diff --word-diff --ignore-all-space 304615f..3db03edf` — SUPERSEDED to cover both commits. The branch re-pads the lifecycle.go verb table and rewrites four doc comments across the first commit, then rewrites two more comment blocks in the fix commit. All eleven original lifecycle rows survive the re-padding with identical content, all thirteen pre-existing runVerbs entries survive, all fourteen pre-existing runVerbTokens entries survive the map re-flow, and every verb name in runUsage and run.go's package doc survives. The cycle-2 reviewer independently re-derived the fix commit's half by word-stream diff of the rendered comment text rather than the raw diff. No word dropped anywhere on the branch. — commit `3db03edf808b8027414b1646e1dace5ee0b1bb9d` (2026-07-28T02:01:36Z)
- **architect scope audit** — pass — `gh api repos/kninetimmy/orch/compare/main...orch/issue-93-provision-a-disposable-unregistered-revi` — CORRECTED AND SUPERSEDED. The entry recorded at pr-open described only the first commit and became false when the fix commit landed; the cycle-2 reviewer caught the staleness and correctly assigned the correction to the Architect rather than the executor. Re-run at head: 2 commits, 13 files, +784/-90, all under internal/, nothing under adapters/. The superseded entry also claimed nothing in internal/adaptertest was touched and that this was correctly left to issue #95; the head tree contradicts that by design, because cycle 1 established that runVerbTokens is an assertion about internal/cli/run.go, a file this PR changes, and that the Architect's original dispatch instruction to leave it alone was wrong. — commit `3db03edf808b8027414b1646e1dace5ee0b1bb9d` (2026-07-28T02:01:36Z)
- **reviewer independent suite run** — pass — `go test -count=1 ./... ; go vet ./... ; gofmt -l .` — Run by the reviewer in a fresh clone outside the repository, detached at the head OID with a clean tree, Go 1.26.5, using git -C throughout. All 22 packages ok; vet clean; gofmt no output. The new tests were additionally run with -v: all six top-level tests and all eleven subtests execute and pass, none skipped and none vacuous. — commit `7cf918c04b783357351bc1495cee5bf6d33580c3` (2026-07-28T01:43:34Z)
- **reviewer guard containment re-derivation** — pass — `source read of internal/guard/resolve.go, internal/guard/guard.go, paths.FindOutermostRoot` — Recorded at cycle 1 and unaffected by the fix commit. The executor's original end-to-end guard evidence was deleted before commit and is not reproducible from the tree, so the claim was re-derived from source: FindOutermostRoot keeps the primary root even though the review checkout carries its own tracked .orchestrator/config.toml, no .git segment lies between, so row 11 denies with 'outside every registered worktree'. Doubly fail-closed, because innermost-root discovery would instead fail state.Load inside the checkout and return an operational error, still a deny. — commit `3db03edf808b8027414b1646e1dace5ee0b1bb9d` (2026-07-28T02:01:36Z)
- **reviewer refactor equivalence audit** — pass — `gate-by-gate pre/post body diff of AddWorktree/prepareWorktreePath and RemoveWorktree/findWorktree` — AddWorktree's order preserved exactly (Canonical, Lstat clobber, paths.Inside, RequireIgnored, then branch-existence rev-parse, ErrBranchExists, worktree add -b, RevParse), all three error strings verbatim, still never --force. RemoveWorktree's extracted findWorktree is behaviourally identical over all four input classes despite moving the Primary check outside the match; ErrUnknownWorktree wrapping byte-identical; Confirmation still gate one and RequireClean still gate three. No silent regression; pre-existing gitops tests pass unmodified. — commit `7cf918c04b783357351bc1495cee5bf6d33580c3` (2026-07-28T01:43:34Z)
- **architect ref-shadowing reproduction** — fail — `git branch deadbeef <oid> ; git rev-parse deadbeef^{commit} ; git worktree add --detach <dir> deadbeef` — Run by the Architect in a throwaway repository to verify item A's justification rather than relay it unchecked. A branch named deadbeef resolved to the branch target, not to any object beginning deadbeef, and worktree add --detach deadbeef checked out the ref target. Recorded as failing because it demonstrates the shipped 7-character floor admits a moving symbolic name, which is precisely the hazard the verb's doc comment claims it rejects. — commit `7cf918c04b783357351bc1495cee5bf6d33580c3` (2026-07-28T01:43:34Z)
- **review-cycle-1** — request-changes — Request changes: three concrete items, everything else approved as written. All seven acceptance criteria are met, scope is clean, the incidental gitops refactor is behaviourally faithful, all six required checks are green on this OID, and the manifest is accurate. Criteria 2, 3 and 5 were checked as one mechanism rather than three independent facts and genuinely cohere: worktreeRel yields issue-N and reviewWorktreeRel yields review-issue-N as siblings so neither can contain the other, paths.Inside uses filepath.Rel rather than a string prefix so issue-1 vs issue-10 false positives are impossible, the verb never calls save, and cleanup therefore must derive the path because state holds nothing to read. Criterion 7's pin is non-vacuous: three widening layers (no Worktree field equal, the serialized state contains the path under no field name, and the state bytes are byte-identical across the call) plus the containment fact via paths.Inside. The reviewer re-derived the guard-containment claim from source rather than inheriting the executor's deleted evidence, and found it doubly fail-closed: FindOutermostRoot keeps the primary root even though the review checkout carries its own committed .orchestrator/, no .git segment lies between, so row 11 fires; and had root discovery been innermost, state.Load inside the checkout would fail and Check would return an operational error, still a deny. Judgement calls 1 and 3 accepted (the detached-only gate is a genuine structural substitute for the Confirmation token, and the amended package doc is accurate since only base.go and worktree.go pass --force; no metrics event is right because recordMetric's own doc says an event describes a completed verb). ITEM A: head_oid's 7-character floor must tighten to full-length hex only. The doc comment asserts a symbolic name is rejected rather than resolved and that an OID cannot move, which the current regex does not deliver: an abbreviation is resolved against the object database at read time and grows ambiguous as that database grows, and a short all-hex string can still be a ref because git tries ref lookup before short-object lookup. The Architect reproduced this empirically: a branch named deadbeef resolves as a ref, and worktree add --detach deadbeef follows the ref target rather than any object id, so the current floor admits exactly the moving name this verb exists to reject. Every real caller has the full OID from gh pr view --json headRefOid, so nothing is lost. ITEM B: internal/adaptertest's runVerbTokens is now false about the file this PR changed. It is documented as the set of verbs internal/cli/run.go dispatches, which this PR took from 13 to 14, and review-worktree is absent. This is not stale prose: the moment issue #95 satisfies its first criterion by documenting the verb in a skill, its only required test fails with a message telling its executor that a live verb does not exist, and #95's criteria say nothing about adaptertest, so its executor would be blocked or forced outside its stated scope. This partially refutes the Architect's scope-audit line that nothing in internal/adaptertest was correctly left to #95: the boundary is right for adapter content but not for an assertion about internal/cli/run.go. ITEM C: the amended CleanupStatement godoc reads 'The disposable review checkout cleanup also removes needs no confirmation of its own', a reduced relative clause that parses as a compound noun and then crashes on 'also removes needs'; rephrase. Non-blocking observations recorded for follow-up: the destructive removal precedes the failure-prone add so a failed add loses the previous cycle's checkout (idempotent re-run still holds and is pinned by test, and cleanup has had the same shape since before this PR); a stale unregistered directory would wedge the issue until manual cleanup; this is the first long-lived Branch=='' worktree, which resume's worktreePresent matches on branch name; and loadVerb with issue_number &lt;= 0 panics identically in all 13 pre-existing verbs, which is a separate pre-existing issue. — commit `7cf918c04b783357351bc1495cee5bf6d33580c3` (2026-07-28T01:43:36Z)
- **executor word-diff audit of the fix commit** — pass — `git diff --word-diff --ignore-all-space (working tree vs index, before committing)` — Run by the executor before committing, applying the duty that merged in PR #96. It audited all 11 removal markers and classified each: two [-13-] paired with {+14+} in adaptertest; the deliberately replaced garden-path phrase in cleanup.go with 'needs' retained inside the replacement; the deliberately replaced sentence and old regex literal in reviewworktree.go; and comment-marker artifacts from re-wrapping, each with a matching adjacent insertion. No marker covered an unintended word. The executor additionally read both rewritten comments back as rendered prose, and confirmed the post-commit timing trap empirically: the bare form and --staged both printed nothing, and only a HEAD~1..HEAD range form still showed the 11 markers. — commit `3db03edf808b8027414b1646e1dace5ee0b1bb9d` (2026-07-28T02:01:36Z)
- **reviewer mutation test of the item A pin** — pass — `copy head tree to scratch, revert headOIDPattern to {7,64}, go test ./internal/run` — Run by the cycle-2 reviewer to settle whether the executor's flagged extra test row was justified, rather than judging it on opinion. Reverting the regex failed exactly one subtest, TestReviewWorktreeBadRequestBeforeMutation/abbreviated_oid, and nothing else in internal/run noticed. That four-line table row is therefore the only thing in the suite capable of detecting a regression of item A, so the deviation is kept. — commit `3db03edf808b8027414b1646e1dace5ee0b1bb9d` (2026-07-28T02:01:36Z)
- **review-cycle-2** — approve — Approve. Fresh cycle-2 reviewer, independent verdict. All three cycle-1 items are fixed and all seven acceptance criteria were re-derived at head rather than inherited. Item A: the regex is now full-length-only, and its exact accept/reject set was probed with a standalone Go program rather than read off the shape (accepts only 40 or 64 pure hex in any case; rejects 7/39/41/63/65/104, empty, main, HEAD~1, leading dash, trailing space, a ^{commit} suffix, and embedded or trailing newlines because Go's default $ is end-of-text). The reviewer reproduced all four ref-versus-object experiments independently on git 2.53.0, and its second is stronger than the Architect's: a branch named with a REAL 7-character prefix of an existing commit, pointed at a different commit, still resolved to the ref for both rev-parse and worktree add --detach, so both interpretations were live and the ref still won. A branch named with a full 40-hex string resolved to the object with git's own 'refname is ambiguous ... ignored when you just specify 40-hex' warning. The doc comment is therefore a reproduced fact, not an assertion. Item B: all 14 pre-existing runVerbTokens entries survive the re-flow, review-worktree is added, both prose counts corrected to 14, and no '13 verbs' prose survives anywhere in the tree; cycle 1 was right to overrule the Architect's original instruction, because the set is an assertion about internal/cli/run.go which this PR changes. Item C: the garden path is gone, verified by reading the block as rendered prose. The reflow-drop check was re-derived rather than inherited by extracting both comment blocks at parent and head, stripping comment markers, splitting to one word per line and diffing the word streams: in headOIDPattern the only removals are the deliberately replaced first sentence, and everything from 'The field is an object id' through 'An OID cannot move' is word-identical across the rewrite; in CleanupStatement the only removal is the replaced phrase, with 'needs' retained. No word was dropped. The flagged deviation is KEPT on the reviewer's judgement, settled by a mutation test rather than opinion: reverting the regex to {7,64} on a copy of the head tree failed exactly one subtest, the newly added abbreviated_oid case, and nothing else in internal/run noticed, so that four-line table row is the only thing in the suite that can detect a regression of item A. Scope clean: 13 files, all under internal/, nothing under adapters/. All six required checks green at head, MERGEABLE and CLEAN. Security strictly tightened: head_oid flows as an argv element, never shell-concatenated, and the pattern now admits no leading dash, revision syntax, whitespace or newline. Non-blocking follow-ups recorded: the regex is not hash-algorithm-aware, so in a SHA-1 repository a 64-hex branch name resolves as a ref and the {64} alternation carries no object-wins guarantee there (reachability effectively nil since head_oid comes from gh pr view and GitHub is SHA-1 only; a future hardening would read git rev-parse --show-object-format and require exactly hexsz); AddDetachedWorktree's godoc still describes general-purpose abbreviated commit-ish handling, which is accurate for the gitops layer but may surprise a reader after the run-layer tightening; and cycle 1's four observations are untouched and remain follow-up material. The cycle-2 defect was in the audit record rather than the code, and was an Architect-authored entry: the reviewer correctly declined to route it to the executor, since an executor rewriting another agent's verification record would itself be a manifest-integrity problem. It is corrected by the replace-by-name entries submitted with this cycle. — commit `3db03edf808b8027414b1646e1dace5ee0b1bb9d` (2026-07-28T02:01:37Z)
- **required-ci** — passing — lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass — commit `3db03edf808b8027414b1646e1dace5ee0b1bb9d` (2026-07-28T02:02:08Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Add an `orch run review-worktree` plumbing verb that checks a reviewed commit out into a disposable detached worktree under `run.WorktreeContainer`, deliberately absent from persisted run state, and fold its teardown into `orch run cleanup`. The point of leaving it unregistered is containment: `internal/guard`'s Delivery evaluation denies a write whose target lies outside every registered worktree, so an unregistered worktree is read-only to the four guarded file tools with no new guard code. Placing it inside the repository is what makes that rule apply at all, since the guard allows any path outside an orch repository. Two live incidents motivate the feature: a reviewer's chained directory change failed and left a state-changing git command running in the primary checkout, and concurrent reviewers raced on a fetched-ref name there, which lets a review report findings against a commit it did not intend to read.",
  "acceptance_criteria": [
    "A new `orch run review-worktree` verb decodes `{schema_version, issue_number, head_oid}` from stdin and emits a JSON result carrying the created worktree's repo-relative path and the head OID it was checked out at; an unsupported `schema_version` is rejected with `ErrBadRequest` before any mutation, the way the existing verbs reject one.",
    "The worktree is created detached at the requested `head_oid` under `run.WorktreeContainer`, at a path derived from the issue number that cannot collide with the per-issue executor worktree path `worktreeRel` returns for the same issue.",
    "No field of the persisted run state refers to the review worktree: after the verb succeeds, no issue's `Worktree` field equals its path. Leaving it unregistered is what makes it read-only, so registering it would invert the feature.",
    "Running the verb a second time for the same issue replaces any existing review worktree at that path rather than failing or accumulating one per review cycle, so a `request-changes` cycle can re-provision at the new head.",
    "`orch run cleanup` removes the issue's review worktree when one exists and still succeeds unchanged when none does, preserving the idempotence it already has, and locates it by the same derivation the verb uses rather than by reading persisted state.",
    "The verb refuses an issue that is not in phase `pr-open` or `in-review` through the package's existing `loadVerb` precondition path rather than a bespoke check, and is refused outside an active Delivery run.",
    "A test asserts the third criterion's invariant directly, so a later change that registers the review worktree in persisted state fails the suite rather than silently making it writable."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "specialist",
  "executor": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to a specialist with a strong reviewer because risk domains (authorization, destructive-operations) and the task is unusually difficult.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "go test ./...",
      "command": "go test -count=1 ./...",
      "result": "pass",
      "detail": "Re-run by the cycle-2 reviewer at the head OID in a fresh clone outside the repository, clean tree, Go 1.26.5. All 22 packages ok. Verbose run of the review tests: 6 top-level tests and 12 subtests, all executed, none skipped, including the newly added abbreviated_oid case. This entry supersedes the parent-pinned result recorded at pr-open.",
      "commit_oid": "3db03edf808b8027414b1646e1dace5ee0b1bb9d",
      "at": "2026-07-28T02:01:36Z"
    },
    {
      "name": "go vet ./...",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Re-run by the cycle-2 reviewer at the head OID in a fresh clone. No output. go build ./... additionally clean. This entry supersedes the parent-pinned result recorded at pr-open.",
      "commit_oid": "3db03edf808b8027414b1646e1dace5ee0b1bb9d",
      "at": "2026-07-28T02:01:36Z"
    },
    {
      "name": "gofmt -l .",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Re-run by the cycle-2 reviewer at the head OID in a fresh clone. No output. This entry supersedes the parent-pinned result recorded at pr-open.",
      "commit_oid": "3db03edf808b8027414b1646e1dace5ee0b1bb9d",
      "at": "2026-07-28T02:01:36Z"
    },
    {
      "name": "guard containment observed end to end",
      "command": "guard.NewChecker(execx.Local{}).Check against a real review checkout in a real Delivery sandbox",
      "result": "pass",
      "detail": "Run by the executor via a throwaway test that was deleted before committing, so this evidence is NOT reproducible from the committed tree. Results observed: executor worktree allow=true; review worktree allow=false reason 'outside every registered worktree'; a deep path inside the review worktree allow=false same reason; primary checkout allow=false same reason. This confirms the objective's central claim, including that root discovery resolves to the primary root via FindOutermostRoot even though the review checkout carries a committed .orchestrator/ of its own, so guard row 11 is what fires.",
      "commit_oid": "7cf918c04b783357351bc1495cee5bf6d33580c3",
      "at": "2026-07-28T01:28:02Z"
    },
    {
      "name": "architect prose audit of the branch",
      "command": "git -C \u003cscratch clone\u003e diff --word-diff --ignore-all-space 304615f..3db03edf",
      "result": "pass",
      "detail": "SUPERSEDED to cover both commits. The branch re-pads the lifecycle.go verb table and rewrites four doc comments across the first commit, then rewrites two more comment blocks in the fix commit. All eleven original lifecycle rows survive the re-padding with identical content, all thirteen pre-existing runVerbs entries survive, all fourteen pre-existing runVerbTokens entries survive the map re-flow, and every verb name in runUsage and run.go's package doc survives. The cycle-2 reviewer independently re-derived the fix commit's half by word-stream diff of the rendered comment text rather than the raw diff. No word dropped anywhere on the branch.",
      "commit_oid": "3db03edf808b8027414b1646e1dace5ee0b1bb9d",
      "at": "2026-07-28T02:01:36Z"
    },
    {
      "name": "architect scope audit",
      "command": "gh api repos/kninetimmy/orch/compare/main...orch/issue-93-provision-a-disposable-unregistered-revi",
      "result": "pass",
      "detail": "CORRECTED AND SUPERSEDED. The entry recorded at pr-open described only the first commit and became false when the fix commit landed; the cycle-2 reviewer caught the staleness and correctly assigned the correction to the Architect rather than the executor. Re-run at head: 2 commits, 13 files, +784/-90, all under internal/, nothing under adapters/. The superseded entry also claimed nothing in internal/adaptertest was touched and that this was correctly left to issue #95; the head tree contradicts that by design, because cycle 1 established that runVerbTokens is an assertion about internal/cli/run.go, a file this PR changes, and that the Architect's original dispatch instruction to leave it alone was wrong.",
      "commit_oid": "3db03edf808b8027414b1646e1dace5ee0b1bb9d",
      "at": "2026-07-28T02:01:36Z"
    },
    {
      "name": "reviewer independent suite run",
      "command": "go test -count=1 ./... ; go vet ./... ; gofmt -l .",
      "result": "pass",
      "detail": "Run by the reviewer in a fresh clone outside the repository, detached at the head OID with a clean tree, Go 1.26.5, using git -C throughout. All 22 packages ok; vet clean; gofmt no output. The new tests were additionally run with -v: all six top-level tests and all eleven subtests execute and pass, none skipped and none vacuous.",
      "commit_oid": "7cf918c04b783357351bc1495cee5bf6d33580c3",
      "at": "2026-07-28T01:43:34Z"
    },
    {
      "name": "reviewer guard containment re-derivation",
      "command": "source read of internal/guard/resolve.go, internal/guard/guard.go, paths.FindOutermostRoot",
      "result": "pass",
      "detail": "Recorded at cycle 1 and unaffected by the fix commit. The executor's original end-to-end guard evidence was deleted before commit and is not reproducible from the tree, so the claim was re-derived from source: FindOutermostRoot keeps the primary root even though the review checkout carries its own tracked .orchestrator/config.toml, no .git segment lies between, so row 11 denies with 'outside every registered worktree'. Doubly fail-closed, because innermost-root discovery would instead fail state.Load inside the checkout and return an operational error, still a deny.",
      "commit_oid": "3db03edf808b8027414b1646e1dace5ee0b1bb9d",
      "at": "2026-07-28T02:01:36Z"
    },
    {
      "name": "reviewer refactor equivalence audit",
      "command": "gate-by-gate pre/post body diff of AddWorktree/prepareWorktreePath and RemoveWorktree/findWorktree",
      "result": "pass",
      "detail": "AddWorktree's order preserved exactly (Canonical, Lstat clobber, paths.Inside, RequireIgnored, then branch-existence rev-parse, ErrBranchExists, worktree add -b, RevParse), all three error strings verbatim, still never --force. RemoveWorktree's extracted findWorktree is behaviourally identical over all four input classes despite moving the Primary check outside the match; ErrUnknownWorktree wrapping byte-identical; Confirmation still gate one and RequireClean still gate three. No silent regression; pre-existing gitops tests pass unmodified.",
      "commit_oid": "7cf918c04b783357351bc1495cee5bf6d33580c3",
      "at": "2026-07-28T01:43:34Z"
    },
    {
      "name": "architect ref-shadowing reproduction",
      "command": "git branch deadbeef \u003coid\u003e ; git rev-parse deadbeef^{commit} ; git worktree add --detach \u003cdir\u003e deadbeef",
      "result": "fail",
      "detail": "Run by the Architect in a throwaway repository to verify item A's justification rather than relay it unchecked. A branch named deadbeef resolved to the branch target, not to any object beginning deadbeef, and worktree add --detach deadbeef checked out the ref target. Recorded as failing because it demonstrates the shipped 7-character floor admits a moving symbolic name, which is precisely the hazard the verb's doc comment claims it rejects.",
      "commit_oid": "7cf918c04b783357351bc1495cee5bf6d33580c3",
      "at": "2026-07-28T01:43:34Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "Request changes: three concrete items, everything else approved as written. All seven acceptance criteria are met, scope is clean, the incidental gitops refactor is behaviourally faithful, all six required checks are green on this OID, and the manifest is accurate. Criteria 2, 3 and 5 were checked as one mechanism rather than three independent facts and genuinely cohere: worktreeRel yields issue-N and reviewWorktreeRel yields review-issue-N as siblings so neither can contain the other, paths.Inside uses filepath.Rel rather than a string prefix so issue-1 vs issue-10 false positives are impossible, the verb never calls save, and cleanup therefore must derive the path because state holds nothing to read. Criterion 7's pin is non-vacuous: three widening layers (no Worktree field equal, the serialized state contains the path under no field name, and the state bytes are byte-identical across the call) plus the containment fact via paths.Inside. The reviewer re-derived the guard-containment claim from source rather than inheriting the executor's deleted evidence, and found it doubly fail-closed: FindOutermostRoot keeps the primary root even though the review checkout carries its own committed .orchestrator/, no .git segment lies between, so row 11 fires; and had root discovery been innermost, state.Load inside the checkout would fail and Check would return an operational error, still a deny. Judgement calls 1 and 3 accepted (the detached-only gate is a genuine structural substitute for the Confirmation token, and the amended package doc is accurate since only base.go and worktree.go pass --force; no metrics event is right because recordMetric's own doc says an event describes a completed verb). ITEM A: head_oid's 7-character floor must tighten to full-length hex only. The doc comment asserts a symbolic name is rejected rather than resolved and that an OID cannot move, which the current regex does not deliver: an abbreviation is resolved against the object database at read time and grows ambiguous as that database grows, and a short all-hex string can still be a ref because git tries ref lookup before short-object lookup. The Architect reproduced this empirically: a branch named deadbeef resolves as a ref, and worktree add --detach deadbeef follows the ref target rather than any object id, so the current floor admits exactly the moving name this verb exists to reject. Every real caller has the full OID from gh pr view --json headRefOid, so nothing is lost. ITEM B: internal/adaptertest's runVerbTokens is now false about the file this PR changed. It is documented as the set of verbs internal/cli/run.go dispatches, which this PR took from 13 to 14, and review-worktree is absent. This is not stale prose: the moment issue #95 satisfies its first criterion by documenting the verb in a skill, its only required test fails with a message telling its executor that a live verb does not exist, and #95's criteria say nothing about adaptertest, so its executor would be blocked or forced outside its stated scope. This partially refutes the Architect's scope-audit line that nothing in internal/adaptertest was correctly left to #95: the boundary is right for adapter content but not for an assertion about internal/cli/run.go. ITEM C: the amended CleanupStatement godoc reads 'The disposable review checkout cleanup also removes needs no confirmation of its own', a reduced relative clause that parses as a compound noun and then crashes on 'also removes needs'; rephrase. Non-blocking observations recorded for follow-up: the destructive removal precedes the failure-prone add so a failed add loses the previous cycle's checkout (idempotent re-run still holds and is pinned by test, and cleanup has had the same shape since before this PR); a stale unregistered directory would wedge the issue until manual cleanup; this is the first long-lived Branch=='' worktree, which resume's worktreePresent matches on branch name; and loadVerb with issue_number \u003c= 0 panics identically in all 13 pre-existing verbs, which is a separate pre-existing issue.",
      "commit_oid": "7cf918c04b783357351bc1495cee5bf6d33580c3",
      "at": "2026-07-28T01:43:36Z"
    },
    {
      "name": "executor word-diff audit of the fix commit",
      "command": "git diff --word-diff --ignore-all-space (working tree vs index, before committing)",
      "result": "pass",
      "detail": "Run by the executor before committing, applying the duty that merged in PR #96. It audited all 11 removal markers and classified each: two [-13-] paired with {+14+} in adaptertest; the deliberately replaced garden-path phrase in cleanup.go with 'needs' retained inside the replacement; the deliberately replaced sentence and old regex literal in reviewworktree.go; and comment-marker artifacts from re-wrapping, each with a matching adjacent insertion. No marker covered an unintended word. The executor additionally read both rewritten comments back as rendered prose, and confirmed the post-commit timing trap empirically: the bare form and --staged both printed nothing, and only a HEAD~1..HEAD range form still showed the 11 markers.",
      "commit_oid": "3db03edf808b8027414b1646e1dace5ee0b1bb9d",
      "at": "2026-07-28T02:01:36Z"
    },
    {
      "name": "reviewer mutation test of the item A pin",
      "command": "copy head tree to scratch, revert headOIDPattern to {7,64}, go test ./internal/run",
      "result": "pass",
      "detail": "Run by the cycle-2 reviewer to settle whether the executor's flagged extra test row was justified, rather than judging it on opinion. Reverting the regex failed exactly one subtest, TestReviewWorktreeBadRequestBeforeMutation/abbreviated_oid, and nothing else in internal/run noticed. That four-line table row is therefore the only thing in the suite capable of detecting a regression of item A, so the deviation is kept.",
      "commit_oid": "3db03edf808b8027414b1646e1dace5ee0b1bb9d",
      "at": "2026-07-28T02:01:36Z"
    },
    {
      "name": "review-cycle-2",
      "result": "approve",
      "detail": "Approve. Fresh cycle-2 reviewer, independent verdict. All three cycle-1 items are fixed and all seven acceptance criteria were re-derived at head rather than inherited. Item A: the regex is now full-length-only, and its exact accept/reject set was probed with a standalone Go program rather than read off the shape (accepts only 40 or 64 pure hex in any case; rejects 7/39/41/63/65/104, empty, main, HEAD~1, leading dash, trailing space, a ^{commit} suffix, and embedded or trailing newlines because Go's default $ is end-of-text). The reviewer reproduced all four ref-versus-object experiments independently on git 2.53.0, and its second is stronger than the Architect's: a branch named with a REAL 7-character prefix of an existing commit, pointed at a different commit, still resolved to the ref for both rev-parse and worktree add --detach, so both interpretations were live and the ref still won. A branch named with a full 40-hex string resolved to the object with git's own 'refname is ambiguous ... ignored when you just specify 40-hex' warning. The doc comment is therefore a reproduced fact, not an assertion. Item B: all 14 pre-existing runVerbTokens entries survive the re-flow, review-worktree is added, both prose counts corrected to 14, and no '13 verbs' prose survives anywhere in the tree; cycle 1 was right to overrule the Architect's original instruction, because the set is an assertion about internal/cli/run.go which this PR changes. Item C: the garden path is gone, verified by reading the block as rendered prose. The reflow-drop check was re-derived rather than inherited by extracting both comment blocks at parent and head, stripping comment markers, splitting to one word per line and diffing the word streams: in headOIDPattern the only removals are the deliberately replaced first sentence, and everything from 'The field is an object id' through 'An OID cannot move' is word-identical across the rewrite; in CleanupStatement the only removal is the replaced phrase, with 'needs' retained. No word was dropped. The flagged deviation is KEPT on the reviewer's judgement, settled by a mutation test rather than opinion: reverting the regex to {7,64} on a copy of the head tree failed exactly one subtest, the newly added abbreviated_oid case, and nothing else in internal/run noticed, so that four-line table row is the only thing in the suite that can detect a regression of item A. Scope clean: 13 files, all under internal/, nothing under adapters/. All six required checks green at head, MERGEABLE and CLEAN. Security strictly tightened: head_oid flows as an argv element, never shell-concatenated, and the pattern now admits no leading dash, revision syntax, whitespace or newline. Non-blocking follow-ups recorded: the regex is not hash-algorithm-aware, so in a SHA-1 repository a 64-hex branch name resolves as a ref and the {64} alternation carries no object-wins guarantee there (reachability effectively nil since head_oid comes from gh pr view and GitHub is SHA-1 only; a future hardening would read git rev-parse --show-object-format and require exactly hexsz); AddDetachedWorktree's godoc still describes general-purpose abbreviated commit-ish handling, which is accurate for the gitops layer but may surprise a reader after the run-layer tightening; and cycle 1's four observations are untouched and remain follow-up material. The cycle-2 defect was in the audit record rather than the code, and was an Architect-authored entry: the reviewer correctly declined to route it to the executor, since an executor rewriting another agent's verification record would itself be a manifest-integrity problem. It is corrected by the replace-by-name entries submitted with this cycle.",
      "commit_oid": "3db03edf808b8027414b1646e1dace5ee0b1bb9d",
      "at": "2026-07-28T02:01:37Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass",
      "commit_oid": "3db03edf808b8027414b1646e1dace5ee0b1bb9d",
      "at": "2026-07-28T02:02:08Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->