### PR TITLE
Rewrite README.md: plain-language opening, agent-first install, and honest known-issues and fixed sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,99 +1,321 @@
 # Orch
 
-Orch is a development orchestrator for AI coding agents — currently
-the Claude Code CLI and the Codex CLI. You keep working in your agent
-of choice the way you already do; Orch sits underneath it and does two
-things:
+Orch is a development orchestrator for the Claude Code CLI and the
+Codex CLI. You keep working in the agent you already use. Orch sits
+underneath it and takes over two decisions you would otherwise be
+trusting the agent to make on its own: which model does a given piece
+of work, and what that agent is allowed to write.
 
-1. **Spends your tokens where they matter.** A strong "frontier" model
-   stays in charge of planning, architecture, and final review, while
-   routine work — exploring the codebase, writing the code, reviewing
-   diffs — is delegated to cheaper, faster models at tuned
-   reasoning-effort levels. You choose exactly which model does which
-   job; Orch enforces that choice mechanically instead of hoping the
-   agent remembers.
+**Two modes.** A repository running Orch is in exactly one of two
+states. **Assist** is the default and is read-only: the agent can read
+anything, search, explain and plan, but a write to a file git does not
+ignore is refused. **Delivery** is entered only for a plan you have
+read and approved. Each task in that plan becomes a GitHub issue, a
+branch, and its own git worktree; the work happens there, lands as a
+pull request, is reviewed by a separate agent, runs CI, and waits for
+you to approve the merge. When every task is merged or abandoned, the
+repository returns to Assist on its own.
 
-2. **Keeps changes disciplined.** No matter which model wrote the
-   code, every change to tracked files goes through the same pipeline:
-   a GitHub issue, an isolated git worktree, a pull request, an
-   independent review by a different model, CI, and finally a merge
-   that only a human can approve. An agent can never quietly edit your
-   working tree — writes outside the pipeline are blocked at the tool
-   level, not by prompt instructions.
-
-The full product definition lives in [ORCH-PRD.md](ORCH-PRD.md).
-
-**Status: early software, but the workflow is real.** The shared Go
-core and both host adapters — Claude Code and Codex CLI — are
-complete, cross-host parity-tested against each other, and
-smoke-validated end to end (see each adapter's README for the honest
-"Known limitations" list). The project already dogfoods itself: `orch
-init` bootstrapped this repository's own `.orchestrator/config.toml`
-through the Claude Code adapter, and the first real Delivery run drove
-an issue through the full pipeline — plan gate, isolated worktree,
-independent review, CI, and a human-approved pinned merge — to land
-[PR #40](https://github.com/kninetimmy/orch/pull/40). It has not yet
-been exercised outside its own repository, so treat it as early: watch
-for rough edges, not as a mature, battle-tested tool.
-
-## Quickstart
-
-1. **Install the binary** — pick a path under [Install](#install)
-   below; the quick-install scripts and the manual download both
-   verify the binary's SHA-256 before anything runs.
-2. **Initialize the repository** — from the repo root, run `orch
-   init`. It detects your environment, interviews you about hosts and
-   models, and delivers `.orchestrator/config.toml` as a pull request
-   for you to review and merge (see [Using it](#using-it)).
-3. **Finish the host-specific setup** — install your host's plugin and
-   follow its install-order steps:
-   [Claude Code](adapters/claude/README.md#install-order) or
-   [Codex CLI](adapters/codex/README.md#install-order).
-4. **Run your first Delivery** — plan a task with your agent in Assist
-   mode; once you approve the plan, Orch opens an issue and worktree
-   per task and walks each one through
-   [the Delivery pipeline](#the-delivery-pipeline) up to the human
-   merge gate on GitHub.
-
-## How it works, in short
-
-Orch has two operating modes:
-
-- **Assist** (the default): the agent can read anything and answer
-  questions, but writes to tracked files are blocked. This is the safe
-  everyday mode — investigation, explanation, planning.
-- **Delivery**: entered only for an approved, task-scoped plan. Each
-  task in the plan becomes a GitHub issue and an isolated worktree;
-  an implementer model does the work there; a reviewer model reviews
-  it; CI runs; you approve the merge on GitHub. When every task is
-  merged or abandoned, Orch returns to Assist automatically.
-
-Work inside Delivery is divided among five **roles**, each pinned to a
-model and effort level you configure:
+**Six roles.** Delivery work is split across roles, and you pin each
+one to an exact model version and reasoning-effort level:
 
 | Role | What it does |
 |---|---|
-| Architect | Plans, routes work, makes final calls — your strongest model |
+| Architect | Plans the work, drives the pipeline, talks to you — your strongest model |
 | Scout | Read-only exploration and fact-finding — cheap and fast |
-| Implementer | Writes the code in the isolated worktree |
-| Specialist | Takes over risky or hard tasks (security, concurrency, migrations…) |
-| Reviewer | Independently reviews every PR — never the model that wrote it |
+| Implementer | Writes the code inside the issue's worktree |
+| Specialist | Takes the issues routing marks risky or unusually difficult |
+| Reviewer | Reviews the pull request in a separate dispatch from the one that wrote it |
+| Review downgrade | A cheaper reviewer, allowed only when the change is provably low-risk |
 
-Routing is deterministic: risky domains or hard tasks force the
-Specialist and a strong Reviewer, and when a model fails at a task it
-is retired for that task permanently and the next candidate steps up —
-escalating back to the Architect if everything else is exhausted.
+Which role gets an issue is derived from the issue's own facts by a
+deterministic table, not chosen by the model that will run it. The
+reviewer is always a separate dispatch, never the session that wrote
+the code — but it is not always a different model: with the shipped
+defaults a downgraded review runs the same model as the implementer
+(on Codex, at the same effort too).
+
+**The guard.** None of the above is an instruction the agent is asked
+to honor. Both host adapters wire the CLI's pre-write hook to `orch
+guard`, a subcommand of the same binary, which is consulted before the
+agent writes a file and answers allow or deny. In Assist it denies
+every write to a file git does not ignore. In Delivery it allows a
+write only inside a worktree registered to the running plan, on that
+worktree's registered branch, in a phase where writing is allowed.
+`.orchestrator/` and anything under `.git` are never writable. It
+fails closed: anything it cannot establish is a denial. What it
+enforces is containment — it cannot tell which role is writing, and a
+file written by a shell command never reaches it at all (see
+[Known issues](#known-issues-and-limitations)).
+
+Concretely, asking for a change goes like this:
+
+1. You describe what you want. The Architect plans it in Assist and
+   shows you the plan: one issue per task, each carrying the model,
+   effort and reviewer it will get and why.
+2. You approve it or send it back. Approving is what enters Delivery.
+3. Each issue gets a branch and a worktree. An implementer or a
+   specialist does the work there and pushes.
+4. A reviewer reviews the pull request. CI runs.
+5. You merge on GitHub. Orch pins the head commit you approved and
+   refuses if the pull request moved after you approved it.
+
+The full product definition lives in [ORCH-PRD.md](ORCH-PRD.md).
+
+## Status
+
+Early software. What can be stated as fact: 9 tagged releases (v0.1.0
+through v0.5.4) and 65 merged pull requests, 28 of which carry an Orch
+audit record in their body — every merge from PR #40 through PR #97
+except #50, which `orch configure` delivered in its own format. Since
+PR #40, this repository has been built through the pipeline described
+above: a plan gate, an isolated worktree per issue, a review by a
+model that did not write the code, CI, and a merge no agent can
+perform.
+
+All of that evidence comes from one repository: this one.
+
+<details>
+<summary><b>Known issues and limitations</b> — what will bite you today</summary>
+
+**Writes made through the shell are not guarded.** The pre-write hook
+covers Claude Code's `Write`, `Edit`, `MultiEdit` and `NotebookEdit`
+and Codex CLI's `apply_patch`. A file written by a shell command —
+`echo > file`, a script, a `git checkout` — never reaches `orch
+guard`, so neither Assist's read-only rule nor Delivery's worktree
+containment applies to it. Symptom: an agent modifies your working
+tree in Assist and nothing denies it. Workaround: the host's own
+permission and approval prompts on shell commands are the only
+backstop; leave them on.
+
+**The guard cannot tell one role from another.** `orch guard` has a
+`--role` flag that would make a role mechanically read-only. Neither
+adapter passes it: host hooks are plugin-global rather than scoped per
+dispatched agent, so both `hooks.json` files run the bare command.
+Inside a worktree the guard treats as writable, a scout or a
+reviewer is no more restricted than the implementer. On Claude Code
+the `orch-scout` subagent's tool whitelist does close its write
+surface — it carries no `Bash` — but `orch-reviewer` and
+`orch-reviewer-safe` both carry `Bash`, so their read-only discipline
+rests on their instructions. Codex agent definitions carry no tool
+whitelist at all.
+
+**An `orch run` verb invoked from inside a Delivery worktree reports
+Assist and names the wrong fix.** Every `orch` command resolves
+`.orchestrator/` from its own working directory. A Delivery worktree
+carries the committed `.orchestrator/config.toml` but no
+`state.json` — that file is machine-local and gitignored — so `orch
+status` run there prints `mode: assist` while a run is active, and a
+lifecycle verb fails with ``no delivery run is active; run `orch run
+activate` to enter Delivery first``. Activating a second run is exactly
+the wrong move. Workaround: run every `orch run` verb with the primary
+checkout as the working directory.
+
+**A missing binary fails open, not closed.** Both adapters' hooks are
+bare `orch guard <host>` commands. If `orch` does not resolve on
+`PATH`, the hook exits with a shell "command not found", which both
+hook protocols treat as non-blocking: the guard silently stops
+enforcing and the session-start context stops being injected. No
+error, no denial. On Codex CLI the same is true while the plugin's
+one-time hook trust approval is outstanding — until you approve it,
+the bundled hooks do not run at all. Symptom: no denial where you
+expected one, and no Orch block at session start. Workaround: install
+the binary before the plugin, approve the trust prompt, and run `orch
+doctor`; a missing session-start block is the visible tell.
+
+**Codex `workspace-write` sandbox mode on Windows fails every agent
+write where the sandbox helper infrastructure is absent.** Observed
+live: every `apply_patch` fails with `orchestrator_helper_launch_failed`
+before any mutation, which stops Delivery execution cold. Workaround:
+confirm the sandbox actually works on that machine before setting
+`sandbox_mode = "workspace-write"` there.
+
+**Claude Code has no per-subagent effort parameter.** The routed
+effort reaches a Claude subagent as a cue in its prompt, not as a host
+parameter, so the effort in the audit record is what was routed rather
+than something the host applied. The record says so outright, as
+`Effort delivery: prompt-cue`. Codex pins effort in the installed
+agent TOML and the host enforces it.
+
+**On Codex, agent definitions are a separate install step and a
+configuration change does not reach them by itself.** Codex plugins
+cannot bundle agent TOMLs, so the marketplace install does not put
+them in place — you copy them or run `orch render-agents`. If you
+later change `hosts.codex.roles`, dispatched agents keep running the
+model pinned in the installed TOMLs until you re-run `orch
+render-agents`.
+
+**A Codex CLI upgrade that adds a new `apply_patch` directive causes
+denials until `orch` catches up.** The guard's envelope parser treats
+any `*** ` directive line it does not recognize as a malformed
+envelope and denies the write. That is deliberate — an unparsed write
+must never be allowed — but it means a host upgrade can produce
+spurious denials. Workaround: update `orch`.
+
+**A crashed run leaves the Delivery lock held; there is no automatic
+takeover.** `.orchestrator/delivery.lock` is created with `O_EXCL` and
+Orch never steals it on a staleness guess. Symptom: the next run
+refuses to start, and `orch doctor` notes that the acquiring process
+is no longer running. Workaround: `orch resume` to reconcile and
+continue, or `orch abort` to end it.
+
+</details>
+
+<details>
+<summary><b>Fixed</b> — defects already corrected, newest first</summary>
+
+Everything here is merged on `main`. The top entry landed after v0.5.4
+was tagged, so it ships in the next release rather than the current
+one.
+
+- Both adapters stopped claiming that per-agent tool whitelists make
+  every read-only role unable to write; the shipped prose now matches
+  what the guard actually enforces —
+  [#90](https://github.com/kninetimmy/orch/pull/90)
+- After two or more escalations on one issue, the skills resolve the
+  routing in force from the most recent escalation instead of an
+  unqualified one —
+  [#84](https://github.com/kninetimmy/orch/pull/84)
+- A rerouted issue's agent definition is checked against the model it
+  was rerouted to, not the one it was dispatched with —
+  [#76](https://github.com/kninetimmy/orch/pull/76)
+- A review submitted after an escalation is no longer rejected as a
+  reviewer mismatch: the skills echo the reviewer currently in force —
+  [#71](https://github.com/kninetimmy/orch/pull/71)
+- Claude spawns stopped passing a coarse tier alias as the model,
+  which could never express an exact routed version; a spawn now
+  matches the installed agent's frontmatter or stops —
+  [#70](https://github.com/kninetimmy/orch/pull/70)
+- Claude Code gained an `orch-reviewer-safe` agent, so a routed
+  reviewer downgrade dispatches the reviewer the audit record names —
+  [#66](https://github.com/kninetimmy/orch/pull/66)
+- Verification entries carry the commit they were gathered at, so
+  evidence from an earlier head is distinguishable from evidence at
+  the head that merges —
+  [#62](https://github.com/kninetimmy/orch/pull/62)
+- A review summary gets a 6000-character allowance of its own instead
+  of the 2000 that cut a real reviewer's findings mid-criterion, and
+  evidence re-run on a fix commit can now reach the audit record —
+  [#61](https://github.com/kninetimmy/orch/pull/61)
+- A requested-changes cycle no longer sends the issue back through
+  `pr-open`, and the skills' stdin form works under PowerShell —
+  [#58](https://github.com/kninetimmy/orch/pull/58)
+- A pull request with no required checks reports `no-checks` instead
+  of erroring on an empty response from `gh pr checks --required` —
+  [#44](https://github.com/kninetimmy/orch/pull/44)
+- On Windows, a just-exited process no longer probes as still running,
+  so `orch doctor`'s dead-acquirer note can fire at all —
+  [#7](https://github.com/kninetimmy/orch/pull/7)
+
+</details>
 
 ## Install
 
-### Quick install (script)
+### Have your agent do it
 
-Both scripts download the release binary for your OS and architecture,
-verify its SHA-256 against the release's `SHA256SUMS` **before**
-installing, and fail closed on any mismatch.
+Paste this into a Claude Code or Codex CLI session, started anywhere.
+It does not assume you have cloned this repository.
+
+```text
+Install the Orch development orchestrator (https://github.com/kninetimmy/orch)
+on this machine. Work in a scratch directory, not in one of my projects.
+
+1. Detect my OS and run the matching installer:
+     - Linux or macOS: download
+       https://raw.githubusercontent.com/kninetimmy/orch/main/install.sh
+       and run it with `sh install.sh`
+     - Windows: download
+       https://raw.githubusercontent.com/kninetimmy/orch/main/install.ps1
+       and run it with
+       `powershell -ExecutionPolicy Bypass -File .\install.ps1`
+   The installer downloads the release binary for this OS and architecture
+   and verifies its SHA-256 against the release's published SHA256SUMS
+   before installing anything. If that verification fails, STOP and report
+   the failure to me. Do not retry with verification skipped, do not fetch
+   the binary another way, and never install an unverified binary.
+
+2. Confirm that `orch` resolves on PATH and that `orch status` prints a
+   release version on its first line — a line beginning `orch:` and giving
+   a release tag such as v0.5.4. Run it from anywhere: outside an
+   initialized repository it prints that version line first and then exits
+   non-zero saying the repository is not initialized, which is expected
+   here. On Windows the installer adds its install directory to my user
+   PATH and a new terminal is needed to pick that up: if `orch` is not
+   found, ask me to open a new terminal rather than guessing or editing
+   PATH yourself.
+
+3. Install the plugin for the host you are running in. Use exactly these
+   commands:
+     - Claude Code:
+         claude plugin marketplace add kninetimmy/orch
+         claude plugin install orch-claude@orch
+     - Codex CLI:
+         codex plugin marketplace add kninetimmy/orch
+         codex plugin add orch@orch
+
+4. Codex CLI only. Skip this entire step on Claude Code, which needs no
+   clone:
+   a. Codex plugins cannot ship agent definitions, so clone the repository
+      into a temporary directory outside my projects:
+        git clone --depth 1 https://github.com/kninetimmy/orch.git <tmp>/orch
+   b. Copy these five files from <tmp>/orch/adapters/codex/agents/ into
+      .codex/agents/ — use ~/.codex/agents/ for a user-global install, or
+      a specific repository's own .codex/agents/:
+        orch-scout.toml
+        orch-implementer.toml
+        orch-specialist.toml
+        orch-reviewer.toml
+        orch-reviewer-safe.toml
+   c. Delete <tmp>/orch afterwards. Nothing else from the clone is needed.
+   d. Add both of these stanzas to ~/.codex/config.toml, leaving any
+      existing content in place:
+        [tools.experimental_request_user_input]
+
+        [features]
+        default_mode_request_user_input = true
+   e. Tell me that Codex CLI shows a one-time trust prompt for the
+      plugin's bundled hooks, that approving it is an action only I can
+      take, and that the hooks do not run at all until I approve it. Do
+      not report the install as finished as though the hooks were live.
+
+5. Run `orch doctor` and report its full output to me, including every
+   note and every failing check. Run outside an initialized repository it
+   reports the git-repository and configuration checks as failures; say so
+   rather than hiding it.
+
+6. Finish by telling me all three of these: `orch init` has to be run once
+   inside every repository I want orchestrated; Orch does nothing at all
+   in a repository that has not been initialized; and `orch init` does not
+   write the configuration into my working tree — it opens a pull request
+   carrying .orchestrator/config.toml for me to review and merge.
+```
+
+### Then initialize each repository you want orchestrated
+
+Installing the binary and the plugin sets up the machine. It does not
+touch any repository. In a repository that has not been initialized,
+Orch does nothing.
+
+Run `orch init` from the root of each repository you want orchestrated.
+It detects your environment (hosts, git, `gh`, memhub), interviews you
+about which hosts to enable and which models each role should use —
+every question has a default — and then bootstraps itself through its
+own pipeline: `.orchestrator/config.toml` arrives as a pull request you
+review and merge, not as a silent write to your working tree.
+
+Delivery additionally needs `git` and the
+[GitHub CLI](https://cli.github.com/) (`gh`) authenticated against the
+repository's remote. Assist works without a remote.
+
+<details>
+<summary><b>Install it yourself</b> — scripts, plugins, manual download, source builds</summary>
+
+**Quick install (script).** Both scripts download the release binary for
+your OS and architecture, verify its SHA-256 against the release's
+`SHA256SUMS` **before** installing, and fail closed on any mismatch.
 
 Linux / macOS — installs to `~/.local/bin` (override with
-`ORCH_INSTALL_DIR`); pin a version with `ORCH_VERSION=v0.1.0`:
+`ORCH_INSTALL_DIR`); pin a version with `ORCH_VERSION=v0.5.4`:
 
 ```sh
 curl -fsSLO https://raw.githubusercontent.com/kninetimmy/orch/main/install.sh
@@ -102,8 +324,8 @@ sh install.sh
 ```
 
 Windows (PowerShell) — installs to `%LOCALAPPDATA%\Programs\orch` and
-adds that directory to your user `PATH` (skip the PATH change with
-`-NoPathUpdate`; pin a version with `-Version v0.1.0`):
+appends that directory to your user `PATH`; skip the `PATH` change with
+`-NoPathUpdate`, pin a version with `-Version v0.5.4`:
 
 ```powershell
 iwr https://raw.githubusercontent.com/kninetimmy/orch/main/install.ps1 -OutFile install.ps1
@@ -111,10 +333,9 @@ iwr https://raw.githubusercontent.com/kninetimmy/orch/main/install.ps1 -OutFile 
 powershell -ExecutionPolicy Bypass -File .\install.ps1
 ```
 
-### Plugin install (two commands per host)
-
-With the binary on `PATH`, each host installs its adapter straight from
-this repository's marketplace manifest:
+**Plugin install (two commands per host).** With the binary on `PATH`,
+each host installs its adapter from this repository's marketplace
+manifest:
 
 ```sh
 # Claude Code
@@ -126,51 +347,23 @@ codex plugin marketplace add kninetimmy/orch
 codex plugin add orch@orch
 ```
 
-Then follow the host-specific steps in the adapter READMEs
-([Claude Code](adapters/claude/README.md#install-order),
-[Codex CLI](adapters/codex/README.md#install-order)) — Codex CLI
-additionally needs the one-time hook trust approval, the five agent
-TOMLs copied, and the `request_user_input` feature enabled.
+One manifest (`.claude-plugin/marketplace.json`) serves both hosts, and
+the other host's entry may show up in your listing too — install yours
+by its exact name: `orch-claude` on Claude Code, `orch` on Codex CLI.
+Then follow the host-specific steps in the adapter
+READMEs — [Claude Code](adapters/claude/README.md#install-order),
+[Codex CLI](adapters/codex/README.md#install-order). Codex CLI needs
+three more things the plugin install cannot do for you: the one-time
+hook trust approval, the five agent TOMLs copied into `.codex/agents/`
+(or rendered there with `orch render-agents`), and the two
+`request_user_input` stanzas in `~/.codex/config.toml`.
 
-### Bootstrap with your agent
-
-Paste this into a Claude Code or Codex CLI session to have the agent
-run the install end to end:
-
-```text
-Install the Orch orchestrator from https://github.com/kninetimmy/orch:
-1. Detect my OS and run the matching install script from the repository
-   root (install.sh on Linux/macOS; install.ps1 on Windows — download
-   it, then run: powershell -ExecutionPolicy Bypass -File .\install.ps1).
-   The script verifies the binary's SHA-256 against the release's
-   SHA256SUMS. If that verification fails, STOP and report the failure —
-   never bypass it or install an unverified binary.
-2. Confirm `orch` resolves on PATH and `orch status` prints a release
-   version on its first line. On Windows a new terminal may be needed
-   for the PATH change — ask me instead of guessing.
-3. Install your host's adapter plugin:
-   - Claude Code: claude plugin marketplace add kninetimmy/orch
-     then: claude plugin install orch-claude@orch
-   - Codex CLI: codex plugin marketplace add kninetimmy/orch
-     then: codex plugin add orch@orch
-4. Codex CLI only: copy the five agent TOMLs (orch-scout,
-   orch-implementer, orch-specialist, orch-reviewer, orch-reviewer-safe)
-   from the plugin's agents/ directory into ./.codex/agents/ or
-   ~/.codex/agents/, add the two request_user_input stanzas from
-   adapters/codex/README.md to ~/.codex/config.toml, and tell me that
-   the plugin hook trust prompt is a one-time approval only I can
-   confirm — do not proceed as if hooks are active until I do.
-5. Run `orch doctor`, report what it says, and point me at `orch init`
-   for the repository I want orchestrated.
-```
-
-### Manual download
-
-Download the static binary for your OS and architecture from
+**Manual download.** Take the static binary for your OS and
+architecture from
 [GitHub Releases](https://github.com/kninetimmy/orch/releases)
-(`orch_<os>_<arch>`, Windows binaries end in `.exe`), then verify its
-SHA-256 against the `SHA256SUMS` file published with the release
-**before running it** — don't skip this:
+(`orch_<os>_<arch>`; Windows assets end in `.exe`), then verify its
+SHA-256 against the `SHA256SUMS` file published with that release
+**before running it**:
 
 ```sh
 # Linux / macOS
@@ -180,13 +373,11 @@ sha256sum --check --ignore-missing SHA256SUMS
 (Get-FileHash orch_windows_amd64.exe -Algorithm SHA256).Hash
 ```
 
-Rename it to `orch` (or `orch.exe`) and place it on your PATH.
-`orch status` and `orch doctor` print the binary's release version on
-their first line; adapters and docs pin a release version.
+Rename it to `orch` (or `orch.exe`) and put it on your `PATH`. `orch
+status` and `orch doctor` each print the binary's release version on
+their first line.
 
-### Build from source
-
-Build with Go 1.26+ (source builds report version `dev`):
+**Build from source.** Go 1.26+; source builds report version `dev`:
 
 ```sh
 git clone https://github.com/kninetimmy/orch.git
@@ -194,54 +385,50 @@ cd orch
 go build ./cmd/orch        # produces ./orch (orch.exe on Windows)
 ```
 
-or install straight onto your PATH:
+or install straight onto your `PATH`:
 
 ```sh
 go install github.com/kninetimmy/orch/cmd/orch@latest
 ```
 
-Delivery mode additionally needs `git` and the
-[GitHub CLI](https://cli.github.com/) (`gh`) authenticated against the
-repository's remote. Assist mode works without a remote.
+</details>
 
-## Using it
+## Day to day
 
-Run `orch init` in the repository you want to orchestrate. It detects
-your environment (hosts, git, gh, memhub), interviews you about which
-hosts to enable and which models to use — sensible defaults are
-offered for every question — and then bootstraps everything through
-its own pipeline: the configuration lands as a pull request you review
-and merge, not as a silent write to your working tree.
-
-Day-to-day commands:
+These are the commands `orch help` lists for you:
 
 ```text
 orch init             Interview and bootstrap this repository
 orch status           Show mode and configuration summary
 orch doctor           Check environment and configuration health
-orch configure        Change committed settings (delivered as a PR)
-orch configure-local  Change machine-local overrides (applied directly)
-orch resume           Reconcile an interrupted Delivery run and continue
-orch abort            Stop a Delivery run and return to Assist
-orch metrics          Local usage metrics
-orch render-agents    Render the five Codex agent TOMLs from config into .codex/agents/
+orch configure        Interview and deliver committed configuration changes
+orch configure-local  Interview and apply machine-local overrides
+orch resume           Reconcile an interrupted Delivery run against GitHub and continue
+orch abort            Stop dispatch and return to Assist
+orch metrics          Show local metrics
+orch render-agents    Render the five Codex agent TOMLs from configuration into .codex/agents/
 ```
 
-`orch run`, `orch guard`, and `orch hook` also exist but are plumbing —
-the host adapters drive them; you never call them by hand.
+`orch run`, `orch guard` and `orch hook` also exist, but they are
+adapter plumbing: they read and write JSON, the host adapters drive
+them, and you never call them by hand.
+
+On Claude Code the three interviews also have slash commands:
+`/orch:init`, `/orch:configure`, `/orch:configure-local`.
 
 ## Settings — what you can tune
 
 Configuration lives in two TOML files under `.orchestrator/`:
 
-- **`config.toml`** — committed to git, shared by everyone on the
-  repo. Changed via `orch configure`, which delivers the edit as a
-  reviewable PR.
+- **`config.toml`** — committed to git, shared by everyone working on
+  the repository. Changed with `orch configure`, which delivers the
+  edit as a reviewable pull request.
 - **`config.local.toml`** — machine-local and gitignored, for personal
-  preferences. Changed via `orch configure-local`, applied directly.
+  preferences. Changed with `orch configure-local`, applied directly.
 
-Policy decisions can only live in the committed file — a local
-override can never weaken the shared workflow rules. What goes where:
+The split is a closed table over every key in the schema, not a
+convention: policy keys can only live in the committed file, so a
+local override can never weaken a shared workflow rule.
 
 | Setting | Values (default) | Local override? |
 |---|---|---|
@@ -249,15 +436,18 @@ override can never weaken the shared workflow rules. What goes where:
 | `hosts.<host>.roles.<role>.model` | exact model version string | yes |
 | `hosts.<host>.roles.<role>.effort` | `low` `medium` `high` (+ `xhigh` on claude) | yes |
 | `concurrency.max_subagents` | integer ≥ 1 (`3`) | yes |
-| `metrics.enabled` | `true` / `false` (`false`) | yes |
+| `metrics.enabled` | `true` / `false` (`false` when omitted) | yes |
 | `merge.strategy` | `squash` `rebase` `merge-commit` (`squash`) | no (committed) |
 | `memhub.mode` | `required` `best-effort` `off` (no default — you choose) | no (committed) |
 
-The six roles per enabled host are `architect`, `scout`,
+Every enabled host carries the same six roles: `architect`, `scout`,
 `implementer`, `specialist`, `reviewer`, and `review_downgrade` (the
-cheaper reviewer Orch is allowed to use only when a task is provably
-low-risk). Every role pins an exact model version — never an alias —
-so what ran is always auditable. The defaults `orch init` offers:
+cheaper reviewer Orch may use only when routing proves the change is
+mechanical, low-risk, fully specified and unsurprising). Each role
+names one model string; the interview offers exact versions rather
+than tier aliases, and whatever string is configured is the one that
+lands in the audit record, so the record says what ran instead of what
+tier it belonged to. The defaults `orch init` offers:
 
 | Role | Claude Code | Codex |
 |---|---|---|
@@ -268,117 +458,140 @@ so what ran is always auditable. The defaults `orch init` offers:
 | Reviewer | `claude-opus-5` / high | `gpt-5.6-sol` / medium |
 | Review downgrade | `claude-sonnet-5` / high | `gpt-5.6-terra` / high |
 
-Typical tuning: point a role at a bigger/smaller model on one machine
-via `configure-local` (e.g. run the Architect on a frontier model only
-where you have the subscription), raise `max_subagents` on a beefy
-machine, or enable local metrics while experimenting. Every applied
-override is listed by `orch status` and `orch doctor`, so the exact
-models in effect are always visible.
+Typical tuning: point a role at a bigger or smaller model on one
+machine with `configure-local` (run the Architect on a frontier model
+only where you have the subscription), raise `max_subagents` on a
+machine that can take it, or turn on local metrics while experimenting.
+`orch status` reports how many overrides are in effect and `orch
+doctor` names the exact keys they set, so a machine-local change is
+never invisible.
 
 ## Memhub integration
 
-memhub is an external, optional, local-first per-repo project-memory
-CLI. Orch integrates with it when it's present but neither requires it
-nor ships it: leave `memhub.mode` at `off` and Orch never looks for
-it.
+memhub is an external, optional, local-first per-repository
+project-memory CLI. Orch talks to it when it is present but neither
+requires it nor ships it: set `memhub.mode` to `off` and Orch never
+looks for it.
 
-`memhub.mode` (committed, in `config.toml`) has three values:
+`memhub.mode` is committed, in `config.toml`, and has three values:
 
 - **`off`** — memhub is skipped entirely: no probes, no doctor checks.
 - **`best-effort`** — memhub's health and recall are probed and
   reported, but a failure never blocks anything.
-- **`required`** — Delivery planning fails closed if either check
-  fails: the plan gate refuses to activate a run.
+- **`required`** — Delivery planning fails closed if either probe
+  fails: the plan gate refuses to activate the run.
 
-Both the Delivery plan gate and `orch doctor` run the same two-step
-check: first a `memhub status` health probe, then — only once that
-succeeds — a `memhub recall` call against a fixed canary query, so a
-wedged retrieval path that still exits 0 is caught, not just a dead
-process. `orch doctor` is mode-aware: `off` prints a skip note,
-`best-effort` reports the result as a note without failing the check,
-and `required` fails the check outright if either probe fails.
+Both the plan gate and `orch doctor` run the same two-step check: a
+`memhub status` health probe, then — only if that succeeds — a `memhub
+recall` against a fixed canary query, so a wedged retrieval path that
+still exits 0 is caught rather than trusted. `orch doctor` is
+mode-aware: `off` prints a skip note, `best-effort` reports the result
+as a note without failing, and `required` fails the check outright.
 
-By discipline, only the Architect role initiates memhub writes (facts,
-decisions, renders, reindexing) — Scouts and executors may only read —
-and every memhub command always runs with the primary checkout as its
-working directory, never inside a per-issue worktree, since worktrees
-never receive a copied memhub database.
+Orch's own memhub client is read-only: it probes and recalls, and
+never writes, renders, reindexes or syncs. Writes are the Architect's
+alone, and that boundary is stated in the skills rather than enforced
+mechanically — a subagent carrying a shell can reach the memhub CLI
+too. Anything a subagent wants remembered comes back in its report.
+Every memhub command runs with the primary checkout as its working
+directory, never inside a per-issue worktree, because worktrees never
+receive a copy of the memhub database.
 
 ---
 
 ## Under the hood
 
-This section is for contributors and the curious; nothing here is
-needed to use the tool.
+This section is for contributors and the curious; none of it is needed
+to use the tool.
 
 ### Enforcement, not convention
 
-The mode rules are enforced mechanically. Host adapters wire the agent
-CLI's pre-write hooks to `orch guard`, which resolves a closed
-decision table: in Assist, any write to a tracked file inside the repo
-is denied (git-ignored paths are allowed); in Delivery, writes are
-allowed only inside a worktree registered to the active run, in a
-writable phase, with the worktree's HEAD on the registered branch.
-`.orchestrator/` state and anything under `.git` are never writable.
-The guard fails closed: if it cannot determine the facts, it denies.
+The mode rules are resolved by a closed decision table in
+`internal/guard`, reached through the host CLI's pre-write hook. In
+Assist, a write to any in-repo file git does not ignore is denied;
+git-ignored paths are allowed as local scratch. In Delivery, a write
+is allowed only inside a worktree registered to the active run, in a
+writable phase, with that worktree's HEAD on its registered branch.
+`.orchestrator/` and anything under `.git` are never writable. If the
+guard cannot determine a fact — an unreadable state file, a path it
+cannot canonicalize, an ignore probe that fails to run — it denies.
+
+What the table decides is containment. The guard is given the write's
+target paths, not the identity of the agent making the write, so it
+cannot make one role read-only and another writable; the `--role`
+narrowing that exists for that purpose is passed by neither adapter.
+Nor does it see writes the host does not route through a guarded tool,
+which is why shell-mediated writes escape it entirely. Both gaps are
+in [Known issues](#known-issues-and-limitations).
 
 Delivery is exclusive across hosts and machines: a lock file
-(`.orchestrator/delivery.lock`, created `O_CREATE|O_EXCL`) is the
-lock, and there is no automatic staleness takeover — recovery is
-always an explicit `orch abort` or `orch resume`. Run state is
-schema-versioned JSON at `.orchestrator/state.json` (machine-local,
-atomic writes, fail-closed loads), persisted after every sub-step so a
-crash at any point is recoverable.
+(`.orchestrator/delivery.lock`, created with `O_EXCL`) is the lock,
+and there is no automatic staleness takeover — recovery is always an
+explicit `orch abort` or `orch resume`. Run state is schema-versioned
+JSON at `.orchestrator/state.json` (machine-local, atomic writes,
+fail-closed loads), persisted after every sub-step, so a crash at any
+point is recoverable.
 
 ### The Delivery pipeline
 
 A run starts at the **plan gate**: a schema-versioned plan document
 (issues, dependency waves, risk facts) is validated fail-closed, and a
-gate document derives each issue's executor and reviewer from facts
-alone via the routing table — the model never picks its own reviewer.
-The gate also runs the memhub health/recall check described above,
-gated by `memhub.mode`. Activation then creates the GitHub label
-taxonomy, one issue per task carrying a structured **audit record**
-(rendered markdown plus canonical JSON in a managed body region — the
-approved objective, acceptance criteria, and required tests, plus the
-exact model, effort, how the host actually delivered that effort, and
-the routing rationale, mirrored onto the PR), and one branch +
-isolated worktree per issue under `.orchestrator/worktrees/`.
+gate document derives each issue's executor and reviewer from those
+facts alone through the routing table — the model never picks its own
+reviewer. The gate also runs the memhub health and recall check
+described above, gated by `memhub.mode`. Activation then creates the
+GitHub label taxonomy, one issue per task carrying a structured
+**audit record** (rendered markdown plus canonical JSON in a managed
+body region: the approved objective, acceptance criteria and required
+tests, plus the exact model, the effort, how the host actually
+delivered that effort, and the routing rationale, mirrored onto the
+pull request), and one branch and isolated worktree per issue under
+`.orchestrator/worktrees/`.
 
 Each issue then walks a closed lifecycle driven by plumbing verbs:
-`dispatch` (dependencies must be merged; branch fast-forwarded onto
-the default branch) → `pr-open` (clean, strictly-ahead, orphan-PR
-guarded) → `review` (routed reviewer verified against the live PR
-head) → `ci` (reads required checks as one of four honest states —
-`passing`, `failing`, `pending`, or the explicit `no-checks`, which is
-never conflated with passing) → `merge-report` (pins the approved head
-SHA; carries a `no_ci_statement` in its report whenever `no-checks` is
-what's gating the merge, so "nothing gates this" is always said
-outright, never implied) → `merge` (human-approved, re-checked against
-the live PR, pinned with `--match-head-commit`, and setting the
-issue's terminal `delivered` status label) → `cleanup` → `complete`
-(fast-forward the primary checkout, auto-return to Assist). Failures
-route through `escalate` (the routing ladder), `block` (closed failure
-classes; a secret found stops the whole run), or `abandon`. Errors
-never mutate state; state advances only on success.
+`dispatch` (dependencies must be merged; the branch is fast-forwarded
+onto the default branch) → `pr-open` (clean, strictly-ahead,
+orphan-PR guarded) → `review` (the routed reviewer, verified against
+the live PR head) → `ci` (reads required checks as one of four honest
+states — `passing`, `failing`, `pending`, or the explicit `no-checks`,
+which is never conflated with passing) → `merge-report` (pins the
+approved head SHA, and carries a `no_ci_statement` whenever
+`no-checks` is what gates the merge, so "nothing gates this" is always
+said outright) → `merge` (human-approved, re-checked against the live
+PR, pinned with `--match-head-commit`, setting the issue's terminal
+`delivered` label) → `cleanup` → `complete` (fast-forward the primary
+checkout, return to Assist). Failures route through `escalate` (the
+routing ladder), `block` (closed failure classes; a secret found stops
+the whole run) or `abandon`. Errors never mutate state; state advances
+only on success.
 
 `orch resume` reconciles an interrupted run against GitHub reality in
 three strict stages — observe (all reads up front), classify (a pure
-30-row decision table), apply (one state write, skipped when already
-converged). It never fabricates approval, never advances past the
-human merge gate, and never deletes or recreates anything.
+30-row decision table), apply (one state write, skipped when the run
+has already converged). It never fabricates approval, never advances
+past the human merge gate, and never deletes or recreates anything.
 
 ### Routing and escalation
 
-`internal/routing` is pure and deterministic: a first-match-wins table
-over a closed nine-domain risk enum plus difficulty/consensus facts.
-Reviewer downgrade requires four affirmative facts; any conflict
-silently takes the stronger route and says so in the rationale. On
-failure, escalation retires the failed model permanently for that
-issue (an effort bump is still a retry; a model swap is not),
-restores the strong reviewer on any reroute, and resolves exhaustion
-to an explicit return-to-Architect — the code never ranks model
-strength on its own.
+`internal/routing` is pure and deterministic: a five-row,
+first-match-wins table over four task facts — whether the work is
+read-only, whether it is unusually difficult, which of a closed
+nine-domain risk enum it touches, and four affirmative claims
+(mechanical, low-risk, fully specified, unsurprising) that alone
+permit a cheaper reviewer — plus the models that have already failed
+this issue. Read-only work goes to a scout, on the specialist model
+when it is risky, difficult, or the scout model has already failed.
+Risky, difficult or previously-failed work goes to a specialist with a
+strong reviewer and refuses the downgrade there even when all four
+claims hold, recording the refusal in the rationale. Everything else
+goes to an implementer. Any conflict takes the stronger route and says
+so in the rationale.
+
+On failure, escalation retires the failed model permanently for that
+issue (an effort bump is still a retry; a model swap is not), restores
+the strong reviewer on any reroute, and resolves exhaustion to an
+explicit return-to-Architect. The code never ranks model strength on
+its own.
 
 ### Package layout
 
@@ -402,10 +615,10 @@ strength on its own.
 | `internal/agents/` | Renders the five Codex agent TOMLs `orch render-agents` writes, substituting model/effort onto the canonical embedded bodies |
 | `internal/instructions/` | Managed instruction-block engine for AGENTS.md/CLAUDE.md |
 | `internal/question/` | Host-neutral native question contract (documents out, answer sets back) |
-| `internal/interview/` | Pure question engines for `init`, `configure`, and `configure-local` |
+| `internal/interview/` | Pure question engines for `init`, `configure` and `configure-local` |
 | `internal/bootstrap/` | Mechanical PR-flow executors behind `init --bootstrap` and `configure --deliver` |
 | `internal/adaptertest/` | Shared cross-host parity-test layer consumed by both adapters' plugin tests |
-| `adapters/claude/`, `adapters/codex/` | Host-adapter artifacts (skills, hooks, templates) — shipped, cross-host parity-tested |
+| `adapters/claude/`, `adapters/codex/` | Host-adapter artifacts: plugin manifest, hooks, skills, agent definitions, plus Claude Code's slash commands — cross-host parity-tested |
 | `ORCH-PRD.md` | Product requirements — source of truth for v1 |
 
 ### Design principles
@@ -416,9 +629,11 @@ strength on its own.
 - **Mechanics are policy-free.** `gitops`/`ghops`/`manifest` know how;
   `internal/run` alone decides when and why.
 - **Humans gate merges.** Orch pins the approved head SHA and refuses
-  if the PR moved after approval; the merge itself happens on GitHub.
-- **Everything auditable.** Exact model versions and routing
-  rationale live in the issue/PR audit record and in `orch status`.
+  if the pull request moved after approval; the merge itself happens
+  on GitHub.
+- **Everything auditable.** The exact model, the effort, how the host
+  actually delivered that effort, and the routing rationale live in the
+  issue's audit record and are mirrored onto its pull request.
 
 ### Build / test
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ read and approved. Each task in that plan becomes a GitHub issue, a
 branch, and its own git worktree; the work happens there, lands as a
 pull request, is reviewed by a separate agent, runs CI, and waits for
 you to approve the merge. When every task is merged or abandoned, the
-repository returns to Assist on its own.
+run's last step puts the repository back in Assist.
 
 **Six roles.** Delivery work is split across roles, and you pin each
 one to an exact model version and reasoning-effort level:
@@ -458,7 +458,7 @@ agents keep running the model pinned in the installed TOMLs until you
 re-render. On Claude Code the failure is louder: if the routed model
 matches no installed agent's frontmatter, the spawn stops and the
 Architect tells you, rather than silently running a different model.
-Either way, changing a role's model — which the Settings section below
+Either way, changing a role's model — which the Settings section above
 recommends as ordinary tuning — is not finished until the installed
 agent definitions carry it too.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ one to an exact model version and reasoning-effort level:
 | Implementer | Writes the code inside the issue's worktree |
 | Specialist | Takes the issues routing marks risky or unusually difficult |
 | Reviewer | Reviews the pull request in a separate dispatch from the one that wrote it |
-| Review downgrade | A cheaper reviewer, allowed only when the plan affirms the change is mechanical and low-risk |
+| Review downgrade | A cheaper reviewer, allowed only when the plan affirms all four of mechanical, low-risk, fully specified, unsurprising |
 
 Which role gets an issue is derived from the issue's own facts by a
 deterministic table, not chosen by the model that will run it. The
@@ -34,8 +34,9 @@ reviewer is always a separate dispatch and never the session that wrote
 the code, but it is often not a different model: the shipped defaults
 put the specialist and the reviewer on one model, and the implementer
 and the downgraded reviewer on another. Any specialist run and any
-downgraded review therefore has the same model on both sides — on
-Codex, at the same effort as well.
+downgraded review therefore has the same model on both sides. For a
+specialist run the effort matches too, on either host; only a Claude
+downgrade drops it.
 
 **The guard.** None of the above is an instruction the agent is asked
 to honor. Both host adapters wire the CLI's pre-write hook to `orch
@@ -44,10 +45,11 @@ agent writes a file and answers allow or deny. In Assist it denies
 every write to a file git does not ignore. In Delivery it allows a
 write only inside a worktree registered to the running plan, on that
 worktree's registered branch, in a phase where writing is allowed.
-`.orchestrator/` and anything under `.git` are never writable. It
-fails closed: anything it cannot establish is a denial. What it
-enforces is containment — it cannot tell which role is writing, and a
-file written by a shell command never reaches it at all (see
+Git internals are never writable, and neither is the orchestrator
+state your session is running against. It fails closed: anything it
+cannot establish is a denial. What it enforces is containment — it
+cannot tell which role is writing, and a file written by a shell
+command never reaches it at all (see
 [Known issues](#known-issues-and-limitations)).
 
 Concretely, asking for a change goes like this:
@@ -82,163 +84,6 @@ defaults put on one model. The reviewer's independence is a separate
 dispatch against the pull request, not a different model.
 
 All of that evidence comes from one repository: this one.
-
-## Known issues and limitations
-
-<details>
-<summary>What will bite you today — symptom, cause, workaround</summary>
-
-**Writes made through the shell are not guarded.** The pre-write hook
-covers Claude Code's `Write`, `Edit`, `MultiEdit` and `NotebookEdit`
-and Codex CLI's `apply_patch`. A file written by a shell command —
-`echo > file`, a script, a `git checkout` — never reaches `orch
-guard`, so neither Assist's read-only rule nor Delivery's worktree
-containment applies to it. Symptom: an agent modifies your working
-tree in Assist and nothing denies it. Workaround: the host's own
-permission and approval prompts on shell commands are the only
-backstop; leave them on.
-
-**The guard cannot tell one role from another.** `orch guard` has a
-`--role` flag that would make a role mechanically read-only. Neither
-adapter passes it: host hooks are plugin-global rather than scoped per
-dispatched agent, so both `hooks.json` files run the bare command.
-Inside a worktree the guard treats as writable, a scout or a
-reviewer is no more restricted than the implementer. On Claude Code
-the `orch-scout` subagent's tool whitelist does close its write
-surface — it carries no `Bash` — but `orch-reviewer` and
-`orch-reviewer-safe` both carry `Bash`, so their read-only discipline
-rests on their instructions. Codex agent definitions carry no tool
-whitelist at all.
-
-**An `orch run` verb invoked from inside a Delivery worktree reports
-Assist and names the wrong fix.** Every `orch` command resolves
-`.orchestrator/` from its own working directory. A Delivery worktree
-carries the committed `.orchestrator/config.toml` but no
-`state.json` — that file is machine-local and gitignored — so `orch
-status` run there prints `mode: assist` while a run is active, and a
-lifecycle verb fails with ``no delivery run is active; run `orch run
-activate` to enter Delivery first``. Activating a second run is exactly
-the wrong move. Workaround: run every `orch run` verb with the primary
-checkout as the working directory.
-
-**A missing binary fails open, not closed.** Both adapters' hooks are
-bare `orch guard <host>` commands. If `orch` does not resolve on
-`PATH`, the hook exits with a shell "command not found", which both
-hook protocols treat as non-blocking: the guard silently stops
-enforcing and the session-start context stops being injected. No
-error, no denial. On Codex CLI the same is true while the plugin's
-one-time hook trust approval is outstanding — until you approve it,
-the bundled hooks do not run at all. Symptom: no denial where you
-expected one, and no Orch block at session start. Workaround: install
-the binary before the plugin, approve the trust prompt, and run `orch
-doctor`; a missing session-start block is the visible tell.
-
-**Codex `workspace-write` sandbox mode on Windows fails every agent
-write where the sandbox helper infrastructure is absent.** Observed
-live: every `apply_patch` fails with `orchestrator_helper_launch_failed`
-before any mutation, which stops Delivery execution cold. Workaround:
-confirm the sandbox actually works on that machine before setting
-`sandbox_mode = "workspace-write"` there.
-
-**Claude Code has no per-subagent effort parameter.** The routed
-effort reaches a Claude subagent as a cue in its prompt, not as a host
-parameter, so the effort in the audit record is what was routed rather
-than something the host applied. The record says so outright, as
-`Effort delivery: prompt-cue`. Codex pins effort in the installed
-agent TOML and the host enforces it.
-
-**A model override does not reach a dispatched agent by itself, on
-either host.** Neither host can override a model per spawn, so the
-routed selection has to match an installed agent definition. On Codex
-that means the five agent TOMLs are a separate install step the
-marketplace install does not perform — you copy them or run `orch
-render-agents` — and after you change `hosts.codex.roles`, dispatched
-agents keep running the model pinned in the installed TOMLs until you
-re-render. On Claude Code the failure is louder: if the routed model
-matches no installed agent's frontmatter, the spawn stops and the
-Architect tells you, rather than silently running a different model.
-Either way, changing a role's model — which the Settings section below
-recommends as ordinary tuning — is not finished until the installed
-agent definitions carry it too.
-
-**A Codex CLI upgrade that adds a new `apply_patch` directive causes
-denials until `orch` catches up.** The guard's envelope parser treats
-any `*** ` directive line it does not recognize as a malformed
-envelope and denies the write. That is deliberate — an unparsed write
-must never be allowed — but it means a host upgrade can produce
-spurious denials. Workaround: update `orch`.
-
-**The merge gate cannot tell a human's approval from an agent's.** The
-engine requires an approval carrying the exact literal `approve-merge`,
-pinned to the pull request and head commit `merge-report` recorded, and
-`gh pr merge --match-head-commit` refuses if that commit is no longer
-the head — so a stale or swapped merge fails closed. What none of that
-establishes is who produced the approval: the agent assembles that JSON
-itself, and `internal/run/merge.go` says so outright ("the engine
-cannot verify a human, so this recorded string is the proof one
-approved this specific merge"). Symptom: the audit trail's approval is
-the agent's assertion that you approved. Workaround: the merge runs
-through `gh` against GitHub, so GitHub-side branch protection is the
-one control on this path that does not depend on the agent.
-
-**A crashed run leaves the Delivery lock held; there is no automatic
-takeover.** `.orchestrator/delivery.lock` is created with `O_EXCL` and
-Orch never steals it on a staleness guess. Symptom: the next run
-refuses to start, and `orch doctor` notes that the acquiring process
-is no longer running. Workaround: `orch resume` to reconcile and
-continue, or `orch abort` to end it.
-
-</details>
-
-## Fixed
-
-<details>
-<summary>Defects already corrected, newest first</summary>
-
-Everything here is merged on `main`. The top entry landed after v0.5.4
-was tagged, so it ships in the next release rather than the current
-one.
-
-- Both adapters stopped claiming that per-agent tool whitelists make
-  every read-only role unable to write; the shipped prose now matches
-  what the guard actually enforces —
-  [#90](https://github.com/kninetimmy/orch/pull/90)
-- After two or more escalations on one issue, the skills resolve the
-  routing in force from the most recent escalation instead of an
-  unqualified one —
-  [#84](https://github.com/kninetimmy/orch/pull/84)
-- A rerouted issue's agent definition is checked against the model it
-  was rerouted to, not the one it was dispatched with —
-  [#76](https://github.com/kninetimmy/orch/pull/76)
-- A review submitted after an escalation is no longer rejected as a
-  reviewer mismatch: the skills echo the reviewer currently in force —
-  [#71](https://github.com/kninetimmy/orch/pull/71)
-- Claude spawns stopped passing a coarse tier alias as the model,
-  which could never express an exact routed version; a spawn now
-  matches the installed agent's frontmatter or stops —
-  [#70](https://github.com/kninetimmy/orch/pull/70)
-- Claude Code gained an `orch-reviewer-safe` agent, so a routed
-  reviewer downgrade dispatches the reviewer the audit record names —
-  [#66](https://github.com/kninetimmy/orch/pull/66)
-- Verification entries carry the commit they were gathered at, so
-  evidence from an earlier head is distinguishable from evidence at
-  the head that merges —
-  [#62](https://github.com/kninetimmy/orch/pull/62)
-- A review summary gets a 6000-character allowance of its own instead
-  of the 2000 that cut a real reviewer's findings mid-criterion, and
-  evidence re-run on a fix commit can now reach the audit record —
-  [#61](https://github.com/kninetimmy/orch/pull/61)
-- A requested-changes cycle no longer sends the issue back through
-  `pr-open`, and the skills' stdin form works under PowerShell —
-  [#58](https://github.com/kninetimmy/orch/pull/58)
-- A pull request with no required checks reports `no-checks` instead
-  of erroring on an empty response from `gh pr checks --required` —
-  [#44](https://github.com/kninetimmy/orch/pull/44)
-- On Windows, a just-exited process no longer probes as still running,
-  so `orch doctor`'s dead-acquirer note can fire at all —
-  [#7](https://github.com/kninetimmy/orch/pull/7)
-
-</details>
 
 ## Install
 
@@ -314,11 +159,10 @@ on this machine. Work in a scratch directory, not in one of my projects.
    repository it reports the git-repository and configuration checks as
    failures; say so rather than hiding it.
 
-6. Tell me to restart this CLI once you are done. A plugin installed
-   during a running session does not load its hooks into that session,
-   so the guard and the session-start context are not live until I start
-   a new one. After I restart, the tell that it worked is an Orch block
-   at session start inside an initialized repository.
+6. Tell me to restart this CLI before relying on any of it, and to treat
+   the hooks as not yet running until I have. Do not assume a plugin
+   installed mid-session is live in this session. The tell that it took
+   is an Orch block at session start inside an initialized repository.
 
 7. Finish by telling me all three of these: `orch init` has to be run once
    inside every repository I want orchestrated; Orch does nothing at all
@@ -343,6 +187,11 @@ review and merge, not as a silent write to your working tree.
 Delivery additionally needs `git` and the
 [GitHub CLI](https://cli.github.com/) (`gh`) authenticated against the
 repository's remote. Assist works without a remote.
+
+Each adapter's README carries its host's exact install order and its
+own known limitations, worth reading once for the host you use:
+[Claude Code](adapters/claude/README.md#install-order),
+[Codex CLI](adapters/codex/README.md#install-order).
 
 <details>
 <summary><b>Install it yourself</b> — scripts, plugins, manual download, source builds</summary>
@@ -535,6 +384,163 @@ Every memhub command runs with the primary checkout as its working
 directory, never inside a per-issue worktree, because worktrees never
 receive a copy of the memhub database.
 
+## Known issues and limitations
+
+<details>
+<summary>What will bite you today — symptom, cause, workaround</summary>
+
+**Writes made through the shell are not guarded.** The pre-write hook
+covers Claude Code's `Write`, `Edit`, `MultiEdit` and `NotebookEdit`
+and Codex CLI's `apply_patch`. A file written by a shell command —
+`echo > file`, a script, a `git checkout` — never reaches `orch
+guard`, so neither Assist's read-only rule nor Delivery's worktree
+containment applies to it. Symptom: an agent modifies your working
+tree in Assist and nothing denies it. Workaround: the host's own
+permission and approval prompts on shell commands are the only
+backstop; leave them on.
+
+**The guard cannot tell one role from another.** `orch guard` has a
+`--role` flag that would make a role mechanically read-only. Neither
+adapter passes it: host hooks are plugin-global rather than scoped per
+dispatched agent, so both `hooks.json` files run the bare command.
+Inside a worktree the guard treats as writable, a scout or a
+reviewer is no more restricted than the implementer. On Claude Code
+the `orch-scout` subagent's tool whitelist does close its write
+surface — it carries no `Bash` — but `orch-reviewer` and
+`orch-reviewer-safe` both carry `Bash`, so their read-only discipline
+rests on their instructions. Codex agent definitions carry no tool
+whitelist at all.
+
+**An `orch run` verb invoked from inside a Delivery worktree reports
+Assist and names the wrong fix.** Every `orch` command resolves
+`.orchestrator/` from its own working directory. A Delivery worktree
+carries the committed `.orchestrator/config.toml` but no
+`state.json` — that file is machine-local and gitignored — so `orch
+status` run there prints `mode: assist` while a run is active, and a
+lifecycle verb fails with ``no delivery run is active; run `orch run
+activate` to enter Delivery first``. Activating a second run is exactly
+the wrong move. Workaround: run every `orch run` verb with the primary
+checkout as the working directory.
+
+**A missing binary fails open, not closed.** Both adapters' hooks are
+bare `orch guard <host>` commands. If `orch` does not resolve on
+`PATH`, the hook exits with a shell "command not found", which both
+hook protocols treat as non-blocking: the guard silently stops
+enforcing and the session-start context stops being injected. No
+error, no denial. On Codex CLI the same is true while the plugin's
+one-time hook trust approval is outstanding — until you approve it,
+the bundled hooks do not run at all. Symptom: no denial where you
+expected one, and no Orch block at session start. Workaround: install
+the binary before the plugin, approve the trust prompt, and run `orch
+doctor`; a missing session-start block is the visible tell.
+
+**Codex `workspace-write` sandbox mode on Windows fails every agent
+write where the sandbox helper infrastructure is absent.** Observed
+live: every `apply_patch` fails with `orchestrator_helper_launch_failed`
+before any mutation, which stops Delivery execution cold. Workaround:
+confirm the sandbox actually works on that machine before setting
+`sandbox_mode = "workspace-write"` there.
+
+**Claude Code has no per-subagent effort parameter.** The routed
+effort reaches a Claude subagent as a cue in its prompt, not as a host
+parameter, so the effort in the audit record is what was routed rather
+than something the host applied. The record says so outright, as
+`Effort delivery: prompt-cue`. Codex pins effort in the installed
+agent TOML and the host enforces it.
+
+**A model override does not reach a dispatched agent by itself, on
+either host.** Neither host can override a model per spawn, so the
+routed selection has to match an installed agent definition. On Codex
+that means the five agent TOMLs are a separate install step the
+marketplace install does not perform — you copy them or run `orch
+render-agents` — and after you change `hosts.codex.roles`, dispatched
+agents keep running the model pinned in the installed TOMLs until you
+re-render. On Claude Code the failure is louder: if the routed model
+matches no installed agent's frontmatter, the spawn stops and the
+Architect tells you, rather than silently running a different model.
+Either way, changing a role's model — which the Settings section below
+recommends as ordinary tuning — is not finished until the installed
+agent definitions carry it too.
+
+**A Codex CLI upgrade that adds a new `apply_patch` directive causes
+denials until `orch` catches up.** The guard's envelope parser treats
+any `*** ` directive line it does not recognize as a malformed
+envelope and denies the write. That is deliberate — an unparsed write
+must never be allowed — but it means a host upgrade can produce
+spurious denials. Workaround: update `orch`.
+
+**The merge gate cannot tell a human's approval from an agent's.** The
+engine requires an approval carrying the exact literal `approve-merge`,
+pinned to the pull request and head commit `merge-report` recorded, and
+`gh pr merge --match-head-commit` refuses if that commit is no longer
+the head — so a stale or swapped merge fails closed. What none of that
+establishes is who produced the approval: the agent assembles that JSON
+itself, and `internal/run/merge.go` says so outright ("the engine
+cannot verify a human, so this recorded string is the proof one
+approved this specific merge"). Symptom: the audit trail's approval is
+the agent's assertion that you approved. Workaround: the merge runs
+through `gh` against GitHub, so GitHub-side branch protection is the
+one control on this path that does not depend on the agent.
+
+**A crashed run leaves the Delivery lock held; there is no automatic
+takeover.** `.orchestrator/delivery.lock` is created with `O_EXCL` and
+Orch never steals it on a staleness guess. Symptom: the next run
+refuses to start, and `orch doctor` notes that the acquiring process
+is no longer running. Workaround: `orch resume` to reconcile and
+continue, or `orch abort` to end it.
+
+</details>
+
+## Fixed
+
+<details>
+<summary>Defects already corrected, newest first</summary>
+
+Everything here is merged on `main`. The top entry landed after v0.5.4
+was tagged, so it ships in the next release rather than the current
+one.
+
+- Both adapters stopped claiming that per-agent tool whitelists make
+  every read-only role unable to write; the shipped prose now matches
+  what the guard actually enforces —
+  [#90](https://github.com/kninetimmy/orch/pull/90)
+- After two or more escalations on one issue, the skills resolve the
+  routing in force from the most recent escalation instead of an
+  unqualified one —
+  [#84](https://github.com/kninetimmy/orch/pull/84)
+- A rerouted issue's agent definition is checked against the model it
+  was rerouted to, not the one it was dispatched with —
+  [#76](https://github.com/kninetimmy/orch/pull/76)
+- A review submitted after an escalation is no longer rejected as a
+  reviewer mismatch: the skills echo the reviewer currently in force —
+  [#71](https://github.com/kninetimmy/orch/pull/71)
+- Claude spawns stopped passing a coarse tier alias as the model,
+  which could never express an exact routed version; a spawn now
+  matches the installed agent's frontmatter or stops —
+  [#70](https://github.com/kninetimmy/orch/pull/70)
+- Claude Code gained an `orch-reviewer-safe` agent, so a routed
+  reviewer downgrade dispatches the reviewer the audit record names —
+  [#66](https://github.com/kninetimmy/orch/pull/66)
+- Verification entries carry the commit they were gathered at, so
+  evidence from an earlier head is distinguishable from evidence at
+  the head that merges —
+  [#62](https://github.com/kninetimmy/orch/pull/62)
+- A review summary gets a 6000-character allowance of its own instead
+  of the 2000 that cut a real reviewer's findings mid-criterion, and
+  evidence re-run on a fix commit can now reach the audit record —
+  [#61](https://github.com/kninetimmy/orch/pull/61)
+- A requested-changes cycle no longer sends the issue back through
+  `pr-open`, and the skills' stdin form works under PowerShell —
+  [#58](https://github.com/kninetimmy/orch/pull/58)
+- A pull request with no required checks reports `no-checks` instead
+  of erroring on an empty response from `gh pr checks --required` —
+  [#44](https://github.com/kninetimmy/orch/pull/44)
+- On Windows, a just-exited process no longer probes as still running,
+  so `orch doctor`'s dead-acquirer note can fire at all —
+  [#7](https://github.com/kninetimmy/orch/pull/7)
+
+</details>
+
 ---
 
 ## Under the hood
@@ -549,10 +555,24 @@ The mode rules are resolved by a closed decision table in
 Assist, a write to any in-repo file git does not ignore is denied;
 git-ignored paths are allowed as local scratch. In Delivery, a write
 is allowed only inside a worktree registered to the active run, in a
-writable phase, with that worktree's HEAD on its registered branch.
-`.orchestrator/` and anything under `.git` are never writable. If the
-guard cannot determine a fact — an unreadable state file, a path it
+writable phase, with that worktree's HEAD on its registered branch. If
+the guard cannot determine a fact — an unreadable state file, a path it
 cannot canonicalize, an ignore probe that fails to run — it denies.
+
+Two things are off limits in either mode, and one that looks like it
+is, is not. Anything under `.git` is denied before the mode is even
+consulted. The orchestrator state a session runs against —
+`state.json` and the lock, in the primary checkout — is never writable
+by an agent either: Assist denies it as orchestrator internals,
+Delivery denies it as lying outside every registered worktree. A
+worktree's own committed `.orchestrator/config.toml` is covered by
+neither rule. Inside a registered worktree it is repository content on
+a branch under review, so an executor can edit it, and that edit
+reaches your configuration the way every other change does — through
+the pull-request diff and the human merge gate. It cannot alter
+enforcement mid-run, because the guard resolves state from the
+outermost `.orchestrator` root, which is the primary checkout and
+never the worktree's copy.
 
 What the table decides is containment. The guard is given the write's
 target paths, not the identity of the agent making the write, so it

--- a/README.md
+++ b/README.md
@@ -26,14 +26,16 @@ one to an exact model version and reasoning-effort level:
 | Implementer | Writes the code inside the issue's worktree |
 | Specialist | Takes the issues routing marks risky or unusually difficult |
 | Reviewer | Reviews the pull request in a separate dispatch from the one that wrote it |
-| Review downgrade | A cheaper reviewer, allowed only when the change is provably low-risk |
+| Review downgrade | A cheaper reviewer, allowed only when the plan affirms the change is mechanical and low-risk |
 
 Which role gets an issue is derived from the issue's own facts by a
 deterministic table, not chosen by the model that will run it. The
-reviewer is always a separate dispatch, never the session that wrote
-the code — but it is not always a different model: with the shipped
-defaults a downgraded review runs the same model as the implementer
-(on Codex, at the same effort too).
+reviewer is always a separate dispatch and never the session that wrote
+the code, but it is often not a different model: the shipped defaults
+put the specialist and the reviewer on one model, and the implementer
+and the downgraded reviewer on another. Any specialist run and any
+downgraded review therefore has the same model on both sides — on
+Codex, at the same effort as well.
 
 **The guard.** None of the above is an instruction the agent is asked
 to honor. Both host adapters wire the CLI's pre-write hook to `orch
@@ -57,8 +59,9 @@ Concretely, asking for a change goes like this:
 3. Each issue gets a branch and a worktree. An implementer or a
    specialist does the work there and pushes.
 4. A reviewer reviews the pull request. CI runs.
-5. You merge on GitHub. Orch pins the head commit you approved and
-   refuses if the pull request moved after you approved it.
+5. You approve the merge, and it runs against GitHub pinned to the
+   commit that approval names — it fails closed if the pull request
+   moved after that.
 
 The full product definition lives in [ORCH-PRD.md](ORCH-PRD.md).
 
@@ -69,14 +72,21 @@ through v0.5.4) and 65 merged pull requests, 28 of which carry an Orch
 audit record in their body — every merge from PR #40 through PR #97
 except #50, which `orch configure` delivered in its own format. Since
 PR #40, this repository has been built through the pipeline described
-above: a plan gate, an isolated worktree per issue, a review by a
-model that did not write the code, CI, and a merge no agent can
-perform.
+above: a plan gate, an isolated worktree per issue, a review dispatched
+separately from the work, CI, and a merge that fails closed unless it
+carries an approval pinned to the commit `merge-report` recorded.
+
+In 12 of those 28 the reviewer ran the same model as the executor — 6
+specialist runs and 6 downgraded reviews, both of which the shipped
+defaults put on one model. The reviewer's independence is a separate
+dispatch against the pull request, not a different model.
 
 All of that evidence comes from one repository: this one.
 
+## Known issues and limitations
+
 <details>
-<summary><b>Known issues and limitations</b> — what will bite you today</summary>
+<summary>What will bite you today — symptom, cause, workaround</summary>
 
 **Writes made through the shell are not guarded.** The pre-write hook
 covers Claude Code's `Write`, `Edit`, `MultiEdit` and `NotebookEdit`
@@ -137,13 +147,19 @@ than something the host applied. The record says so outright, as
 `Effort delivery: prompt-cue`. Codex pins effort in the installed
 agent TOML and the host enforces it.
 
-**On Codex, agent definitions are a separate install step and a
-configuration change does not reach them by itself.** Codex plugins
-cannot bundle agent TOMLs, so the marketplace install does not put
-them in place — you copy them or run `orch render-agents`. If you
-later change `hosts.codex.roles`, dispatched agents keep running the
-model pinned in the installed TOMLs until you re-run `orch
-render-agents`.
+**A model override does not reach a dispatched agent by itself, on
+either host.** Neither host can override a model per spawn, so the
+routed selection has to match an installed agent definition. On Codex
+that means the five agent TOMLs are a separate install step the
+marketplace install does not perform — you copy them or run `orch
+render-agents` — and after you change `hosts.codex.roles`, dispatched
+agents keep running the model pinned in the installed TOMLs until you
+re-render. On Claude Code the failure is louder: if the routed model
+matches no installed agent's frontmatter, the spawn stops and the
+Architect tells you, rather than silently running a different model.
+Either way, changing a role's model — which the Settings section below
+recommends as ordinary tuning — is not finished until the installed
+agent definitions carry it too.
 
 **A Codex CLI upgrade that adds a new `apply_patch` directive causes
 denials until `orch` catches up.** The guard's envelope parser treats
@@ -151,6 +167,19 @@ any `*** ` directive line it does not recognize as a malformed
 envelope and denies the write. That is deliberate — an unparsed write
 must never be allowed — but it means a host upgrade can produce
 spurious denials. Workaround: update `orch`.
+
+**The merge gate cannot tell a human's approval from an agent's.** The
+engine requires an approval carrying the exact literal `approve-merge`,
+pinned to the pull request and head commit `merge-report` recorded, and
+`gh pr merge --match-head-commit` refuses if that commit is no longer
+the head — so a stale or swapped merge fails closed. What none of that
+establishes is who produced the approval: the agent assembles that JSON
+itself, and `internal/run/merge.go` says so outright ("the engine
+cannot verify a human, so this recorded string is the proof one
+approved this specific merge"). Symptom: the audit trail's approval is
+the agent's assertion that you approved. Workaround: the merge runs
+through `gh` against GitHub, so GitHub-side branch protection is the
+one control on this path that does not depend on the agent.
 
 **A crashed run leaves the Delivery lock held; there is no automatic
 takeover.** `.orchestrator/delivery.lock` is created with `O_EXCL` and
@@ -161,8 +190,10 @@ continue, or `orch abort` to end it.
 
 </details>
 
+## Fixed
+
 <details>
-<summary><b>Fixed</b> — defects already corrected, newest first</summary>
+<summary>Defects already corrected, newest first</summary>
 
 Everything here is merged on `main`. The top entry landed after v0.5.4
 was tagged, so it ships in the next release rather than the current
@@ -279,11 +310,17 @@ on this machine. Work in a scratch directory, not in one of my projects.
       not report the install as finished as though the hooks were live.
 
 5. Run `orch doctor` and report its full output to me, including every
-   note and every failing check. Run outside an initialized repository it
-   reports the git-repository and configuration checks as failures; say so
-   rather than hiding it.
+   note and every failing check. When run outside an initialized
+   repository it reports the git-repository and configuration checks as
+   failures; say so rather than hiding it.
 
-6. Finish by telling me all three of these: `orch init` has to be run once
+6. Tell me to restart this CLI once you are done. A plugin installed
+   during a running session does not load its hooks into that session,
+   so the guard and the session-start context are not live until I start
+   a new one. After I restart, the tell that it worked is an Orch block
+   at session start inside an initialized repository.
+
+7. Finish by telling me all three of these: `orch init` has to be run once
    inside every repository I want orchestrated; Orch does nothing at all
    in a repository that has not been initialized; and `orch init` does not
    write the configuration into my working tree — it opens a pull request
@@ -442,8 +479,9 @@ local override can never weaken a shared workflow rule.
 
 Every enabled host carries the same six roles: `architect`, `scout`,
 `implementer`, `specialist`, `reviewer`, and `review_downgrade` (the
-cheaper reviewer Orch may use only when routing proves the change is
-mechanical, low-risk, fully specified and unsurprising). Each role
+cheaper reviewer Orch may use only when the plan affirms all four of
+mechanical, low-risk, fully specified and unsurprising — claims routing
+takes at face value rather than checks). Each role
 names one model string; the interview offers exact versions rather
 than tier aliases, and whatever string is configured is the one that
 lands in the audit record, so the record says what ran instead of what


### PR DESCRIPTION
Delivers issue #98: Rewrite README.md: plain-language opening, agent-first install, and honest known-issues and fixed sections

Closes #98

**Plan digest:** `sha256:65a33c1fb0cca56834deb3ded8a359ca1e3828895c3a9190946772492cb7570f`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Rewrite README.md end to end so a newcomer understands what Orch is within the first screen, can install it by pasting one prompt into their agent, and can see honestly what works and what does not.

This is a wholesale rewrite of a 437-line document, not a set of edits. Nothing in the Go test suite pins README.md - verified by grep over every *_test.go in the tree - so `go test ./...` passing is not evidence that any criterion below is met. Every factual claim in the new document must be checked against the committed tree, the orch binary's own output, or the GitHub API, and anything that cannot be checked must be cut rather than carried forward on trust. This repository's recurring defect is prose that reads correctly and is false; that is the thing to guard against here.

Voice matters as much as structure. Write it the way a competent engineer explains their own tool to a colleague: direct, concrete, no marketing register, no throat-clearing, and no sentence that exists only to introduce the next one. Do not pad a section to make it look complete - say the thing and stop. The reader is assumed to be a developer who has never seen this project, not a beginner who needs hand-holding.

Source material for the two new sections is in the repository and on GitHub: adapters/claude/README.md and adapters/codex/README.md each carry a Known limitations section, ORCH-PRD.md is the product definition, and `gh pr list --state merged` plus `gh release list` are the record of what has shipped.

**Acceptance criteria:**
- The document opens with a plain-language explanation of what Orch is and what it does for the reader, placed before any install, configuration, or status content. It introduces the terms it relies on (Assist, Delivery, the roles, the guard) rather than assuming them, and it does not open with the ORCH-PRD.md link or with a status caveat.
- The Install section's first subsection is a single fenced copy-paste prompt intended to be pasted into a Claude Code or Codex CLI session. The prompt is self-contained: nothing in it assumes the session's working directory is a clone of this repository, and it is correct when pasted into a session started in an arbitrary directory.
- That prompt instructs the agent to: detect the OS and fetch the matching installer (install.sh or install.ps1) from https://raw.githubusercontent.com/kninetimmy/orch/main; stop and report rather than continue if the installer's SHA-256 verification of the downloaded binary fails, and never install an unverified binary; confirm that orch resolves on PATH and that `orch status` prints a release version on its first line, asking the human rather than guessing when a Windows PATH change needs a new terminal; install the host's plugin using the exact marketplace commands for that host; run `orch doctor` and report its output; and finish by telling the human that `orch init` must be run once inside every repository they want orchestrated, that Orch does nothing in a repository that has not been initialized, and that `orch init` delivers the configuration as a pull request for the human to review and merge.
- The prompt's Codex-only branch instructs the agent to clone the repository into a temporary directory outside the user's projects, copy the five agent TOMLs (orch-scout.toml, orch-implementer.toml, orch-specialist.toml, orch-reviewer.toml, orch-reviewer-safe.toml) into .codex/agents/, delete the clone afterwards, add both request_user_input stanzas to the user's Codex config, and state that approving the plugin's one-time hook trust prompt is an action only the human can take and that the hooks do not run until they do. The Claude-only path performs no clone.
- The do-it-yourself install path - the quick-install script commands for both platforms, the per-host plugin commands, the manual download with its SHA-256 verification step, and build-from-source - is preserved in full inside a single collapsed &lt;details&gt; block that is the last subsection of Install. The per-repository `orch init` step appears before that block, not inside it.
- A collapsed &lt;details&gt; section lists the known issues and limitations that affect someone using Orch today, each stating the user-visible symptom and, where one exists, the workaround. It includes at minimum: file writes made through the shell bypass the guard on both hosts; an `orch run` verb invoked with the working directory inside a Delivery worktree reports Assist and names the wrong remedy; a missing orch binary - and, on Codex, plugin hooks whose one-time trust approval is still outstanding - fail open silently rather than blocking; and Codex workspace-write sandbox mode on Windows fails every agent write when the sandbox helper infrastructure is absent. It contains no test-infrastructure or editorial backlog entries.
- A second collapsed &lt;details&gt; section lists shipped fixes, newest first, each a single line describing what a user would have noticed and linking its merged pull request. Every pull-request number in that list is confirmed with `gh pr view &lt;n&gt;` to be merged and to match the description given; any number that does not confirm is removed rather than adjusted to fit.
- The status statement is current: it no longer presents PR #40 as the most recent evidence that the pipeline works, and instead states the project's actual track record using numbers confirmed with `gh pr list --state merged` and `gh release list`.
- No material present in the current README is lost. The enforcement, Delivery-pipeline, routing-and-escalation, package-layout, design-principles and build/test content; the two-configuration-file explanation, the settings table, and the six roles with their shipped model defaults; the memhub section; and the day-to-day command list all appear in the new document with their substance intact or improved.
- Every command, path, file name and flag the document shows is verified to exist as written, including the nine human commands `orch help` lists, both hosts' plugin install commands, the installer options ORCH_INSTALL_DIR, ORCH_VERSION, -NoPathUpdate and -Version, and the two request_user_input stanzas. Anything that cannot be verified against the tree or against a command's own output is removed rather than carried over.
- Every &lt;details&gt; block has a &lt;summary&gt;, and a blank line separates each &lt;summary&gt; from the markdown that follows it, so collapsed content renders as markdown rather than as raw text on GitHub.
- The document contains none of the words seamless, seamlessly, robust, powerful, leverage, delve, elevate, unlock or cutting-edge, and no sentence of the form 'not just X, but Y'. Confirm with a case-insensitive grep over the finished file and report the command and its output.

**Required tests:**
- `go test ./...`

| Field | Value |
| --- | --- |
| Role | `specialist` |
| Executor | `claude-opus-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to a specialist with a strong reviewer because the task is unusually difficult.

**Escalations:** _none_

**Verification:**
- **go test** — pass — `go test -count=1 ./...` — commit `9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0` (2026-07-28T17:03:12Z)
- **go vet** — pass — `go vet ./...` — commit `9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0` (2026-07-28T17:03:12Z)
- **gofmt** — pass — `gofmt -l .` — commit `9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0` (2026-07-28T17:03:12Z)
- **go build** — pass — `go build ./...` — commit `9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0` (2026-07-28T17:03:12Z)
- **architect scope check at 460688e** — pass — `git diff --name-status origin/main..HEAD; git diff --numstat origin/main..HEAD; git status --porcelain` — commit `460688ec420f762f93ce2240f681f6c2d55ae2f3` (2026-07-28T15:34:44Z)
- **banned-word grep (acceptance criterion 12)** — pass — `grep -n -i -E "seamless|seamlessly|robust|powerful|leverage|delve|elevate|unlock|cutting-edge" README.md` — commit `460688ec420f762f93ce2240f681f6c2d55ae2f3` (2026-07-28T15:34:44Z)
- **details/summary rendering (acceptance criterion 11)** — pass — `python scan of ^<details> blocks in README.md` — commit `460688ec420f762f93ce2240f681f6c2d55ae2f3` (2026-07-28T15:34:44Z)
- **command-block fidelity (acceptance criterion 10)** — pass — `diff <(orch help | sed -n '/^  init/,/^  render-agents/p') <README command block>` — commit `460688ec420f762f93ce2240f681f6c2d55ae2f3` (2026-07-28T15:34:44Z)
- **material-survival audit (acceptance criterion 9)** — pass — ``python: extract all backticked code spans from `git show HEAD~1:README.md` and search each, whitespace-normalized, in the new file`` — commit `460688ec420f762f93ce2240f681f6c2d55ae2f3` (2026-07-28T15:34:44Z)
- **merged-PR record (acceptance criteria 7 and 8)** — pass — `gh pr view <n> on 13 candidates; gh pr list --state merged --limit 200; gh release list --limit 100` — commit `460688ec420f762f93ce2240f681f6c2d55ae2f3` (2026-07-28T15:34:44Z)
- **stale-claim sweep of the previous README** — pass — `read of internal/interview/sequence.go:80-85, internal/cli/status.go:41, internal/cli/doctor.go:83, internal/config/validate.go:74, internal/routing/task.go, internal/run/derive.go:83` — commit `460688ec420f762f93ce2240f681f6c2d55ae2f3` (2026-07-28T15:34:44Z)
- **reviewer criterion audit** — 10 of 12 met; criterion 8 not met — `claim-by-claim audit of all twelve acceptance criteria against README.md at 460688e` — commit `460688ec420f762f93ce2240f681f6c2d55ae2f3` (2026-07-28T15:51:06Z)
- **reviewer audit-record model comparison** — 12 of 28 same model — `parse canonical JSON audit record from every merged PR body; compare executor.model to reviewer.model` — commit `460688ec420f762f93ce2240f681f6c2d55ae2f3` (2026-07-28T15:51:06Z)
- **reviewer anchor-link check** — 2 hrefs, 0 matching ids — `gh api markdown --method POST --input md2.json; count href="#known-issues-and-limitations" vs id="user-content-known-issues-and-limitations"` — commit `460688ec420f762f93ce2240f681f6c2d55ae2f3` (2026-07-28T15:51:06Z)
- **reviewer merge-mechanism check** — claim falsified — `read internal/run/merge.go:18-22,63-90; internal/ghops/pr.go:155; adapters/claude/skills/orch-delivery/SKILL.md:332` — commit `460688ec420f762f93ce2240f681f6c2d55ae2f3` (2026-07-28T15:51:06Z)
- **reviewer enforcement-claim audit** — pass — `read internal/guard/guard.go evaluate(); both adapters' hooks.json; all five Claude agent frontmatter tools lines; all five Codex agent TOMLs` — commit `460688ec420f762f93ce2240f681f6c2d55ae2f3` (2026-07-28T15:51:06Z)
- **reviewer live behavioral check** — pass — `orch status inside .orchestrator/worktrees/issue-98 during the active run; orch status and orch doctor in an uninitialized directory` — commit `460688ec420f762f93ce2240f681f6c2d55ae2f3` (2026-07-28T15:51:06Z)
- **reviewer scope check at 460688e** — pass — `gh api repos/kninetimmy/orch/pulls/99/commits; gh api repos/kninetimmy/orch/pulls/99/files` — commit `460688ec420f762f93ce2240f681f6c2d55ae2f3` (2026-07-28T15:51:06Z)
- **reviewer manifest accuracy check** — 10 of 11 accurate; 2 defects — `reproduce each of the eleven pr-open verification entries against the tree at 460688e` — commit `460688ec420f762f93ce2240f681f6c2d55ae2f3` (2026-07-28T15:51:06Z)
- **review-cycle-1** — request-changes — commit `460688ec420f762f93ce2240f681f6c2d55ae2f3` (2026-07-28T15:51:07Z)
- **cycle-2 guard execution check** — claim falsified — `go run ./cmd/orch guard check -- <four paths> during an active Delivery run with issue 98 in phase in-review` — commit `e4601a898f16f13c271eeb52bc3d6f349ed31bd8` (2026-07-28T16:17:46Z)
- **cycle-2 audit-record staleness check** — 20 of 20 stale — `parse the orch:manifest:data JSON from the PR #99 body; group verification entries by the commit OID they are stamped at` — commit `e4601a898f16f13c271eeb52bc3d6f349ed31bd8` (2026-07-28T16:17:46Z)
- **cycle-2 criteria audit** — 12 of 12 met — `claim-by-claim audit of all twelve acceptance criteria against README.md at e4601a8` — commit `e4601a898f16f13c271eeb52bc3d6f349ed31bd8` (2026-07-28T16:17:46Z)
- **cycle-2 B1 two-cause verification** — pass — `parse the canonical JSON manifest from all 65 merged PR bodies; group the same-model set by routed role and rationale` — commit `e4601a898f16f13c271eeb52bc3d6f349ed31bd8` (2026-07-28T16:17:46Z)
- **cycle-2 B2 merge-gate entry audit** — pass — `clause-by-clause check of the new known-issues merge entry against internal/run/merge.go, internal/ghops/pr.go, and both hosts' orch-delivery skills` — commit `e4601a898f16f13c271eeb52bc3d6f349ed31bd8` (2026-07-28T16:17:46Z)
- **cycle-2 B3 anchor verification** — pass — `gh api markdown --method POST --input md2.json in mode markdown; enumerate user-content ids and internal hrefs` — commit `e4601a898f16f13c271eeb52bc3d6f349ed31bd8` (2026-07-28T16:17:46Z)
- **cycle-2 word-diff of the fix commit** — pass — `git -C <repo> diff --word-diff --ignore-all-space 460688e e4601a8 -- README.md` — commit `e4601a898f16f13c271eeb52bc3d6f349ed31bd8` (2026-07-28T16:17:46Z)
- **cycle-2 enforcement-claim audit** — pass except BL1 — `read internal/guard/guard.go evaluate() and resolve.go; both hooks.json; all five Claude agent frontmatter tools lines; all five Codex agent TOMLs; internal/routing; internal/memhub; internal/cli/status.go and doctor.go` — commit `e4601a898f16f13c271eeb52bc3d6f349ed31bd8` (2026-07-28T16:17:46Z)
- **architect scope check at e4601a8** — pass — `gh pr view 99 --json headRefOid; git -C <worktree> log --oneline origin/main..HEAD; git -C <worktree> diff --name-status origin/main..HEAD; git -C <worktree> diff --numstat origin/main..HEAD` — commit `e4601a898f16f13c271eeb52bc3d6f349ed31bd8` (2026-07-28T16:17:46Z)
- **merged-PR record** — pass — `gh release list; gh pr list --state merged; fetch every merged PR body in the range and grep for the manifest marker; parse role, executor.model and reviewer.model from all 28 audit records; gh pr view on all 11 linked PRs` — commit `9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0` (2026-07-28T17:03:12Z)
- **command-block fidelity** — pass — `build orch from the branch, run orch help, and compare its nine human commands against the README command block under indent-and-padding normalization` — commit `9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0` (2026-07-28T17:03:12Z)
- **review-cycle-2** — request-changes — commit `e4601a898f16f13c271eeb52bc3d6f349ed31bd8` (2026-07-28T16:17:47Z)
- **cycle-3 guard execution check against the tree binary** — new prose confirmed true — `go build -o <scratch>/orch-tree.exe ./cmd/orch; orch-tree.exe guard check -- <seven paths>` — commit `cefbc1cb16779d23efce43bf19fc32bd27199c2c` (2026-07-28T16:45:48Z)
- **cycle-3 block-move integrity check** — lossless and non-duplicating — `cmp old.md lines 86-242 against new.md lines 387-543; grep -c on six distinct strings from the moved block` — commit `cefbc1cb16779d23efce43bf19fc32bd27199c2c` (2026-07-28T16:45:48Z)
- **cycle-3 directional-reference audit** — 1 defect found — `grep for positional cross-references across README.md at cefbc1c` — commit `cefbc1cb16779d23efce43bf19fc32bd27199c2c` (2026-07-28T16:45:48Z)
- **cycle-3 criteria audit** — 12 of 12 met — `claim-by-claim audit of all twelve acceptance criteria against README.md at cefbc1c` — commit `cefbc1cb16779d23efce43bf19fc32bd27199c2c` (2026-07-28T16:45:48Z)
- **cycle-3 audit-record staleness check** — 0 of 32 at the head — `parse the orch:manifest:data JSON from the PR #99 body; group verification entries by stamped commit` — commit `cefbc1cb16779d23efce43bf19fc32bd27199c2c` (2026-07-28T16:45:48Z)
- **cycle-3 status-numbers re-derivation** — pass — `gh release list; gh pr list --state merged --limit 300; fetch all 65 PR bodies and count real audit records; parse executor and reviewer models from all 28` — commit `cefbc1cb16779d23efce43bf19fc32bd27199c2c` (2026-07-28T16:45:48Z)
- **cycle-3 security review** — pass — `read of the install prompt, the do-it-yourself block, and the enforcement passages at cefbc1c` — commit `cefbc1cb16779d23efce43bf19fc32bd27199c2c` (2026-07-28T16:45:48Z)
- **review-cycle-3** — request-changes — commit `cefbc1cb16779d23efce43bf19fc32bd27199c2c` (2026-07-28T16:45:50Z)
- **architect scope check at 9f09641** — pass — `gh pr view 99 --json headRefOid; git -C <worktree> log --oneline origin/main..HEAD; git -C <worktree> diff --name-status origin/main..HEAD; git -C <worktree> diff --numstat origin/main..HEAD; git -C <worktree> show HEAD:README.md | wc -l` — commit `9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0` (2026-07-28T17:03:12Z)
- **final-commit word-diff** — pass — `git diff --word-diff --ignore-all-space HEAD~1..HEAD -- README.md; and independently git show 9f09641 --word-diff=plain --word-diff-regex='[^[:space:]]+'` — commit `9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0` (2026-07-28T17:03:12Z)
- **directional-reference sweep at 9f09641** — pass — `grep for positional cross-references over the whole document` — commit `9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0` (2026-07-28T17:03:12Z)
- **order-dependent cross-reference check** — pass — `enumerate every named cross-reference in the document and resolve each` — commit `9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0` (2026-07-28T17:03:12Z)
- **structural hygiene at 9f09641** — pass — `count and pair fence lines; check line endings, tabs, trailing whitespace, doubled blank lines, trailing newline; git diff --check` — commit `9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0` (2026-07-28T17:03:12Z)
- **criterion 11 details rendering at 9f09641** — pass — `source scan of <details>/<summary> over git show HEAD:README.md, plus gh api markdown --method POST in mode markdown` — commit `9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0` (2026-07-28T17:03:12Z)
- **criterion 12 banned-word check at 9f09641** — pass — `grep -n -i -E "seamless|seamlessly|robust|powerful|leverage|delve|elevate|unlock|cutting-edge" README.md; and the same over git show HEAD:README.md; plus tr '\n' ' ' | grep -o -i -E "not just [^.]{0,150}, but" over both` — commit `9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0` (2026-07-28T17:03:12Z)
- **anchor render at 9f09641** — pass — `git show HEAD:README.md | gh api markdown --method POST --input - (mode markdown, not gfm)` — commit `9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0` (2026-07-28T17:03:12Z)
- **cycle-4 criteria confirmation** — 12 of 12 met — `claim-by-claim audit of all twelve acceptance criteria against README.md at 9f09641` — commit `9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0` (2026-07-28T17:03:12Z)
- **cycle-4 live behavioral check of the install prompt** — pass — `build the binary from the branch, then run orch status and orch doctor in an empty non-repository directory` — Built from the branch so the check exercised the code under review rather than the installed v0.5.3. orch status printed the version line first, then the not-initialized message, exit 1 - exactly what prompt step 2 promises. orch doctor printed the version note first and reported FAIL on precisely the git repository and configuration checks - exactly what prompt step 5 promises. The prompt's behavioral claims are therefore executed evidence, not documentary. — commit `9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0` (2026-07-28T17:03:12Z)
- **review-cycle-4** — approve — Approved on the fourth cycle. All twelve acceptance criteria met at the merging head, and the reviewer re-derived essentially everything from primary sources rather than inheriting cycles 1-3, stating explicitly which items it re-derived and which it accepted (its answer: it accepted nothing external, and judged criteria 1-6 by reading all 710 lines itself).

The two-word delta is correct and is genuinely two words: git show 9f09641 is one file, +2/-2, two hunks, and a word-diff with an explicit non-whitespace regex shows exactly two changed spans with no other prose touched. Fix 1, README.md:461 below to above, verified positionally - Settings is line 305 and the reference is line 461 inside Known issues at 387. Fix 2, README.md:17, verified against code rather than prose: complete.go is a run-level verb the Architect invokes, refusing unless every issue is PhaseCleaned before calling state.CompleteDelivery, which writes ModeAssist and releases the lock at state/transition.go:144-148. Nothing transitions on a timer or in the background, so 'returns to Assist on its own' was wrong and the replacement is right, and it is consistent with the two other places the document describes the transition (lines 620 and 293) rather than introducing a new contradiction.

The reviewer judged the executor's restraint correct in leaving the understated enforcement sentence alone. It confirmed cycle 3's underlying observation - go list -deps ./internal/guard returns only execx, lockfile, manifest, paths and state, so internal/config appears nowhere directly or transitively and the guard never reads configuration at all - but held that the shipped sentence is true as written and precisely so: it claims the guard resolves STATE from the outermost root, which is exactly what resolve.go:49 does via paths.FindOutermostRoot, and the conclusion it draws is correct with a real cited mechanism. No criterion demands the strongest available justification, only that what is shown be verifiable. It added that rewriting prose three reviewers have accepted at cycle 4 carries real regression risk, and that this PR is its own proof: the cycle-2 block move was byte-identical, passed both a word-multiset check and a cmp, and still broke a positional reference. Recorded as an optional future tightening, explicitly not a finding: the paragraph poses a question about config.toml and answers it with a fact about state resolution, where the tighter answer is that config never reaches the guard at all.

It also checked two structural classes nobody had looked at in four cycles. First, order-dependent cross-references WITHOUT directional words - the other way the block move could have broken something; only four named cross-references exist in the document (lines 53, 461, 583, 710) and all resolve. Second, structural hygiene: 18 fence lines forming 9 balanced pairs with no stray or indented triple-backticks (an unbalanced fence would have swallowed the rest of the document), LF throughout, no CRLF, no tabs, no trailing whitespace, no doubled blank lines, trailing newline present, git diff --check clean. It independently confirmed the standing caveat too - no Go file pins the root README.md, every apparent hit being either a comment about an adapter README or a throwaway fixture in a temp dir - so the green suite really is no evidence for any criterion.

Two non-blocking observations, neither actionable. The commit message for 9f09641 labels line 600's 'described above' temporal when it is positional; the document is correct and only the parenthetical in the message is off. And the Status numbers drift inherently - once this merges, 65 becomes 66 - but every number is exactly right at this head, criterion 8 asks only that they be confirmed against gh pr list and gh release list, and removing them would violate the criterion.

Security: the prompt fetches installers over HTTPS from raw.githubusercontent.com, mandates SHA-256 verification, and forbids retrying with verification skipped or installing an unverified binary. The do-it-yourself block uses download-then-inspect-then-run rather than pipe-to-shell. No secrets, no weakened boundary. — commit `9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0` (2026-07-28T17:03:13Z)
- **required-ci** — passing — scripts (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, test (windows-latest)=pass, test (ubuntu-latest)=pass — commit `9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0` (2026-07-28T17:03:29Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Rewrite README.md end to end so a newcomer understands what Orch is within the first screen, can install it by pasting one prompt into their agent, and can see honestly what works and what does not.\n\nThis is a wholesale rewrite of a 437-line document, not a set of edits. Nothing in the Go test suite pins README.md - verified by grep over every *_test.go in the tree - so `go test ./...` passing is not evidence that any criterion below is met. Every factual claim in the new document must be checked against the committed tree, the orch binary's own output, or the GitHub API, and anything that cannot be checked must be cut rather than carried forward on trust. This repository's recurring defect is prose that reads correctly and is false; that is the thing to guard against here.\n\nVoice matters as much as structure. Write it the way a competent engineer explains their own tool to a colleague: direct, concrete, no marketing register, no throat-clearing, and no sentence that exists only to introduce the next one. Do not pad a section to make it look complete - say the thing and stop. The reader is assumed to be a developer who has never seen this project, not a beginner who needs hand-holding.\n\nSource material for the two new sections is in the repository and on GitHub: adapters/claude/README.md and adapters/codex/README.md each carry a Known limitations section, ORCH-PRD.md is the product definition, and `gh pr list --state merged` plus `gh release list` are the record of what has shipped.",
  "acceptance_criteria": [
    "The document opens with a plain-language explanation of what Orch is and what it does for the reader, placed before any install, configuration, or status content. It introduces the terms it relies on (Assist, Delivery, the roles, the guard) rather than assuming them, and it does not open with the ORCH-PRD.md link or with a status caveat.",
    "The Install section's first subsection is a single fenced copy-paste prompt intended to be pasted into a Claude Code or Codex CLI session. The prompt is self-contained: nothing in it assumes the session's working directory is a clone of this repository, and it is correct when pasted into a session started in an arbitrary directory.",
    "That prompt instructs the agent to: detect the OS and fetch the matching installer (install.sh or install.ps1) from https://raw.githubusercontent.com/kninetimmy/orch/main; stop and report rather than continue if the installer's SHA-256 verification of the downloaded binary fails, and never install an unverified binary; confirm that orch resolves on PATH and that `orch status` prints a release version on its first line, asking the human rather than guessing when a Windows PATH change needs a new terminal; install the host's plugin using the exact marketplace commands for that host; run `orch doctor` and report its output; and finish by telling the human that `orch init` must be run once inside every repository they want orchestrated, that Orch does nothing in a repository that has not been initialized, and that `orch init` delivers the configuration as a pull request for the human to review and merge.",
    "The prompt's Codex-only branch instructs the agent to clone the repository into a temporary directory outside the user's projects, copy the five agent TOMLs (orch-scout.toml, orch-implementer.toml, orch-specialist.toml, orch-reviewer.toml, orch-reviewer-safe.toml) into .codex/agents/, delete the clone afterwards, add both request_user_input stanzas to the user's Codex config, and state that approving the plugin's one-time hook trust prompt is an action only the human can take and that the hooks do not run until they do. The Claude-only path performs no clone.",
    "The do-it-yourself install path - the quick-install script commands for both platforms, the per-host plugin commands, the manual download with its SHA-256 verification step, and build-from-source - is preserved in full inside a single collapsed \u003cdetails\u003e block that is the last subsection of Install. The per-repository `orch init` step appears before that block, not inside it.",
    "A collapsed \u003cdetails\u003e section lists the known issues and limitations that affect someone using Orch today, each stating the user-visible symptom and, where one exists, the workaround. It includes at minimum: file writes made through the shell bypass the guard on both hosts; an `orch run` verb invoked with the working directory inside a Delivery worktree reports Assist and names the wrong remedy; a missing orch binary - and, on Codex, plugin hooks whose one-time trust approval is still outstanding - fail open silently rather than blocking; and Codex workspace-write sandbox mode on Windows fails every agent write when the sandbox helper infrastructure is absent. It contains no test-infrastructure or editorial backlog entries.",
    "A second collapsed \u003cdetails\u003e section lists shipped fixes, newest first, each a single line describing what a user would have noticed and linking its merged pull request. Every pull-request number in that list is confirmed with `gh pr view \u003cn\u003e` to be merged and to match the description given; any number that does not confirm is removed rather than adjusted to fit.",
    "The status statement is current: it no longer presents PR #40 as the most recent evidence that the pipeline works, and instead states the project's actual track record using numbers confirmed with `gh pr list --state merged` and `gh release list`.",
    "No material present in the current README is lost. The enforcement, Delivery-pipeline, routing-and-escalation, package-layout, design-principles and build/test content; the two-configuration-file explanation, the settings table, and the six roles with their shipped model defaults; the memhub section; and the day-to-day command list all appear in the new document with their substance intact or improved.",
    "Every command, path, file name and flag the document shows is verified to exist as written, including the nine human commands `orch help` lists, both hosts' plugin install commands, the installer options ORCH_INSTALL_DIR, ORCH_VERSION, -NoPathUpdate and -Version, and the two request_user_input stanzas. Anything that cannot be verified against the tree or against a command's own output is removed rather than carried over.",
    "Every \u003cdetails\u003e block has a \u003csummary\u003e, and a blank line separates each \u003csummary\u003e from the markdown that follows it, so collapsed content renders as markdown rather than as raw text on GitHub.",
    "The document contains none of the words seamless, seamlessly, robust, powerful, leverage, delve, elevate, unlock or cutting-edge, and no sentence of the form 'not just X, but Y'. Confirm with a case-insensitive grep over the finished file and report the command and its output."
  ],
  "required_tests": [
    "go test ./..."
  ],
  "role": "specialist",
  "executor": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to a specialist with a strong reviewer because the task is unusually difficult.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "go test",
      "command": "go test -count=1 ./...",
      "result": "pass",
      "commit_oid": "9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0",
      "at": "2026-07-28T17:03:12Z"
    },
    {
      "name": "go vet",
      "command": "go vet ./...",
      "result": "pass",
      "commit_oid": "9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0",
      "at": "2026-07-28T17:03:12Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "commit_oid": "9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0",
      "at": "2026-07-28T17:03:12Z"
    },
    {
      "name": "go build",
      "command": "go build ./...",
      "result": "pass",
      "commit_oid": "9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0",
      "at": "2026-07-28T17:03:12Z"
    },
    {
      "name": "architect scope check at 460688e",
      "command": "git diff --name-status origin/main..HEAD; git diff --numstat origin/main..HEAD; git status --porcelain",
      "result": "pass",
      "commit_oid": "460688ec420f762f93ce2240f681f6c2d55ae2f3",
      "at": "2026-07-28T15:34:44Z"
    },
    {
      "name": "banned-word grep (acceptance criterion 12)",
      "command": "grep -n -i -E \"seamless|seamlessly|robust|powerful|leverage|delve|elevate|unlock|cutting-edge\" README.md",
      "result": "pass",
      "commit_oid": "460688ec420f762f93ce2240f681f6c2d55ae2f3",
      "at": "2026-07-28T15:34:44Z"
    },
    {
      "name": "details/summary rendering (acceptance criterion 11)",
      "command": "python scan of ^\u003cdetails\u003e blocks in README.md",
      "result": "pass",
      "commit_oid": "460688ec420f762f93ce2240f681f6c2d55ae2f3",
      "at": "2026-07-28T15:34:44Z"
    },
    {
      "name": "command-block fidelity (acceptance criterion 10)",
      "command": "diff \u003c(orch help | sed -n '/^  init/,/^  render-agents/p') \u003cREADME command block\u003e",
      "result": "pass",
      "commit_oid": "460688ec420f762f93ce2240f681f6c2d55ae2f3",
      "at": "2026-07-28T15:34:44Z"
    },
    {
      "name": "material-survival audit (acceptance criterion 9)",
      "command": "python: extract all backticked code spans from `git show HEAD~1:README.md` and search each, whitespace-normalized, in the new file",
      "result": "pass",
      "commit_oid": "460688ec420f762f93ce2240f681f6c2d55ae2f3",
      "at": "2026-07-28T15:34:44Z"
    },
    {
      "name": "merged-PR record (acceptance criteria 7 and 8)",
      "command": "gh pr view \u003cn\u003e on 13 candidates; gh pr list --state merged --limit 200; gh release list --limit 100",
      "result": "pass",
      "commit_oid": "460688ec420f762f93ce2240f681f6c2d55ae2f3",
      "at": "2026-07-28T15:34:44Z"
    },
    {
      "name": "stale-claim sweep of the previous README",
      "command": "read of internal/interview/sequence.go:80-85, internal/cli/status.go:41, internal/cli/doctor.go:83, internal/config/validate.go:74, internal/routing/task.go, internal/run/derive.go:83",
      "result": "pass",
      "commit_oid": "460688ec420f762f93ce2240f681f6c2d55ae2f3",
      "at": "2026-07-28T15:34:44Z"
    },
    {
      "name": "reviewer criterion audit",
      "command": "claim-by-claim audit of all twelve acceptance criteria against README.md at 460688e",
      "result": "10 of 12 met; criterion 8 not met",
      "commit_oid": "460688ec420f762f93ce2240f681f6c2d55ae2f3",
      "at": "2026-07-28T15:51:06Z"
    },
    {
      "name": "reviewer audit-record model comparison",
      "command": "parse canonical JSON audit record from every merged PR body; compare executor.model to reviewer.model",
      "result": "12 of 28 same model",
      "commit_oid": "460688ec420f762f93ce2240f681f6c2d55ae2f3",
      "at": "2026-07-28T15:51:06Z"
    },
    {
      "name": "reviewer anchor-link check",
      "command": "gh api markdown --method POST --input md2.json; count href=\"#known-issues-and-limitations\" vs id=\"user-content-known-issues-and-limitations\"",
      "result": "2 hrefs, 0 matching ids",
      "commit_oid": "460688ec420f762f93ce2240f681f6c2d55ae2f3",
      "at": "2026-07-28T15:51:06Z"
    },
    {
      "name": "reviewer merge-mechanism check",
      "command": "read internal/run/merge.go:18-22,63-90; internal/ghops/pr.go:155; adapters/claude/skills/orch-delivery/SKILL.md:332",
      "result": "claim falsified",
      "commit_oid": "460688ec420f762f93ce2240f681f6c2d55ae2f3",
      "at": "2026-07-28T15:51:06Z"
    },
    {
      "name": "reviewer enforcement-claim audit",
      "command": "read internal/guard/guard.go evaluate(); both adapters' hooks.json; all five Claude agent frontmatter tools lines; all five Codex agent TOMLs",
      "result": "pass",
      "commit_oid": "460688ec420f762f93ce2240f681f6c2d55ae2f3",
      "at": "2026-07-28T15:51:06Z"
    },
    {
      "name": "reviewer live behavioral check",
      "command": "orch status inside .orchestrator/worktrees/issue-98 during the active run; orch status and orch doctor in an uninitialized directory",
      "result": "pass",
      "commit_oid": "460688ec420f762f93ce2240f681f6c2d55ae2f3",
      "at": "2026-07-28T15:51:06Z"
    },
    {
      "name": "reviewer scope check at 460688e",
      "command": "gh api repos/kninetimmy/orch/pulls/99/commits; gh api repos/kninetimmy/orch/pulls/99/files",
      "result": "pass",
      "commit_oid": "460688ec420f762f93ce2240f681f6c2d55ae2f3",
      "at": "2026-07-28T15:51:06Z"
    },
    {
      "name": "reviewer manifest accuracy check",
      "command": "reproduce each of the eleven pr-open verification entries against the tree at 460688e",
      "result": "10 of 11 accurate; 2 defects",
      "commit_oid": "460688ec420f762f93ce2240f681f6c2d55ae2f3",
      "at": "2026-07-28T15:51:06Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "commit_oid": "460688ec420f762f93ce2240f681f6c2d55ae2f3",
      "at": "2026-07-28T15:51:07Z"
    },
    {
      "name": "cycle-2 guard execution check",
      "command": "go run ./cmd/orch guard check -- \u003cfour paths\u003e during an active Delivery run with issue 98 in phase in-review",
      "result": "claim falsified",
      "commit_oid": "e4601a898f16f13c271eeb52bc3d6f349ed31bd8",
      "at": "2026-07-28T16:17:46Z"
    },
    {
      "name": "cycle-2 audit-record staleness check",
      "command": "parse the orch:manifest:data JSON from the PR #99 body; group verification entries by the commit OID they are stamped at",
      "result": "20 of 20 stale",
      "commit_oid": "e4601a898f16f13c271eeb52bc3d6f349ed31bd8",
      "at": "2026-07-28T16:17:46Z"
    },
    {
      "name": "cycle-2 criteria audit",
      "command": "claim-by-claim audit of all twelve acceptance criteria against README.md at e4601a8",
      "result": "12 of 12 met",
      "commit_oid": "e4601a898f16f13c271eeb52bc3d6f349ed31bd8",
      "at": "2026-07-28T16:17:46Z"
    },
    {
      "name": "cycle-2 B1 two-cause verification",
      "command": "parse the canonical JSON manifest from all 65 merged PR bodies; group the same-model set by routed role and rationale",
      "result": "pass",
      "commit_oid": "e4601a898f16f13c271eeb52bc3d6f349ed31bd8",
      "at": "2026-07-28T16:17:46Z"
    },
    {
      "name": "cycle-2 B2 merge-gate entry audit",
      "command": "clause-by-clause check of the new known-issues merge entry against internal/run/merge.go, internal/ghops/pr.go, and both hosts' orch-delivery skills",
      "result": "pass",
      "commit_oid": "e4601a898f16f13c271eeb52bc3d6f349ed31bd8",
      "at": "2026-07-28T16:17:46Z"
    },
    {
      "name": "cycle-2 B3 anchor verification",
      "command": "gh api markdown --method POST --input md2.json in mode markdown; enumerate user-content ids and internal hrefs",
      "result": "pass",
      "commit_oid": "e4601a898f16f13c271eeb52bc3d6f349ed31bd8",
      "at": "2026-07-28T16:17:46Z"
    },
    {
      "name": "cycle-2 word-diff of the fix commit",
      "command": "git -C \u003crepo\u003e diff --word-diff --ignore-all-space 460688e e4601a8 -- README.md",
      "result": "pass",
      "commit_oid": "e4601a898f16f13c271eeb52bc3d6f349ed31bd8",
      "at": "2026-07-28T16:17:46Z"
    },
    {
      "name": "cycle-2 enforcement-claim audit",
      "command": "read internal/guard/guard.go evaluate() and resolve.go; both hooks.json; all five Claude agent frontmatter tools lines; all five Codex agent TOMLs; internal/routing; internal/memhub; internal/cli/status.go and doctor.go",
      "result": "pass except BL1",
      "commit_oid": "e4601a898f16f13c271eeb52bc3d6f349ed31bd8",
      "at": "2026-07-28T16:17:46Z"
    },
    {
      "name": "architect scope check at e4601a8",
      "command": "gh pr view 99 --json headRefOid; git -C \u003cworktree\u003e log --oneline origin/main..HEAD; git -C \u003cworktree\u003e diff --name-status origin/main..HEAD; git -C \u003cworktree\u003e diff --numstat origin/main..HEAD",
      "result": "pass",
      "commit_oid": "e4601a898f16f13c271eeb52bc3d6f349ed31bd8",
      "at": "2026-07-28T16:17:46Z"
    },
    {
      "name": "merged-PR record",
      "command": "gh release list; gh pr list --state merged; fetch every merged PR body in the range and grep for the manifest marker; parse role, executor.model and reviewer.model from all 28 audit records; gh pr view on all 11 linked PRs",
      "result": "pass",
      "commit_oid": "9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0",
      "at": "2026-07-28T17:03:12Z"
    },
    {
      "name": "command-block fidelity",
      "command": "build orch from the branch, run orch help, and compare its nine human commands against the README command block under indent-and-padding normalization",
      "result": "pass",
      "commit_oid": "9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0",
      "at": "2026-07-28T17:03:12Z"
    },
    {
      "name": "review-cycle-2",
      "result": "request-changes",
      "commit_oid": "e4601a898f16f13c271eeb52bc3d6f349ed31bd8",
      "at": "2026-07-28T16:17:47Z"
    },
    {
      "name": "cycle-3 guard execution check against the tree binary",
      "command": "go build -o \u003cscratch\u003e/orch-tree.exe ./cmd/orch; orch-tree.exe guard check -- \u003cseven paths\u003e",
      "result": "new prose confirmed true",
      "commit_oid": "cefbc1cb16779d23efce43bf19fc32bd27199c2c",
      "at": "2026-07-28T16:45:48Z"
    },
    {
      "name": "cycle-3 block-move integrity check",
      "command": "cmp old.md lines 86-242 against new.md lines 387-543; grep -c on six distinct strings from the moved block",
      "result": "lossless and non-duplicating",
      "commit_oid": "cefbc1cb16779d23efce43bf19fc32bd27199c2c",
      "at": "2026-07-28T16:45:48Z"
    },
    {
      "name": "cycle-3 directional-reference audit",
      "command": "grep for positional cross-references across README.md at cefbc1c",
      "result": "1 defect found",
      "commit_oid": "cefbc1cb16779d23efce43bf19fc32bd27199c2c",
      "at": "2026-07-28T16:45:48Z"
    },
    {
      "name": "cycle-3 criteria audit",
      "command": "claim-by-claim audit of all twelve acceptance criteria against README.md at cefbc1c",
      "result": "12 of 12 met",
      "commit_oid": "cefbc1cb16779d23efce43bf19fc32bd27199c2c",
      "at": "2026-07-28T16:45:48Z"
    },
    {
      "name": "cycle-3 audit-record staleness check",
      "command": "parse the orch:manifest:data JSON from the PR #99 body; group verification entries by stamped commit",
      "result": "0 of 32 at the head",
      "commit_oid": "cefbc1cb16779d23efce43bf19fc32bd27199c2c",
      "at": "2026-07-28T16:45:48Z"
    },
    {
      "name": "cycle-3 status-numbers re-derivation",
      "command": "gh release list; gh pr list --state merged --limit 300; fetch all 65 PR bodies and count real audit records; parse executor and reviewer models from all 28",
      "result": "pass",
      "commit_oid": "cefbc1cb16779d23efce43bf19fc32bd27199c2c",
      "at": "2026-07-28T16:45:48Z"
    },
    {
      "name": "cycle-3 security review",
      "command": "read of the install prompt, the do-it-yourself block, and the enforcement passages at cefbc1c",
      "result": "pass",
      "commit_oid": "cefbc1cb16779d23efce43bf19fc32bd27199c2c",
      "at": "2026-07-28T16:45:48Z"
    },
    {
      "name": "review-cycle-3",
      "result": "request-changes",
      "commit_oid": "cefbc1cb16779d23efce43bf19fc32bd27199c2c",
      "at": "2026-07-28T16:45:50Z"
    },
    {
      "name": "architect scope check at 9f09641",
      "command": "gh pr view 99 --json headRefOid; git -C \u003cworktree\u003e log --oneline origin/main..HEAD; git -C \u003cworktree\u003e diff --name-status origin/main..HEAD; git -C \u003cworktree\u003e diff --numstat origin/main..HEAD; git -C \u003cworktree\u003e show HEAD:README.md | wc -l",
      "result": "pass",
      "commit_oid": "9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0",
      "at": "2026-07-28T17:03:12Z"
    },
    {
      "name": "final-commit word-diff",
      "command": "git diff --word-diff --ignore-all-space HEAD~1..HEAD -- README.md; and independently git show 9f09641 --word-diff=plain --word-diff-regex='[^[:space:]]+'",
      "result": "pass",
      "commit_oid": "9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0",
      "at": "2026-07-28T17:03:12Z"
    },
    {
      "name": "directional-reference sweep at 9f09641",
      "command": "grep for positional cross-references over the whole document",
      "result": "pass",
      "commit_oid": "9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0",
      "at": "2026-07-28T17:03:12Z"
    },
    {
      "name": "order-dependent cross-reference check",
      "command": "enumerate every named cross-reference in the document and resolve each",
      "result": "pass",
      "commit_oid": "9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0",
      "at": "2026-07-28T17:03:12Z"
    },
    {
      "name": "structural hygiene at 9f09641",
      "command": "count and pair fence lines; check line endings, tabs, trailing whitespace, doubled blank lines, trailing newline; git diff --check",
      "result": "pass",
      "commit_oid": "9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0",
      "at": "2026-07-28T17:03:12Z"
    },
    {
      "name": "criterion 11 details rendering at 9f09641",
      "command": "source scan of \u003cdetails\u003e/\u003csummary\u003e over git show HEAD:README.md, plus gh api markdown --method POST in mode markdown",
      "result": "pass",
      "commit_oid": "9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0",
      "at": "2026-07-28T17:03:12Z"
    },
    {
      "name": "criterion 12 banned-word check at 9f09641",
      "command": "grep -n -i -E \"seamless|seamlessly|robust|powerful|leverage|delve|elevate|unlock|cutting-edge\" README.md; and the same over git show HEAD:README.md; plus tr '\\n' ' ' | grep -o -i -E \"not just [^.]{0,150}, but\" over both",
      "result": "pass",
      "commit_oid": "9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0",
      "at": "2026-07-28T17:03:12Z"
    },
    {
      "name": "anchor render at 9f09641",
      "command": "git show HEAD:README.md | gh api markdown --method POST --input - (mode markdown, not gfm)",
      "result": "pass",
      "commit_oid": "9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0",
      "at": "2026-07-28T17:03:12Z"
    },
    {
      "name": "cycle-4 criteria confirmation",
      "command": "claim-by-claim audit of all twelve acceptance criteria against README.md at 9f09641",
      "result": "12 of 12 met",
      "commit_oid": "9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0",
      "at": "2026-07-28T17:03:12Z"
    },
    {
      "name": "cycle-4 live behavioral check of the install prompt",
      "command": "build the binary from the branch, then run orch status and orch doctor in an empty non-repository directory",
      "result": "pass",
      "detail": "Built from the branch so the check exercised the code under review rather than the installed v0.5.3. orch status printed the version line first, then the not-initialized message, exit 1 - exactly what prompt step 2 promises. orch doctor printed the version note first and reported FAIL on precisely the git repository and configuration checks - exactly what prompt step 5 promises. The prompt's behavioral claims are therefore executed evidence, not documentary.",
      "commit_oid": "9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0",
      "at": "2026-07-28T17:03:12Z"
    },
    {
      "name": "review-cycle-4",
      "result": "approve",
      "detail": "Approved on the fourth cycle. All twelve acceptance criteria met at the merging head, and the reviewer re-derived essentially everything from primary sources rather than inheriting cycles 1-3, stating explicitly which items it re-derived and which it accepted (its answer: it accepted nothing external, and judged criteria 1-6 by reading all 710 lines itself).\n\nThe two-word delta is correct and is genuinely two words: git show 9f09641 is one file, +2/-2, two hunks, and a word-diff with an explicit non-whitespace regex shows exactly two changed spans with no other prose touched. Fix 1, README.md:461 below to above, verified positionally - Settings is line 305 and the reference is line 461 inside Known issues at 387. Fix 2, README.md:17, verified against code rather than prose: complete.go is a run-level verb the Architect invokes, refusing unless every issue is PhaseCleaned before calling state.CompleteDelivery, which writes ModeAssist and releases the lock at state/transition.go:144-148. Nothing transitions on a timer or in the background, so 'returns to Assist on its own' was wrong and the replacement is right, and it is consistent with the two other places the document describes the transition (lines 620 and 293) rather than introducing a new contradiction.\n\nThe reviewer judged the executor's restraint correct in leaving the understated enforcement sentence alone. It confirmed cycle 3's underlying observation - go list -deps ./internal/guard returns only execx, lockfile, manifest, paths and state, so internal/config appears nowhere directly or transitively and the guard never reads configuration at all - but held that the shipped sentence is true as written and precisely so: it claims the guard resolves STATE from the outermost root, which is exactly what resolve.go:49 does via paths.FindOutermostRoot, and the conclusion it draws is correct with a real cited mechanism. No criterion demands the strongest available justification, only that what is shown be verifiable. It added that rewriting prose three reviewers have accepted at cycle 4 carries real regression risk, and that this PR is its own proof: the cycle-2 block move was byte-identical, passed both a word-multiset check and a cmp, and still broke a positional reference. Recorded as an optional future tightening, explicitly not a finding: the paragraph poses a question about config.toml and answers it with a fact about state resolution, where the tighter answer is that config never reaches the guard at all.\n\nIt also checked two structural classes nobody had looked at in four cycles. First, order-dependent cross-references WITHOUT directional words - the other way the block move could have broken something; only four named cross-references exist in the document (lines 53, 461, 583, 710) and all resolve. Second, structural hygiene: 18 fence lines forming 9 balanced pairs with no stray or indented triple-backticks (an unbalanced fence would have swallowed the rest of the document), LF throughout, no CRLF, no tabs, no trailing whitespace, no doubled blank lines, trailing newline present, git diff --check clean. It independently confirmed the standing caveat too - no Go file pins the root README.md, every apparent hit being either a comment about an adapter README or a throwaway fixture in a temp dir - so the green suite really is no evidence for any criterion.\n\nTwo non-blocking observations, neither actionable. The commit message for 9f09641 labels line 600's 'described above' temporal when it is positional; the document is correct and only the parenthetical in the message is off. And the Status numbers drift inherently - once this merges, 65 becomes 66 - but every number is exactly right at this head, criterion 8 asks only that they be confirmed against gh pr list and gh release list, and removing them would violate the criterion.\n\nSecurity: the prompt fetches installers over HTTPS from raw.githubusercontent.com, mandates SHA-256 verification, and forbids retrying with verification skipped or installing an unverified binary. The do-it-yourself block uses download-then-inspect-then-run rather than pipe-to-shell. No secrets, no weakened boundary.",
      "commit_oid": "9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0",
      "at": "2026-07-28T17:03:13Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "scripts (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, test (windows-latest)=pass, test (ubuntu-latest)=pass",
      "commit_oid": "9f0964137a0f4e85f99d89a3fa1bd5c69a06e7b0",
      "at": "2026-07-28T17:03:29Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->