### PR TITLE
Add the missing .gitattributes rule so .gitignore is checked out LF on every platform

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,4 @@
 *.txt text eol=lf
 *.sh text eol=lf
 *.ps1 text eol=lf
+.gitignore text eol=lf


### PR DESCRIPTION
Delivers issue #109: Add the missing .gitattributes rule so .gitignore is checked out LF on every platform

Closes #109

**Plan digest:** `sha256:8382b3be3e2ac775ff5924047b4a22e2250b72b7d0780c88c2b55f185b8ec82e`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Close task 99. .gitattributes carries '* text=auto' plus eol=lf rules keyed to file extensions; .gitignore is extensionless so no rule matches it, and with core.autocrlf=true the working-tree copy is CRLF while the committed blob is LF. Add the rule covering .gitignore. This is repository hygiene, not a bug fix - the real fix for the empty-pattern hazard already shipped in b02f613 - and it must not weaken the synthetic test coverage that pins that fix.

**Acceptance criteria:**
- The tracked .gitattributes contains a rule that causes .gitignore to be checked out with LF line endings on every platform, placed consistently with the existing extension-keyed eol=lf rules.
- TestIntegrationRequireIgnoredEmptyPatternHazard in internal/gitops/integration_test.go is unchanged and still constructs its own repository fixture, so the empty-pattern coverage does not depend on this checkout's .gitignore line endings.
- No file other than .gitattributes is modified.
- go test ./... passes and gofmt -l . produces no output.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-sonnet-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:dd23c00b6bd5` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **go test ./...** — pass — `go test ./...` — CORRECTED ON REVIEW CYCLE 1, superseding the pr-open text of this entry, which said 21. Independently re-run by the reviewer from a git archive export at commit 21f8b80f02ec96b531e6892e82deef04b95e0751: 22 packages report ok and 3 report [no test files] (cmd/orch, internal/adaptertest, internal/execx/execxtest), 25 packages total. No failures. The executor's earlier count of 21 ok was wrong by one; the pass/fail substance was correct in both accounts. — commit `21f8b80f02ec96b531e6892e82deef04b95e0751` (2026-07-28T23:25:25Z)
- **gofmt -l .** — pass — `gofmt -l .` — Run by the executor from the worktree root at commit 21f8b80f02ec96b531e6892e82deef04b95e0751. Empty output, so no file in the tree is unformatted. — commit `21f8b80f02ec96b531e6892e82deef04b95e0751` (2026-07-28T23:20:06Z)
- **criterion 2 - empty-pattern fixture is self-contained and unchanged** — pass — `git diff origin/main HEAD -- internal/gitops/integration_test.go` — Produced no output, so TestIntegrationRequireIgnoredEmptyPatternHazard (internal/gitops/integration_test.go:380-419) is byte-unchanged. The executor also read the test and confirmed it builds its own fixture per subtest via newRepo(t) plus an explicit os.WriteFile of .gitignore bytes drawn from a local map of the two hazard payloads (CRLF blank line; whitespace-only line under LF). The empty-pattern coverage that pins b02f613 therefore does not depend on this checkout's .gitignore line endings, which was the risk the criterion existed to bound. — commit `21f8b80f02ec96b531e6892e82deef04b95e0751` (2026-07-28T23:20:06Z)
- **criterion 3 - scope bound holds** — pass — `git show --stat HEAD && git status --porcelain` — git show --stat HEAD reports exactly one file touched: .gitattributes | 1 +, 1 file changed, 1 insertion(+). git status --porcelain is empty, so the working tree is clean and nothing was left unstaged. The executor confirmed it did not run git add --renormalize and did not restage the working-tree .gitignore, either of which would have breached the criterion. — commit `21f8b80f02ec96b531e6892e82deef04b95e0751` (2026-07-28T23:20:06Z)
- **branch-scope: architect scope audit** — pass — `git log --oneline origin/main..HEAD && git diff --stat origin/main..HEAD` — BRANCH-SCOPED ENTRY - describes the whole branch and must be resubmitted on every review cycle if the branch moves. As of commit 21f8b80f02ec96b531e6892e82deef04b95e0751 the branch is 1 commit ahead of origin/main, touching 1 file, +1/-0: .gitattributes gains the literal-filename rule '.gitignore text eol=lf' appended after the existing '*.ps1 text eol=lf' line. This matches the approved scope exactly - no source file, no test, and no configuration is touched. The change is inert in existing checkouts until a fresh checkout or renormalize, which is expected and was called out in the plan. — commit `21f8b80f02ec96b531e6892e82deef04b95e0751` (2026-07-28T23:20:06Z)
- **review-cycle-1** — approve — VERDICT: approve. BLOCKING FINDINGS: none. NON-BLOCKING FINDINGS: one - the audit record's 'go test ./...' entry said 21 testable packages report ok; the reviewer's independent re-run counted 22 ok plus the same 3 [no test files], 25 total. The pass/fail substance was correct; only the count was wrong. That entry has been corrected in place on this cycle by resubmitting it under the same name, so no stale claim survives to the merge candidate.

All four acceptance criteria MET, each verified by the reviewer independently rather than inherited from the executor. (1) The diff is exactly one appended line, '.gitignore text eol=lf', after '*.ps1 text eol=lf'. Confirmed by 'git check-attr eol' against a copy: '.gitignore: eol: lf'. The reviewer addressed the placement question I raised directly: every other rule is a '*.ext' glob because those files have extensions, .gitignore does not, so a literal filename is the only way to target it - a necessity, not a deviation. It also confirmed the rule matches nested .gitignore files too (checked via check-attr on a synthetic nested path); this repo has only the root .gitignore so the broader match is inert today, and 'on every platform' concerns OS, not path depth. Not a defect. (2) TestIntegrationRequireIgnoredEmptyPatternHazard is byte-identical to origin/main ('git diff origin/main..HEAD -- internal/gitops/integration_test.go' empty) and was read in full: each subtest calls newRepo(t), which git-inits into a fresh t.TempDir() committing only a README.md - no .gitattributes and no dependency on this checkout - then os.WriteFile's .gitignore bytes from a local hazards map holding both payloads (CRLF blank line; whitespace-only line under LF). Both subtests were run in isolation from an exported tree and pass. The synthetic coverage that replaces this checkout's now-removed live reproduction is intact, which is the entire reason the criterion existed. (3) Exactly one file changed: 'gh pr view --json files', 'git diff --stat origin/main...HEAD' and 'git show --stat' all agree on .gitattributes +1/-0, 1 commit ahead. (4) Re-run independently from the exported tree: 'go build ./...' clean, 'gofmt -l .' empty, 'go test ./...' no failures.

SCOPE: confined to .gitattributes; no source, test, or config file touched, and no attempt to re-touch the b02f613 empty-pattern fix in internal/gitops. CORRECTNESS: the change forces LF checkout for .gitignore regardless of core.autocrlf, closing the CRLF-working-tree/LF-blob drift without disturbing the RequireIgnored two-child-probe fix or its coverage. TESTS: both required tests re-run with matching results. CI: all six required checks (lint; scripts ubuntu/windows; test ubuntu/macos/windows) report pass - two test jobs were IN_PROGRESS at first poll and completed successfully by the second. SECURITY: not applicable; a line-ending attribute introduces no secret, no shell/SQL/path input, and no trust-boundary change. AUDIT-RECORD ACCURACY: everything else in the manifest - routed selection, commit OID, diff description, the byte-unchanged claim, the scope-bound claim, the clean-worktree claim - checked out against independent observation.

REVIEWER DISCIPLINE: worked entirely from gh pr view/diff, read-only git in the main checkout, and a git archive export to a scratch directory outside the repository, which it cleaned up. It made no writes, checkouts, or commits in the primary checkout - the concurrent-issue hazard recorded as task 74 did not recur. — commit `21f8b80f02ec96b531e6892e82deef04b95e0751` (2026-07-28T23:25:26Z)
- **required-ci** — passing — scripts (windows-latest)=pass, test (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass — commit `21f8b80f02ec96b531e6892e82deef04b95e0751` (2026-07-28T23:25:30Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Close task 99. .gitattributes carries '* text=auto' plus eol=lf rules keyed to file extensions; .gitignore is extensionless so no rule matches it, and with core.autocrlf=true the working-tree copy is CRLF while the committed blob is LF. Add the rule covering .gitignore. This is repository hygiene, not a bug fix - the real fix for the empty-pattern hazard already shipped in b02f613 - and it must not weaken the synthetic test coverage that pins that fix.",
  "acceptance_criteria": [
    "The tracked .gitattributes contains a rule that causes .gitignore to be checked out with LF line endings on every platform, placed consistently with the existing extension-keyed eol=lf rules.",
    "TestIntegrationRequireIgnoredEmptyPatternHazard in internal/gitops/integration_test.go is unchanged and still constructs its own repository fixture, so the empty-pattern coverage does not depend on this checkout's .gitignore line endings.",
    "No file other than .gitattributes is modified.",
    "go test ./... passes and gofmt -l . produces no output."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "claude-sonnet-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:dd23c00b6bd5",
  "verifications": [
    {
      "name": "go test ./...",
      "command": "go test ./...",
      "result": "pass",
      "detail": "CORRECTED ON REVIEW CYCLE 1, superseding the pr-open text of this entry, which said 21. Independently re-run by the reviewer from a git archive export at commit 21f8b80f02ec96b531e6892e82deef04b95e0751: 22 packages report ok and 3 report [no test files] (cmd/orch, internal/adaptertest, internal/execx/execxtest), 25 packages total. No failures. The executor's earlier count of 21 ok was wrong by one; the pass/fail substance was correct in both accounts.",
      "commit_oid": "21f8b80f02ec96b531e6892e82deef04b95e0751",
      "at": "2026-07-28T23:25:25Z"
    },
    {
      "name": "gofmt -l .",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Run by the executor from the worktree root at commit 21f8b80f02ec96b531e6892e82deef04b95e0751. Empty output, so no file in the tree is unformatted.",
      "commit_oid": "21f8b80f02ec96b531e6892e82deef04b95e0751",
      "at": "2026-07-28T23:20:06Z"
    },
    {
      "name": "criterion 2 - empty-pattern fixture is self-contained and unchanged",
      "command": "git diff origin/main HEAD -- internal/gitops/integration_test.go",
      "result": "pass",
      "detail": "Produced no output, so TestIntegrationRequireIgnoredEmptyPatternHazard (internal/gitops/integration_test.go:380-419) is byte-unchanged. The executor also read the test and confirmed it builds its own fixture per subtest via newRepo(t) plus an explicit os.WriteFile of .gitignore bytes drawn from a local map of the two hazard payloads (CRLF blank line; whitespace-only line under LF). The empty-pattern coverage that pins b02f613 therefore does not depend on this checkout's .gitignore line endings, which was the risk the criterion existed to bound.",
      "commit_oid": "21f8b80f02ec96b531e6892e82deef04b95e0751",
      "at": "2026-07-28T23:20:06Z"
    },
    {
      "name": "criterion 3 - scope bound holds",
      "command": "git show --stat HEAD \u0026\u0026 git status --porcelain",
      "result": "pass",
      "detail": "git show --stat HEAD reports exactly one file touched: .gitattributes | 1 +, 1 file changed, 1 insertion(+). git status --porcelain is empty, so the working tree is clean and nothing was left unstaged. The executor confirmed it did not run git add --renormalize and did not restage the working-tree .gitignore, either of which would have breached the criterion.",
      "commit_oid": "21f8b80f02ec96b531e6892e82deef04b95e0751",
      "at": "2026-07-28T23:20:06Z"
    },
    {
      "name": "branch-scope: architect scope audit",
      "command": "git log --oneline origin/main..HEAD \u0026\u0026 git diff --stat origin/main..HEAD",
      "result": "pass",
      "detail": "BRANCH-SCOPED ENTRY - describes the whole branch and must be resubmitted on every review cycle if the branch moves. As of commit 21f8b80f02ec96b531e6892e82deef04b95e0751 the branch is 1 commit ahead of origin/main, touching 1 file, +1/-0: .gitattributes gains the literal-filename rule '.gitignore text eol=lf' appended after the existing '*.ps1 text eol=lf' line. This matches the approved scope exactly - no source file, no test, and no configuration is touched. The change is inert in existing checkouts until a fresh checkout or renormalize, which is expected and was called out in the plan.",
      "commit_oid": "21f8b80f02ec96b531e6892e82deef04b95e0751",
      "at": "2026-07-28T23:20:06Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "VERDICT: approve. BLOCKING FINDINGS: none. NON-BLOCKING FINDINGS: one - the audit record's 'go test ./...' entry said 21 testable packages report ok; the reviewer's independent re-run counted 22 ok plus the same 3 [no test files], 25 total. The pass/fail substance was correct; only the count was wrong. That entry has been corrected in place on this cycle by resubmitting it under the same name, so no stale claim survives to the merge candidate.\n\nAll four acceptance criteria MET, each verified by the reviewer independently rather than inherited from the executor. (1) The diff is exactly one appended line, '.gitignore text eol=lf', after '*.ps1 text eol=lf'. Confirmed by 'git check-attr eol' against a copy: '.gitignore: eol: lf'. The reviewer addressed the placement question I raised directly: every other rule is a '*.ext' glob because those files have extensions, .gitignore does not, so a literal filename is the only way to target it - a necessity, not a deviation. It also confirmed the rule matches nested .gitignore files too (checked via check-attr on a synthetic nested path); this repo has only the root .gitignore so the broader match is inert today, and 'on every platform' concerns OS, not path depth. Not a defect. (2) TestIntegrationRequireIgnoredEmptyPatternHazard is byte-identical to origin/main ('git diff origin/main..HEAD -- internal/gitops/integration_test.go' empty) and was read in full: each subtest calls newRepo(t), which git-inits into a fresh t.TempDir() committing only a README.md - no .gitattributes and no dependency on this checkout - then os.WriteFile's .gitignore bytes from a local hazards map holding both payloads (CRLF blank line; whitespace-only line under LF). Both subtests were run in isolation from an exported tree and pass. The synthetic coverage that replaces this checkout's now-removed live reproduction is intact, which is the entire reason the criterion existed. (3) Exactly one file changed: 'gh pr view --json files', 'git diff --stat origin/main...HEAD' and 'git show --stat' all agree on .gitattributes +1/-0, 1 commit ahead. (4) Re-run independently from the exported tree: 'go build ./...' clean, 'gofmt -l .' empty, 'go test ./...' no failures.\n\nSCOPE: confined to .gitattributes; no source, test, or config file touched, and no attempt to re-touch the b02f613 empty-pattern fix in internal/gitops. CORRECTNESS: the change forces LF checkout for .gitignore regardless of core.autocrlf, closing the CRLF-working-tree/LF-blob drift without disturbing the RequireIgnored two-child-probe fix or its coverage. TESTS: both required tests re-run with matching results. CI: all six required checks (lint; scripts ubuntu/windows; test ubuntu/macos/windows) report pass - two test jobs were IN_PROGRESS at first poll and completed successfully by the second. SECURITY: not applicable; a line-ending attribute introduces no secret, no shell/SQL/path input, and no trust-boundary change. AUDIT-RECORD ACCURACY: everything else in the manifest - routed selection, commit OID, diff description, the byte-unchanged claim, the scope-bound claim, the clean-worktree claim - checked out against independent observation.\n\nREVIEWER DISCIPLINE: worked entirely from gh pr view/diff, read-only git in the main checkout, and a git archive export to a scratch directory outside the repository, which it cleaned up. It made no writes, checkouts, or commits in the primary checkout - the concurrent-issue hazard recorded as task 74 did not recur.",
      "commit_oid": "21f8b80f02ec96b531e6892e82deef04b95e0751",
      "at": "2026-07-28T23:25:26Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "scripts (windows-latest)=pass, test (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "21f8b80f02ec96b531e6892e82deef04b95e0751",
      "at": "2026-07-28T23:25:30Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->