### PR TITLE
Make the metrics ignore line unconditional and the un-ignored-metrics failure legible

### DIFF
--- a/internal/bootstrap/configure.go
+++ b/internal/bootstrap/configure.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kninetimmy/orch/internal/gitops"
 	"github.com/kninetimmy/orch/internal/interview"
 	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/question"
 	"github.com/kninetimmy/orch/internal/state"
 )
@@ -64,7 +65,16 @@ func ExecuteConfigure(ctx context.Context, deps Deps) (Report, error) {
 	// it stood when NextConfigure last ran; a dirty tree could mean
 	// those diffs no longer describe what Stage 1 is about to write.
 	if err := git.RequireClean(ctx, ""); err != nil {
-		return Report{}, err
+		// currentCfg is the committed configuration as it stands right
+		// now (not complete's not-yet-committed proposal, parsed below):
+		// a dirty tree here reflects what the currently effective
+		// configuration has already written, so that is what the
+		// metrics-trap explanation must be about. A failed load degrades
+		// to no explanation — RequireClean's own error already says
+		// enough there.
+		currentCfg, cfgErr := config.Load(gitRoot)
+		enabled := cfgErr == nil && currentCfg.Metrics.Enabled
+		return Report{}, fmt.Errorf("%w%s", err, metrics.ExplainTrap(enabled, gitRoot))
 	}
 	gh, err := ghops.Open(ctx, deps.Runner, gitRoot)
 	if err != nil {

--- a/internal/bootstrap/configure_test.go
+++ b/internal/bootstrap/configure_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kninetimmy/orch/internal/instructions"
 	"github.com/kninetimmy/orch/internal/interview"
 	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/paths"
 	"github.com/kninetimmy/orch/internal/question"
 	"github.com/kninetimmy/orch/internal/state"
@@ -151,6 +152,82 @@ func writeConfiguredFixtureFilesClaudeOnly(t *testing.T, root string) {
 	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(gitignore), 0o644); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// newConfiguredRepoMetricsEnabled is newConfiguredRepo (claude-only)
+// with metrics already committed-enabled and .gitignore missing the
+// metrics ignore line — the ExecuteConfigure RequireClean-trap
+// fixture: a leftover untracked metrics document (metrics.Append's own
+// shape) reproduces what a prior enabled-metrics run would have left
+// behind in the primary checkout.
+func newConfiguredRepoMetricsEnabled(t *testing.T) string {
+	t.Helper()
+	setupGitEnv(t)
+	root, err := paths.Canonical(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawGit(t, root, "init", "-b", "main")
+
+	cfg := &config.Config{
+		SchemaVersion: 1,
+		Concurrency:   config.Concurrency{MaxSubagents: 3},
+		Merge:         config.Merge{Strategy: "squash"},
+		Memhub:        config.Memhub{Mode: "off"},
+		Metrics:       config.Metrics{Enabled: true},
+		Hosts: config.Hosts{
+			Claude: &config.Host{Roles: config.Roles{
+				Architect:       config.RoleProfile{Model: "claude-opus-4-8", Effort: "xhigh"},
+				Scout:           config.RoleProfile{Model: "claude-sonnet-5", Effort: "low"},
+				Implementer:     config.RoleProfile{Model: "claude-sonnet-5", Effort: "xhigh"},
+				Specialist:      config.RoleProfile{Model: "claude-opus-4-8", Effort: "high"},
+				Reviewer:        config.RoleProfile{Model: "claude-opus-4-8", Effort: "high"},
+				ReviewDowngrade: config.RoleProfile{Model: "claude-sonnet-5", Effort: "high"},
+			}},
+		},
+	}
+	rev, err := config.Revision(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.ConfigRevision = rev
+	rendered, err := config.Render(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".orchestrator"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(config.Path)), rendered, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	block, err := instructions.Render(instructions.CurrentVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "CLAUDE.md"), []byte(block), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	gitignore := strings.Join([]string{
+		".orchestrator/worktrees/",
+		".orchestrator/config.local.toml",
+		".orchestrator/state.json",
+		".orchestrator/delivery.lock",
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(gitignore), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rawGit(t, root, "add", "-A")
+	rawGit(t, root, "commit", "-m", "initial")
+
+	origin := filepath.Join(t.TempDir(), "origin.git")
+	rawGit(t, filepath.Dir(origin), "init", "--bare", origin)
+	rawGit(t, root, "remote", "add", "origin", origin)
+	rawGit(t, root, "push", "origin", "main")
+	return root
 }
 
 // newConfiguredRepo builds a real sandbox repository on branch main,
@@ -426,6 +503,35 @@ func TestExecuteConfigureDirtyTreeFailsClosed(t *testing.T) {
 	_, err := ExecuteConfigure(context.Background(), deps)
 	if !errors.Is(err, gitops.ErrNotClean) {
 		t.Fatalf("err = %v, want ErrNotClean", err)
+	}
+}
+
+// TestExecuteConfigureMetricsTrapNamesCause proves that when
+// RequireClean fails on the primary checkout in a repository where
+// metrics is enabled and .gitignore lacks the metrics ignore line,
+// ExecuteConfigure's error names metrics as the cause and the remedy —
+// not merely ErrNotClean. The dirty tree is a leftover untracked
+// metrics document, exactly what an earlier enabled-metrics run would
+// leave behind — the very self-blocking trap this flow would otherwise
+// be the only repair path for.
+func TestExecuteConfigureMetricsTrapNamesCause(t *testing.T) {
+	root := newConfiguredRepoMetricsEnabled(t)
+	answers := fullConfigureAnswers(t, bothHostsFacts(root), root, changeMergeStrategyOverrides)
+
+	if err := metrics.Append(root, "run-leftover", metrics.Event{At: "2026-07-11T12:00:00Z", Verb: "activate"}); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := testDeps(root, answers, &execxtest.Script{T: t}, muxRunner{git: execx.Local{}})
+	_, err := ExecuteConfigure(context.Background(), deps)
+	if !errors.Is(err, gitops.ErrNotClean) {
+		t.Fatalf("err = %v, want ErrNotClean", err)
+	}
+	if !strings.Contains(err.Error(), "metrics") {
+		t.Errorf("err = %v, want it to name metrics as the cause", err)
+	}
+	if !strings.Contains(err.Error(), "orch configure") {
+		t.Errorf("err = %v, want it to name the orch configure remedy", err)
 	}
 }
 

--- a/internal/cli/configurelocal_test.go
+++ b/internal/cli/configurelocal_test.go
@@ -218,6 +218,75 @@ func TestConfigureLocalApplyNotCompleteIsError(t *testing.T) {
 	}
 }
 
+// TestConfigureLocalApplyMetricsTrapWritesNoFile proves an --apply
+// whose answers would enable metrics while .gitignore lacks the
+// metrics ignore line never re-derives to an approved configuration
+// (the summary stays blocked), exits non-zero, and — the acceptance
+// criterion this test pins — writes no config.local.toml at all.
+func TestConfigureLocalApplyMetricsTrapWritesNoFile(t *testing.T) {
+	env, _, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML) // metrics.enabled = false (unset); no .gitignore
+
+	req := question.AnswerSet{SchemaVersion: question.SchemaVersion, Answers: map[string]string{}}
+	const maxSteps = 20
+	var summary question.Document
+	reachedSummary := false
+	for step := 1; step <= maxSteps && !reachedSummary; step++ {
+		doc := configureLocalStepOnce(t, env, req)
+		switch doc.Kind {
+		case question.DocQuestions:
+			for _, q := range doc.Questions {
+				switch q.ID {
+				case "pick.settings", "metrics.enabled":
+					req.Answers[q.ID] = "yes"
+				default:
+					req.Answers[q.ID] = q.Default
+				}
+			}
+		case question.DocSummary:
+			summary = doc
+			reachedSummary = true
+		default:
+			t.Fatalf("step %d: unexpected document kind %q", step, doc.Kind)
+		}
+	}
+	if !reachedSummary {
+		t.Fatalf("did not reach a summary document within %d steps", maxSteps)
+	}
+	if len(summary.Summary.Blockers) == 0 {
+		t.Fatalf("expected a blocked summary, got %+v", summary)
+	}
+	found := false
+	for _, b := range summary.Summary.Blockers {
+		if strings.Contains(b, "orch configure") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Blockers = %v, want one naming orch configure as the remedy", summary.Summary.Blockers)
+	}
+
+	req.Answers["approval"] = "approve"
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	env.Stdin = bytes.NewReader(data)
+	env.Stdout = &stdout
+	env.Stderr = &stderr
+	if code := Run([]string{"configure-local", "--apply"}, env); code != ExitError {
+		t.Fatalf("exit = %d, want %d; stdout=%s stderr=%s", code, ExitError, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "orch configure") {
+		t.Errorf("stderr = %q, want it to carry the blocker naming orch configure as the remedy", stderr.String())
+	}
+
+	if _, err := os.Stat(filepath.Join(env.RepoRoot, filepath.FromSlash(config.LocalOverridePath))); !os.IsNotExist(err) {
+		t.Errorf("config.local.toml present (or unreadable) after a blocked --apply: stat err = %v", err)
+	}
+}
+
 // TestConfigureLocalRefusesDuringActiveDelivery proves both --step and
 // --apply fail closed while a Delivery lock is held.
 func TestConfigureLocalRefusesDuringActiveDelivery(t *testing.T) {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kninetimmy/orch/internal/gitops"
 	"github.com/kninetimmy/orch/internal/lockfile"
 	"github.com/kninetimmy/orch/internal/memhub"
+	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/state"
 )
 
@@ -83,6 +84,23 @@ func runDoctor(env Env) error {
 			fmt.Fprintf(env.Stdout, "note  %s applied; overrides: %s\n", config.LocalOverridePath, strings.Join(cfg.Overrides, ", "))
 		} else {
 			fmt.Fprintf(env.Stdout, "note  %s present; no overrides set\n", config.LocalOverridePath)
+		}
+	}
+
+	// Metrics-ignore trap (only meaningful, and only checked, when the
+	// effective configuration has metrics enabled): a repository already
+	// in this state gets no chance to self-report it through a failing
+	// RequireClean gate until metrics has already written an untracked
+	// file, so doctor names it directly.
+	if cfgErr == nil && cfg.Metrics.Enabled {
+		trapped, trapErr := metrics.TrapActive(cfg.Metrics.Enabled, env.RepoRoot)
+		switch {
+		case trapErr != nil:
+			check("metrics .gitignore", trapErr)
+		case trapped:
+			check("metrics .gitignore", fmt.Errorf("metrics is enabled but %s is missing from .gitignore; run `orch configure` to add it", metrics.GitignoreLine))
+		default:
+			check("metrics .gitignore", nil)
 		}
 	}
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -383,6 +383,60 @@ func TestDoctorNotesAppliedLocalOverride(t *testing.T) {
 	}
 }
 
+// metricsEnabledTOML is validTOML with metrics turned on.
+const metricsEnabledTOML = validTOML + "\n[metrics]\nenabled = true\n"
+
+// TestDoctorMetricsDisabledSkipsCheck proves a metrics-disabled
+// repository (validTOML's default) gets no "metrics .gitignore" check
+// line at all, and does not fail on this account, whether or not
+// .gitignore exists.
+func TestDoctorMetricsDisabledSkipsCheck(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	if strings.Contains(stdout.String(), "metrics .gitignore") {
+		t.Errorf("stdout carries a metrics .gitignore check though metrics is disabled:\n%s", stdout.String())
+	}
+}
+
+// TestDoctorMetricsEnabledMissingGitignoreLineFails proves doctor fails
+// closed, naming metrics and the missing .gitignore line, when the
+// effective configuration has metrics enabled and .gitignore does not
+// carry the metrics ignore line.
+func TestDoctorMetricsEnabledMissingGitignoreLineFails(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, metricsEnabledTOML)
+	if code := Run([]string{"doctor"}, env); code != ExitError {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitError, stdout.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "FAIL  metrics .gitignore") {
+		t.Errorf("stdout missing the metrics .gitignore failure:\n%s", out)
+	}
+	if !strings.Contains(out, "metrics") || !strings.Contains(out, ".orchestrator/metrics/") {
+		t.Errorf("stdout does not name metrics and the missing line:\n%s", out)
+	}
+}
+
+// TestDoctorMetricsEnabledGitignoreLinePresentPasses proves doctor
+// reports the metrics .gitignore check as passing once .gitignore
+// already carries the line.
+func TestDoctorMetricsEnabledGitignoreLinePresentPasses(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, metricsEnabledTOML)
+	if err := os.WriteFile(filepath.Join(env.RepoRoot, ".gitignore"), []byte(".orchestrator/metrics/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "ok    metrics .gitignore") {
+		t.Errorf("stdout missing the passing metrics .gitignore check:\n%s", stdout.String())
+	}
+}
+
 func TestDoctorPolicyViolatingLocalOverrideFails(t *testing.T) {
 	env, stdout, _ := testEnv(t)
 	writeConfig(t, env.RepoRoot, validTOML)

--- a/internal/interview/configure.go
+++ b/internal/interview/configure.go
@@ -478,7 +478,7 @@ func buildConfigureSummary(cfg, committed *config.Config, committedRaw []byte, r
 		conflictLines = append(conflictLines, fmt.Sprintf("%s: %s", filepath.ToSlash(rel), c.Report.Detail))
 	}
 
-	gitignore, err := gitignoreLines(repoRoot, cfg.Metrics.Enabled)
+	gitignore, err := gitignoreLines(repoRoot)
 	if err != nil {
 		return question.Summary{}, err
 	}

--- a/internal/interview/configure_test.go
+++ b/internal/interview/configure_test.go
@@ -81,13 +81,15 @@ func writeInstalledBlock(t *testing.T, root, name string) {
 }
 
 // writeNoMissingGitignore writes root/.gitignore with every line
-// baseGitignoreLines wants already present, so gitignoreLines proposes
+// gitignoreLines wants already present (baseGitignoreLines plus the
+// always-proposed metricsGitignoreLine), so gitignoreLines proposes
 // nothing missing — the third precondition (alongside unchanged config
 // bytes and unchanged instruction files) for the no-change blocker to
 // ever fire.
 func writeNoMissingGitignore(t *testing.T, root string) {
 	t.Helper()
-	content := strings.Join(baseGitignoreLines, "\n") + "\n"
+	lines := append(append([]string{}, baseGitignoreLines...), metricsGitignoreLine)
+	content := strings.Join(lines, "\n") + "\n"
 	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/interview/configurelocal.go
+++ b/internal/interview/configurelocal.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kninetimmy/orch/internal/config"
 	"github.com/kninetimmy/orch/internal/instructions"
+	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/question"
 )
 
@@ -736,12 +737,33 @@ func buildSummaryLocal(committed *config.Config, overrides map[string]string, re
 		blockers = append(blockers, "no local override changes; nothing to write")
 	}
 
+	trapped, err := metrics.TrapActive(effectiveMetricsEnabled(committed, overrides), repoRoot)
+	if err != nil {
+		return question.Summary{}, err
+	}
+	if trapped {
+		blockers = append(blockers, fmt.Sprintf("this change's effective configuration would enable metrics while %s is not yet in .gitignore; orch configure (not configure-local) is the flow that adds that line — run it first, then re-enable metrics here", metrics.GitignoreLine))
+	}
+
 	return question.Summary{
 		ConfigTOML:     newContent,
 		ConfigRevision: committed.ConfigRevision,
 		Files:          []question.FileChange{change},
 		Blockers:       blockers,
 	}, nil
+}
+
+// effectiveMetricsEnabled resolves overrides' final metrics.enabled
+// value: overrides[idMetricsEnabled] parsed as a bool when present
+// (materializeLocal's canonical true/false string form), else
+// committed's own value.
+func effectiveMetricsEnabled(committed *config.Config, overrides map[string]string) bool {
+	v, ok := overrides[idMetricsEnabled]
+	if !ok {
+		return committed.Metrics.Enabled
+	}
+	b, err := strconv.ParseBool(v)
+	return err == nil && b
 }
 
 // approvalQuestionLocal is approvalQuestion with configure-local's own

--- a/internal/interview/configurelocal_test.go
+++ b/internal/interview/configurelocal_test.go
@@ -239,6 +239,90 @@ func TestNextConfigureLocalNoChangeBlocked(t *testing.T) {
 	}
 }
 
+// answerLocalWithOverrides walks NextConfigureLocal from an empty
+// answer set, answering every "questions"-kind document with overrides'
+// value where the question id has one, else its Default, and returns
+// the first non-questions document reached (answerAllLocalWithDefaults'
+// shape, but for a session that must pick a non-default path to reach a
+// summary worth inspecting — unlike walkConfigureLocal, it never
+// auto-approves, since a blocked summary makes that an error).
+func answerLocalWithOverrides(t *testing.T, root string, overrides map[string]string) (question.Document, map[string]string) {
+	t.Helper()
+	answers := map[string]string{}
+	for i := 0; i < 100; i++ {
+		doc, err := NextConfigureLocal(answers, root)
+		if err != nil {
+			t.Fatalf("NextConfigureLocal: %v", err)
+		}
+		if doc.Kind != question.DocQuestions {
+			return doc, answers
+		}
+		for _, q := range doc.Questions {
+			if v, ok := overrides[q.ID]; ok {
+				answers[q.ID] = v
+				continue
+			}
+			if q.Default == "" {
+				t.Fatalf("question %s has no default to answer with", q.ID)
+			}
+			answers[q.ID] = q.Default
+		}
+	}
+	t.Fatal("NextConfigureLocal did not reach a non-questions document within 100 steps")
+	return question.Document{}, nil
+}
+
+// TestNextConfigureLocalMetricsTrapBlocked proves configure-local
+// refuses, through the same summary-blocker mechanism the no-change
+// case uses, any change whose resulting effective configuration would
+// enable metrics while .gitignore does not already carry the metrics
+// ignore line — naming `orch configure` as the flow that adds it — and
+// that submitting approval anyway is still ErrApprovalBlocked.
+func TestNextConfigureLocalMetricsTrapBlocked(t *testing.T) {
+	root := t.TempDir()
+	writeCommittedConfigLocal(t, root) // committed metrics.enabled = false; no .gitignore at all
+
+	doc, answers := answerLocalWithOverrides(t, root, map[string]string{idPickSettings: "yes", idMetricsEnabled: "yes"})
+	if doc.Kind != question.DocSummary || len(doc.Summary.Blockers) == 0 {
+		t.Fatalf("expected a blocked summary document, got %+v", doc)
+	}
+	var found bool
+	for _, b := range doc.Summary.Blockers {
+		if strings.Contains(b, "orch configure") {
+			found = true
+			if !strings.Contains(b, ".orchestrator/metrics/") {
+				t.Errorf("blocker %q does not name the missing .gitignore line", b)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("Blockers = %v, want one naming orch configure as the flow that adds the .gitignore line", doc.Summary.Blockers)
+	}
+
+	answers[idApproval] = "approve"
+	_, err := NextConfigureLocal(answers, root)
+	if !errors.Is(err, ErrApprovalBlocked) {
+		t.Fatalf("NextConfigureLocal err = %v, want ErrApprovalBlocked", err)
+	}
+}
+
+// TestNextConfigureLocalMetricsTrapClearedByGitignore proves the same
+// enabling session is unblocked once .gitignore already carries the
+// metrics ignore line — the trap is about the line's absence, not about
+// enabling metrics itself.
+func TestNextConfigureLocalMetricsTrapClearedByGitignore(t *testing.T) {
+	root := t.TempDir()
+	writeCommittedConfigLocal(t, root)
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(".orchestrator/metrics/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	doc, _ := answerLocalWithOverrides(t, root, map[string]string{idPickSettings: "yes", idMetricsEnabled: "yes"})
+	if doc.Kind != question.DocSummary || len(doc.Summary.Blockers) != 0 {
+		t.Fatalf("expected an unblocked summary document, got %+v", doc)
+	}
+}
+
 // TestNextConfigureLocalUnknownAnswerRejected proves a role answer
 // submitted before its host is even picked is unreachable.
 func TestNextConfigureLocalUnknownAnswerRejected(t *testing.T) {

--- a/internal/interview/summary.go
+++ b/internal/interview/summary.go
@@ -56,9 +56,20 @@ var baseGitignoreLines = []string{
 }
 
 // metricsGitignoreLine is the local, gitignored metrics storage
-// directory PRD §21 describes ("local gitignored storage"); no other
-// package names this path yet, so interview owns choosing it — a
-// judgment call flagged for reviewer attention.
+// directory PRD §21 describes ("local gitignored storage"), mirroring
+// (as a literal string, baseGitignoreLines' own precedent) internal/
+// metrics' Dir constant plus a trailing slash — pinned against it in
+// summary_test.go rather than imported directly, so this pre-init-safe
+// package still need not depend on a repository already being
+// initialized.
+//
+// Always proposed for .gitignore (gitignoreLines below), regardless of
+// whether metrics is currently enabled: a later enable — through `orch
+// configure` (committed) or `orch configure-local` (machine-only,
+// which cannot itself touch .gitignore) — must never be the first time
+// this line appears, since a metrics document written before it exists
+// would show up as an untracked file and trip gitops.RequireClean with
+// no mention of metrics anywhere in the error.
 const metricsGitignoreLine = ".orchestrator/metrics/"
 
 // buildSummary materializes cfg's rendered TOML and proposed
@@ -93,7 +104,7 @@ func buildSummary(cfg *config.Config, repoRoot string) (question.Summary, error)
 		conflictLines = append(conflictLines, fmt.Sprintf("%s: %s", filepath.ToSlash(rel), c.Report.Detail))
 	}
 
-	gitignore, err := gitignoreLines(repoRoot, cfg.Metrics.Enabled)
+	gitignore, err := gitignoreLines(repoRoot)
 	if err != nil {
 		return question.Summary{}, err
 	}
@@ -149,15 +160,13 @@ func isBlockingPlanError(err error) bool {
 		errors.Is(err, instructions.ErrMalformed)
 }
 
-// gitignoreLines returns baseGitignoreLines (plus metricsGitignoreLine
-// when metricsEnabled) filtered against whatever repoRoot's .gitignore
-// already contains, so the summary proposes only genuinely missing
-// lines.
-func gitignoreLines(repoRoot string, metricsEnabled bool) ([]string, error) {
-	want := append([]string{}, baseGitignoreLines...)
-	if metricsEnabled {
-		want = append(want, metricsGitignoreLine)
-	}
+// gitignoreLines returns baseGitignoreLines plus metricsGitignoreLine
+// — always, independent of whether metrics is currently enabled (see
+// metricsGitignoreLine's own doc comment) — filtered against whatever
+// repoRoot's .gitignore already contains, so the summary proposes only
+// genuinely missing lines.
+func gitignoreLines(repoRoot string) ([]string, error) {
+	want := append(append([]string{}, baseGitignoreLines...), metricsGitignoreLine)
 
 	existing, err := readGitignore(repoRoot)
 	if err != nil {

--- a/internal/interview/summary_test.go
+++ b/internal/interview/summary_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kninetimmy/orch/internal/config"
 	"github.com/kninetimmy/orch/internal/instructions"
 	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/run"
 	"github.com/kninetimmy/orch/internal/state"
 )
@@ -33,6 +34,17 @@ func TestBaseGitignoreLinesMatchSourceConstants(t *testing.T) {
 		if baseGitignoreLines[i] != w {
 			t.Errorf("baseGitignoreLines[%d] = %q, want %q (source constant changed?)", i, baseGitignoreLines[i], w)
 		}
+	}
+}
+
+// TestMetricsGitignoreLineMatchesSourceConstant pins
+// metricsGitignoreLine to internal/metrics' exported Dir constant, the
+// same test-only way TestBaseGitignoreLinesMatchSourceConstants pins
+// the base lines against theirs.
+func TestMetricsGitignoreLineMatchesSourceConstant(t *testing.T) {
+	want := metrics.Dir + "/"
+	if metricsGitignoreLine != want {
+		t.Errorf("metricsGitignoreLine = %q, want %q (source constant changed?)", metricsGitignoreLine, want)
 	}
 }
 
@@ -80,6 +92,7 @@ func TestBuildSummaryFreshRepo(t *testing.T) {
 		".orchestrator/config.local.toml",
 		".orchestrator/state.json",
 		".orchestrator/delivery.lock",
+		metricsGitignoreLine,
 	}
 	if len(summary.GitignoreLines) != len(want) {
 		t.Fatalf("GitignoreLines = %v, want %v", summary.GitignoreLines, want)
@@ -91,12 +104,18 @@ func TestBuildSummaryFreshRepo(t *testing.T) {
 	}
 }
 
-func TestBuildSummaryMetricsEnabledAddsGitignoreLine(t *testing.T) {
-	answers := fullAnswers()
-	answers[idMetricsEnabled] = "yes"
-	cfg, err := materialize(answers)
+// TestBuildSummaryGitignoreLineUnconditional proves the metrics ignore
+// line is proposed even when metrics is disabled (fullAnswers'
+// default): no remaining code path makes it conditional on the metrics
+// setting, so a later enable — committed or machine-local — never finds
+// the line missing.
+func TestBuildSummaryGitignoreLineUnconditional(t *testing.T) {
+	cfg, err := materialize(fullAnswers())
 	if err != nil {
 		t.Fatalf("materialize: %v", err)
+	}
+	if cfg.Metrics.Enabled {
+		t.Fatal("fullAnswers' metrics answer is not disabled; fixture drifted")
 	}
 	summary, err := buildSummary(cfg, t.TempDir())
 	if err != nil {
@@ -109,7 +128,7 @@ func TestBuildSummaryMetricsEnabledAddsGitignoreLine(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Errorf("GitignoreLines = %v, want %q present when metrics is enabled", summary.GitignoreLines, metricsGitignoreLine)
+		t.Errorf("GitignoreLines = %v, want %q present even though metrics is disabled", summary.GitignoreLines, metricsGitignoreLine)
 	}
 }
 
@@ -235,7 +254,7 @@ func TestBuildSummaryFiltersExistingGitignoreLines(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildSummary: %v", err)
 	}
-	want := []string{".orchestrator/config.local.toml", ".orchestrator/delivery.lock"}
+	want := []string{".orchestrator/config.local.toml", ".orchestrator/delivery.lock", metricsGitignoreLine}
 	if len(summary.GitignoreLines) != len(want) {
 		t.Fatalf("GitignoreLines = %v, want %v", summary.GitignoreLines, want)
 	}

--- a/internal/interview/testdata/transcript/step_15.json
+++ b/internal/interview/testdata/transcript/step_15.json
@@ -40,7 +40,8 @@
       ".orchestrator/worktrees/",
       ".orchestrator/config.local.toml",
       ".orchestrator/state.json",
-      ".orchestrator/delivery.lock"
+      ".orchestrator/delivery.lock",
+      ".orchestrator/metrics/"
     ]
   }
 }

--- a/internal/interview/testdata/transcript/step_16.json
+++ b/internal/interview/testdata/transcript/step_16.json
@@ -23,7 +23,8 @@
         ".orchestrator/worktrees/",
         ".orchestrator/config.local.toml",
         ".orchestrator/state.json",
-        ".orchestrator/delivery.lock"
+        ".orchestrator/delivery.lock",
+        ".orchestrator/metrics/"
       ]
     },
     "detection": {

--- a/internal/interview/testdata/transcript_configure/disable_codex/step_03.json
+++ b/internal/interview/testdata/transcript_configure/disable_codex/step_03.json
@@ -40,7 +40,8 @@
       ".orchestrator/worktrees/",
       ".orchestrator/config.local.toml",
       ".orchestrator/state.json",
-      ".orchestrator/delivery.lock"
+      ".orchestrator/delivery.lock",
+      ".orchestrator/metrics/"
     ],
     "config_diff": "@@ -3,7 +3,7 @@\n # a Delivery PR.\n \n schema_version  = 1\n-config_revision = \"sha256:6240dc99e81e\"\n+config_revision = \"sha256:1a09dc2e9cd2\"\n \n [concurrency]\n max_subagents = 3\n@@ -40,27 +40,3 @@\n [hosts.claude.roles.review_downgrade]\n model  = \"claude-sonnet-5\"\n effort = \"high\"\n-\n-[hosts.codex.roles.architect]\n-model  = \"gpt-5.6-sol\"\n-effort = \"high\"\n-\n-[hosts.codex.roles.scout]\n-model  = \"gpt-5.6-terra\"\n-effort = \"low\"\n-\n-[hosts.codex.roles.implementer]\n-model  = \"gpt-5.6-terra\"\n-effort = \"high\"\n-\n-[hosts.codex.roles.specialist]\n-model  = \"gpt-5.6-sol\"\n-effort = \"medium\"\n-\n-[hosts.codex.roles.reviewer]\n-model  = \"gpt-5.6-sol\"\n-effort = \"medium\"\n-\n-[hosts.codex.roles.review_downgrade]\n-model  = \"gpt-5.6-terra\"\n-effort = \"high\"\n"
   }

--- a/internal/interview/testdata/transcript_configure/disable_codex/step_04.json
+++ b/internal/interview/testdata/transcript_configure/disable_codex/step_04.json
@@ -23,7 +23,8 @@
         ".orchestrator/worktrees/",
         ".orchestrator/config.local.toml",
         ".orchestrator/state.json",
-        ".orchestrator/delivery.lock"
+        ".orchestrator/delivery.lock",
+        ".orchestrator/metrics/"
       ],
       "config_diff": "@@ -3,7 +3,7 @@\n # a Delivery PR.\n \n schema_version  = 1\n-config_revision = \"sha256:6240dc99e81e\"\n+config_revision = \"sha256:1a09dc2e9cd2\"\n \n [concurrency]\n max_subagents = 3\n@@ -40,27 +40,3 @@\n [hosts.claude.roles.review_downgrade]\n model  = \"claude-sonnet-5\"\n effort = \"high\"\n-\n-[hosts.codex.roles.architect]\n-model  = \"gpt-5.6-sol\"\n-effort = \"high\"\n-\n-[hosts.codex.roles.scout]\n-model  = \"gpt-5.6-terra\"\n-effort = \"low\"\n-\n-[hosts.codex.roles.implementer]\n-model  = \"gpt-5.6-terra\"\n-effort = \"high\"\n-\n-[hosts.codex.roles.specialist]\n-model  = \"gpt-5.6-sol\"\n-effort = \"medium\"\n-\n-[hosts.codex.roles.reviewer]\n-model  = \"gpt-5.6-sol\"\n-effort = \"medium\"\n-\n-[hosts.codex.roles.review_downgrade]\n-model  = \"gpt-5.6-terra\"\n-effort = \"high\"\n"
     },

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_09.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_09.json
@@ -40,7 +40,8 @@
       ".orchestrator/worktrees/",
       ".orchestrator/config.local.toml",
       ".orchestrator/state.json",
-      ".orchestrator/delivery.lock"
+      ".orchestrator/delivery.lock",
+      ".orchestrator/metrics/"
     ],
     "config_diff": "@@ -3,7 +3,7 @@\n # a Delivery PR.\n \n schema_version  = 1\n-config_revision = \"sha256:1a09dc2e9cd2\"\n+config_revision = \"sha256:6240dc99e81e\"\n \n [concurrency]\n max_subagents = 3\n@@ -40,3 +40,27 @@\n [hosts.claude.roles.review_downgrade]\n model  = \"claude-sonnet-5\"\n effort = \"high\"\n+\n+[hosts.codex.roles.architect]\n+model  = \"gpt-5.6-sol\"\n+effort = \"high\"\n+\n+[hosts.codex.roles.scout]\n+model  = \"gpt-5.6-terra\"\n+effort = \"low\"\n+\n+[hosts.codex.roles.implementer]\n+model  = \"gpt-5.6-terra\"\n+effort = \"high\"\n+\n+[hosts.codex.roles.specialist]\n+model  = \"gpt-5.6-sol\"\n+effort = \"medium\"\n+\n+[hosts.codex.roles.reviewer]\n+model  = \"gpt-5.6-sol\"\n+effort = \"medium\"\n+\n+[hosts.codex.roles.review_downgrade]\n+model  = \"gpt-5.6-terra\"\n+effort = \"high\"\n"
   }

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_10.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_10.json
@@ -23,7 +23,8 @@
         ".orchestrator/worktrees/",
         ".orchestrator/config.local.toml",
         ".orchestrator/state.json",
-        ".orchestrator/delivery.lock"
+        ".orchestrator/delivery.lock",
+        ".orchestrator/metrics/"
       ],
       "config_diff": "@@ -3,7 +3,7 @@\n # a Delivery PR.\n \n schema_version  = 1\n-config_revision = \"sha256:1a09dc2e9cd2\"\n+config_revision = \"sha256:6240dc99e81e\"\n \n [concurrency]\n max_subagents = 3\n@@ -40,3 +40,27 @@\n [hosts.claude.roles.review_downgrade]\n model  = \"claude-sonnet-5\"\n effort = \"high\"\n+\n+[hosts.codex.roles.architect]\n+model  = \"gpt-5.6-sol\"\n+effort = \"high\"\n+\n+[hosts.codex.roles.scout]\n+model  = \"gpt-5.6-terra\"\n+effort = \"low\"\n+\n+[hosts.codex.roles.implementer]\n+model  = \"gpt-5.6-terra\"\n+effort = \"high\"\n+\n+[hosts.codex.roles.specialist]\n+model  = \"gpt-5.6-sol\"\n+effort = \"medium\"\n+\n+[hosts.codex.roles.reviewer]\n+model  = \"gpt-5.6-sol\"\n+effort = \"medium\"\n+\n+[hosts.codex.roles.review_downgrade]\n+model  = \"gpt-5.6-terra\"\n+effort = \"high\"\n"
     },

--- a/internal/interview/testdata/transcript_configure/merge_and_model/step_09.json
+++ b/internal/interview/testdata/transcript_configure/merge_and_model/step_09.json
@@ -38,7 +38,8 @@
       ".orchestrator/worktrees/",
       ".orchestrator/config.local.toml",
       ".orchestrator/state.json",
-      ".orchestrator/delivery.lock"
+      ".orchestrator/delivery.lock",
+      ".orchestrator/metrics/"
     ],
     "config_diff": "@@ -3,13 +3,13 @@\n # a Delivery PR.\n \n schema_version  = 1\n-config_revision = \"sha256:6240dc99e81e\"\n+config_revision = \"sha256:9040056536a9\"\n \n [concurrency]\n max_subagents = 3\n \n [merge]\n-strategy = \"squash\"\n+strategy = \"rebase\"\n \n [memhub]\n mode = \"off\"\n@@ -22,7 +22,7 @@\n effort = \"xhigh\"\n \n [hosts.claude.roles.scout]\n-model  = \"claude-sonnet-5\"\n+model  = \"claude-opus-4-8\"\n effort = \"low\"\n \n [hosts.claude.roles.implementer]\n"
   }

--- a/internal/interview/testdata/transcript_configure/merge_and_model/step_10.json
+++ b/internal/interview/testdata/transcript_configure/merge_and_model/step_10.json
@@ -21,7 +21,8 @@
         ".orchestrator/worktrees/",
         ".orchestrator/config.local.toml",
         ".orchestrator/state.json",
-        ".orchestrator/delivery.lock"
+        ".orchestrator/delivery.lock",
+        ".orchestrator/metrics/"
       ],
       "config_diff": "@@ -3,13 +3,13 @@\n # a Delivery PR.\n \n schema_version  = 1\n-config_revision = \"sha256:6240dc99e81e\"\n+config_revision = \"sha256:9040056536a9\"\n \n [concurrency]\n max_subagents = 3\n \n [merge]\n-strategy = \"squash\"\n+strategy = \"rebase\"\n \n [memhub]\n mode = \"off\"\n@@ -22,7 +22,7 @@\n effort = \"xhigh\"\n \n [hosts.claude.roles.scout]\n-model  = \"claude-sonnet-5\"\n+model  = \"claude-opus-4-8\"\n effort = \"low\"\n \n [hosts.claude.roles.implementer]\n"
     },

--- a/internal/metrics/ignoretrap.go
+++ b/internal/metrics/ignoretrap.go
@@ -1,0 +1,77 @@
+package metrics
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// GitignoreLine is Dir expressed as the .gitignore directory pattern
+// internal/interview proposes for it: Dir plus a trailing slash.
+const GitignoreLine = Dir + "/"
+
+// TrapActive reports whether repoRoot is in the metrics-ignore trap: an
+// enabled metrics configuration while GitignoreLine is absent from
+// repoRoot's .gitignore. In that state, Append's writes under Dir show
+// up as untracked files that gitops.RequireClean counts, and nothing
+// in RequireClean's own error names metrics as the cause — the
+// activation, run-completion, and committed-configure RequireClean
+// gates all trip on it with no clue what to fix. enabled is the
+// caller's already-resolved cfg.Metrics.Enabled: this package stays
+// policy-free and never reads *config.Config itself.
+//
+// This is the module's single implementation of that predicate: `orch
+// configure-local`'s summary blocker, `orch doctor`'s own check, and
+// every RequireClean-failure explanation below call it rather than
+// re-deriving it.
+func TrapActive(enabled bool, repoRoot string) (bool, error) {
+	if !enabled {
+		return false, nil
+	}
+	lines, err := gitignoreLines(repoRoot)
+	if err != nil {
+		return false, err
+	}
+	for _, l := range lines {
+		if l == GitignoreLine {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// ExplainTrap returns the parenthetical cause-and-remedy text a
+// RequireClean-failure caller appends to its own error when repoRoot is
+// in the metrics-ignore trap (TrapActive(enabled, repoRoot)), or "" when
+// it is not — including when the trap check itself fails, since
+// RequireClean's own error already says enough there. The one wording
+// lives here so activation, run completion, and orch configure's own
+// RequireClean gate never drift apart.
+func ExplainTrap(enabled bool, repoRoot string) string {
+	trapped, err := TrapActive(enabled, repoRoot)
+	if err != nil || !trapped {
+		return ""
+	}
+	return fmt.Sprintf(" (cause: metrics is enabled but %s is not yet in .gitignore, so the metrics directory shows as untracked; remedy: run `orch configure` to add the .gitignore line, or disable metrics)", GitignoreLine)
+}
+
+// gitignoreLines reads repoRoot's .gitignore into individual lines (CR
+// trimmed, mirroring internal/interview's own readGitignore), or nil if
+// the file does not exist.
+func gitignoreLines(repoRoot string) ([]string, error) {
+	data, err := os.ReadFile(filepath.Join(repoRoot, ".gitignore"))
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read .gitignore: %w", err)
+	}
+	lines := strings.Split(string(data), "\n")
+	for i, l := range lines {
+		lines[i] = strings.TrimRight(l, "\r")
+	}
+	return lines, nil
+}

--- a/internal/metrics/ignoretrap_test.go
+++ b/internal/metrics/ignoretrap_test.go
@@ -1,0 +1,106 @@
+package metrics
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeGitignore(t *testing.T, root, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestTrapActiveDisabledNeverTrips proves TrapActive never trips when
+// metrics is disabled, regardless of .gitignore's contents (including a
+// missing file).
+func TestTrapActiveDisabledNeverTrips(t *testing.T) {
+	root := t.TempDir()
+	trapped, err := TrapActive(false, root)
+	if err != nil {
+		t.Fatalf("TrapActive: %v", err)
+	}
+	if trapped {
+		t.Error("TrapActive(false, ...) = true, want false with no .gitignore at all")
+	}
+
+	writeGitignore(t, root, "node_modules/\n")
+	trapped, err = TrapActive(false, root)
+	if err != nil {
+		t.Fatalf("TrapActive: %v", err)
+	}
+	if trapped {
+		t.Error("TrapActive(false, ...) = true, want false with an unrelated .gitignore")
+	}
+}
+
+// TestTrapActiveEnabledMissingLine proves TrapActive trips when metrics
+// is enabled and .gitignore either does not exist or lacks the line.
+func TestTrapActiveEnabledMissingLine(t *testing.T) {
+	root := t.TempDir()
+	trapped, err := TrapActive(true, root)
+	if err != nil {
+		t.Fatalf("TrapActive: %v", err)
+	}
+	if !trapped {
+		t.Error("TrapActive(true, ...) = false, want true with no .gitignore at all")
+	}
+
+	writeGitignore(t, root, "node_modules/\n.orchestrator/state.json\n")
+	trapped, err = TrapActive(true, root)
+	if err != nil {
+		t.Fatalf("TrapActive: %v", err)
+	}
+	if !trapped {
+		t.Error("TrapActive(true, ...) = false, want true when .gitignore omits the metrics line")
+	}
+}
+
+// TestTrapActiveEnabledLinePresent proves the line's presence — CRLF
+// tolerated, mirroring interview's own readGitignore — clears the trap.
+func TestTrapActiveEnabledLinePresent(t *testing.T) {
+	root := t.TempDir()
+	writeGitignore(t, root, "node_modules/\r\n"+GitignoreLine+"\r\n")
+	trapped, err := TrapActive(true, root)
+	if err != nil {
+		t.Fatalf("TrapActive: %v", err)
+	}
+	if trapped {
+		t.Error("TrapActive(true, ...) = true, want false once .gitignore carries the line")
+	}
+}
+
+// TestExplainTrapWording proves ExplainTrap names metrics as the cause
+// and orch configure as the remedy when trapped, and is empty otherwise.
+func TestExplainTrapWording(t *testing.T) {
+	root := t.TempDir()
+	explain := ExplainTrap(true, root)
+	if explain == "" {
+		t.Fatal("ExplainTrap = \"\", want a cause-and-remedy suffix while trapped")
+	}
+	if !strings.Contains(explain, "metrics") {
+		t.Errorf("ExplainTrap = %q, want it to name metrics", explain)
+	}
+	if !strings.Contains(explain, "orch configure") {
+		t.Errorf("ExplainTrap = %q, want it to name the orch configure remedy", explain)
+	}
+
+	writeGitignore(t, root, GitignoreLine+"\n")
+	if got := ExplainTrap(true, root); got != "" {
+		t.Errorf("ExplainTrap = %q, want empty once the line is present", got)
+	}
+	if got := ExplainTrap(false, root); got != "" {
+		t.Errorf("ExplainTrap = %q, want empty when metrics is disabled", got)
+	}
+}
+
+// TestGitignoreLineMatchesDir pins GitignoreLine against Dir plus a
+// trailing slash — the directory-only ignore-pattern form.
+func TestGitignoreLineMatchesDir(t *testing.T) {
+	if GitignoreLine != Dir+"/" {
+		t.Errorf("GitignoreLine = %q, want %q", GitignoreLine, Dir+"/")
+	}
+}

--- a/internal/run/activate.go
+++ b/internal/run/activate.go
@@ -186,7 +186,7 @@ func Activate(ctx context.Context, env Env, reqJSON []byte) (*ActivationResult, 
 		return nil, err
 	}
 	if err := git.RequireClean(ctx, ""); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w%s", err, metrics.ExplainTrap(cfg.Metrics.Enabled, env.RepoRoot))
 	}
 	gh, err := ghops.Open(ctx, env.Runner, env.RepoRoot)
 	if err != nil {

--- a/internal/run/activate_test.go
+++ b/internal/run/activate_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kninetimmy/orch/internal/gitops"
 	"github.com/kninetimmy/orch/internal/lockfile"
 	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/paths"
 	"github.com/kninetimmy/orch/internal/state"
 )
@@ -52,9 +53,10 @@ func rawGit(t *testing.T, dir string, args ...string) string {
 	return res.Stdout
 }
 
-// newActivateRepoWithIgnore builds a real sandbox repo on branch main
-// with a committed config.toml and the given .gitignore content.
-func newActivateRepoWithIgnore(t *testing.T, gitignore string) string {
+// newActivateRepoWithConfigAndIgnore builds a real sandbox repo on
+// branch main with the given committed config.toml content and
+// .gitignore content.
+func newActivateRepoWithConfigAndIgnore(t *testing.T, tomlContent, gitignore string) string {
 	t.Helper()
 	setupGitEnv(t)
 	root, err := paths.Canonical(t.TempDir())
@@ -71,7 +73,7 @@ func newActivateRepoWithIgnore(t *testing.T, gitignore string) string {
 	if err := os.MkdirAll(filepath.Join(root, ".orchestrator"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(root, ".orchestrator", "config.toml"), []byte(testConfigTOML), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, ".orchestrator", "config.toml"), []byte(tomlContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	rawGit(t, root, "add", "-A")
@@ -79,10 +81,23 @@ func newActivateRepoWithIgnore(t *testing.T, gitignore string) string {
 	return root
 }
 
+// newActivateRepoWithIgnore builds a real sandbox repo on branch main
+// with testConfigTOML and the given .gitignore content.
+func newActivateRepoWithIgnore(t *testing.T, gitignore string) string {
+	t.Helper()
+	return newActivateRepoWithConfigAndIgnore(t, testConfigTOML, gitignore)
+}
+
 // fullGitignore ignores the worktree container plus Orch's own
 // machine-local files (mirroring this repo's real .gitignore), so a
 // completed activation leaves the primary checkout clean.
 const fullGitignore = ".orchestrator/worktrees/\n.orchestrator/state.json\n.orchestrator/delivery.lock\n"
+
+// testConfigTOMLMetricsEnabled is testConfigTOML with metrics enabled —
+// the metrics-ignore-trap fixture: fullGitignore deliberately carries
+// no metrics line, so a leftover untracked metrics document reproduces
+// what an earlier enabled-metrics run would have left behind.
+const testConfigTOMLMetricsEnabled = testConfigTOML + "\n[metrics]\nenabled = true\n"
 
 func newActivateRepo(t *testing.T) string {
 	t.Helper()
@@ -489,6 +504,35 @@ func TestActivateDirtyTreeLeavesNothing(t *testing.T) {
 	_, err := Activate(context.Background(), env, activationJSON(t, twoIssuePlanJSON()))
 	if !errors.Is(err, gitops.ErrNotClean) {
 		t.Fatalf("err = %v, want ErrNotClean", err)
+	}
+	script.AssertExhausted()
+	assertNoDeliveryState(t, root)
+}
+
+// TestActivateMetricsTrapNamesCause proves that when RequireClean fails
+// on the primary checkout in a repository where metrics is enabled and
+// .gitignore lacks the metrics ignore line, Activate's error names
+// metrics as the cause and the remedy — not merely ErrNotClean, which
+// (pre-fix) names no cause at all. The dirty tree is a leftover
+// untracked metrics document, exactly what an earlier enabled-metrics
+// run would leave behind.
+func TestActivateMetricsTrapNamesCause(t *testing.T) {
+	root := newActivateRepoWithConfigAndIgnore(t, testConfigTOMLMetricsEnabled, fullGitignore)
+	if err := metrics.Append(root, "run-leftover", metrics.Event{At: "2026-07-11T12:00:00Z", Verb: "activate"}); err != nil {
+		t.Fatal(err)
+	}
+	script := &execxtest.Script{T: t}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	_, err := Activate(context.Background(), env, activationJSON(t, twoIssuePlanJSON()))
+	if !errors.Is(err, gitops.ErrNotClean) {
+		t.Fatalf("err = %v, want ErrNotClean", err)
+	}
+	if !strings.Contains(err.Error(), "metrics") {
+		t.Errorf("err = %v, want it to name metrics as the cause", err)
+	}
+	if !strings.Contains(err.Error(), "orch configure") {
+		t.Errorf("err = %v, want it to name the orch configure remedy", err)
 	}
 	script.AssertExhausted()
 	assertNoDeliveryState(t, root)

--- a/internal/run/complete.go
+++ b/internal/run/complete.go
@@ -77,7 +77,7 @@ func Complete(ctx context.Context, env Env, reqJSON []byte) (*CompleteResult, er
 		return nil, fmt.Errorf("primary checkout is on %s, not the default branch %s; completion requires the primary checkout on the default branch", branch, repo.DefaultBranch)
 	}
 	if err := git.RequireClean(ctx, ""); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w%s", err, metrics.ExplainTrap(c.cfg.Metrics.Enabled, env.RepoRoot))
 	}
 	if err := git.FastForward(ctx, "origin", repo.DefaultBranch); err != nil {
 		return nil, err

--- a/internal/run/complete_test.go
+++ b/internal/run/complete_test.go
@@ -1,0 +1,45 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/execx/execxtest"
+	"github.com/kninetimmy/orch/internal/gitops"
+	"github.com/kninetimmy/orch/internal/metrics"
+	"github.com/kninetimmy/orch/internal/state"
+)
+
+// TestCompleteMetricsTrapNamesCause proves that when RequireClean fails
+// on the primary checkout during run completion in a repository where
+// metrics is enabled and .gitignore lacks the metrics ignore line,
+// Complete's error names metrics as the cause and the remedy — not
+// merely ErrNotClean. The dirty tree is a leftover untracked metrics
+// document, exactly what an earlier enabled-metrics run would leave
+// behind.
+func TestCompleteMetricsTrapNamesCause(t *testing.T) {
+	root := newActivateRepoWithConfigAndIgnore(t, testConfigTOMLMetricsEnabled, fullGitignore)
+
+	enterDeliveryAt(t, root, "r1", []state.Issue{fixtureIssue("a", 1, state.PhaseCleaned)})
+	if err := metrics.Append(root, "run-leftover", metrics.Event{At: "2026-07-11T12:00:00Z", Verb: "activate"}); err != nil {
+		t.Fatal(err)
+	}
+
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{ghAuth(), ghRepoViewCall("main")}}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	_, err := Complete(context.Background(), env, []byte(`{"schema_version":1}`))
+	if !errors.Is(err, gitops.ErrNotClean) {
+		t.Fatalf("err = %v, want ErrNotClean", err)
+	}
+	if !strings.Contains(err.Error(), "metrics") {
+		t.Errorf("err = %v, want it to name metrics as the cause", err)
+	}
+	if !strings.Contains(err.Error(), "orch configure") {
+		t.Errorf("err = %v, want it to name the orch configure remedy", err)
+	}
+	script.AssertExhausted()
+}


### PR DESCRIPTION
Delivers issue #104: Make the metrics ignore line unconditional and the un-ignored-metrics failure legible

Closes #104

**Plan digest:** `sha256:9482206213b9f814c34619fdb141ce54afcfe41dab20296a275b89851ebbe808`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Enabling metrics must never be able to arm a silent Delivery-loop failure. Today internal/interview holds the metrics ignore line outside its base ignore-line set and appends it only when metrics is enabled, and only the committed init/configure flows call that code. The orch configure-local command legitimately accepts metrics.enabled as a preference override but writes only the machine-local override file, so a local enable leaves the metrics directory un-ignored. Because metrics documents are written into the primary checkout and RequireClean counts untracked files, the consequence is that the first run's completion fails, every later activation fails, and the committed configure flow that would add the ignore line also demands a clean checkout - and no error text anywhere names metrics. Make the ignore line unconditional so new repositories are safe by construction, refuse the local enable that would arm the trap, report the condition from doctor for repositories already in it, and make the cleanliness failure name its own cause wherever it can still occur.

**Acceptance criteria:**
- The gitignore lines internal/interview proposes always include the metrics directory line: a repository initialized or configured with metrics disabled still has that line proposed for .gitignore, and no remaining code path makes the line conditional on the metrics setting.
- A test in internal/interview pins the metrics ignore line's value against internal/metrics' exported directory constant, in the same test-only way the existing base ignore lines are pinned against their source constants; the non-test code keeps its own literal so the package stays usable before a repository is initialized.
- orch configure-local refuses, through the summary-blocker mechanism it already uses, any change whose resulting effective configuration enables metrics while .gitignore does not already contain the metrics ignore line; the blocker text names orch configure as the flow that adds the line, and an --apply carrying that blocker writes no file.
- orch doctor fails, with a message naming metrics and the missing .gitignore line, when the effective configuration has metrics enabled and .gitignore does not contain the metrics ignore line; when metrics is disabled it emits no metrics ignore check and does not fail on this account.
- When RequireClean fails at any of the three gates that check the primary checkout - activation, run completion, and the committed configure flow - in a repository where metrics is enabled and .gitignore lacks the metrics ignore line, the resulting error additionally names enabled-metrics-with-an-un-ignored-metrics-directory as the cause and names the remedy. internal/gitops stays policy-free: the metrics-specific explanation is added by the callers, never by RequireClean itself.
- The predicate shared by the previous three criteria - metrics enabled and the metrics ignore line absent from .gitignore - has exactly one implementation in the module rather than one copy per call site.
- Each of the four behavior changes above is covered by a test that fails against the pre-change code, and go test ./..., go vet ./..., and gofmt -l . are all clean.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:dd23c00b6bd5` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **go-test-all** — pass — `go clean -testcache && go test ./...` — All 25 packages ok, including new tests in internal/metrics, internal/interview, internal/cli, internal/run and internal/bootstrap. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:10:05Z)
- **go-vet** — pass — `go vet ./...` — No output. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:10:05Z)
- **gofmt-check** — pass — `gofmt -l .` — No files listed. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:10:05Z)
- **criterion-1-unconditional-gitignore-line** — pass — `go test ./internal/interview/... -run TestBuildSummaryGitignoreLineUnconditional` — gitignoreLines drops its metricsEnabled parameter and always appends the metrics line. The test proves the line is proposed even with the disabled default from fullAnswers(). Falsified against pre-change code: see the falsification entry. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:10:05Z)
- **criterion-2-pin-against-metrics-dir** — pass — `go test ./internal/interview/... -run TestMetricsGitignoreLineMatchesSourceConstant` — Test-only pin of metricsGitignoreLine against metrics.Dir + "/"; the production literal is unchanged, so internal/interview keeps its pre-init-safe literal-plus-test-pin idiom. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:10:05Z)
- **criterion-3-configure-local-blocker** — pass — `go test ./internal/interview/... -run TestNextConfigureLocalMetricsTrap and go test ./internal/cli/... -run TestConfigureLocalApplyMetricsTrapWritesNoFile` — The blocker text names orch configure. An --apply carrying the blocker exits ExitError and writes no config.local.toml, checked via os.Stat rather than inferred. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:10:05Z)
- **criterion-4-doctor-check** — pass — `go test ./internal/cli/... -run TestDoctorMetrics` — Three subtests pass: enabled with the line missing fails doctor, enabled with the line present passes, and disabled emits no metrics ignore check at all. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:10:05Z)
- **criterion-5-requireclean-explains-cause** — pass — `go test ./internal/run/... -run 'TestActivateMetricsTrapNamesCause|TestCompleteMetricsTrapNamesCause' and go test ./internal/bootstrap/... -run TestExecuteConfigureMetricsTrapNamesCause` — All three gates - activation, run completion and the committed configure flow - assert errors.Is(err, gitops.ErrNotClean) plus the strings "metrics" and "orch configure" in the error text. internal/gitops is unchanged, so RequireClean itself stays policy-free. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:10:05Z)
- **criterion-6-single-predicate-implementation** — pass — `grep -rn "TrapActive|ExplainTrap" internal --include=*.go | grep -v _test.go` — Exactly one definition, in the new internal/metrics/ignoretrap.go, consumed by all five call sites (doctor, configure-local, activate, complete, bootstrap/configure). No per-call-site copies. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:10:05Z)
- **criterion-7-pre-change-falsification** — pass — `git stash push -- <production files> per behavior, re-run that behavior's new test, git stash pop` — Demonstrated for all four behaviors, not asserted. Stashing summary.go+configure.go made TestBuildSummaryGitignoreLineUnconditional fail with the metrics line missing from GitignoreLines; stashing configurelocal.go made TestNextConfigureLocalMetricsTrapBlocked reach DocComplete instead of a blocked summary; stashing doctor.go made both doctor tests fail with exit 0 and no metrics check line emitted; stashing activate.go+complete.go+bootstrap/configure.go made all three gate tests fail with the bare ErrNotClean message mentioning neither metrics nor orch configure. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:10:05Z)
- **word-diff-reflowed-prose** — pass — `git diff --cached --word-diff --ignore-all-space -- internal/interview/summary.go internal/interview/configure.go internal/interview/configurelocal.go internal/cli/doctor.go internal/run/activate.go internal/run/complete.go internal/bootstrap/configure.go internal/interview/configure_test.go` — Reviewed for silent word loss. The only paragraph-level rewrites are the doc comments on metricsGitignoreLine, gitignoreLines and writeNoMissingGitignore, each deliberately rewritten to describe the new unconditional behavior; every removed word is an intentional replacement, not a silent drop. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:10:05Z)
- **golden-transcript-regeneration** — pass — `go test ./internal/interview -update` — Eight golden transcript JSON fixtures regenerated. Each diff is exactly one added line, ".orchestrator/metrics/" appended to gitignore_lines, which is the expected consequence of criterion 1. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:10:05Z)
- **reviewer-crlf-predicate-against-real-repo** — pass — `metrics.TrapActive(true, "C:/Users/Kninetimmy/Orch") against the primary checkout's actual on-disk .gitignore, plus throwaway tests for CRLF with and without a trailing newline` — Verified the file is CRLF on this machine and that the predicate correctly reports not-trapped. A CR-intolerant predicate would have produced a spurious doctor FAIL here. Confirmed by construction, not by reading the code. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:22:43Z)
- **reviewer-falsification-reproduced** — pass — `revert production files to base 52f505c one behavior at a time in a disposable clone, re-run each new test` — Not inherited from the executor. Reverting interview/summary.go+configure.go fails the unconditional-line test; reverting configurelocal.go fails both configure-local tests; reverting doctor.go fails both doctor tests; reverting activate.go+complete.go+bootstrap/configure.go fails all three gate tests with bare ErrNotClean. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:22:43Z)
- **reviewer-must-not-mislead-at-gate-level** — pass — `throwaway tests in internal/run: metrics enabled with line present, metrics disabled with line absent, and the trapped case, each with an unrelated dirty file` — The first two produce the bare cleanliness error with no metrics text; only the trapped case appends the cause and remedy. fmt.Errorf("%w%s") preserves errors.Is(err, gitops.ErrNotClean), and no non-test code compares ErrNotClean by ==. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:22:43Z)
- **reviewer-configure-local-writes-nothing** — pass — `pre-create a real config.local.toml via config.RenderLocal/WriteLocal, drive the interview to the blocked summary, run configure-local --apply` — Exit ExitError; the file was byte-identical afterward with unchanged mtime. Structurally, the only two mutation calls sit strictly after the DocComplete early return, so no partial-write path is reachable. The shipped test covers only the no-pre-existing-file case. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:22:43Z)
- **reviewer-gitops-untouched** — pass — `git diff 52f505c..pr107 -- internal/gitops` — Empty diff. Criterion 5's requirement that the explanation live at the callers rather than in RequireClean is satisfied mechanically. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:22:43Z)
- **reviewer-golden-fixtures-audit** — pass — `read all eight regenerated testdata transcript JSON diffs in full` — Each is exactly one added array element ".orchestrator/metrics/" appended to gitignore_lines. No reordering, no config_diff churn, no revision drift, nothing rode along. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:22:43Z)
- **reviewer-ci-at-reviewed-oid** — pass — `gh run view 30399527993 head_sha check` — All six required checks SUCCESS at exactly c6640faa91cda7796763d0ef5e1cad4e9d630c2f: lint, scripts on ubuntu and windows, test on ubuntu, macos and windows. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:22:43Z)
- **reviewer-manifest-accuracy** — pass — `programmatic comparison of the PR audit record against issue #104's body` — Objective and all seven criteria verbatim-identical; required tests, routed selection, config revision sha256:dd23c00b6bd5 and plan digest all match. Two cosmetic imprecisions only: "all 25 packages ok" is really 22 ok plus 3 with no test files, and criterion 4's "three subtests" are three sibling top-level functions sharing a prefix. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:22:43Z)
- **review-cycle-1** — approve — All seven acceptance criteria hold simultaneously, each verified independently rather than inherited. The reviewer reproduced the falsification for all four behaviors by reverting production files to the base commit one behavior at a time and watching each new test fail. The highest-risk failure mode this change could have shipped - a CR-intolerant predicate silently inverting on every Windows checkout - is not present: the new internal/metrics predicate mirrors interview's readGitignore CR trimming, and the reviewer confirmed it by pointing TrapActive at this repository's real on-disk .gitignore, which it verified is CRLF (385 bytes, CR on every line, no .gitattributes rule covering it), getting the correct not-trapped answer. It also constructed the must-not-mislead cases at gate level: metrics enabled with the line present, and metrics disabled with the line absent, both produce the bare cleanliness error with no metrics text, while the trapped case adds the cause and remedy. internal/gitops is genuinely untouched (empty diff), so RequireClean stays policy-free. The writes-no-file half of criterion 3 was confirmed both structurally (the only two mutation calls sit after the DocComplete early return) and empirically against a pre-existing config.local.toml, which was byte-identical and mtime-unchanged after a blocked --apply - a case the shipped test does not cover. All eight regenerated golden fixtures were read in full: each is exactly one appended array element and nothing else. Scope decomposes cleanly as 8 production, 9 test, 8 fixture files with no refactor of untouched code. CI is green on all six checks at exactly the reviewed OID, Windows included, which matters given the CRLF exposure. Non-blocking observations recorded for follow-up: the strings.Contains(err, "metrics") assertion in the three gate tests would pass pre-change too because the untracked path itself contains the word metrics, so the "orch configure" assertion is what actually carries those tests; the predicate is line-literal rather than semantic and that is undocumented in its doc comment; and the bootstrap gate's remedy is mildly self-referential. — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:22:44Z)
- **required-ci** — passing — lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass — commit `c6640faa91cda7796763d0ef5e1cad4e9d630c2f` (2026-07-28T21:22:49Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Enabling metrics must never be able to arm a silent Delivery-loop failure. Today internal/interview holds the metrics ignore line outside its base ignore-line set and appends it only when metrics is enabled, and only the committed init/configure flows call that code. The orch configure-local command legitimately accepts metrics.enabled as a preference override but writes only the machine-local override file, so a local enable leaves the metrics directory un-ignored. Because metrics documents are written into the primary checkout and RequireClean counts untracked files, the consequence is that the first run's completion fails, every later activation fails, and the committed configure flow that would add the ignore line also demands a clean checkout - and no error text anywhere names metrics. Make the ignore line unconditional so new repositories are safe by construction, refuse the local enable that would arm the trap, report the condition from doctor for repositories already in it, and make the cleanliness failure name its own cause wherever it can still occur.",
  "acceptance_criteria": [
    "The gitignore lines internal/interview proposes always include the metrics directory line: a repository initialized or configured with metrics disabled still has that line proposed for .gitignore, and no remaining code path makes the line conditional on the metrics setting.",
    "A test in internal/interview pins the metrics ignore line's value against internal/metrics' exported directory constant, in the same test-only way the existing base ignore lines are pinned against their source constants; the non-test code keeps its own literal so the package stays usable before a repository is initialized.",
    "orch configure-local refuses, through the summary-blocker mechanism it already uses, any change whose resulting effective configuration enables metrics while .gitignore does not already contain the metrics ignore line; the blocker text names orch configure as the flow that adds the line, and an --apply carrying that blocker writes no file.",
    "orch doctor fails, with a message naming metrics and the missing .gitignore line, when the effective configuration has metrics enabled and .gitignore does not contain the metrics ignore line; when metrics is disabled it emits no metrics ignore check and does not fail on this account.",
    "When RequireClean fails at any of the three gates that check the primary checkout - activation, run completion, and the committed configure flow - in a repository where metrics is enabled and .gitignore lacks the metrics ignore line, the resulting error additionally names enabled-metrics-with-an-un-ignored-metrics-directory as the cause and names the remedy. internal/gitops stays policy-free: the metrics-specific explanation is added by the callers, never by RequireClean itself.",
    "The predicate shared by the previous three criteria - metrics enabled and the metrics ignore line absent from .gitignore - has exactly one implementation in the module rather than one copy per call site.",
    "Each of the four behavior changes above is covered by a test that fails against the pre-change code, and go test ./..., go vet ./..., and gofmt -l . are all clean."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:dd23c00b6bd5",
  "verifications": [
    {
      "name": "go-test-all",
      "command": "go clean -testcache \u0026\u0026 go test ./...",
      "result": "pass",
      "detail": "All 25 packages ok, including new tests in internal/metrics, internal/interview, internal/cli, internal/run and internal/bootstrap.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:10:05Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "No output.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:10:05Z"
    },
    {
      "name": "gofmt-check",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No files listed.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:10:05Z"
    },
    {
      "name": "criterion-1-unconditional-gitignore-line",
      "command": "go test ./internal/interview/... -run TestBuildSummaryGitignoreLineUnconditional",
      "result": "pass",
      "detail": "gitignoreLines drops its metricsEnabled parameter and always appends the metrics line. The test proves the line is proposed even with the disabled default from fullAnswers(). Falsified against pre-change code: see the falsification entry.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:10:05Z"
    },
    {
      "name": "criterion-2-pin-against-metrics-dir",
      "command": "go test ./internal/interview/... -run TestMetricsGitignoreLineMatchesSourceConstant",
      "result": "pass",
      "detail": "Test-only pin of metricsGitignoreLine against metrics.Dir + \"/\"; the production literal is unchanged, so internal/interview keeps its pre-init-safe literal-plus-test-pin idiom.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:10:05Z"
    },
    {
      "name": "criterion-3-configure-local-blocker",
      "command": "go test ./internal/interview/... -run TestNextConfigureLocalMetricsTrap and go test ./internal/cli/... -run TestConfigureLocalApplyMetricsTrapWritesNoFile",
      "result": "pass",
      "detail": "The blocker text names orch configure. An --apply carrying the blocker exits ExitError and writes no config.local.toml, checked via os.Stat rather than inferred.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:10:05Z"
    },
    {
      "name": "criterion-4-doctor-check",
      "command": "go test ./internal/cli/... -run TestDoctorMetrics",
      "result": "pass",
      "detail": "Three subtests pass: enabled with the line missing fails doctor, enabled with the line present passes, and disabled emits no metrics ignore check at all.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:10:05Z"
    },
    {
      "name": "criterion-5-requireclean-explains-cause",
      "command": "go test ./internal/run/... -run 'TestActivateMetricsTrapNamesCause|TestCompleteMetricsTrapNamesCause' and go test ./internal/bootstrap/... -run TestExecuteConfigureMetricsTrapNamesCause",
      "result": "pass",
      "detail": "All three gates - activation, run completion and the committed configure flow - assert errors.Is(err, gitops.ErrNotClean) plus the strings \"metrics\" and \"orch configure\" in the error text. internal/gitops is unchanged, so RequireClean itself stays policy-free.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:10:05Z"
    },
    {
      "name": "criterion-6-single-predicate-implementation",
      "command": "grep -rn \"TrapActive|ExplainTrap\" internal --include=*.go | grep -v _test.go",
      "result": "pass",
      "detail": "Exactly one definition, in the new internal/metrics/ignoretrap.go, consumed by all five call sites (doctor, configure-local, activate, complete, bootstrap/configure). No per-call-site copies.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:10:05Z"
    },
    {
      "name": "criterion-7-pre-change-falsification",
      "command": "git stash push -- \u003cproduction files\u003e per behavior, re-run that behavior's new test, git stash pop",
      "result": "pass",
      "detail": "Demonstrated for all four behaviors, not asserted. Stashing summary.go+configure.go made TestBuildSummaryGitignoreLineUnconditional fail with the metrics line missing from GitignoreLines; stashing configurelocal.go made TestNextConfigureLocalMetricsTrapBlocked reach DocComplete instead of a blocked summary; stashing doctor.go made both doctor tests fail with exit 0 and no metrics check line emitted; stashing activate.go+complete.go+bootstrap/configure.go made all three gate tests fail with the bare ErrNotClean message mentioning neither metrics nor orch configure.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:10:05Z"
    },
    {
      "name": "word-diff-reflowed-prose",
      "command": "git diff --cached --word-diff --ignore-all-space -- internal/interview/summary.go internal/interview/configure.go internal/interview/configurelocal.go internal/cli/doctor.go internal/run/activate.go internal/run/complete.go internal/bootstrap/configure.go internal/interview/configure_test.go",
      "result": "pass",
      "detail": "Reviewed for silent word loss. The only paragraph-level rewrites are the doc comments on metricsGitignoreLine, gitignoreLines and writeNoMissingGitignore, each deliberately rewritten to describe the new unconditional behavior; every removed word is an intentional replacement, not a silent drop.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:10:05Z"
    },
    {
      "name": "golden-transcript-regeneration",
      "command": "go test ./internal/interview -update",
      "result": "pass",
      "detail": "Eight golden transcript JSON fixtures regenerated. Each diff is exactly one added line, \".orchestrator/metrics/\" appended to gitignore_lines, which is the expected consequence of criterion 1.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:10:05Z"
    },
    {
      "name": "reviewer-crlf-predicate-against-real-repo",
      "command": "metrics.TrapActive(true, \"C:/Users/Kninetimmy/Orch\") against the primary checkout's actual on-disk .gitignore, plus throwaway tests for CRLF with and without a trailing newline",
      "result": "pass",
      "detail": "Verified the file is CRLF on this machine and that the predicate correctly reports not-trapped. A CR-intolerant predicate would have produced a spurious doctor FAIL here. Confirmed by construction, not by reading the code.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:22:43Z"
    },
    {
      "name": "reviewer-falsification-reproduced",
      "command": "revert production files to base 52f505c one behavior at a time in a disposable clone, re-run each new test",
      "result": "pass",
      "detail": "Not inherited from the executor. Reverting interview/summary.go+configure.go fails the unconditional-line test; reverting configurelocal.go fails both configure-local tests; reverting doctor.go fails both doctor tests; reverting activate.go+complete.go+bootstrap/configure.go fails all three gate tests with bare ErrNotClean.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:22:43Z"
    },
    {
      "name": "reviewer-must-not-mislead-at-gate-level",
      "command": "throwaway tests in internal/run: metrics enabled with line present, metrics disabled with line absent, and the trapped case, each with an unrelated dirty file",
      "result": "pass",
      "detail": "The first two produce the bare cleanliness error with no metrics text; only the trapped case appends the cause and remedy. fmt.Errorf(\"%w%s\") preserves errors.Is(err, gitops.ErrNotClean), and no non-test code compares ErrNotClean by ==.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:22:43Z"
    },
    {
      "name": "reviewer-configure-local-writes-nothing",
      "command": "pre-create a real config.local.toml via config.RenderLocal/WriteLocal, drive the interview to the blocked summary, run configure-local --apply",
      "result": "pass",
      "detail": "Exit ExitError; the file was byte-identical afterward with unchanged mtime. Structurally, the only two mutation calls sit strictly after the DocComplete early return, so no partial-write path is reachable. The shipped test covers only the no-pre-existing-file case.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:22:43Z"
    },
    {
      "name": "reviewer-gitops-untouched",
      "command": "git diff 52f505c..pr107 -- internal/gitops",
      "result": "pass",
      "detail": "Empty diff. Criterion 5's requirement that the explanation live at the callers rather than in RequireClean is satisfied mechanically.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:22:43Z"
    },
    {
      "name": "reviewer-golden-fixtures-audit",
      "command": "read all eight regenerated testdata transcript JSON diffs in full",
      "result": "pass",
      "detail": "Each is exactly one added array element \".orchestrator/metrics/\" appended to gitignore_lines. No reordering, no config_diff churn, no revision drift, nothing rode along.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:22:43Z"
    },
    {
      "name": "reviewer-ci-at-reviewed-oid",
      "command": "gh run view 30399527993 head_sha check",
      "result": "pass",
      "detail": "All six required checks SUCCESS at exactly c6640faa91cda7796763d0ef5e1cad4e9d630c2f: lint, scripts on ubuntu and windows, test on ubuntu, macos and windows.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:22:43Z"
    },
    {
      "name": "reviewer-manifest-accuracy",
      "command": "programmatic comparison of the PR audit record against issue #104's body",
      "result": "pass",
      "detail": "Objective and all seven criteria verbatim-identical; required tests, routed selection, config revision sha256:dd23c00b6bd5 and plan digest all match. Two cosmetic imprecisions only: \"all 25 packages ok\" is really 22 ok plus 3 with no test files, and criterion 4's \"three subtests\" are three sibling top-level functions sharing a prefix.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:22:43Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "All seven acceptance criteria hold simultaneously, each verified independently rather than inherited. The reviewer reproduced the falsification for all four behaviors by reverting production files to the base commit one behavior at a time and watching each new test fail. The highest-risk failure mode this change could have shipped - a CR-intolerant predicate silently inverting on every Windows checkout - is not present: the new internal/metrics predicate mirrors interview's readGitignore CR trimming, and the reviewer confirmed it by pointing TrapActive at this repository's real on-disk .gitignore, which it verified is CRLF (385 bytes, CR on every line, no .gitattributes rule covering it), getting the correct not-trapped answer. It also constructed the must-not-mislead cases at gate level: metrics enabled with the line present, and metrics disabled with the line absent, both produce the bare cleanliness error with no metrics text, while the trapped case adds the cause and remedy. internal/gitops is genuinely untouched (empty diff), so RequireClean stays policy-free. The writes-no-file half of criterion 3 was confirmed both structurally (the only two mutation calls sit after the DocComplete early return) and empirically against a pre-existing config.local.toml, which was byte-identical and mtime-unchanged after a blocked --apply - a case the shipped test does not cover. All eight regenerated golden fixtures were read in full: each is exactly one appended array element and nothing else. Scope decomposes cleanly as 8 production, 9 test, 8 fixture files with no refactor of untouched code. CI is green on all six checks at exactly the reviewed OID, Windows included, which matters given the CRLF exposure. Non-blocking observations recorded for follow-up: the strings.Contains(err, \"metrics\") assertion in the three gate tests would pass pre-change too because the untracked path itself contains the word metrics, so the \"orch configure\" assertion is what actually carries those tests; the predicate is line-literal rather than semantic and that is undocumented in its doc comment; and the bootstrap gate's remedy is mildly self-referential.",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:22:44Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass",
      "commit_oid": "c6640faa91cda7796763d0ef5e1cad4e9d630c2f",
      "at": "2026-07-28T21:22:49Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->