### PR TITLE
Make gitops.RequireIgnored fail closed again when .gitignore contains an empty pattern

### DIFF
--- a/internal/gitops/checks.go
+++ b/internal/gitops/checks.go
@@ -73,6 +73,15 @@ func (g *Git) RevParse(ctx context.Context, ref string) (string, error) {
 	return g.git(ctx, g.root, "rev-parse", "--verify", ref+"^{commit}")
 }
 
+// requireIgnoredProbe is the basename RequireIgnored appends to the
+// directory it is checking before asking git about it — see the
+// function doc for why a bare directory query is unsafe. It is
+// deliberately not dot-prefixed: a leading dot risks being swallowed
+// by an unrelated ".*" convention some repositories use to ignore all
+// hidden files, which would report the probe "ignored" for a reason
+// that says nothing about whether the directory itself is covered.
+const requireIgnoredProbe = "orch-check-ignore-probe"
+
 // RequireIgnored returns nil only when path is git-ignored relative to
 // the primary checkout (F1: an inside-primary worktree relaxation is
 // only safe because an ignored path never appears in
@@ -83,12 +92,32 @@ func (g *Git) RevParse(ctx context.Context, ref string) (string, error) {
 // to root before the check. A path outside root is an error: this
 // check only makes sense for a candidate inside-primary location.
 //
-// The query is always sent to git with a trailing slash: path is
-// always a directory in every caller of this method (a worktree or
-// its container), and a directory-only .gitignore pattern (the common
-// case, e.g. "foo/") only matches a bare, non-existent path when git
-// is told it is a directory this way — without it, `check-ignore`
-// silently refuses to match.
+// The query sent to git is not path itself but a synthetic child of
+// it — path plus "/" plus the fixed probe basename requireIgnoredProbe
+// — rather than path alone with a bare trailing slash. Two properties
+// are both needed, and a trailing slash on path alone provides only
+// the first while silently breaking the second:
+//
+//   - Every caller passes a directory (a worktree or its container).
+//     A directory-only .gitignore pattern (the common case, e.g.
+//     "foo/") does not match a path that does not yet exist on disk
+//     unless git is told the path is a directory. Querying a child
+//     path inside the directory accomplishes that without needing a
+//     trailing slash on path itself, and the match still holds when
+//     the directory is nested several levels deep under the pattern
+//     (verified against real git).
+//   - A bare trailing slash on path (e.g. "foo/") produces a query
+//     whose final path component is empty. Git does not always skip a
+//     blank .gitignore line before turning it into a pattern: a line
+//     that is empty except for a trailing CRLF, and a line containing
+//     only whitespace under a plain LF file, both trim down to an
+//     empty pattern rather than being dropped — on any OS, since
+//     neither case depends on how the file itself is line-ended. An
+//     empty pattern matches an empty basename, so a trailing-slash-only
+//     query comes back "ignored" against such a .gitignore regardless
+//     of whether path is covered by any real pattern (verified against
+//     real git 2.53). Appending a non-empty probe basename closes this
+//     off: an empty pattern can never match a non-empty basename.
 func (g *Git) RequireIgnored(ctx context.Context, path string) error {
 	canon, err := paths.Canonical(path)
 	if err != nil {
@@ -98,7 +127,7 @@ func (g *Git) RequireIgnored(ctx context.Context, path string) error {
 	if err != nil {
 		return fmt.Errorf("compute path for %s relative to %s: %w", canon, g.root, err)
 	}
-	query := filepath.ToSlash(rel) + "/"
+	query := filepath.ToSlash(rel) + "/" + requireIgnoredProbe
 	res, err := g.run(ctx, g.root, "check-ignore", "-q", "--", query)
 	if err != nil {
 		return err

--- a/internal/gitops/checks.go
+++ b/internal/gitops/checks.go
@@ -73,14 +73,18 @@ func (g *Git) RevParse(ctx context.Context, ref string) (string, error) {
 	return g.git(ctx, g.root, "rev-parse", "--verify", ref+"^{commit}")
 }
 
-// requireIgnoredProbe is the basename RequireIgnored appends to the
+// requireIgnoredProbes are the basenames RequireIgnored appends to the
 // directory it is checking before asking git about it — see the
-// function doc for why a bare directory query is unsafe. It is
-// deliberately not dot-prefixed: a leading dot risks being swallowed
-// by an unrelated ".*" convention some repositories use to ignore all
-// hidden files, which would report the probe "ignored" for a reason
-// that says nothing about whether the directory itself is covered.
-const requireIgnoredProbe = "orch-check-ignore-probe"
+// function doc for why a single, fixed basename is unsafe on its own
+// and why two structurally dissimilar ones close that gap. Neither is
+// dot-prefixed (a leading dot risks being swallowed by an unrelated
+// ".*" convention some repositories use to ignore all hidden files),
+// and the two are chosen to have as little in common as possible —
+// one descriptive and orch-namespaced for readability in failure
+// output, the other a single bare digit sharing no substring, prefix,
+// or shape with the first — so that no single realistic .gitignore
+// glob is likely to match both by coincidence.
+var requireIgnoredProbes = [2]string{"orch-check-ignore-probe", "0"}
 
 // RequireIgnored returns nil only when path is git-ignored relative to
 // the primary checkout (F1: an inside-primary worktree relaxation is
@@ -92,11 +96,14 @@ const requireIgnoredProbe = "orch-check-ignore-probe"
 // to root before the check. A path outside root is an error: this
 // check only makes sense for a candidate inside-primary location.
 //
-// The query sent to git is not path itself but a synthetic child of
-// it — path plus "/" plus the fixed probe basename requireIgnoredProbe
-// — rather than path alone with a bare trailing slash. Two properties
-// are both needed, and a trailing slash on path alone provides only
-// the first while silently breaking the second:
+// The queries sent to git are not path itself but synthetic children
+// of it — path plus "/" plus each of requireIgnoredProbes in turn,
+// never path alone with a bare trailing slash. All probes must come
+// back ignored for RequireIgnored to return nil; any one reporting
+// not-ignored is decisive proof path is not covered and short-circuits
+// the rest. Three properties are all needed, and a trailing slash on
+// path alone provides only the first while silently breaking the
+// other two:
 //
 //   - Every caller passes a directory (a worktree or its container).
 //     A directory-only .gitignore pattern (the common case, e.g.
@@ -116,8 +123,23 @@ const requireIgnoredProbe = "orch-check-ignore-probe"
 //     empty pattern matches an empty basename, so a trailing-slash-only
 //     query comes back "ignored" against such a .gitignore regardless
 //     of whether path is covered by any real pattern (verified against
-//     real git 2.53). Appending a non-empty probe basename closes this
-//     off: an empty pattern can never match a non-empty basename.
+//     real git 2.53). Giving the query a non-empty basename closes
+//     this off: an empty pattern can never match a non-empty basename.
+//   - A single fixed, non-empty probe basename is not enough by
+//     itself: it reopens the same class of bug through a different
+//     trigger. A .gitignore line unrelated to path — "orch-*", "orch*",
+//     "*probe*", or the literal probe basename itself, none of them
+//     contrived for a binary named orch — matches that one basename by
+//     coincidence and reports every uncovered directory in the
+//     repository "ignored" (verified against real git). Querying two
+//     probes that share no prefix, suffix, or substring and requiring
+//     both to match closes this off too: a single unrelated pattern
+//     would need to separately and coincidentally match both an
+//     orch-namespaced, multi-word name and a bare digit to reproduce
+//     the failure, which no realistic .gitignore line does. A pattern
+//     that legitimately matches everything under path (e.g. a bare
+//     "*") still matches both probes and is correctly treated as
+//     ignored.
 func (g *Git) RequireIgnored(ctx context.Context, path string) error {
 	canon, err := paths.Canonical(path)
 	if err != nil {
@@ -127,17 +149,21 @@ func (g *Git) RequireIgnored(ctx context.Context, path string) error {
 	if err != nil {
 		return fmt.Errorf("compute path for %s relative to %s: %w", canon, g.root, err)
 	}
-	query := filepath.ToSlash(rel) + "/" + requireIgnoredProbe
-	res, err := g.run(ctx, g.root, "check-ignore", "-q", "--", query)
-	if err != nil {
-		return err
+	relSlash := filepath.ToSlash(rel)
+	for _, probe := range requireIgnoredProbes {
+		query := relSlash + "/" + probe
+		res, err := g.run(ctx, g.root, "check-ignore", "-q", "--", query)
+		if err != nil {
+			return err
+		}
+		switch res.ExitCode {
+		case 0:
+			continue
+		case 1:
+			return fmt.Errorf("%w: %s; add a line like \"%s/\" to .gitignore", ErrNotIgnored, canon, relSlash)
+		default:
+			return fmt.Errorf("git check-ignore in %s exited %d: %s", g.root, res.ExitCode, strings.TrimSpace(res.Stderr))
+		}
 	}
-	switch res.ExitCode {
-	case 0:
-		return nil
-	case 1:
-		return fmt.Errorf("%w: %s; add a line like \"%s/\" to .gitignore", ErrNotIgnored, canon, filepath.ToSlash(rel))
-	default:
-		return fmt.Errorf("git check-ignore in %s exited %d: %s", g.root, res.ExitCode, strings.TrimSpace(res.Stderr))
-	}
+	return nil
 }

--- a/internal/gitops/checks_test.go
+++ b/internal/gitops/checks_test.go
@@ -116,7 +116,7 @@ func TestRequireIgnored(t *testing.T) {
 
 	t.Run("ignored", func(t *testing.T) {
 		g, script := openScripted(t, root, execxtest.Call{
-			Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/"}, Dir: root,
+			Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbe}, Dir: root,
 		})
 		if err := g.RequireIgnored(context.Background(), abs); err != nil {
 			t.Errorf("RequireIgnored: %v", err)
@@ -126,7 +126,7 @@ func TestRequireIgnored(t *testing.T) {
 
 	t.Run("not ignored", func(t *testing.T) {
 		g, script := openScripted(t, root, execxtest.Call{
-			Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/"}, Dir: root, Exit: 1,
+			Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbe}, Dir: root, Exit: 1,
 		})
 		err := g.RequireIgnored(context.Background(), abs)
 		script.AssertExhausted()
@@ -140,7 +140,7 @@ func TestRequireIgnored(t *testing.T) {
 
 	t.Run("other exit code", func(t *testing.T) {
 		g, script := openScripted(t, root, execxtest.Call{
-			Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/"}, Dir: root,
+			Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbe}, Dir: root,
 			Stderr: "fatal: bad", Exit: 128,
 		})
 		err := g.RequireIgnored(context.Background(), abs)

--- a/internal/gitops/checks_test.go
+++ b/internal/gitops/checks_test.go
@@ -115,9 +115,10 @@ func TestRequireIgnored(t *testing.T) {
 	abs := filepath.Join(root, rel)
 
 	t.Run("ignored", func(t *testing.T) {
-		g, script := openScripted(t, root, execxtest.Call{
-			Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbe}, Dir: root,
-		})
+		g, script := openScripted(t, root,
+			execxtest.Call{Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbes[0]}, Dir: root},
+			execxtest.Call{Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbes[1]}, Dir: root},
+		)
 		if err := g.RequireIgnored(context.Background(), abs); err != nil {
 			t.Errorf("RequireIgnored: %v", err)
 		}
@@ -125,8 +126,10 @@ func TestRequireIgnored(t *testing.T) {
 	})
 
 	t.Run("not ignored", func(t *testing.T) {
+		// The first probe already comes back not-ignored: that alone is
+		// decisive, so the second probe is never queried.
 		g, script := openScripted(t, root, execxtest.Call{
-			Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbe}, Dir: root, Exit: 1,
+			Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbes[0]}, Dir: root, Exit: 1,
 		})
 		err := g.RequireIgnored(context.Background(), abs)
 		script.AssertExhausted()
@@ -138,9 +141,25 @@ func TestRequireIgnored(t *testing.T) {
 		}
 	})
 
+	t.Run("second probe not ignored", func(t *testing.T) {
+		// The first probe alone matching is not enough: a pattern that
+		// coincidentally matches only requireIgnoredProbes[0] (the
+		// basename-collision hazard) must still fail closed once the
+		// dissimilar second probe disagrees.
+		g, script := openScripted(t, root,
+			execxtest.Call{Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbes[0]}, Dir: root},
+			execxtest.Call{Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbes[1]}, Dir: root, Exit: 1},
+		)
+		err := g.RequireIgnored(context.Background(), abs)
+		script.AssertExhausted()
+		if !errors.Is(err, ErrNotIgnored) {
+			t.Fatalf("err = %v, want ErrNotIgnored", err)
+		}
+	})
+
 	t.Run("other exit code", func(t *testing.T) {
 		g, script := openScripted(t, root, execxtest.Call{
-			Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbe}, Dir: root,
+			Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbes[0]}, Dir: root,
 			Stderr: "fatal: bad", Exit: 128,
 		})
 		err := g.RequireIgnored(context.Background(), abs)

--- a/internal/gitops/integration_test.go
+++ b/internal/gitops/integration_test.go
@@ -394,8 +394,15 @@ func TestIntegrationRequireIgnoredEmptyPatternHazard(t *testing.T) {
 
 			// Criterion 2: a directory covered only by a directory-only
 			// pattern and not yet on disk must still come back ignored,
-			// hazard line notwithstanding — this must not regress.
-			covered := filepath.Join(root, ".orchestrator", "worktrees", "issue-9")
+			// hazard line notwithstanding — this must not regress. The
+			// query must be the container itself (what
+			// internal/run/activate.go actually checks), not a path
+			// nested a level deeper under it: a nested path's directory
+			// pattern lands on a non-final component of the query, which
+			// git resolves as a directory regardless of query shape and
+			// so cannot discriminate a correct query from a bare,
+			// unmodified one.
+			covered := filepath.Join(root, ".orchestrator", "worktrees")
 			if err := g.RequireIgnored(ctx, covered); err != nil {
 				t.Errorf("dir-only pattern with hazard present: RequireIgnored(%s) = %v, want nil", covered, err)
 			}
@@ -409,6 +416,52 @@ func TestIntegrationRequireIgnoredEmptyPatternHazard(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestIntegrationRequireIgnoredProbeBasenameCollisionHazard pins the
+// fix for a second, distinct fail-open: a .gitignore glob that has
+// nothing to do with the directory being checked but happens to match
+// RequireIgnored's own fixed probe basename by coincidence. A repo
+// building a binary named orch is a realistic source of such a glob —
+// "orch-*" or "orch*" cover cross-compiled release artifacts (a
+// standard Go release convention, e.g. "orch-linux-amd64"). A single,
+// fixed probe basename cannot tell that match apart from the directory
+// genuinely being ignored; requiring two probes that share no prefix,
+// suffix, or substring can, because no single one of these patterns
+// matches both. Each subtest fails if RequireIgnored queries only
+// requireIgnoredProbes[0].
+func TestIntegrationRequireIgnoredProbeBasenameCollisionHazard(t *testing.T) {
+	setupGitEnv(t)
+	ctx := context.Background()
+
+	globs := []string{"orch-*", "orch*", "*probe*", requireIgnoredProbes[0]}
+	for _, glob := range globs {
+		t.Run(glob, func(t *testing.T) {
+			g, root := newRepo(t)
+			if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(glob+"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			uncovered := filepath.Join(root, "scratch", "issue-9")
+			if err := g.RequireIgnored(ctx, uncovered); !errors.Is(err, ErrNotIgnored) {
+				t.Errorf(".gitignore %q coincidentally matching one probe: RequireIgnored(%s) err = %v, want ErrNotIgnored", glob, uncovered, err)
+			}
+		})
+	}
+
+	// A genuine directory-only pattern must still be honored: the
+	// defense against basename collisions must not turn into a refusal
+	// of every real pattern.
+	t.Run("genuine directory pattern still allowed", func(t *testing.T) {
+		g, root := newRepo(t)
+		if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(".orchestrator/worktrees/\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		covered := filepath.Join(root, ".orchestrator", "worktrees")
+		if err := g.RequireIgnored(ctx, covered); err != nil {
+			t.Errorf("genuine dir-only pattern: RequireIgnored(%s) = %v, want nil", covered, err)
+		}
+	})
 }
 
 func TestIntegrationWithBaseWorktree(t *testing.T) {

--- a/internal/gitops/integration_test.go
+++ b/internal/gitops/integration_test.go
@@ -365,6 +365,52 @@ func TestIntegrationAddWorktreeInsidePrimary(t *testing.T) {
 	}
 }
 
+// TestIntegrationRequireIgnoredEmptyPatternHazard pins the fix for the
+// empty-.gitignore-pattern hazard: a bare trailing-slash query (path +
+// "/") has an empty final path component, and git accepts a line that
+// trims down to an empty pattern from two distinct sources — a blank
+// line whose own terminator is CRLF (which survives git's
+// skip-if-blank check before the CR is trimmed off) and a
+// whitespace-only line under a plain LF file (which trims the same
+// way, independent of the file's line endings). Either produces an
+// empty pattern that matches the empty basename a bare trailing-slash
+// query produces, making every path in the repository look "ignored"
+// regardless of any real pattern. Each subtest fails against the
+// pre-fix trailing-slash-only query.
+func TestIntegrationRequireIgnoredEmptyPatternHazard(t *testing.T) {
+	setupGitEnv(t)
+	ctx := context.Background()
+
+	hazards := map[string]string{
+		"crlf blank line":               ".orchestrator/worktrees/\n\r\n",
+		"whitespace-only line under lf": ".orchestrator/worktrees/\n \n",
+	}
+	for name, gitignore := range hazards {
+		t.Run(name, func(t *testing.T) {
+			g, root := newRepo(t)
+			if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(gitignore), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			// Criterion 2: a directory covered only by a directory-only
+			// pattern and not yet on disk must still come back ignored,
+			// hazard line notwithstanding — this must not regress.
+			covered := filepath.Join(root, ".orchestrator", "worktrees", "issue-9")
+			if err := g.RequireIgnored(ctx, covered); err != nil {
+				t.Errorf("dir-only pattern with hazard present: RequireIgnored(%s) = %v, want nil", covered, err)
+			}
+
+			// Criterion 1: a path no pattern covers must not be reported
+			// ignored merely because the .gitignore also carries a line
+			// that trims to an empty pattern.
+			uncovered := filepath.Join(root, "scratch", "issue-9")
+			if err := g.RequireIgnored(ctx, uncovered); !errors.Is(err, ErrNotIgnored) {
+				t.Errorf("uncovered path with hazard present: RequireIgnored(%s) err = %v, want ErrNotIgnored", uncovered, err)
+			}
+		})
+	}
+}
+
 func TestIntegrationWithBaseWorktree(t *testing.T) {
 	setupGitEnv(t)
 	g, _ := newRepo(t)

--- a/internal/gitops/worktree_test.go
+++ b/internal/gitops/worktree_test.go
@@ -110,7 +110,7 @@ func TestAddWorktreeInsidePrimaryNotIgnoredFailsClosed(t *testing.T) {
 		t.Fatal(err)
 	}
 	g, script := openScripted(t, root, execxtest.Call{
-		Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbe}, Dir: root, Exit: 1,
+		Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbes[0]}, Dir: root, Exit: 1,
 	})
 	_, err = g.AddWorktree(context.Background(), path, "orch/issue-4", "main")
 	script.AssertExhausted()
@@ -131,7 +131,8 @@ func TestAddWorktreeInsidePrimaryIgnoredSucceeds(t *testing.T) {
 	}
 	const head = "5555555555555555555555555555555555555555"
 	g, script := openScripted(t, root,
-		execxtest.Call{Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbe}, Dir: root},
+		execxtest.Call{Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbes[0]}, Dir: root},
+		execxtest.Call{Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbes[1]}, Dir: root},
 		execxtest.Call{Name: "git", Args: []string{"rev-parse", "--verify", "--quiet", "refs/heads/orch/issue-4"}, Dir: root, Exit: 1},
 		execxtest.Call{Name: "git", Args: []string{"worktree", "add", "-b", "orch/issue-4", path, "main"}, Dir: root},
 		execxtest.Call{Name: "git", Args: []string{"rev-parse", "--verify", "orch/issue-4^{commit}"}, Stdout: head + "\n"},
@@ -166,7 +167,8 @@ func TestAddDetachedWorktree(t *testing.T) {
 	}
 	const head = "6666666666666666666666666666666666666666"
 	g, script := openScripted(t, root,
-		execxtest.Call{Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbe}, Dir: root},
+		execxtest.Call{Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbes[0]}, Dir: root},
+		execxtest.Call{Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbes[1]}, Dir: root},
 		execxtest.Call{Name: "git", Args: []string{"worktree", "add", "--detach", path, "6666666"}, Dir: root},
 		// The resolved HEAD is read back inside the new checkout, so an
 		// abbreviated commit-ish comes back in full.
@@ -201,7 +203,7 @@ func TestAddDetachedWorktreeInsidePrimaryNotIgnoredFailsClosed(t *testing.T) {
 		t.Fatal(err)
 	}
 	g, script := openScripted(t, root, execxtest.Call{
-		Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbe}, Dir: root, Exit: 1,
+		Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbes[0]}, Dir: root, Exit: 1,
 	})
 	_, err = g.AddDetachedWorktree(context.Background(), path, "6666666666666666666666666666666666666666")
 	script.AssertExhausted() // no `worktree add` followed

--- a/internal/gitops/worktree_test.go
+++ b/internal/gitops/worktree_test.go
@@ -110,7 +110,7 @@ func TestAddWorktreeInsidePrimaryNotIgnoredFailsClosed(t *testing.T) {
 		t.Fatal(err)
 	}
 	g, script := openScripted(t, root, execxtest.Call{
-		Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/"}, Dir: root, Exit: 1,
+		Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbe}, Dir: root, Exit: 1,
 	})
 	_, err = g.AddWorktree(context.Background(), path, "orch/issue-4", "main")
 	script.AssertExhausted()
@@ -131,7 +131,7 @@ func TestAddWorktreeInsidePrimaryIgnoredSucceeds(t *testing.T) {
 	}
 	const head = "5555555555555555555555555555555555555555"
 	g, script := openScripted(t, root,
-		execxtest.Call{Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/"}, Dir: root},
+		execxtest.Call{Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbe}, Dir: root},
 		execxtest.Call{Name: "git", Args: []string{"rev-parse", "--verify", "--quiet", "refs/heads/orch/issue-4"}, Dir: root, Exit: 1},
 		execxtest.Call{Name: "git", Args: []string{"worktree", "add", "-b", "orch/issue-4", path, "main"}, Dir: root},
 		execxtest.Call{Name: "git", Args: []string{"rev-parse", "--verify", "orch/issue-4^{commit}"}, Stdout: head + "\n"},
@@ -166,7 +166,7 @@ func TestAddDetachedWorktree(t *testing.T) {
 	}
 	const head = "6666666666666666666666666666666666666666"
 	g, script := openScripted(t, root,
-		execxtest.Call{Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/"}, Dir: root},
+		execxtest.Call{Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbe}, Dir: root},
 		execxtest.Call{Name: "git", Args: []string{"worktree", "add", "--detach", path, "6666666"}, Dir: root},
 		// The resolved HEAD is read back inside the new checkout, so an
 		// abbreviated commit-ish comes back in full.
@@ -201,7 +201,7 @@ func TestAddDetachedWorktreeInsidePrimaryNotIgnoredFailsClosed(t *testing.T) {
 		t.Fatal(err)
 	}
 	g, script := openScripted(t, root, execxtest.Call{
-		Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/"}, Dir: root, Exit: 1,
+		Name: "git", Args: []string{"check-ignore", "-q", "--", filepath.ToSlash(rel) + "/" + requireIgnoredProbe}, Dir: root, Exit: 1,
 	})
 	_, err = g.AddDetachedWorktree(context.Background(), path, "6666666666666666666666666666666666666666")
 	script.AssertExhausted() // no `worktree add` followed


### PR DESCRIPTION
Delivers issue #105: Make gitops.RequireIgnored fail closed again when .gitignore contains an empty pattern

Closes #105

**Plan digest:** `sha256:9482206213b9f814c34619fdb141ce54afcfe41dab20296a275b89851ebbe808`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** gitops.RequireIgnored is the only enforcement point for the rule that a worktree placed inside the primary checkout must be git-ignored, and it is currently vacuous on any repository whose working-tree .gitignore contains an empty pattern: it asks git about the directory with a trailing slash, which produces an empty final path component, and an empty pattern matches an empty basename. Reproduced on git 2.53.0.windows.1: a .gitignore that is byte-identical apart from line endings gives exit 1 (correct refusal) with LF and exit 0 (wrong) with CRLF, because a CRLF blank line survives git's empty-line skip and is then trimmed to an empty pattern; a whitespace-only line under LF produces the identical empty pattern and the identical false positive, so this is not Windows-specific. Concrete file paths are unaffected, which is why git status stays correct and why the guard's own file-oriented probe is not affected. A verified fix shape: query a concrete sentinel child path inside the directory with no trailing slash - a non-empty basename can never match the empty pattern, and a directory-only pattern still matches a child path that does not exist on disk (both confirmed by direct experiment). The executor may implement a different shape if it satisfies the criteria, but must verify it against real git rather than reasoning about it.

**Acceptance criteria:**
- RequireIgnored returns ErrNotIgnored for a path that no .gitignore pattern covers, in a repository whose working-tree .gitignore contains an empty pattern - both the CRLF-blank-line form and the whitespace-only-line-under-LF form.
- RequireIgnored still returns nil for a directory that is covered only by a directory-only pattern such as foo/ and that does not yet exist on disk; this is the property the trailing-slash query was introduced to provide and it must not regress.
- Both behaviors are pinned by tests in internal/gitops' real-git integration suite rather than by the scripted argument-vector fakes, because a fake that asserts the argument vector cannot detect that the query it asserts is vacuous; each new test fails against the pre-change implementation.
- RequireIgnored's doc comment explains the shape the implementation actually uses and why, including the empty-pattern hazard that makes a bare trailing-slash directory query unsafe; it no longer justifies a query shape the code does not use.
- go test ./..., go vet ./..., and gofmt -l . are all clean, including any scripted tests elsewhere in the module that assert RequireIgnored's argument vector.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:dd23c00b6bd5` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **go-test-all** — pass — `go test ./...` — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:28:57Z)
- **go-vet** — pass — `go vet ./...` — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:28:57Z)
- **gofmt-check** — pass — `gofmt -l .` — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:28:57Z)
- **criterion-1-empty-pattern-fails-closed** — pass — `go test ./internal/gitops/... -run TestIntegrationRequireIgnoredEmptyPatternHazard -v` — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:41:31Z)
- **criterion-2-dir-only-pattern-no-regression** — pass — `go test ./internal/gitops/... -run TestIntegrationRequireIgnoredEmptyPatternHazard -v, plus a bare-relSlash mutation to prove the assertion discriminates` — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:41:31Z)
- **criterion-3-new-tests-fail-pre-change** — pass — `revert the query construction to filepath.ToSlash(rel) + "/", then go test ./internal/gitops/... -run TestIntegrationRequireIgnoredEmptyPatternHazard -v, then restore` — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:41:31Z)
- **criterion-4-doc-comment** — pass — `manual read of internal/gitops/checks.go lines 76-142 at af0f944` — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:51:17Z)
- **word-diff-checks-go** — pass — `git diff --word-diff --ignore-all-space fd5ddfa af0f944 -- internal/gitops/checks.go` — Cycle-2 word-diff, performed independently by the reviewer as well as the executor. The doc comment was rewritten again this cycle to describe the two-probe design; every removed span is old single-probe justification being replaced. No meaning-bearing prose was silently dropped. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:28:57Z)
- **real-git-manual-repro** — pass — `ad hoc git check-ignore probes on git 2.53.0.windows.1 comparing the old trailing-slash shape against the implemented two-probe shape` — RE-SCOPED AND RE-STAMPED at af0f944. The cycle-1 text described a single-probe query, which is not what the merge candidate implements; a reader could have concluded the shipped query is one probe. Superseded in scope by executor-two-probe-design-real-git and reviewer-probe-collision-property, both at af0f944, which cover the implemented two-probe conjunction across genuine dir-only patterns, all four collision globs, the CRLF hazard combined with a real pattern, and a catch-all. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:41:31Z)
- **reviewer-probe-collision-property** — pass — `real-git probes at af0f944 for orch-*, orch*, *probe*, the literal probe basename, and the two-line combinations, resolved against two candidate query paths` — REFINED at af0f944 with ground truth settled by the cycle-4 reviewer. All four single-line cycle-1 triggers fail closed: each ignores probe 0 but not probe 1, so the conjunction refuses. Residual two-line fail-open confirmed real and demonstrated: orch-* plus *[0-9] on scratch/foo gives container rc=1, both probes rc=0 and main.go rc=1 - a genuine fail-open. The apparent disagreement between earlier entries is resolved: on the path scratch/issue-9 the same pattern pair is CORRECTLY allowed, because *[0-9] matches the issue-9 component itself and the container is genuinely ignored, so cycle 3's observation was right about that specific demonstration path while *[0-9] does belong to the residual class in general. Same class for orch-* plus [0-9]*, ? or a literal 0. Requires two independent unrelated conventions to co-occur, against a pre-existing hole that fires on any CRLF blank line. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:51:17Z)
- **reviewer-mutation-reproduction** — pass — `revert query to the trailing-slash shape in a disposable clone, then go test ./internal/gitops/... -run TestIntegrationRequireIgnoredEmptyPatternHazard -v` — RE-STAMPED at af0f944 with the cited line corrected from integration_test.go:408 to :415. Re-run independently by the cycle-3 reviewer, a third reviewer reproducing it from scratch: both subtests still fail against the pre-change implementation, so the criterion-3 trailing-slash demonstration now has attestation at the merge head rather than only at the superseded one. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:41:31Z)
- **reviewer-criterion-2-discrimination** — pass — `mutate query to bare filepath.ToSlash(rel) at af0f944, then go test ./internal/gitops/... and ./internal/run/...` — SUPERSEDES the cycle-1 fail entry recorded at fd5ddfa. The strengthened container-path assertion now fails under the bare-path mutation at integration_test.go:407 in both hazard subtests, and the collision test's genuine-directory-pattern subtest fails at :462. The pin is inside internal/gitops where criterion 3 asked for it. 11 real-git tests in internal/run also fail under the same mutation, confirming activate.go:219 and worktree.go:100 genuinely depend on the property. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:28:57Z)
- **reviewer-negation-inverse-risk** — pass — `16 real-git configurations at af0f944 including four negation variants, content-enumeration containers, and this repository's live .gitignore` — CORRECTS the over-broad cycle-1 claim that a negation can never cause a spurious refusal. Narrowed: a negation cannot re-include a probe under a directory that is itself excluded AS A DIRECTORY. But when the container is ignored by content enumeration instead, .orchestrator/worktrees/* plus !0 (or !orch*, or the literal probe names) does produce a spurious refusal. This is the fail-closed direction, it is contrived, and the error's own remediation - add a line like .orchestrator/worktrees/ - resolves it, because a dir-only pattern makes both probes match. Across all 16 configurations plus four plausible real-world Go and node .gitignore files there was no old-allow / new-refuse case other than these enumeration-plus-negation constructions. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:28:57Z)
- **reviewer-live-repo-fail-open** — pass — `byte-level inspection of the primary checkout's .gitignore plus git check-ignore -v -- scratch/issue-9/ and both probe paths` — RESULT CHANGED FROM fail TO pass AND RE-STAMPED at af0f944. This entry records successful reproduction of the PRE-FIX bug - evidence for this PR, not a defect in it - and as the record's only fail result it would have misled any future reader scanning results. Verified this cycle: .gitignore is checked out CRLF in this working tree (line 15 is a bare CR), the old shape scratch/issue-9/ matches .gitignore:15 with an empty pattern at rc=0, while at this head both probes return rc=1 on that uncovered path and rc=0 on .orchestrator/worktrees matching .gitignore:19. The fix works against this repository's real .gitignore. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:41:31Z)
- **review-cycle-1** — request-changes — The fix is real, in scope, CI-green on all six checks, and repairs a fail-open that the reviewer confirmed is live in this repository's own Windows working tree today (.gitignore is checked out CRLF because .gitattributes has no eol=lf rule covering it, so check-ignore matched the empty pattern at .gitignore:15 and reported every directory ignored). Criteria 1, 2 and 5 are met and independently verified; the reviewer reproduced the executor's mutation demonstration rather than inheriting it, and confirmed the dir-only-pattern property still holds for bare, nested and glob-shaped patterns. Blocking defect: the fixed probe basename orch-check-ignore-probe reintroduces a fail-open on a different trigger. A property test written against this head fails on four .gitignore contents - orch-*, orch*, *probe*, and the literal name - each making RequireIgnored return nil for a directory no pattern covers. The repo is safe today only because it uses anchored /orch and /orch.exe; changing that to orch-* to cover cross-compiled release artifacts, a standard Go convention, would silently re-open the hole with no test and no comment to warn anyone. The const's doc comment asserts collision-safety while reasoning only about the dot-prefix family, which is the wrong family for a project whose binary is named orch. Two secondary defects: the criterion-2 assertion in the new integration test does not discriminate (it passes under a bare-path query too, because its covered path matches a non-final component; the container path .orchestrator/worktrees, which activate.go:219 actually queries, is the discriminating case), and the criterion-2 manifest entry therefore overstates what its test demonstrates. The reviewer verified the inverse risk is not real: a negation cannot un-ignore a probe under an excluded directory, so no spurious refusal is possible. Five concrete changes requested; the approach itself is sound and the remedy is small. — commit `fd5ddfa27fea9976f0629f36ade3a121594b354b` (2026-07-28T21:04:44Z)
- **executor-two-probe-design-real-git** — pass — `ad hoc git check-ignore probes comparing single-probe vs two-probe across genuine dir-only patterns, orch-*, orch*, *probe*, the literal name, CRLF hazard combined with a genuine pattern, and a catch-all *` — Executor evidence at af0f944. Covered dir 0/0 allow; every collision glob on an uncovered dir 0/1 fails closed; hazard plus real pattern correct both ways; catch-all * matches both probes and is correctly allowed because everything genuinely is ignored. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:28:57Z)
- **executor-mutation-single-probe** — pass — `change the loop to requireIgnoredProbes[:1], go test ./internal/gitops/... -run TestIntegrationRequireIgnoredProbeBasenameCollisionHazard -v, then restore` — Executor demonstration at af0f944, reproduced independently by the reviewer. All four collision subtests FAIL with err = &lt;nil&gt;, want ErrNotIgnored, while the genuine-directory-pattern subtest still passes. Two scripted subtests also fail with script not exhausted: 2 of 3 calls made. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:28:57Z)
- **executor-mutation-bare-query** — pass — `change the per-probe query to the bare relSlash, go test ./internal/gitops/... -run TestIntegrationRequireIgnoredEmptyPatternHazard -v, then restore` — Executor demonstration at af0f944, reproduced independently by the reviewer. Both subtests FAIL reporting the container path as not git-ignored, confirming the strengthened criterion-2 assertion discriminates where the old nested-child assertion did not. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:28:57Z)
- **reviewer-scripted-fake-call-counts** — pass — `read execxtest/script.go and every scripted RequireIgnored expectation at af0f944` — The fake fails on both an unscripted extra call and an unconsumed one, so each expectation is an exact call-count assertion in both directions. Short-circuit paths are pinned correctly: the not-ignored and other-exit-code subtests and both AddWorktree failure tests script exactly one probe call and pass AssertExhausted, proving the second probe is never issued after a decisive first result. The new second-probe-not-ignored subtest pins the AND semantics with two calls. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:28:57Z)
- **reviewer-scope-and-cost** — pass — `git diff at af0f944 plus timed go test ./internal/run/... ./internal/gitops/...` — Exactly 4 files, all under internal/gitops. internal/guard/resolve.go correctly untouched. RequireIgnored now runs two subprocesses per call at two call sites that fire once per activation and once per worktree creation: measured 25.39s on main vs 25.50s at head, immaterial. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:28:57Z)
- **reviewer-ci-at-reviewed-oid** — pass — `gh pr checks at af0f9445dd38c818372dd16db502dd33828921ca` — 6 of 6 green at the reviewed head: lint, scripts on ubuntu and windows, test on ubuntu, windows and macos. The windows job that was still running when the review started has since passed in 2m16s. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:28:57Z)
- **architect-audit-record-restamped** — pass — `orch run review at af0f944 carrying cycle-3 record corrections` — Second and final pass at the Architect-authored record defect. Cycle 2 re-stamped the required tests and superseded two fail entries but left all four criterion-* entries at the superseded head, so the record still did not attest that the acceptance criteria hold at the merge candidate. This call corrects and re-stamps criterion-1 through criterion-4, flips reviewer-live-repo-fail-open from fail to pass, and re-scopes real-git-manual-repro and reviewer-mutation-reproduction. The root cause is an ordering property of the loop rather than an oversight: an executor's fix-cycle evidence has no verb to attach to until the next orch run review call, so unless the Architect deliberately carries it forward, every fix cycle leaves the record stamped at a superseded head. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:41:31Z)
- **review-cycle-2** — request-changes — Cycle 2 finds the CODE correct and every acceptance criterion met, independently verified: the reviewer reproduced all three mutations itself (single-probe fails all four collision subtests; pre-change trailing-slash fails both empty-pattern subtests; bare-path fails the strengthened criterion-2 assertion inside internal/gitops and 11 real-git tests in internal/run), confirmed the fail-open is live in this checkout today, and confirmed CI 6/6 green at the reviewed head. It probed the conjunction in both directions: no single realistic .gitignore line can match both probes without being a genuine catch-all, and 0 is a defensible second probe because character-class conventions that match it push toward refusal, never fail-open. Two honest residuals it documented rather than hid: a TWO-line coincidence (orch-* together with [0-9]*, ?, or a literal 0) still reopens the fail-open, and when a container is ignored by content enumeration rather than as a directory, a negation such as .orchestrator/worktrees/* plus !0 does produce a spurious refusal - the fail-closed direction, resolved by the error's own remediation. The blocking defect is the AUDIT RECORD, and it is Architect-authored, not the executor's: all 15 entries cited the superseded cycle-1 head fd5ddfa, so the required tests were unrecorded at what would merge, none of the executor's cycle-2 work appeared, and two reviewer entries still stood as fail with nothing superseding them. This review call stamps the cycle-2 evidence at af0f944, supersedes those two fail entries by name, adds the missing cycle-2 word-diff, and narrows the over-broad negation claim. No code change was requested, so the head is unchanged. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:28:58Z)
- **reviewer-independent-code-verification-cycle-3** — pass — `full independent re-verification at af0f944: three mutations, go test/vet/gofmt, CI check-runs API with head_sha matching, scope diff, and execxtest/script.go semantics` — A third opus reviewer verified the code from scratch rather than inheriting cycles 1 and 2. All 25 packages ok; vet and gofmt clean; 6/6 CI green at exactly af0f944 with head_sha matched on every run; exactly 4 files changed, all under internal/gitops, with internal/guard/resolve.go untouched and structurally immune because its query carries no trailing slash. Under the bare-path mutation exactly 11 real-git tests in internal/run fail, every one at .orchestrator/worktrees, confirming activate.go:219 and worktree.go:100 genuinely depend on the property. Nothing outside internal/gitops asserts RequireIgnored's argument vector: internal/cli's fake matches check-ignore generically and scripts the guard's probe, not this one. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:41:31Z)
- **review-cycle-3** — request-changes — Third consecutive cycle finding the CODE correct with nothing to change in it; a third independent opus reviewer verified all five criteria from scratch, reproduced all three mutations, confirmed exactly 11 internal/run tests fail under the bare-path mutation, and confirmed 6/6 CI at the reviewed head. It also isolated the mechanism more precisely than any prior cycle: a plain LF blank line does NOT trigger the hazard, only a CRLF blank line or a whitespace-only line, and only when the query's final component is empty. Both residuals were independently confirmed and judged non-blocking: the two-line coincidence is real and a configuration exists where the new code is worse than the old, but it needs two unrelated conventions to co-occur against a pre-existing hole that fires on any CRLF-blank line - that is, on this repository today; and content-enumeration plus a negation is the fail-closed direction with a self-healing error message. It corrected one imprecision in the prior record: for the path scratch/issue-9 the pattern *[0-9] matches the issue-9 component itself, so that allow is correct and does not belong in the two-line fail-open list. The blocking defects remain entirely Architect-authored record defects. The clearest: criterion-2-dir-only-pattern-no-regression still describes an assertion on .orchestrator/worktrees/issue-9, but the cycle-2 commit changed that assertion to the container path .orchestrator/worktrees - so the entry is FALSE about the head that would merge, and it still carries the exact overstatement cycle 1 asked to have corrected. The code fix landed; the record correction did not, across two cycles. Also: all four criterion-* entries were still stamped at the superseded head, and reviewer-live-repo-fail-open stood as the record's only fail result while actually describing successful reproduction of the pre-fix bug - evidence FOR this PR, not a defect in it. This call corrects and re-stamps all of them at af0f944. One requested correction is not actionable: the reviewer asked for a pointer clause inside review-cycle-1, but review-cycle-&lt;n&gt; is an engine-owned verification name that the engine rejects with ErrBadRequest before any mutation, so it is recorded here instead - review-cycle-1's sentence claiming the negation inverse risk is not real was superseded by the corrected reviewer-negation-inverse-risk entry at af0f944, and review-cycle-1 correctly remains stamped at fd5ddfa as the cycle-1 verdict on the cycle-1 head. The head has not moved and must not: af0f944 is the commit all three reviewers judged. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:41:32Z)
- **reviewer-scoped-cycle-4-code-check** — pass — `go test -count=1 ./internal/gitops/... ./internal/run/... ./internal/guard/... ./internal/cli/..., go test ./..., go vet ./..., gofmt -l ., CI check-runs API, and an independent requireIgnoredProbes[:1] mutation` — All 25 packages ok including an uncached run (gitops 5.6s, run 24.8s); vet and gofmt clean; CI 6/6 green at exactly af0f9445dd38c818372dd16db502dd33828921ca with head_sha matched on every run; scope exactly 4 files under internal/gitops with git log on internal/guard/resolve.go returning zero commits. The reviewer's own single-probe mutation failed all four collision subtests at integration_test.go:447 with err = &lt;nil&gt;, want ErrNotIgnored, while the genuine-directory-pattern subtest still passed, isolating the intended property; checks_test.go:125 and :154 additionally failed with script not exhausted: 2 of 3 calls made. Implementation confirmed at checks.go:143-169: per-probe query relSlash + "/" + probe, exit 0 continue, exit 1 short-circuit refuse, any other exit surfacing the git error. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:51:17Z)
- **reviewer-engine-owned-name-proof** — pass — `read internal/run/manifestbody.go and internal/run/review.go at af0f944` — Confirms the one cycle-3 correction that could not be applied really is impossible rather than skipped: manifestbody.go:154 defines reviewCycleNamePattern as ^review-cycle-[0-9]+$ and :161-168 rejectEngineOwnedNames returns ErrBadRequest on a match before any mutation, with review.go:38-43 documenting the same. The reviewer further judged the supersede-by-later-entry resolution correct on the merits, since editing a past reviewer's verdict on a past head would falsify history, and confirmed a reader meets the superseding entry under a later timestamp at the merge head. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:51:17Z)
- **reviewer-record-as-a-set** — pass — `parse the orch:manifest:data JSON block and read every entry against the code at af0f944` — 25 entries, zero duplicate names, zero fail results. 24 stamped at af0f944; the sole fd5ddfa entry is review-cycle-1, correct as the cycle-1 verdict on the cycle-1 head. The reviewer's judgement: a future reader is correctly informed about what was verified, at which commit, and what limits remain - including that three cycles requested changes and why, that cycle 1's two fail entries were superseded by named entries rather than deleted, and that two residual weaknesses survive, stated in the entries themselves rather than buried. Commit-OID stamping now does real work, with fd5ddfa marking superseded history and af0f944 marking what merges. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:51:17Z)
- **review-cycle-4** — approve — Fourth and final cycle, deliberately scoped to audit-record verification plus a minimal independent code check, because the code at this head had already been verified from scratch by three separate opus reviewers and had not changed since cycle 2 - a fourth full re-derivation would have been exactly the low-value repetition this repository's Delivery-cost investigation exists to find. The reviewer was told the scope and told to request changes anyway if it found anything. It verified all eight cycle-3 corrections against the source rather than against the prior reviews, and every one is true of the code at af0f944: the criterion-2 entry that had been false across two cycles now correctly describes the container-path assertion at integration_test.go:405-407 and is corroborated by the cycle-2 diff; the LF-blank-line refinement was independently reproduced (plain LF blank rc=1, CRLF blank rc=0, whitespace-only rc=0); :415 is confirmed to be the want-ErrNotIgnored assertion where :408 was a closing brace; the doc range 76-142 and the three-property count are exact. It reproduced the live fail-open against the primary checkout read-only, confirming .gitignore is CRLF and that the old shape matches .gitignore:15's empty pattern at rc=0 while both probes correctly refuse. It proved the review-cycle-1 edit really is impossible by reading the engine source - manifestbody.go:154 rejectEngineOwnedNames returns ErrBadRequest on the review-cycle-&lt;n&gt; pattern before any mutation - and judged the supersede-by-later-entry resolution correct on the merits, since editing a past reviewer's verdict on a past head would falsify history. Independent code check at this head: all 25 packages ok uncached, vet and gofmt clean, CI 6/6 green with head_sha matched on every run, scope unchanged at 4 files under internal/gitops with internal/guard/resolve.go carrying zero commits on that path, and its own requireIgnoredProbes[:1] mutation failing all four collision subtests at :447 plus two scripted call-count pins. It settled one set-level tension with real git rather than picking a side, and this call records the settled ground truth. The manifest carries 25 entries, no duplicate names, no fail results, 24 stamped at the merge head and only the cycle-1 verdict at the superseded one. — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:51:19Z)
- **required-ci** — passing — test (macos-latest)=pass, scripts (windows-latest)=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass — commit `af0f9445dd38c818372dd16db502dd33828921ca` (2026-07-28T21:51:23Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "gitops.RequireIgnored is the only enforcement point for the rule that a worktree placed inside the primary checkout must be git-ignored, and it is currently vacuous on any repository whose working-tree .gitignore contains an empty pattern: it asks git about the directory with a trailing slash, which produces an empty final path component, and an empty pattern matches an empty basename. Reproduced on git 2.53.0.windows.1: a .gitignore that is byte-identical apart from line endings gives exit 1 (correct refusal) with LF and exit 0 (wrong) with CRLF, because a CRLF blank line survives git's empty-line skip and is then trimmed to an empty pattern; a whitespace-only line under LF produces the identical empty pattern and the identical false positive, so this is not Windows-specific. Concrete file paths are unaffected, which is why git status stays correct and why the guard's own file-oriented probe is not affected. A verified fix shape: query a concrete sentinel child path inside the directory with no trailing slash - a non-empty basename can never match the empty pattern, and a directory-only pattern still matches a child path that does not exist on disk (both confirmed by direct experiment). The executor may implement a different shape if it satisfies the criteria, but must verify it against real git rather than reasoning about it.",
  "acceptance_criteria": [
    "RequireIgnored returns ErrNotIgnored for a path that no .gitignore pattern covers, in a repository whose working-tree .gitignore contains an empty pattern - both the CRLF-blank-line form and the whitespace-only-line-under-LF form.",
    "RequireIgnored still returns nil for a directory that is covered only by a directory-only pattern such as foo/ and that does not yet exist on disk; this is the property the trailing-slash query was introduced to provide and it must not regress.",
    "Both behaviors are pinned by tests in internal/gitops' real-git integration suite rather than by the scripted argument-vector fakes, because a fake that asserts the argument vector cannot detect that the query it asserts is vacuous; each new test fails against the pre-change implementation.",
    "RequireIgnored's doc comment explains the shape the implementation actually uses and why, including the empty-pattern hazard that makes a bare trailing-slash directory query unsafe; it no longer justifies a query shape the code does not use.",
    "go test ./..., go vet ./..., and gofmt -l . are all clean, including any scripted tests elsewhere in the module that assert RequireIgnored's argument vector."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:dd23c00b6bd5",
  "verifications": [
    {
      "name": "go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:28:57Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:28:57Z"
    },
    {
      "name": "gofmt-check",
      "command": "gofmt -l .",
      "result": "pass",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:28:57Z"
    },
    {
      "name": "criterion-1-empty-pattern-fails-closed",
      "command": "go test ./internal/gitops/... -run TestIntegrationRequireIgnoredEmptyPatternHazard -v",
      "result": "pass",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:41:31Z"
    },
    {
      "name": "criterion-2-dir-only-pattern-no-regression",
      "command": "go test ./internal/gitops/... -run TestIntegrationRequireIgnoredEmptyPatternHazard -v, plus a bare-relSlash mutation to prove the assertion discriminates",
      "result": "pass",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:41:31Z"
    },
    {
      "name": "criterion-3-new-tests-fail-pre-change",
      "command": "revert the query construction to filepath.ToSlash(rel) + \"/\", then go test ./internal/gitops/... -run TestIntegrationRequireIgnoredEmptyPatternHazard -v, then restore",
      "result": "pass",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:41:31Z"
    },
    {
      "name": "criterion-4-doc-comment",
      "command": "manual read of internal/gitops/checks.go lines 76-142 at af0f944",
      "result": "pass",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:51:17Z"
    },
    {
      "name": "word-diff-checks-go",
      "command": "git diff --word-diff --ignore-all-space fd5ddfa af0f944 -- internal/gitops/checks.go",
      "result": "pass",
      "detail": "Cycle-2 word-diff, performed independently by the reviewer as well as the executor. The doc comment was rewritten again this cycle to describe the two-probe design; every removed span is old single-probe justification being replaced. No meaning-bearing prose was silently dropped.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:28:57Z"
    },
    {
      "name": "real-git-manual-repro",
      "command": "ad hoc git check-ignore probes on git 2.53.0.windows.1 comparing the old trailing-slash shape against the implemented two-probe shape",
      "result": "pass",
      "detail": "RE-SCOPED AND RE-STAMPED at af0f944. The cycle-1 text described a single-probe query, which is not what the merge candidate implements; a reader could have concluded the shipped query is one probe. Superseded in scope by executor-two-probe-design-real-git and reviewer-probe-collision-property, both at af0f944, which cover the implemented two-probe conjunction across genuine dir-only patterns, all four collision globs, the CRLF hazard combined with a real pattern, and a catch-all.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:41:31Z"
    },
    {
      "name": "reviewer-probe-collision-property",
      "command": "real-git probes at af0f944 for orch-*, orch*, *probe*, the literal probe basename, and the two-line combinations, resolved against two candidate query paths",
      "result": "pass",
      "detail": "REFINED at af0f944 with ground truth settled by the cycle-4 reviewer. All four single-line cycle-1 triggers fail closed: each ignores probe 0 but not probe 1, so the conjunction refuses. Residual two-line fail-open confirmed real and demonstrated: orch-* plus *[0-9] on scratch/foo gives container rc=1, both probes rc=0 and main.go rc=1 - a genuine fail-open. The apparent disagreement between earlier entries is resolved: on the path scratch/issue-9 the same pattern pair is CORRECTLY allowed, because *[0-9] matches the issue-9 component itself and the container is genuinely ignored, so cycle 3's observation was right about that specific demonstration path while *[0-9] does belong to the residual class in general. Same class for orch-* plus [0-9]*, ? or a literal 0. Requires two independent unrelated conventions to co-occur, against a pre-existing hole that fires on any CRLF blank line.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:51:17Z"
    },
    {
      "name": "reviewer-mutation-reproduction",
      "command": "revert query to the trailing-slash shape in a disposable clone, then go test ./internal/gitops/... -run TestIntegrationRequireIgnoredEmptyPatternHazard -v",
      "result": "pass",
      "detail": "RE-STAMPED at af0f944 with the cited line corrected from integration_test.go:408 to :415. Re-run independently by the cycle-3 reviewer, a third reviewer reproducing it from scratch: both subtests still fail against the pre-change implementation, so the criterion-3 trailing-slash demonstration now has attestation at the merge head rather than only at the superseded one.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:41:31Z"
    },
    {
      "name": "reviewer-criterion-2-discrimination",
      "command": "mutate query to bare filepath.ToSlash(rel) at af0f944, then go test ./internal/gitops/... and ./internal/run/...",
      "result": "pass",
      "detail": "SUPERSEDES the cycle-1 fail entry recorded at fd5ddfa. The strengthened container-path assertion now fails under the bare-path mutation at integration_test.go:407 in both hazard subtests, and the collision test's genuine-directory-pattern subtest fails at :462. The pin is inside internal/gitops where criterion 3 asked for it. 11 real-git tests in internal/run also fail under the same mutation, confirming activate.go:219 and worktree.go:100 genuinely depend on the property.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:28:57Z"
    },
    {
      "name": "reviewer-negation-inverse-risk",
      "command": "16 real-git configurations at af0f944 including four negation variants, content-enumeration containers, and this repository's live .gitignore",
      "result": "pass",
      "detail": "CORRECTS the over-broad cycle-1 claim that a negation can never cause a spurious refusal. Narrowed: a negation cannot re-include a probe under a directory that is itself excluded AS A DIRECTORY. But when the container is ignored by content enumeration instead, .orchestrator/worktrees/* plus !0 (or !orch*, or the literal probe names) does produce a spurious refusal. This is the fail-closed direction, it is contrived, and the error's own remediation - add a line like .orchestrator/worktrees/ - resolves it, because a dir-only pattern makes both probes match. Across all 16 configurations plus four plausible real-world Go and node .gitignore files there was no old-allow / new-refuse case other than these enumeration-plus-negation constructions.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:28:57Z"
    },
    {
      "name": "reviewer-live-repo-fail-open",
      "command": "byte-level inspection of the primary checkout's .gitignore plus git check-ignore -v -- scratch/issue-9/ and both probe paths",
      "result": "pass",
      "detail": "RESULT CHANGED FROM fail TO pass AND RE-STAMPED at af0f944. This entry records successful reproduction of the PRE-FIX bug - evidence for this PR, not a defect in it - and as the record's only fail result it would have misled any future reader scanning results. Verified this cycle: .gitignore is checked out CRLF in this working tree (line 15 is a bare CR), the old shape scratch/issue-9/ matches .gitignore:15 with an empty pattern at rc=0, while at this head both probes return rc=1 on that uncovered path and rc=0 on .orchestrator/worktrees matching .gitignore:19. The fix works against this repository's real .gitignore.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:41:31Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "The fix is real, in scope, CI-green on all six checks, and repairs a fail-open that the reviewer confirmed is live in this repository's own Windows working tree today (.gitignore is checked out CRLF because .gitattributes has no eol=lf rule covering it, so check-ignore matched the empty pattern at .gitignore:15 and reported every directory ignored). Criteria 1, 2 and 5 are met and independently verified; the reviewer reproduced the executor's mutation demonstration rather than inheriting it, and confirmed the dir-only-pattern property still holds for bare, nested and glob-shaped patterns. Blocking defect: the fixed probe basename orch-check-ignore-probe reintroduces a fail-open on a different trigger. A property test written against this head fails on four .gitignore contents - orch-*, orch*, *probe*, and the literal name - each making RequireIgnored return nil for a directory no pattern covers. The repo is safe today only because it uses anchored /orch and /orch.exe; changing that to orch-* to cover cross-compiled release artifacts, a standard Go convention, would silently re-open the hole with no test and no comment to warn anyone. The const's doc comment asserts collision-safety while reasoning only about the dot-prefix family, which is the wrong family for a project whose binary is named orch. Two secondary defects: the criterion-2 assertion in the new integration test does not discriminate (it passes under a bare-path query too, because its covered path matches a non-final component; the container path .orchestrator/worktrees, which activate.go:219 actually queries, is the discriminating case), and the criterion-2 manifest entry therefore overstates what its test demonstrates. The reviewer verified the inverse risk is not real: a negation cannot un-ignore a probe under an excluded directory, so no spurious refusal is possible. Five concrete changes requested; the approach itself is sound and the remedy is small.",
      "commit_oid": "fd5ddfa27fea9976f0629f36ade3a121594b354b",
      "at": "2026-07-28T21:04:44Z"
    },
    {
      "name": "executor-two-probe-design-real-git",
      "command": "ad hoc git check-ignore probes comparing single-probe vs two-probe across genuine dir-only patterns, orch-*, orch*, *probe*, the literal name, CRLF hazard combined with a genuine pattern, and a catch-all *",
      "result": "pass",
      "detail": "Executor evidence at af0f944. Covered dir 0/0 allow; every collision glob on an uncovered dir 0/1 fails closed; hazard plus real pattern correct both ways; catch-all * matches both probes and is correctly allowed because everything genuinely is ignored.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:28:57Z"
    },
    {
      "name": "executor-mutation-single-probe",
      "command": "change the loop to requireIgnoredProbes[:1], go test ./internal/gitops/... -run TestIntegrationRequireIgnoredProbeBasenameCollisionHazard -v, then restore",
      "result": "pass",
      "detail": "Executor demonstration at af0f944, reproduced independently by the reviewer. All four collision subtests FAIL with err = \u003cnil\u003e, want ErrNotIgnored, while the genuine-directory-pattern subtest still passes. Two scripted subtests also fail with script not exhausted: 2 of 3 calls made.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:28:57Z"
    },
    {
      "name": "executor-mutation-bare-query",
      "command": "change the per-probe query to the bare relSlash, go test ./internal/gitops/... -run TestIntegrationRequireIgnoredEmptyPatternHazard -v, then restore",
      "result": "pass",
      "detail": "Executor demonstration at af0f944, reproduced independently by the reviewer. Both subtests FAIL reporting the container path as not git-ignored, confirming the strengthened criterion-2 assertion discriminates where the old nested-child assertion did not.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:28:57Z"
    },
    {
      "name": "reviewer-scripted-fake-call-counts",
      "command": "read execxtest/script.go and every scripted RequireIgnored expectation at af0f944",
      "result": "pass",
      "detail": "The fake fails on both an unscripted extra call and an unconsumed one, so each expectation is an exact call-count assertion in both directions. Short-circuit paths are pinned correctly: the not-ignored and other-exit-code subtests and both AddWorktree failure tests script exactly one probe call and pass AssertExhausted, proving the second probe is never issued after a decisive first result. The new second-probe-not-ignored subtest pins the AND semantics with two calls.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:28:57Z"
    },
    {
      "name": "reviewer-scope-and-cost",
      "command": "git diff at af0f944 plus timed go test ./internal/run/... ./internal/gitops/...",
      "result": "pass",
      "detail": "Exactly 4 files, all under internal/gitops. internal/guard/resolve.go correctly untouched. RequireIgnored now runs two subprocesses per call at two call sites that fire once per activation and once per worktree creation: measured 25.39s on main vs 25.50s at head, immaterial.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:28:57Z"
    },
    {
      "name": "reviewer-ci-at-reviewed-oid",
      "command": "gh pr checks at af0f9445dd38c818372dd16db502dd33828921ca",
      "result": "pass",
      "detail": "6 of 6 green at the reviewed head: lint, scripts on ubuntu and windows, test on ubuntu, windows and macos. The windows job that was still running when the review started has since passed in 2m16s.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:28:57Z"
    },
    {
      "name": "architect-audit-record-restamped",
      "command": "orch run review at af0f944 carrying cycle-3 record corrections",
      "result": "pass",
      "detail": "Second and final pass at the Architect-authored record defect. Cycle 2 re-stamped the required tests and superseded two fail entries but left all four criterion-* entries at the superseded head, so the record still did not attest that the acceptance criteria hold at the merge candidate. This call corrects and re-stamps criterion-1 through criterion-4, flips reviewer-live-repo-fail-open from fail to pass, and re-scopes real-git-manual-repro and reviewer-mutation-reproduction. The root cause is an ordering property of the loop rather than an oversight: an executor's fix-cycle evidence has no verb to attach to until the next orch run review call, so unless the Architect deliberately carries it forward, every fix cycle leaves the record stamped at a superseded head.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:41:31Z"
    },
    {
      "name": "review-cycle-2",
      "result": "request-changes",
      "detail": "Cycle 2 finds the CODE correct and every acceptance criterion met, independently verified: the reviewer reproduced all three mutations itself (single-probe fails all four collision subtests; pre-change trailing-slash fails both empty-pattern subtests; bare-path fails the strengthened criterion-2 assertion inside internal/gitops and 11 real-git tests in internal/run), confirmed the fail-open is live in this checkout today, and confirmed CI 6/6 green at the reviewed head. It probed the conjunction in both directions: no single realistic .gitignore line can match both probes without being a genuine catch-all, and 0 is a defensible second probe because character-class conventions that match it push toward refusal, never fail-open. Two honest residuals it documented rather than hid: a TWO-line coincidence (orch-* together with [0-9]*, ?, or a literal 0) still reopens the fail-open, and when a container is ignored by content enumeration rather than as a directory, a negation such as .orchestrator/worktrees/* plus !0 does produce a spurious refusal - the fail-closed direction, resolved by the error's own remediation. The blocking defect is the AUDIT RECORD, and it is Architect-authored, not the executor's: all 15 entries cited the superseded cycle-1 head fd5ddfa, so the required tests were unrecorded at what would merge, none of the executor's cycle-2 work appeared, and two reviewer entries still stood as fail with nothing superseding them. This review call stamps the cycle-2 evidence at af0f944, supersedes those two fail entries by name, adds the missing cycle-2 word-diff, and narrows the over-broad negation claim. No code change was requested, so the head is unchanged.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:28:58Z"
    },
    {
      "name": "reviewer-independent-code-verification-cycle-3",
      "command": "full independent re-verification at af0f944: three mutations, go test/vet/gofmt, CI check-runs API with head_sha matching, scope diff, and execxtest/script.go semantics",
      "result": "pass",
      "detail": "A third opus reviewer verified the code from scratch rather than inheriting cycles 1 and 2. All 25 packages ok; vet and gofmt clean; 6/6 CI green at exactly af0f944 with head_sha matched on every run; exactly 4 files changed, all under internal/gitops, with internal/guard/resolve.go untouched and structurally immune because its query carries no trailing slash. Under the bare-path mutation exactly 11 real-git tests in internal/run fail, every one at .orchestrator/worktrees, confirming activate.go:219 and worktree.go:100 genuinely depend on the property. Nothing outside internal/gitops asserts RequireIgnored's argument vector: internal/cli's fake matches check-ignore generically and scripts the guard's probe, not this one.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:41:31Z"
    },
    {
      "name": "review-cycle-3",
      "result": "request-changes",
      "detail": "Third consecutive cycle finding the CODE correct with nothing to change in it; a third independent opus reviewer verified all five criteria from scratch, reproduced all three mutations, confirmed exactly 11 internal/run tests fail under the bare-path mutation, and confirmed 6/6 CI at the reviewed head. It also isolated the mechanism more precisely than any prior cycle: a plain LF blank line does NOT trigger the hazard, only a CRLF blank line or a whitespace-only line, and only when the query's final component is empty. Both residuals were independently confirmed and judged non-blocking: the two-line coincidence is real and a configuration exists where the new code is worse than the old, but it needs two unrelated conventions to co-occur against a pre-existing hole that fires on any CRLF-blank line - that is, on this repository today; and content-enumeration plus a negation is the fail-closed direction with a self-healing error message. It corrected one imprecision in the prior record: for the path scratch/issue-9 the pattern *[0-9] matches the issue-9 component itself, so that allow is correct and does not belong in the two-line fail-open list. The blocking defects remain entirely Architect-authored record defects. The clearest: criterion-2-dir-only-pattern-no-regression still describes an assertion on .orchestrator/worktrees/issue-9, but the cycle-2 commit changed that assertion to the container path .orchestrator/worktrees - so the entry is FALSE about the head that would merge, and it still carries the exact overstatement cycle 1 asked to have corrected. The code fix landed; the record correction did not, across two cycles. Also: all four criterion-* entries were still stamped at the superseded head, and reviewer-live-repo-fail-open stood as the record's only fail result while actually describing successful reproduction of the pre-fix bug - evidence FOR this PR, not a defect in it. This call corrects and re-stamps all of them at af0f944. One requested correction is not actionable: the reviewer asked for a pointer clause inside review-cycle-1, but review-cycle-\u003cn\u003e is an engine-owned verification name that the engine rejects with ErrBadRequest before any mutation, so it is recorded here instead - review-cycle-1's sentence claiming the negation inverse risk is not real was superseded by the corrected reviewer-negation-inverse-risk entry at af0f944, and review-cycle-1 correctly remains stamped at fd5ddfa as the cycle-1 verdict on the cycle-1 head. The head has not moved and must not: af0f944 is the commit all three reviewers judged.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:41:32Z"
    },
    {
      "name": "reviewer-scoped-cycle-4-code-check",
      "command": "go test -count=1 ./internal/gitops/... ./internal/run/... ./internal/guard/... ./internal/cli/..., go test ./..., go vet ./..., gofmt -l ., CI check-runs API, and an independent requireIgnoredProbes[:1] mutation",
      "result": "pass",
      "detail": "All 25 packages ok including an uncached run (gitops 5.6s, run 24.8s); vet and gofmt clean; CI 6/6 green at exactly af0f9445dd38c818372dd16db502dd33828921ca with head_sha matched on every run; scope exactly 4 files under internal/gitops with git log on internal/guard/resolve.go returning zero commits. The reviewer's own single-probe mutation failed all four collision subtests at integration_test.go:447 with err = \u003cnil\u003e, want ErrNotIgnored, while the genuine-directory-pattern subtest still passed, isolating the intended property; checks_test.go:125 and :154 additionally failed with script not exhausted: 2 of 3 calls made. Implementation confirmed at checks.go:143-169: per-probe query relSlash + \"/\" + probe, exit 0 continue, exit 1 short-circuit refuse, any other exit surfacing the git error.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:51:17Z"
    },
    {
      "name": "reviewer-engine-owned-name-proof",
      "command": "read internal/run/manifestbody.go and internal/run/review.go at af0f944",
      "result": "pass",
      "detail": "Confirms the one cycle-3 correction that could not be applied really is impossible rather than skipped: manifestbody.go:154 defines reviewCycleNamePattern as ^review-cycle-[0-9]+$ and :161-168 rejectEngineOwnedNames returns ErrBadRequest on a match before any mutation, with review.go:38-43 documenting the same. The reviewer further judged the supersede-by-later-entry resolution correct on the merits, since editing a past reviewer's verdict on a past head would falsify history, and confirmed a reader meets the superseding entry under a later timestamp at the merge head.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:51:17Z"
    },
    {
      "name": "reviewer-record-as-a-set",
      "command": "parse the orch:manifest:data JSON block and read every entry against the code at af0f944",
      "result": "pass",
      "detail": "25 entries, zero duplicate names, zero fail results. 24 stamped at af0f944; the sole fd5ddfa entry is review-cycle-1, correct as the cycle-1 verdict on the cycle-1 head. The reviewer's judgement: a future reader is correctly informed about what was verified, at which commit, and what limits remain - including that three cycles requested changes and why, that cycle 1's two fail entries were superseded by named entries rather than deleted, and that two residual weaknesses survive, stated in the entries themselves rather than buried. Commit-OID stamping now does real work, with fd5ddfa marking superseded history and af0f944 marking what merges.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:51:17Z"
    },
    {
      "name": "review-cycle-4",
      "result": "approve",
      "detail": "Fourth and final cycle, deliberately scoped to audit-record verification plus a minimal independent code check, because the code at this head had already been verified from scratch by three separate opus reviewers and had not changed since cycle 2 - a fourth full re-derivation would have been exactly the low-value repetition this repository's Delivery-cost investigation exists to find. The reviewer was told the scope and told to request changes anyway if it found anything. It verified all eight cycle-3 corrections against the source rather than against the prior reviews, and every one is true of the code at af0f944: the criterion-2 entry that had been false across two cycles now correctly describes the container-path assertion at integration_test.go:405-407 and is corroborated by the cycle-2 diff; the LF-blank-line refinement was independently reproduced (plain LF blank rc=1, CRLF blank rc=0, whitespace-only rc=0); :415 is confirmed to be the want-ErrNotIgnored assertion where :408 was a closing brace; the doc range 76-142 and the three-property count are exact. It reproduced the live fail-open against the primary checkout read-only, confirming .gitignore is CRLF and that the old shape matches .gitignore:15's empty pattern at rc=0 while both probes correctly refuse. It proved the review-cycle-1 edit really is impossible by reading the engine source - manifestbody.go:154 rejectEngineOwnedNames returns ErrBadRequest on the review-cycle-\u003cn\u003e pattern before any mutation - and judged the supersede-by-later-entry resolution correct on the merits, since editing a past reviewer's verdict on a past head would falsify history. Independent code check at this head: all 25 packages ok uncached, vet and gofmt clean, CI 6/6 green with head_sha matched on every run, scope unchanged at 4 files under internal/gitops with internal/guard/resolve.go carrying zero commits on that path, and its own requireIgnoredProbes[:1] mutation failing all four collision subtests at :447 plus two scripted call-count pins. It settled one set-level tension with real git rather than picking a side, and this call records the settled ground truth. The manifest carries 25 entries, no duplicate names, no fail results, 24 stamped at the merge head and only the cycle-1 verdict at the superseded one.",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:51:19Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (macos-latest)=pass, scripts (windows-latest)=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass",
      "commit_oid": "af0f9445dd38c818372dd16db502dd33828921ca",
      "at": "2026-07-28T21:51:23Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->