### PR TITLE
Record executor and reviewer cost separately per review cycle

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "kninetimmy" },
   "metadata": {
     "description": "Host adapters for the Orch development orchestrator",
-    "version": "0.5.4"
+    "version": "0.5.5"
   },
   "plugins": [
     {

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Claude Code host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -78,8 +78,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.4" {
-		t.Errorf("version = %q, want 0.5.4", m.Version)
+	if m.Version != "0.5.5" {
+		t.Errorf("version = %q, want 0.5.5", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -231,16 +231,18 @@ in flight at once. For each issue:
    {"schema_version": 1, "issue_number": N,
     "verifications": [{"name": "...", "command": "...", "result": "...", "detail": "..."}],
     "usage": {"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0,
-               "cache_creation_tokens": 0, "duration_ms": 0}}
+               "cache_creation_tokens": 0, "total_tokens": 0, "duration_ms": 0}}
    ```
 
    At least one verification is required. The verification names
    `required-ci`, `merge`, `abandoned`, and `review-cycle-<n>` are
    engine-owned and are rejected with `ErrBadRequest` before any
    mutation when supplied by a caller. `usage` is optional (PRD
-   §21): supply only the fields the executor's Task result actually
-   reports (token totals and duration), never an estimate. Result
-   carries `pr_number`, `pr_url`.
+   §21) and is the executor's own cost: supply only the fields the
+   executor's Task result actually reports — token totals, duration,
+   and `total_tokens` when that is what it reports instead of the
+   input/output/cache split — never an estimate. Result carries
+   `pr_number`, `pr_url`.
 
 4. **Spawn the reviewer** — once the PR stops changing, spawn the
    reviewer **fresh** (a new instance, not the executor continuing):
@@ -289,14 +291,23 @@ in flight at once. For each issue:
     "reviewer": {"model": "...", "effort": "..."},
     "verifications": [{"name": "...", "command": "...", "result": "...", "detail": "..."}],
     "usage": {"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0,
-               "cache_creation_tokens": 0, "duration_ms": 0}}
+               "cache_creation_tokens": 0, "total_tokens": 0, "duration_ms": 0},
+    "executor_usage": {"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0,
+               "cache_creation_tokens": 0, "total_tokens": 0, "duration_ms": 0}}
    ```
 
-   `usage` is optional (PRD §21), same rule as PR-open: only report
-   what the reviewer subagent's Task result actually carries.
+   `usage` is optional (PRD §21), same rule as PR-open: it is the
+   reviewer's own cost — only report what the reviewer subagent's
+   Task result actually carries, including `total_tokens` when that
+   is what it reports instead of the input/output/cache split.
    `request-changes` loops the same executor in the **same worktree**
    on the same branch: it fixes and pushes, then a **fresh** reviewer
-   is spawned (step 4) and `orch run review` is called again.
+   is spawned (step 4) and `orch run review` is called again. Because
+   this is the only verb call on that cycle, `executor_usage` (same
+   optional shape as `usage`) carries the executor's fix-and-push
+   cost for the cycle just finished — report only what its Task
+   result actually gives you, never an estimate, and omit it when
+   there was no fix cycle (the first review after pr-open).
    `orch run pr-open` is not reachable a second time, so `verifications`
    is optional and takes pr-open's input shape — use it to carry
    evidence re-run on the fix commit (e.g. tests re-run before

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Codex CLI host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -79,8 +79,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.4" {
-		t.Errorf("version = %q, want 0.5.4", m.Version)
+	if m.Version != "0.5.5" {
+		t.Errorf("version = %q, want 0.5.5", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -233,15 +233,18 @@ in flight at once. For each issue:
    {"schema_version": 1, "issue_number": N,
     "verifications": [{"name": "...", "command": "...", "result": "...", "detail": "..."}],
     "usage": {"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0,
-               "cache_creation_tokens": 0, "duration_ms": 0}}
+               "cache_creation_tokens": 0, "total_tokens": 0, "duration_ms": 0}}
    ```
 
    At least one verification is required. The verification names
    `required-ci`, `merge`, `abandoned`, and `review-cycle-<n>` are
    engine-owned and are rejected with `ErrBadRequest` before any
    mutation when supplied by a caller. `usage` is optional (PRD
-   §21): supply only the fields the executor's own reporting actually
-   gives you, never an estimate. Result carries `pr_number`, `pr_url`.
+   §21) and is the executor's own cost: supply only the fields the
+   executor's own reporting actually gives you — token totals,
+   duration, and `total_tokens` when that is what it reports instead
+   of the input/output/cache split — never an estimate. Result
+   carries `pr_number`, `pr_url`.
 
 4. **Dispatch the reviewer** — once the PR stops changing, dispatch
    `orch-reviewer` **fresh** (a new instance, not the executor
@@ -276,14 +279,23 @@ in flight at once. For each issue:
     "reviewer": {"model": "...", "effort": "..."},
     "verifications": [{"name": "...", "command": "...", "result": "...", "detail": "..."}],
     "usage": {"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0,
-               "cache_creation_tokens": 0, "duration_ms": 0}}
+               "cache_creation_tokens": 0, "total_tokens": 0, "duration_ms": 0},
+    "executor_usage": {"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0,
+               "cache_creation_tokens": 0, "total_tokens": 0, "duration_ms": 0}}
    ```
 
-   `usage` is optional (PRD §21), same rule as PR-open: only report
-   what the reviewer agent's own reporting actually gives you.
+   `usage` is optional (PRD §21), same rule as PR-open: it is the
+   reviewer's own cost — only report what the reviewer agent's own
+   reporting actually gives you, including `total_tokens` when that
+   is what it reports instead of the input/output/cache split.
    `request-changes` loops the same executor in the **same worktree**
    on the same branch: it fixes and pushes, then a **fresh** reviewer
    is dispatched (step 4) and `orch run review` is called again.
+   Because this is the only verb call on that cycle, `executor_usage`
+   (same optional shape as `usage`) carries the executor's
+   fix-and-push cost for the cycle just finished — report only what
+   its own reporting actually gives you, never an estimate, and omit
+   it when there was no fix cycle (the first review after pr-open).
    `orch run pr-open` is not reachable a second time, so
    `verifications` is optional and takes pr-open's input shape — use
    it to carry evidence re-run on the fix commit (e.g. tests re-run

--- a/internal/cli/metrics.go
+++ b/internal/cli/metrics.go
@@ -84,6 +84,54 @@ type runSummary struct {
 	// counts how many of eventCount did.
 	usage       metrics.Usage
 	usageEvents int
+
+	// usageDetail is one row per event that carries a usage payload, in
+	// document order — the per-event, role- and cycle-attributed detail
+	// that the run-level usage totals above erase. A summed total hides
+	// exactly the signal this exists to show: a per-dispatch or
+	// per-cycle cost that rises while the work it is buying shrinks.
+	usageDetail []usageEventRow
+}
+
+// usageEventRow is one printable per-event usage line: which event
+// (its 1-based position in the document) carried the usage, whose
+// cost it is (role, when attributable), and — for a review event —
+// which review cycle it belongs to.
+type usageEventRow struct {
+	index       int
+	verb        string
+	issueNumber int
+	role        string
+	reviewCycle int // 0 when the event is not a review-verb event
+	usage       metrics.Usage
+}
+
+// eventRole reports the role display label for ev's usage: its own
+// Role field when set (dispatch, activate, pr-open, and a review
+// event's executor fix-cycle sibling all carry one — PRD §21's
+// attribution), and otherwise "reviewer" for a plain review event's
+// own usage — the only other usage-carrying verb, whose cost is
+// unambiguously the reviewer's by construction (including on documents
+// recorded before this field existed on pr-open, which still report
+// "" rather than a guess).
+func eventRole(ev metrics.Event) string {
+	if ev.Role != "" {
+		return ev.Role
+	}
+	if ev.Verb == "review" {
+		return "reviewer"
+	}
+	return ""
+}
+
+// eventReviewCycle reports ev.ReviewCycles for a review-verb event
+// (both the verdict-bearing event and its executor-usage sibling carry
+// the same cycle number) and 0 for every other verb.
+func eventReviewCycle(ev metrics.Event) int {
+	if ev.Verb != "review" {
+		return 0
+	}
+	return ev.ReviewCycles
 }
 
 // summarizeRun computes runSummary from doc in one pass, trusting the
@@ -107,7 +155,7 @@ func summarizeRun(doc metrics.Document) runSummary {
 	firstReviewVerdict := map[int]string{}
 	ciLastState := map[int]string{}
 
-	for _, ev := range doc.Events {
+	for i, ev := range doc.Events {
 		if ev.IssueNumber != 0 {
 			issuesSeen[ev.IssueNumber] = true
 		}
@@ -122,9 +170,17 @@ func summarizeRun(doc metrics.Document) runSummary {
 		case "escalate":
 			s.escalations++
 		case "review":
-			s.reviewCycles++
-			if _, ok := firstReviewVerdict[ev.IssueNumber]; !ok {
-				firstReviewVerdict[ev.IssueNumber] = ev.Verdict
+			// A review-verb event with no verdict is the executor's
+			// fix-cycle usage sibling (PRD §21's executor_usage), not a
+			// reviewed cycle: only the verdict-bearing event counts
+			// toward cycles and first-pass approval, so the sibling
+			// never double-counts a cycle it merely shares a number
+			// with.
+			if ev.Verdict != "" {
+				s.reviewCycles++
+				if _, ok := firstReviewVerdict[ev.IssueNumber]; !ok {
+					firstReviewVerdict[ev.IssueNumber] = ev.Verdict
+				}
 			}
 		case "ci":
 			ciLastState[ev.IssueNumber] = ev.CIState
@@ -135,7 +191,16 @@ func summarizeRun(doc metrics.Document) runSummary {
 			s.usage.OutputTokens += ev.Usage.OutputTokens
 			s.usage.CacheReadTokens += ev.Usage.CacheReadTokens
 			s.usage.CacheCreationTokens += ev.Usage.CacheCreationTokens
+			s.usage.TotalTokens += ev.Usage.TotalTokens
 			s.usage.DurationMS += ev.Usage.DurationMS
+			s.usageDetail = append(s.usageDetail, usageEventRow{
+				index:       i + 1,
+				verb:        ev.Verb,
+				issueNumber: ev.IssueNumber,
+				role:        eventRole(ev),
+				reviewCycle: eventReviewCycle(ev),
+				usage:       *ev.Usage,
+			})
 		}
 	}
 
@@ -192,5 +257,30 @@ func printRunSummary(w io.Writer, s runSummary) {
 		fmt.Fprintf(w, "usage:       input %d, output %d, cache read %d, cache creation %d, duration %dms\n",
 			s.usage.InputTokens, s.usage.OutputTokens, s.usage.CacheReadTokens, s.usage.CacheCreationTokens, s.usage.DurationMS)
 		fmt.Fprintf(w, "             usage reported on %d of %d events\n", s.usageEvents, s.eventCount)
+		printUsageDetail(w, s.usageDetail)
+	}
+}
+
+// printUsageDetail writes one line per event that carried usage, in
+// document order, attributed by role and — for a review event — by
+// review cycle: the per-dispatch/per-cycle detail a run-level total
+// erases. The role column reads "unattributed" only for a usage-
+// carrying event recorded before this build started attributing it
+// (an old pr-open event, for instance) — never a guess at whose cost
+// it was.
+func printUsageDetail(w io.Writer, rows []usageEventRow) {
+	fmt.Fprintln(w, "usage by event:")
+	for _, u := range rows {
+		role := u.role
+		if role == "" {
+			role = "unattributed"
+		}
+		cycle := ""
+		if u.reviewCycle > 0 {
+			cycle = fmt.Sprintf(" cycle %d", u.reviewCycle)
+		}
+		fmt.Fprintf(w, "  %3d. %-9s issue #%-5d role %-13s%-9s input %d, output %d, cache read %d, cache creation %d, total %d, duration %dms\n",
+			u.index, u.verb, u.issueNumber, role, cycle,
+			u.usage.InputTokens, u.usage.OutputTokens, u.usage.CacheReadTokens, u.usage.CacheCreationTokens, u.usage.TotalTokens, u.usage.DurationMS)
 	}
 }

--- a/internal/cli/metrics_test.go
+++ b/internal/cli/metrics_test.go
@@ -105,6 +105,80 @@ func TestMetricsSummarizesFixtureRun(t *testing.T) {
 	}
 }
 
+// TestMetricsReportsPerEventUsageAttributedByRoleAndCycle pins item 5's
+// rework: per-event usage detail attributed by role, and by review
+// cycle for review events, alongside the run-level totals. It also
+// pins the reviewCycles fix that goes with it: a review-verb event
+// with no Verdict (the executor's fix-cycle usage sibling, item 3)
+// shares its ReviewCycles number with the reviewer's own event rather
+// than counting as an additional cycle.
+func TestMetricsReportsPerEventUsageAttributedByRoleAndCycle(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+
+	prOpenUsage := &metrics.Usage{InputTokens: 10, OutputTokens: 5}
+	reviewerUsage := &metrics.Usage{InputTokens: 80, OutputTokens: 30}
+	executorUsage := &metrics.Usage{InputTokens: 300, OutputTokens: 120, TotalTokens: 420}
+	doc := metrics.Document{
+		SchemaVersion: metrics.SchemaVersion,
+		RunID:         "run-20260713T000000Z-cccccccc",
+		Events: []metrics.Event{
+			{At: "t0", Verb: "dispatch", IssueNumber: 1, Role: "implementer"},
+			{At: "t1", Verb: "pr-open", IssueNumber: 1, Role: "implementer", Usage: prOpenUsage},
+			{At: "t2", Verb: "review", IssueNumber: 1, Verdict: "request-changes", ReviewCycles: 1, Usage: reviewerUsage},
+			{At: "t3", Verb: "review", IssueNumber: 1, ReviewCycles: 1, Role: "implementer", Usage: executorUsage},
+			{At: "t4", Verb: "review", IssueNumber: 1, Verdict: "approve", ReviewCycles: 2, Usage: reviewerUsage},
+		},
+	}
+	writeMetricsFixture(t, env.RepoRoot, doc.RunID, doc)
+
+	if code := Run([]string{"metrics"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"reviews:     2 cycles; first-pass approve: 0 of 1 reviewed issues",
+		"usage by event:",
+		"role implementer",
+		"role reviewer",
+		"cycle 1",
+		"cycle 2",
+		"total 420",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	// dispatch never carries usage, so it must not appear in the
+	// per-event usage detail (only pr-open and review do).
+	if strings.Contains(out, "1. dispatch") {
+		t.Errorf("usage detail lists a dispatch event, which never carries usage:\n%s", out)
+	}
+}
+
+// TestMetricsUsageDetailUnattributedWhenRoleMissing pins the fallback
+// for a usage-carrying event recorded before this build started
+// attributing pr-open by role: it prints plainly as unattributed
+// rather than guessing.
+func TestMetricsUsageDetailUnattributedWhenRoleMissing(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	doc := metrics.Document{
+		SchemaVersion: metrics.SchemaVersion,
+		RunID:         "run-20260713T000000Z-eeeeeeee",
+		Events: []metrics.Event{
+			{At: "t0", Verb: "pr-open", IssueNumber: 1, Usage: &metrics.Usage{InputTokens: 5}},
+		},
+	}
+	writeMetricsFixture(t, env.RepoRoot, doc.RunID, doc)
+	if code := Run([]string{"metrics"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "role unattributed") {
+		t.Errorf("output missing the unattributed fallback for a Role-less pr-open event:\n%s", stdout.String())
+	}
+}
+
 func TestMetricsOmitsUsageLinesWhenNoEventCarriesUsage(t *testing.T) {
 	env, stdout, _ := testEnv(t)
 	writeConfig(t, env.RepoRoot, validTOML)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -59,7 +59,12 @@ type Usage struct {
 	OutputTokens        int64 `json:"output_tokens,omitempty"`
 	CacheReadTokens     int64 `json:"cache_read_tokens,omitempty"`
 	CacheCreationTokens int64 `json:"cache_creation_tokens,omitempty"`
-	DurationMS          int64 `json:"duration_ms,omitempty"`
+	// TotalTokens is for a host that reports one aggregate token count
+	// with no input/output/cache split; it is independent of the four
+	// fields above; a caller reporting both is not reconciled against
+	// each other by this package.
+	TotalTokens int64 `json:"total_tokens,omitempty"`
+	DurationMS  int64 `json:"duration_ms,omitempty"`
 }
 
 // Validate reports the first negative field in u. A nil u is valid —
@@ -78,6 +83,8 @@ func (u *Usage) Validate() error {
 		return fmt.Errorf("usage.cache_read_tokens is negative (%d)", u.CacheReadTokens)
 	case u.CacheCreationTokens < 0:
 		return fmt.Errorf("usage.cache_creation_tokens is negative (%d)", u.CacheCreationTokens)
+	case u.TotalTokens < 0:
+		return fmt.Errorf("usage.total_tokens is negative (%d)", u.TotalTokens)
 	case u.DurationMS < 0:
 		return fmt.Errorf("usage.duration_ms is negative (%d)", u.DurationMS)
 	default:

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -35,6 +35,7 @@ func TestAppendThenLoadAllRoundTrip(t *testing.T) {
 	root := t.TempDir()
 	executor := manifest.Selection{Model: "claude-sonnet-5", Effort: "xhigh"}
 	reviewer := manifest.Selection{Model: "claude-opus-4-8", Effort: "high"}
+	usage := Usage{InputTokens: 10, TotalTokens: 42}
 	ev := Event{
 		At:                 "2026-07-13T00:00:00Z",
 		Verb:               "dispatch",
@@ -44,6 +45,7 @@ func TestAppendThenLoadAllRoundTrip(t *testing.T) {
 		Reviewer:           &reviewer,
 		ReviewerDowngraded: false,
 		Rationale:          "impl",
+		Usage:              &usage,
 	}
 	if err := Append(root, "run-1", ev); err != nil {
 		t.Fatalf("Append: %v", err)
@@ -72,6 +74,9 @@ func TestAppendThenLoadAllRoundTrip(t *testing.T) {
 	}
 	if got.Reviewer == nil || *got.Reviewer != *ev.Reviewer {
 		t.Errorf("reviewer = %+v, want %+v", got.Reviewer, ev.Reviewer)
+	}
+	if got.Usage == nil || *got.Usage != *ev.Usage {
+		t.Errorf("usage = %+v, want %+v", got.Usage, ev.Usage)
 	}
 }
 
@@ -146,6 +151,13 @@ func TestAppendFailClosed(t *testing.T) {
 			ev:      Event{At: "t", Verb: "pr-open", Usage: &Usage{InputTokens: -1}},
 			wantMsg: "input_tokens",
 		},
+		{
+			name:    "negative total tokens",
+			setup:   func(t *testing.T, root string) {},
+			runID:   "run-1",
+			ev:      Event{At: "t", Verb: "pr-open", Usage: &Usage{TotalTokens: -1}},
+			wantMsg: "total_tokens",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -201,6 +213,7 @@ func TestUsageValidate(t *testing.T) {
 		{OutputTokens: -1},
 		{CacheReadTokens: -1},
 		{CacheCreationTokens: -1},
+		{TotalTokens: -1},
 		{DurationMS: -1},
 	}
 	for _, u := range cases {

--- a/internal/run/metrics_test.go
+++ b/internal/run/metrics_test.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/kninetimmy/orch/internal/execx"
 	"github.com/kninetimmy/orch/internal/execx/execxtest"
+	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/paths"
 	"github.com/kninetimmy/orch/internal/state"
@@ -70,6 +72,21 @@ func newActivateRepoWithConfig(t *testing.T, tomlContent string) string {
 	return root
 }
 
+// newLifecycleRepoWithConfig mirrors lifecycle_test.go's newLifecycleRepo
+// but writes tomlContent instead of the fixed testConfigTOML, so a
+// metrics test can enable metrics on disk while still driving PROpen's
+// real git preconditions (a pushed origin, a worktree with a commit
+// ahead of it).
+func newLifecycleRepoWithConfig(t *testing.T, tomlContent string) string {
+	t.Helper()
+	root := newActivateRepoWithConfig(t, tomlContent)
+	origin := filepath.Join(t.TempDir(), "origin.git")
+	rawGit(t, filepath.Dir(origin), "init", "--bare", origin)
+	rawGit(t, root, "remote", "add", "origin", origin)
+	rawGit(t, root, "push", "origin", "main")
+	return root
+}
+
 func loadMetricsDocs(t *testing.T, root string) []metrics.Document {
 	t.Helper()
 	docs, err := metrics.LoadAll(root)
@@ -96,6 +113,17 @@ func reviewApproveJSON(usage string) string {
 		extra = `,"usage":` + usage
 	}
 	return `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"}` + extra + `}`
+}
+
+// reviewApproveJSONWithExecutorUsage extends reviewApproveJSON's request
+// with an executor_usage field, for the tests pinning the executor
+// fix-cycle event Review records as its own metrics event.
+func reviewApproveJSONWithExecutorUsage(usage, executorUsage string) string {
+	extra := ""
+	if usage != "" {
+		extra = `,"usage":` + usage
+	}
+	return `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"}` + extra + `,"executor_usage":` + executorUsage + `}`
 }
 
 // TestReviewRecordsMetricWhenEnabled pins internal/run/metrics.go's
@@ -146,6 +174,51 @@ func TestReviewRecordsMetricWhenEnabled(t *testing.T) {
 	}
 }
 
+// TestReviewRecordsExecutorUsageAsDistinctEvent pins the wiring the
+// spec adds to Review: a request carrying executor_usage records it as
+// its own metrics event, separate from the review event carrying the
+// reviewer's own usage, both sharing the same review cycle number, with
+// Role on the new event set to the issue's executor role so the two
+// are distinguishable — and the new event carries no Verdict, so a
+// report counting review cycles by Verdict never double-counts it.
+func TestReviewRecordsExecutorUsageAsDistinctEvent(t *testing.T) {
+	root := setupDeliveryRepoWithConfig(t, metricsEnabledConfigTOML, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
+	body := baseManifestBody(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-1"),
+		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghSetPRBodyCall(10),
+	}}
+	reviewerUsage := `{"input_tokens":100,"output_tokens":50}`
+	executorUsage := `{"input_tokens":300,"output_tokens":120,"total_tokens":420}`
+	req := reviewApproveJSONWithExecutorUsage(reviewerUsage, executorUsage)
+	_, err := Review(context.Background(), ghEnv(root, script), []byte(req))
+	if err != nil {
+		t.Fatalf("Review: %v", err)
+	}
+	script.AssertExhausted()
+
+	docs := loadMetricsDocs(t, root)
+	if len(docs) != 1 || len(docs[0].Events) != 2 {
+		t.Fatalf("docs = %+v, want 1 doc with 2 events", docs)
+	}
+	reviewEv, executorEv := docs[0].Events[0], docs[0].Events[1]
+	if reviewEv.Verb != "review" || reviewEv.Verdict != "approve" || reviewEv.Usage == nil || reviewEv.Usage.InputTokens != 100 {
+		t.Errorf("review event = %+v, want the reviewer's usage and a verdict", reviewEv)
+	}
+	if executorEv.Verb != "review" || executorEv.Verdict != "" {
+		t.Errorf("executor event = %+v, want verb review and no verdict", executorEv)
+	}
+	if executorEv.Role != "implementer" {
+		t.Errorf("executor event role = %q, want the issue's executor role", executorEv.Role)
+	}
+	if executorEv.Usage == nil || executorEv.Usage.InputTokens != 300 || executorEv.Usage.TotalTokens != 420 {
+		t.Errorf("executor event usage = %+v, want the request's executor_usage", executorEv.Usage)
+	}
+	if executorEv.ReviewCycles != reviewEv.ReviewCycles {
+		t.Errorf("executor event cycle = %d, want the review event's cycle %d", executorEv.ReviewCycles, reviewEv.ReviewCycles)
+	}
+}
+
 // TestReviewMetricsDisabledCreatesNoStorage pins PRD §23: the same
 // successful verb call against the ordinary (metrics-disabled)
 // testConfigTOML never creates .orchestrator/metrics at all.
@@ -184,6 +257,26 @@ func TestReviewNegativeUsageIsBadRequestBeforeMutation(t *testing.T) {
 	assertNoMetricsDir(t, root)
 }
 
+// TestReviewNegativeExecutorUsageIsBadRequestBeforeMutation is the
+// executor_usage half of the same wire validation: a negative value
+// there is rejected as ErrBadRequest before any mutation, exactly as
+// the existing usage field is.
+func TestReviewNegativeExecutorUsageIsBadRequestBeforeMutation(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
+	before := stateBytes(t, root)
+	script := &execxtest.Script{T: t}
+	req := reviewApproveJSONWithExecutorUsage("", `{"input_tokens":-1}`)
+	_, err := Review(context.Background(), ghEnv(root, script), []byte(req))
+	if !errors.Is(err, ErrBadRequest) {
+		t.Fatalf("err = %v, want ErrBadRequest", err)
+	}
+	script.AssertExhausted()
+	if got := stateBytes(t, root); string(got) != string(before) {
+		t.Error("state changed on a negative-executor_usage review request")
+	}
+	assertNoMetricsDir(t, root)
+}
+
 // TestPROpenNegativeUsageIsBadRequestBeforeMutation is the pr-open
 // half of the same wire validation.
 func TestPROpenNegativeUsageIsBadRequestBeforeMutation(t *testing.T) {
@@ -200,6 +293,63 @@ func TestPROpenNegativeUsageIsBadRequestBeforeMutation(t *testing.T) {
 		t.Error("state changed on a negative-usage pr-open request")
 	}
 	assertNoMetricsDir(t, root)
+}
+
+// TestPROpenRecordsExecutorRoleWhenEnabled pins the spec's item 4: the
+// pr-open metrics event's Role is set to the issue's executor role, so
+// its usage is attributable rather than, as before, unattributed. It
+// drives a real activate/dispatch/pr-open sequence (PROpen's git
+// preconditions need a real sandbox, unlike Review's).
+func TestPROpenRecordsExecutorRoleWhenEnabled(t *testing.T) {
+	root := newLifecycleRepoWithConfig(t, metricsEnabledConfigTOML)
+	body := baseManifestBody(t)
+	const branch = "orch/issue-1-fix-the-status-lock-race"
+	const title = "Fix the status lock race"
+
+	activateCalls := append(fullTaxonomyScript(), ghIssueCreateCall(title, []string{"ready", "bug", "implementer", "standard"}, 1))
+	script := &execxtest.Script{T: t, Calls: activateCalls}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+	if _, err := Activate(context.Background(), env, activationJSON(t, validPlanJSON())); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	script.AssertExhausted()
+
+	runVerb(t, root, Dispatch, `{"schema_version":2,"issue_number":1}`,
+		ghAuth(), ghRepoViewCall("main"), ghSetStatusCall(1, ghops.StatusInProgress))
+
+	wtDir := filepath.Join(root, ".orchestrator", "worktrees", "issue-1")
+	if err := os.WriteFile(filepath.Join(wtDir, "feature.go"), []byte("package feature\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rawGit(t, wtDir, "add", "-A")
+	rawGit(t, wtDir, "commit", "-m", "work")
+
+	usageJSON := `{"input_tokens":10,"output_tokens":5}`
+	req := fmt.Sprintf(`{"schema_version":1,"issue_number":1,"verifications":[{"name":"go test","result":"pass"}],"usage":%s}`, usageJSON)
+	runVerb(t, root, PROpen, req,
+		ghAuth(), ghRepoViewCall("main"), ghPRListEmptyCall(branch),
+		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1),
+		ghCreatePRCall(branch, title, 10), ghSetStatusCall(1, ghops.StatusAwaitingReview))
+
+	docs := loadMetricsDocs(t, root)
+	if len(docs) != 1 {
+		t.Fatalf("docs = %+v, want 1", docs)
+	}
+	var prOpenEv *metrics.Event
+	for i := range docs[0].Events {
+		if docs[0].Events[i].Verb == "pr-open" {
+			prOpenEv = &docs[0].Events[i]
+		}
+	}
+	if prOpenEv == nil {
+		t.Fatalf("events = %+v, want a pr-open event", docs[0].Events)
+	}
+	if prOpenEv.Role != "implementer" {
+		t.Errorf("pr-open event role = %q, want the issue's executor role %q", prOpenEv.Role, "implementer")
+	}
+	if prOpenEv.Usage == nil || prOpenEv.Usage.InputTokens != 10 {
+		t.Errorf("pr-open event usage = %+v, want the request's usage", prOpenEv.Usage)
+	}
 }
 
 // TestActivateRecordsOneMetricPerIssueWhenEnabled pins activate.go's

--- a/internal/run/propen.go
+++ b/internal/run/propen.go
@@ -179,6 +179,7 @@ func PROpen(ctx context.Context, env Env, reqJSON []byte) (*PROpenResult, error)
 	if err := c.recordMetric(metrics.Event{
 		Verb:        "pr-open",
 		IssueNumber: issue.Number,
+		Role:        string(issue.Decision.Role),
 		Usage:       req.Usage,
 	}); err != nil {
 		return nil, err

--- a/internal/run/review.go
+++ b/internal/run/review.go
@@ -43,8 +43,16 @@ type ReviewRequest struct {
 	// overwritten or duplicated.
 	Verifications []VerificationInput `json:"verifications,omitempty"`
 	// Usage is adapter-reported model usage for this review cycle
-	// (PRD §21 "where available"); optional and best-effort.
+	// (PRD §21 "where available"); optional and best-effort. This is
+	// the reviewer's own usage — the cost of producing this review.
 	Usage *metrics.Usage `json:"usage,omitempty"`
+	// ExecutorUsage is adapter-reported model usage for the executor's
+	// fix-and-push work on this cycle (PRD §21 "where available");
+	// optional and best-effort. A request-changes verdict loops the
+	// same executor in the same worktree to fix and push, and this
+	// verb is the only call that happens on each such cycle — without
+	// this field the executor's fix-cycle cost has nowhere to go.
+	ExecutorUsage *metrics.Usage `json:"executor_usage,omitempty"`
 }
 
 // ReviewResult reports the recorded review cycle.
@@ -81,6 +89,9 @@ func Review(ctx context.Context, env Env, reqJSON []byte) (*ReviewResult, error)
 		return nil, fmt.Errorf("%w: review summary must not be empty (PRD §12.11: one consolidated report per cycle)", ErrBadRequest)
 	}
 	if err := req.Usage.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrBadRequest, err)
+	}
+	if err := req.ExecutorUsage.Validate(); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrBadRequest, err)
 	}
 	verifications, err := convertVerifications(req.Verifications, env.nowStamp())
@@ -164,6 +175,23 @@ func Review(ctx context.Context, env Env, reqJSON []byte) (*ReviewResult, error)
 		Usage:        req.Usage,
 	}); err != nil {
 		return nil, err
+	}
+	// The executor's fix-cycle usage, when supplied, is recorded as its
+	// own event rather than folded into the reviewer's event above: the
+	// two carry different roles' cost, and Role is what keeps them
+	// distinguishable after the fact (this event carries no Verdict, so
+	// it is never mistaken for a review decision when a report counts
+	// review cycles).
+	if req.ExecutorUsage != nil {
+		if err := c.recordMetric(metrics.Event{
+			Verb:         "review",
+			IssueNumber:  issue.Number,
+			ReviewCycles: issue.ReviewCycles,
+			Role:         string(issue.Decision.Role),
+			Usage:        req.ExecutorUsage,
+		}); err != nil {
+			return nil, err
+		}
 	}
 
 	return &ReviewResult{


### PR DESCRIPTION
Delivers issue #100: Record executor and reviewer cost separately per review cycle

Closes #100

**Plan digest:** `sha256:85555ab90811ad4c351ca6ffd61af9d05f932c52f662ba9560fa8d5ef0afce04`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Close the two gaps that make Delivery cost unrecordable, and make the recorded data legible.

1. Add an optional TotalTokens field to metrics.Usage (json tag total_tokens, omitempty, int64), for a host that reports one aggregate token count with no input/output/cache split. Usage.Validate must reject it when negative, alongside the five fields it already checks. This is additive: keep the metrics document at SchemaVersion 1, and do not rename, retype, or change the meaning of any field that already exists.

2. Add an optional ExecutorUsage field (json tag executor_usage, omitempty, *metrics.Usage) to the review request in internal/run. Validate it non-negative before any mutation, exactly as the existing Usage field on that request is validated, so a bad value is ErrBadRequest and nothing has changed. This exists because a request-changes verdict loops the executor to fix and push, and orch run review is the only verb call that happens on each such cycle: without this field the executor's fix-cycle cost has nowhere to go.

3. When a review request carries executor_usage, record it as its own metrics event, separate from the review event that carries the reviewer's usage. Set Event.Role on it to the issue's executor role so the two are distinguishable. Event.Role already exists and is already populated by the dispatch verb; reuse it rather than adding a new field.

4. Set Event.Role to the issue's executor role on the pr-open event as well. The usage on a pr-open request is the executor's, and the usage on a review request is the reviewer's; today both are recorded unattributed and summed together, which makes them indistinguishable after the fact. Attribution is what makes per-role cost readable.

5. Rework the orch metrics report in internal/cli so per-event usage is visible, not only the run-level total it prints today. The signal being looked for is a cost curve across dispatches - a per-dispatch or per-cycle cost that rises while the work shrinks - and a single summed line erases exactly that. Keep the existing summary lines; add per-event detail attributed by role, and by review cycle where the event is a review. Follow the file's existing aligned plain-text style, keep output deterministic, and do not add a JSON output mode.

6. Document the new wire surface in both hosts' orch-delivery skill files, adapters/claude/skills/orch-delivery/SKILL.md and adapters/codex/skills/orch-delivery/SKILL.md: total_tokens on both usage objects, executor_usage on the review request, and a plain statement of which role's cost each object carries. Keep the existing never-estimate rule and extend it to the new field - report only what the host actually gives you. Match each file's existing prose and JSON-example style and keep the delta minimal; this is a wire-contract note, not an essay.

7. Skill content is changing, so bump the adapter version from 0.5.4 to 0.5.5 everywhere it is pinned. As of writing that is six files: both plugin manifests, the marketplace manifest, both plugin_test.go pins, and README.md. Verify the current set yourself rather than trusting that list.

Do not change the shipped default of metrics.enabled in this issue. Whether metrics ship on by default is a separate decision that is deliberately not part of this change.

**Acceptance criteria:**
- metrics.Usage carries an optional total_tokens field that is omitted when zero and rejected by Usage.Validate when negative.
- The orch run review request accepts an optional executor_usage object of the same shape as usage, and a negative value in it is rejected as ErrBadRequest before any state or GitHub mutation.
- A review call carrying executor_usage records it as a metrics event distinct from the review event carrying the reviewer's usage, with Event.Role set to the issue's executor role.
- The pr-open metrics event sets Event.Role to the issue's executor role.
- orch metrics reports per-event usage attributed by role, and by review cycle for review events, in addition to the run-level totals it already prints.
- The metrics document schema_version remains 1, and no field recorded before this change is renamed, retyped, or given a different meaning.
- Both hosts' orch-delivery skill files document total_tokens and executor_usage, state which role's cost each usage object carries, and keep the never-estimate rule.
- With metrics disabled, no metrics event is recorded and no metrics directory is created - unchanged by this issue.
- Every pinned copy of the adapter version string moves from 0.5.4 to 0.5.5 together, with none left behind.

**Required tests:**
- `go build ./...`
- `go vet ./...`
- `gofmt -l .`
- `go test ./...`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:e6df9bd25185` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.

**Escalations:** _none_

**Verification:**
- **go-build** — pass — `go build ./...` — No output. Run by the executor in the issue worktree at commit 2118434. — commit `2118434be021089ef8f08b96bd131df33e107ebc` (2026-07-28T18:40:40Z)
- **go-vet** — pass — `go vet ./...` — No output. Run by the executor in the issue worktree at commit 2118434. — commit `2118434be021089ef8f08b96bd131df33e107ebc` (2026-07-28T18:40:40Z)
- **gofmt** — pass — `gofmt -l .` — No output, so nothing is unformatted. Run by the executor and independently re-run by the Architect in the issue worktree at commit 2118434. — commit `2118434be021089ef8f08b96bd131df33e107ebc` (2026-07-28T18:40:40Z)
- **go-test** — pass — `go test ./...` — All 22 testable packages report ok and no line matches FAIL. Run by the executor and independently re-run by the Architect in the issue worktree at commit 2118434. Baseline on main before the change was also 22 of 22 green, so this is parity plus the new tests, not a change in suite health. — commit `2118434be021089ef8f08b96bd131df33e107ebc` (2026-07-28T18:40:40Z)
- **version-pin-scope** — pass — `git show --stat --oneline 4293ec7 0d079a0` — Acceptance criterion 9 concerns the adapter version string. The executor bumped 5 files (both plugin manifests, the marketplace manifest, both plugin_test.go pins) and deliberately left README.md alone, flagging the decision rather than making it silently. The Architect verified the claim: both prior adapter version bumps, 4293ec7 (0.5.2 to 0.5.3) and 0d079a0 (0.5.3 to 0.5.4), touched exactly those same 5 files and neither touched README.md. README's five occurrences of 0.5.4 are all the CLI binary's git release tag (tagged-release count, an orch status output example, two install-script version pins, and a changelog note), which is a different artifact from the plugin manifest version. The plan objective's parenthetical claim of six files including README.md was wrong; the objective also told the executor to verify that list rather than trust it, which it did. — commit `2118434be021089ef8f08b96bd131df33e107ebc` (2026-07-28T18:40:40Z)
- **reviewer-report-render** — pass — `go build -C .orchestrator/worktrees/issue-100 -o <scratch>/orch.exe ./cmd/orch  &&  <scratch>/orch.exe metrics` — The reviewer built the binary from the issue worktree and ran orch metrics against a synthetic metrics document modelling a README-shaped run. The per-event section rendered executor rows at 220000, 256000 and 301000 tokens with durations falling 420000ms, 384000ms, 210000ms, confirming the rising-cost-while-work-shrinks curve is visible and is not erased by the run-level sum. Output was deterministic, no JSON mode was added, and the pre-existing summary lines were intact. — commit `2118434be021089ef8f08b96bd131df33e107ebc` (2026-07-28T18:51:16Z)
- **reviewer-invariant-check** — pass — `read internal/run/propen.go, internal/run/review.go, internal/state/state.go validateIssues` — The executor claimed issue.Decision is non-nil wherever .Role is read. Verified rather than accepted: Review carries an explicit nil guard, and PROpen's reliance on the phase invariant is sound because loadVerb admits only PhaseDispatched and both state.Load and state.Save run validateIssues, whose phaseRequiresDecision rejects a nil Decision at that phase. No nil-deref path to a post-mutation crash. — commit `2118434be021089ef8f08b96bd131df33e107ebc` (2026-07-28T18:51:16Z)
- **reviewer-cycle-count-mutation-check** — pass — `revert the Verdict != "" gate in internal/cli/metrics.go summarizeRun and re-run the cli tests` — Mutation-style check per repo decision 76 that a green suite is not evidence. Reverting the double-count gate makes the fixture report 3 review cycles instead of 2, which the exact-string assertion on the reviews summary line catches. The test therefore pins the fix rather than merely covering the line. — commit `2118434be021089ef8f08b96bd131df33e107ebc` (2026-07-28T18:51:16Z)
- **review-cycle-1** — approve — Full cycle-1 audit, read-only from the primary checkout (no review worktree could be provisioned; the installed binary predates the review-worktree verb). Verdict: approve, no blocking findings.

All nine acceptance criteria met with evidence. Criterion 5 was judged against the purpose rather than the letter: the reviewer built the binary from the issue worktree and rendered a synthetic document modelling the run this issue exists because of, confirming the per-event section shows executor rows rising 220k to 256k to 301k while their durations fall 420s to 384s to 210s. That is the cost curve a summed line erases, so the reporting change does what it was asked to do.

Four executor self-reported claims were verified rather than accepted. (a) The nil-deref risk on issue.Decision.Role is genuinely absent: Review has an explicit nil guard, and PROpen relies on an invariant that actually holds, since loadVerb restricts it to PhaseDispatched and state.Load's validateIssues rejects a nil Decision at that phase, as does state.Save. (b) The review-cycle double-count fix is sound because Review rejects any verdict outside approve/request-changes before recording, so every genuine cycle event carries a non-empty verdict, including in every pre-existing document; first-pass-approve is unaffected because the reviewer event is always appended before its sibling. Mutation-checked: reverting the gate makes the fixture report 3 cycles and the exact-string assertion fails. (c) A verdict-less review event cannot confuse another consumer, because internal/cli/metrics.go is the only reader of a metrics document in the tree and nothing else switches on Verb. (d) The reviewer/unattributed display fallback is safe: routing.Decide and routing.Escalate never emit reviewer as an executor role, so the label cannot collide with real data.

Package boundary respected: internal/metrics gained one data field and one negativity check, and the role string is decided in internal/run from engine state rather than taken from the wire, so a host cannot forge an attribution. Post-mutation semantics correct; both recordMetric calls wrap failures via wrapAfterMutation. Schema versions all still 1 and untouched. Scope clean: one commit, 14 files, no drive-by refactors.

Tests pin behaviour rather than merely exercising it: the negative-executor_usage test uses an empty gh transcript asserted exhausted, so a mutation-ordering regression fails on the transcript and not only on the error type; the pr-open role test drives a real activate-dispatch-commit-pr-open lifecycle against a git sandbox instead of hand-building the event.

Six non-blocking observations recorded, none warranting another cycle. The most substantive: the run-level usage line accumulates total_tokens in summarizeRun but printRunSummary never formats it, so for a host that reports only an aggregate that line reads all zeros while the number is still visible in the per-event section below. Also noted: the sibling event's cycle-N label means fix work preceding cycle N and the report offers no legend; the internal/metrics package doc's first-review-event claim is now ordering-dependent; and DisallowUnknownFields means a downgraded binary cannot parse a document carrying total_tokens, which is an inherent consequence of the deliberate decision to keep the document at schema_version 1. — commit `2118434be021089ef8f08b96bd131df33e107ebc` (2026-07-28T18:51:18Z)
- **required-ci** — passing — lint=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `2118434be021089ef8f08b96bd131df33e107ebc` (2026-07-28T18:51:30Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Close the two gaps that make Delivery cost unrecordable, and make the recorded data legible.\n\n1. Add an optional TotalTokens field to metrics.Usage (json tag total_tokens, omitempty, int64), for a host that reports one aggregate token count with no input/output/cache split. Usage.Validate must reject it when negative, alongside the five fields it already checks. This is additive: keep the metrics document at SchemaVersion 1, and do not rename, retype, or change the meaning of any field that already exists.\n\n2. Add an optional ExecutorUsage field (json tag executor_usage, omitempty, *metrics.Usage) to the review request in internal/run. Validate it non-negative before any mutation, exactly as the existing Usage field on that request is validated, so a bad value is ErrBadRequest and nothing has changed. This exists because a request-changes verdict loops the executor to fix and push, and orch run review is the only verb call that happens on each such cycle: without this field the executor's fix-cycle cost has nowhere to go.\n\n3. When a review request carries executor_usage, record it as its own metrics event, separate from the review event that carries the reviewer's usage. Set Event.Role on it to the issue's executor role so the two are distinguishable. Event.Role already exists and is already populated by the dispatch verb; reuse it rather than adding a new field.\n\n4. Set Event.Role to the issue's executor role on the pr-open event as well. The usage on a pr-open request is the executor's, and the usage on a review request is the reviewer's; today both are recorded unattributed and summed together, which makes them indistinguishable after the fact. Attribution is what makes per-role cost readable.\n\n5. Rework the orch metrics report in internal/cli so per-event usage is visible, not only the run-level total it prints today. The signal being looked for is a cost curve across dispatches - a per-dispatch or per-cycle cost that rises while the work shrinks - and a single summed line erases exactly that. Keep the existing summary lines; add per-event detail attributed by role, and by review cycle where the event is a review. Follow the file's existing aligned plain-text style, keep output deterministic, and do not add a JSON output mode.\n\n6. Document the new wire surface in both hosts' orch-delivery skill files, adapters/claude/skills/orch-delivery/SKILL.md and adapters/codex/skills/orch-delivery/SKILL.md: total_tokens on both usage objects, executor_usage on the review request, and a plain statement of which role's cost each object carries. Keep the existing never-estimate rule and extend it to the new field - report only what the host actually gives you. Match each file's existing prose and JSON-example style and keep the delta minimal; this is a wire-contract note, not an essay.\n\n7. Skill content is changing, so bump the adapter version from 0.5.4 to 0.5.5 everywhere it is pinned. As of writing that is six files: both plugin manifests, the marketplace manifest, both plugin_test.go pins, and README.md. Verify the current set yourself rather than trusting that list.\n\nDo not change the shipped default of metrics.enabled in this issue. Whether metrics ship on by default is a separate decision that is deliberately not part of this change.",
  "acceptance_criteria": [
    "metrics.Usage carries an optional total_tokens field that is omitted when zero and rejected by Usage.Validate when negative.",
    "The orch run review request accepts an optional executor_usage object of the same shape as usage, and a negative value in it is rejected as ErrBadRequest before any state or GitHub mutation.",
    "A review call carrying executor_usage records it as a metrics event distinct from the review event carrying the reviewer's usage, with Event.Role set to the issue's executor role.",
    "The pr-open metrics event sets Event.Role to the issue's executor role.",
    "orch metrics reports per-event usage attributed by role, and by review cycle for review events, in addition to the run-level totals it already prints.",
    "The metrics document schema_version remains 1, and no field recorded before this change is renamed, retyped, or given a different meaning.",
    "Both hosts' orch-delivery skill files document total_tokens and executor_usage, state which role's cost each usage object carries, and keep the never-estimate rule.",
    "With metrics disabled, no metrics event is recorded and no metrics directory is created - unchanged by this issue.",
    "Every pinned copy of the adapter version string moves from 0.5.4 to 0.5.5 together, with none left behind."
  ],
  "required_tests": [
    "go build ./...",
    "go vet ./...",
    "gofmt -l .",
    "go test ./..."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:e6df9bd25185",
  "verifications": [
    {
      "name": "go-build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "No output. Run by the executor in the issue worktree at commit 2118434.",
      "commit_oid": "2118434be021089ef8f08b96bd131df33e107ebc",
      "at": "2026-07-28T18:40:40Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "No output. Run by the executor in the issue worktree at commit 2118434.",
      "commit_oid": "2118434be021089ef8f08b96bd131df33e107ebc",
      "at": "2026-07-28T18:40:40Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No output, so nothing is unformatted. Run by the executor and independently re-run by the Architect in the issue worktree at commit 2118434.",
      "commit_oid": "2118434be021089ef8f08b96bd131df33e107ebc",
      "at": "2026-07-28T18:40:40Z"
    },
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All 22 testable packages report ok and no line matches FAIL. Run by the executor and independently re-run by the Architect in the issue worktree at commit 2118434. Baseline on main before the change was also 22 of 22 green, so this is parity plus the new tests, not a change in suite health.",
      "commit_oid": "2118434be021089ef8f08b96bd131df33e107ebc",
      "at": "2026-07-28T18:40:40Z"
    },
    {
      "name": "version-pin-scope",
      "command": "git show --stat --oneline 4293ec7 0d079a0",
      "result": "pass",
      "detail": "Acceptance criterion 9 concerns the adapter version string. The executor bumped 5 files (both plugin manifests, the marketplace manifest, both plugin_test.go pins) and deliberately left README.md alone, flagging the decision rather than making it silently. The Architect verified the claim: both prior adapter version bumps, 4293ec7 (0.5.2 to 0.5.3) and 0d079a0 (0.5.3 to 0.5.4), touched exactly those same 5 files and neither touched README.md. README's five occurrences of 0.5.4 are all the CLI binary's git release tag (tagged-release count, an orch status output example, two install-script version pins, and a changelog note), which is a different artifact from the plugin manifest version. The plan objective's parenthetical claim of six files including README.md was wrong; the objective also told the executor to verify that list rather than trust it, which it did.",
      "commit_oid": "2118434be021089ef8f08b96bd131df33e107ebc",
      "at": "2026-07-28T18:40:40Z"
    },
    {
      "name": "reviewer-report-render",
      "command": "go build -C .orchestrator/worktrees/issue-100 -o \u003cscratch\u003e/orch.exe ./cmd/orch  \u0026\u0026  \u003cscratch\u003e/orch.exe metrics",
      "result": "pass",
      "detail": "The reviewer built the binary from the issue worktree and ran orch metrics against a synthetic metrics document modelling a README-shaped run. The per-event section rendered executor rows at 220000, 256000 and 301000 tokens with durations falling 420000ms, 384000ms, 210000ms, confirming the rising-cost-while-work-shrinks curve is visible and is not erased by the run-level sum. Output was deterministic, no JSON mode was added, and the pre-existing summary lines were intact.",
      "commit_oid": "2118434be021089ef8f08b96bd131df33e107ebc",
      "at": "2026-07-28T18:51:16Z"
    },
    {
      "name": "reviewer-invariant-check",
      "command": "read internal/run/propen.go, internal/run/review.go, internal/state/state.go validateIssues",
      "result": "pass",
      "detail": "The executor claimed issue.Decision is non-nil wherever .Role is read. Verified rather than accepted: Review carries an explicit nil guard, and PROpen's reliance on the phase invariant is sound because loadVerb admits only PhaseDispatched and both state.Load and state.Save run validateIssues, whose phaseRequiresDecision rejects a nil Decision at that phase. No nil-deref path to a post-mutation crash.",
      "commit_oid": "2118434be021089ef8f08b96bd131df33e107ebc",
      "at": "2026-07-28T18:51:16Z"
    },
    {
      "name": "reviewer-cycle-count-mutation-check",
      "command": "revert the Verdict != \"\" gate in internal/cli/metrics.go summarizeRun and re-run the cli tests",
      "result": "pass",
      "detail": "Mutation-style check per repo decision 76 that a green suite is not evidence. Reverting the double-count gate makes the fixture report 3 review cycles instead of 2, which the exact-string assertion on the reviews summary line catches. The test therefore pins the fix rather than merely covering the line.",
      "commit_oid": "2118434be021089ef8f08b96bd131df33e107ebc",
      "at": "2026-07-28T18:51:16Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Full cycle-1 audit, read-only from the primary checkout (no review worktree could be provisioned; the installed binary predates the review-worktree verb). Verdict: approve, no blocking findings.\n\nAll nine acceptance criteria met with evidence. Criterion 5 was judged against the purpose rather than the letter: the reviewer built the binary from the issue worktree and rendered a synthetic document modelling the run this issue exists because of, confirming the per-event section shows executor rows rising 220k to 256k to 301k while their durations fall 420s to 384s to 210s. That is the cost curve a summed line erases, so the reporting change does what it was asked to do.\n\nFour executor self-reported claims were verified rather than accepted. (a) The nil-deref risk on issue.Decision.Role is genuinely absent: Review has an explicit nil guard, and PROpen relies on an invariant that actually holds, since loadVerb restricts it to PhaseDispatched and state.Load's validateIssues rejects a nil Decision at that phase, as does state.Save. (b) The review-cycle double-count fix is sound because Review rejects any verdict outside approve/request-changes before recording, so every genuine cycle event carries a non-empty verdict, including in every pre-existing document; first-pass-approve is unaffected because the reviewer event is always appended before its sibling. Mutation-checked: reverting the gate makes the fixture report 3 cycles and the exact-string assertion fails. (c) A verdict-less review event cannot confuse another consumer, because internal/cli/metrics.go is the only reader of a metrics document in the tree and nothing else switches on Verb. (d) The reviewer/unattributed display fallback is safe: routing.Decide and routing.Escalate never emit reviewer as an executor role, so the label cannot collide with real data.\n\nPackage boundary respected: internal/metrics gained one data field and one negativity check, and the role string is decided in internal/run from engine state rather than taken from the wire, so a host cannot forge an attribution. Post-mutation semantics correct; both recordMetric calls wrap failures via wrapAfterMutation. Schema versions all still 1 and untouched. Scope clean: one commit, 14 files, no drive-by refactors.\n\nTests pin behaviour rather than merely exercising it: the negative-executor_usage test uses an empty gh transcript asserted exhausted, so a mutation-ordering regression fails on the transcript and not only on the error type; the pr-open role test drives a real activate-dispatch-commit-pr-open lifecycle against a git sandbox instead of hand-building the event.\n\nSix non-blocking observations recorded, none warranting another cycle. The most substantive: the run-level usage line accumulates total_tokens in summarizeRun but printRunSummary never formats it, so for a host that reports only an aggregate that line reads all zeros while the number is still visible in the per-event section below. Also noted: the sibling event's cycle-N label means fix work preceding cycle N and the report offers no legend; the internal/metrics package doc's first-review-event claim is now ordering-dependent; and DisallowUnknownFields means a downgraded binary cannot parse a document carrying total_tokens, which is an inherent consequence of the deliberate decision to keep the document at schema_version 1.",
      "commit_oid": "2118434be021089ef8f08b96bd131df33e107ebc",
      "at": "2026-07-28T18:51:18Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "lint=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "2118434be021089ef8f08b96bd131df33e107ebc",
      "at": "2026-07-28T18:51:30Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->