### PR TITLE
Tell the Architect to resubmit branch-scoped audit-record verifications every review cycle, and pin the guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "kninetimmy" },
   "metadata": {
     "description": "Host adapters for the Orch development orchestrator",
-    "version": "0.5.5"
+    "version": "0.5.7"
   },
   "plugins": [
     {

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Claude Code host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.5",
+  "version": "0.5.7",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -78,8 +78,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.5" {
-		t.Errorf("version = %q, want 0.5.5", m.Version)
+	if m.Version != "0.5.7" {
+		t.Errorf("version = %q, want 0.5.7", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")
@@ -338,6 +338,10 @@ func TestSetupSkillHasTerminalForms(t *testing.T) {
 
 func TestDeliverySkillHasRoutedSelectionCue(t *testing.T) {
 	adaptertest.CheckRoutedSelectionCue(t, deliverySkillPath)
+}
+
+func TestDeliverySkillHasBranchScopeVerificationGuidance(t *testing.T) {
+	adaptertest.CheckBranchScopeVerificationGuidance(t, deliverySkillPath)
 }
 
 // frontmatterMatchRuleSentence is the exact phrase

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -315,6 +315,17 @@ in flight at once. For each issue:
    verification names as pr-open — `required-ci`, `merge`, `abandoned`,
    and `review-cycle-<n>` — are engine-owned and are rejected with
    `ErrBadRequest` before any mutation when supplied by a caller.
+   A verification whose text describes the branch as a whole —
+   commit counts, file counts, diff totals, or scope claims —
+   becomes false as soon as the executor pushes a fix commit, and
+   must be resubmitted on every subsequent review cycle. This
+   works because verification entries are replace-by-name
+   upserts: submitting the same `name` again on `orch run review`
+   re-stamps that entry at the live head and supersedes its stale
+   text. Prefix such an entry's `name` with `branch-scope:` to mark
+   it as branch-scoped, and therefore resubmit-on-every-cycle; this
+   prefix does not collide with the engine-owned names `required-ci`,
+   `merge`, `abandoned`, and `review-cycle-<n>`.
    `approve` continues.
 
 6. **CI** — `orch run ci` with

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Codex CLI host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.5",
+  "version": "0.5.7",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -79,8 +79,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.5" {
-		t.Errorf("version = %q, want 0.5.5", m.Version)
+	if m.Version != "0.5.7" {
+		t.Errorf("version = %q, want 0.5.7", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")
@@ -277,6 +277,10 @@ func TestSetupSkillHasTerminalForms(t *testing.T) {
 
 func TestDeliverySkillHasRoutedSelectionCue(t *testing.T) {
 	adaptertest.CheckRoutedSelectionCue(t, deliverySkillPath)
+}
+
+func TestDeliverySkillHasBranchScopeVerificationGuidance(t *testing.T) {
+	adaptertest.CheckBranchScopeVerificationGuidance(t, deliverySkillPath)
 }
 
 // tomlMatchRuleSentence is the exact phrase orch-delivery/SKILL.md must

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -303,6 +303,17 @@ in flight at once. For each issue:
    verification names as pr-open — `required-ci`, `merge`, `abandoned`,
    and `review-cycle-<n>` — are engine-owned and are rejected with
    `ErrBadRequest` before any mutation when supplied by a caller.
+   A verification whose text describes the branch as a whole —
+   commit counts, file counts, diff totals, or scope claims —
+   becomes false as soon as the executor pushes a fix commit, and
+   must be resubmitted on every subsequent review cycle. This
+   works because verification entries are replace-by-name
+   upserts: submitting the same `name` again on `orch run review`
+   re-stamps that entry at the live head and supersedes its stale
+   text. Prefix such an entry's `name` with `branch-scope:` to mark
+   it as branch-scoped, and therefore resubmit-on-every-cycle; this
+   prefix does not collide with the engine-owned names `required-ci`,
+   `merge`, `abandoned`, and `review-cycle-<n>`.
    `approve` continues.
 
 6. **CI** — `orch run ci` with

--- a/internal/adaptertest/adaptertest.go
+++ b/internal/adaptertest/adaptertest.go
@@ -312,6 +312,46 @@ func CheckRoutedSelectionCue(t *testing.T, skillPath string) {
 	}
 }
 
+// branchScopeGuidancePhrases are the exact phrases the review step of a
+// delivery skill must state about branch-scoped verifications (memhub
+// task 87): a verification whose text describes the branch as a
+// whole — commit counts, file counts, diff totals, or scope claims —
+// goes false on the next push and must be resubmitted every review
+// cycle; the replace-by-name upsert is the mechanism that makes
+// resubmission supersede the stale entry instead of appending beside
+// it; and `branch-scope:` is the literal name-prefix convention for
+// marking such an entry, which does not collide with the four
+// engine-owned names.
+//
+// These phrases pin the presence of this instruction, not its
+// meaning: NormalizeWhitespace makes the comparison tolerant of a
+// markdown reflow hard-wrapping a phrase across a line break, but a
+// skill author could still reword every unpinned sentence around
+// these phrases, or drift the paragraph's overall sense while every
+// pinned phrase survives verbatim, without this check noticing. It
+// catches deletion of the guidance, not corruption of its meaning.
+var branchScopeGuidancePhrases = []string{
+	"describes the branch as a whole — commit counts, file counts, diff totals, or scope claims — becomes false as soon as the executor pushes a fix commit, and must be resubmitted on every subsequent review cycle",
+	"verification entries are replace-by-name upserts: submitting the same `name` again on `orch run review` re-stamps that entry at the live head and supersedes its stale text",
+	"Prefix such an entry's `name` with `branch-scope:` to mark it as branch-scoped",
+	"this prefix does not collide with the engine-owned names `required-ci`, `merge`, `abandoned`, and `review-cycle-<n>`",
+}
+
+// CheckBranchScopeVerificationGuidance pins deliverySkillPath's review
+// step against the exact branch-scope resubmission guidance above. The
+// comparison runs on whitespace-normalized text on both sides, so a
+// phrase a markdown reflow happens to hard-wrap across a line break
+// still counts as present.
+func CheckBranchScopeVerificationGuidance(t *testing.T, deliverySkillPath string) {
+	t.Helper()
+	content := normalizeWhitespace(readFile(t, deliverySkillPath))
+	for _, phrase := range branchScopeGuidancePhrases {
+		if !strings.Contains(content, normalizeWhitespace(phrase)) {
+			t.Errorf("%s does not contain the branch-scope verification guidance phrase %q", deliverySkillPath, phrase)
+		}
+	}
+}
+
 // CheckMatcherEqualsGuardTools asserts matcher (a "|"-joined hook
 // matcher string) names exactly the tools in want, in both directions:
 // the matcher must name every guard-handled tool, and name nothing


### PR DESCRIPTION
Delivers issue #108: Tell the Architect to resubmit branch-scoped audit-record verifications every review cycle, and pin the guidance

Closes #108

**Plan digest:** `sha256:8382b3be3e2ac775ff5924047b4a22e2250b72b7d0780c88c2b55f185b8ec82e`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Close task 87. Both hosts' orch-delivery skill must tell the Architect that a verification describing the branch as a whole goes false on the next push and has to be resubmitted on every review cycle, name the replace-by-name upsert as the mechanism that supersedes the stale text, and establish a literal name prefix marking which entries are branch-scoped. Pin the new guidance with a drift assertion sourced once and consumed by both hosts, because an unpinned prose section is not defended by the suite. Bump the plugin version so the change is installable and cannot collide with released tag v0.5.6.

**Acceptance criteria:**
- Both adapters/claude/skills/orch-delivery/SKILL.md and adapters/codex/skills/orch-delivery/SKILL.md, in their review step, state that a verification whose text describes the branch as a whole - commit counts, file counts, diff totals, or scope claims - becomes false as soon as the executor pushes a fix commit, and must be resubmitted on every subsequent review cycle.
- Both skill files state the mechanism that makes resubmission work: verification entries are replace-by-name upserts, so submitting the same name again on orch run review re-stamps that entry at the live head and supersedes its stale text.
- Both skill files document the literal name prefix 'branch-scope:' as the convention marking a verification as branch-scoped and therefore resubmit-on-every-cycle, and both state that this prefix does not collide with the engine-owned names required-ci, merge, abandoned, and review-cycle-&lt;n&gt;.
- Deleting the new guidance from either host's skill file makes go test ./... fail. The assertion producing that failure has exactly one source in the module and is consumed by both adapters/claude/plugin_test.go and adapters/codex/plugin_test.go, so the two hosts cannot drift apart.
- Every site that declares or asserts the plugin version declares 0.5.7, and no tracked file still contains the string 0.5.5: adapters/claude/.claude-plugin/plugin.json, adapters/codex/.codex-plugin/plugin.json, .claude-plugin/marketplace.json, adapters/claude/plugin_test.go, and adapters/codex/plugin_test.go.
- go test ./..., go vet ./..., and gofmt -l . are all clean, with gofmt -l . producing no output.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:dd23c00b6bd5` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.

**Escalations:** _none_

**Verification:**
- **go test ./...** — pass — `go test ./...` — CORRECTED ON REVIEW CYCLE 1, superseding the pr-open text of this entry, which said 24 packages with tests and 3 with none. The reviewer re-ran the suite independently from a git archive export at commit cc509f6631088e9960f86ca368202a88c710fd50: 22 packages with tests all report ok, 3 report [no test files], 25 packages total per go list ./... | wc -l. Exit 0, no failures. The executor's earlier arithmetic was wrong by two and its 24+3 exceeded the module's package count; the pass/fail substance was correct in both accounts. — commit `cc509f6631088e9960f86ca368202a88c710fd50` (2026-07-28T23:37:21Z)
- **go vet ./...** — pass — `go vet ./...` — Run by the executor in the issue-108 worktree at commit cc509f6. No output, so clean. — commit `cc509f6631088e9960f86ca368202a88c710fd50` (2026-07-28T23:26:32Z)
- **gofmt -l .** — pass — `gofmt -l .` — Run by the executor in the issue-108 worktree at commit cc509f6. No output, so no file is unformatted. — commit `cc509f6631088e9960f86ca368202a88c710fd50` (2026-07-28T23:26:32Z)
- **criterion 4 - pin proven non-vacuous by two-sided mutation** — pass — `delete the new guidance paragraph from each host SKILL.md in a scratch copy outside the repository, then go test ./...` — The executor copied the worktree (minus .git) to a scratch directory OUTSIDE the repository and mutated only that copy. Deleting the guidance from adapters/claude/skills/orch-delivery/SKILL.md failed TestDeliverySkillHasBranchScopeVerificationGuidance at plugin_test.go:344 in package adapters/claude, reporting four missing-phrase errors, the first naming the phrase 'describes the branch as a whole - commit counts, file counts, diff totals, or scope claims - becomes false as soon as the executor pushes a fix commit, and must be resubmitted on every subsequent review cycle'. Restoring that file and instead deleting the same paragraph from adapters/codex/skills/orch-delivery/SKILL.md failed the same way in package adapters/codex at plugin_test.go:283, with the same four messages. Both failures trace to the single shared assertion internal/adaptertest.CheckBranchScopeVerificationGuidance over branchScopeGuidancePhrases, which is the 'exactly one source consumed by both hosts' the criterion requires. The scratch copy was deleted afterward. This matters because memhub fact 45 established by mutation at commit 3548a04 that a green suite was previously ZERO evidence about prose in these files. — commit `cc509f6631088e9960f86ca368202a88c710fd50` (2026-07-28T23:26:32Z)
- **criterion 4 - the pin's stated non-coverage** — pass — `read the doc comment above branchScopeGuidancePhrases in internal/adaptertest/adaptertest.go` — The pin asserts four literal phrases, compared through NormalizeWhitespace on both sides: (1) the branch-describing-text-goes-false-on-push instruction; (2) 'verification entries are replace-by-name upserts: submitting the same name again on orch run review re-stamps that entry at the live head and supersedes its stale text'; (3) 'Prefix such an entry's name with branch-scope: to mark it as branch-scoped'; (4) 'this prefix does not collide with the engine-owned names required-ci, merge, abandoned, and review-cycle-&lt;n&gt;'. The doc comment states the non-coverage explicitly, per the PR #92 reviewer's recommendation recorded as memhub task 84: the pins guard against these phrases being DELETED, not against an unpinned sentence being reworded, nor against the paragraph's meaning drifting while the pinned phrases survive verbatim. NormalizeWhitespace makes the match reflow-tolerant, not semantics-aware. This is a deliberately partial pin and says so. — commit `cc509f6631088e9960f86ca368202a88c710fd50` (2026-07-28T23:26:32Z)
- **criterion 5 - plugin version bump, verified by the Architect** — pass — `git grep -n "0\.5\.5" cc509f6 ; git grep -n "0\.5\.7" cc509f6` — Verified by the Architect independently of the executor's report, reading the tree at commit cc509f6 rather than a worktree. The 0.5.5 search returns nothing, so the negative half of the criterion holds. The 0.5.7 search returns all five required sites, seven lines in total: .claude-plugin/marketplace.json:6; adapters/claude/.claude-plugin/plugin.json:4; adapters/claude/plugin_test.go:81 and :82; adapters/codex/.codex-plugin/plugin.json:4; adapters/codex/plugin_test.go:82 and :83. 0.5.7 rather than 0.5.6 because tag v0.5.6 is already released with adapters/ declaring 0.5.5, so reusing 0.5.6 would name content absent from that tag - the same-version-different-bytes trap recorded as memhub task 65. — commit `cc509f6631088e9960f86ca368202a88c710fd50` (2026-07-28T23:26:32Z)
- **prose edit is purely additive** — pass — `git diff --word-diff --ignore-all-space -- adapters/claude/skills/orch-delivery/SKILL.md adapters/codex/skills/orch-delivery/SKILL.md` — Showed only {+insertion+} markers and no [-removal-] markers across both skill files, so no word was dropped from the surrounding prose. This check exists because memhub task 72 records two occurrences in a single PR of a prose reflow silently dropping words while every gate stayed green; the executor was instructed to keep the diff additive and not reflow surrounding text. — commit `cc509f6631088e9960f86ca368202a88c710fd50` (2026-07-28T23:26:32Z)
- **branch-scope: architect scope audit** — pass — `git log --oneline main..cc509f6 && git diff --stat main..cc509f6` — BRANCH-SCOPED ENTRY - describes the whole branch and must be resubmitted on every review cycle if the branch moves. Verified by the Architect at commit cc509f6: 1 commit ahead of main, 8 files changed, +77/-7. Breakdown: .claude-plugin/marketplace.json +1/-1; adapters/claude/.claude-plugin/plugin.json +1/-1; adapters/claude/plugin_test.go +6/-2; adapters/claude/skills/orch-delivery/SKILL.md +11/-0; adapters/codex/.codex-plugin/plugin.json +1/-1; adapters/codex/plugin_test.go +6/-2; adapters/codex/skills/orch-delivery/SKILL.md +11/-0; internal/adaptertest/adaptertest.go +40/-0. This matches the approved scope: the two skill files carry the new guidance, adaptertest holds the single shared pin, both plugin_test.go files consume it and carry the version assertion, and the three manifests carry the bump. Nothing outside adapters/ and internal/adaptertest is touched. — commit `cc509f6631088e9960f86ca368202a88c710fd50` (2026-07-28T23:26:32Z)
- **executor judgment call worth reviewer attention** — n/a — `n/a - disclosure, not a check` — The Architect's working notes told the executor that the two host skill files diverge in wording in this passage (Claude says 'its Task result actually gives you', Codex says 'its own reporting actually gives you') and to match each file's existing voice. The executor instead wrote the new guidance IDENTICALLY in both files, reasoning that the text is wholly new rather than a rewrite of the divergent sentences, and that identical text keeps the shared pin simple. It did not touch either divergent sentence. The Architect considers this defensible and better than the instruction given, but is surfacing it rather than burying it: the reviewer should confirm the identical text reads correctly in the Codex file's voice and wrap width, since that was the reason for the original instruction. — commit `cc509f6631088e9960f86ca368202a88c710fd50` (2026-07-28T23:26:32Z)
- **review-cycle-1** — approve — VERDICT: approve. BLOCKING FINDINGS: none. NON-BLOCKING FINDINGS (4, all follow-up grade): (1) This record's 'go test ./...' entry said 24 packages with tests, 3 with none; the actual count at this commit is 22 with tests, 3 without, 25 total, and 24+3 exceeds the package count. CORRECTED IN PLACE on this cycle by resubmitting that entry under the same name, so no false claim survives to the merge candidate. (2) The 'branch-scope:' prefix is documented only at the review step, but the entry is BORN at pr-open. The reviewer proved by probe that an entry first submitted at pr-open as 'architect scope audit' and later resubmitted as 'branch-scope: architect scope audit' does NOT replace - the names differ, setVerification appends, and the stale unprefixed entry persists forever. Criterion 1 deliberately scoped the guidance to the review step, so this is not a miss against the approved criteria, but pr-open needs one clause; filing as a follow-up task. (3) CheckBranchScopeVerificationGuidance reads the whole SKILL.md rather than the review step, so the phrases relocated to another section would still pass, despite the doc comment saying 'the review step must state'. Identical to the sibling CheckRoutedSelectionCue, so a pattern rather than a regression; the non-coverage paragraph could name it. (4) 'verification entries are replace-by-name upserts' is true of caller-supplied entries but not of the engine's own review-cycle-&lt;n&gt; entries, which are appended at internal/run/review.go:152. In context the immediately preceding sentence establishes those names are engine-owned and caller-rejected, so it does not mislead.

ALL SIX CRITERIA MET, each verified by the reviewer independently in a git archive export outside the repository; it accepted no executor transcript. Criterion 2's claim is TRUE about the engine: review.go:148-151 stamps caller verifications with pr.HeadRefOid, the head the engine read itself rather than a request field, then runs setVerification per entry, and manifestbody.go:99-107 replaces on exact name match and appends only when absent. Confirmed empirically by probe: resubmitting the same name held the count at 2, replaced STALE with FRESH, and re-stamped commit_oid to the new head. Criterion 3's non-collision claim is TRUE and was probed adversarially: the rejection logic at manifestbody.go:142-168 is an exact-match map for required-ci/merge/abandoned plus the ANCHORED regex ^review-cycle-[0-9]+$, so no prefixed name can trip it - branch-scope:required-ci, branch-scope: required-ci, branch-scope:merge, branch-scope:abandoned, branch-scope:review-cycle-1 and branch-scope: review-cycle-12 were all accepted while the five bare names were all rejected as a control. The prefix is also safe downstream: Verification.Name has no charset validation beyond non-empty, and mdText passes a colon through untouched.

CRITERION 4 REPRODUCED, NOT INHERITED. Deleting the guidance from the Claude skill alone failed at plugin_test.go:344 with adapters/codex still ok; restoring and deleting from the Codex skill alone failed at plugin_test.go:283 with adapters/claude still ok. Exactly one source: branchScopeGuidancePhrases and CheckBranchScopeVerificationGuidance are defined only in internal/adaptertest/adaptertest.go and consumed by both hosts' plugin_test.go. THE VACUITY CHECK PASSES, and this was the specific risk with a NormalizeWhitespace pin: each single-host deletion reported ALL FOUR phrases missing, which is direct proof that no pinned phrase normalizes to something already present elsewhere in that file. The normalization is load-bearing right now rather than hypothetically - 'replace-by-name upserts' is hard-wrapped across four lines in the SKILL.md, so the pin passes only because normalizeWhitespace works.

CRLF AND EM-DASH SAFETY, three independent grounds: .gitattributes pins *.md and *.go to eol=lf and the blob measures 0 CR bytes; normalizeWhitespace is strings.Join(strings.Fields(s), " ") and strings.Fields splits on \r, so CR is eliminated from both sides regardless; and test (windows-latest) and test (macos-latest) both ran go test ./... at this exact SHA and passed, which is direct execution evidence that the U+2014 em dashes and backtick spans matched against a real Windows checkout.

CRITERION 5 re-derived by the reviewer: 0.5.5 and 0.5.6 both return nothing at cc509f6, 0.5.7 returns seven lines across exactly the five required files, and TestMarketplaceEntryConsistency independently defends manifest/marketplace agreement. It also verified the 0.5.7-not-0.5.6 reasoning at source: git show v0.5.6:adapters/claude/.claude-plugin/plugin.json declares 0.5.5, so 0.5.6 is already spent on different content. CRITERION 6: go build, go vet, gofmt -l and go test all clean in the export.

SCOPE: 1 commit, 8 files, +77/-7, confirmed by --numstat arithmetic; nothing outside adapters/ and internal/adaptertest; go.mod and go.sum untouched. The prose edit is PURELY ADDITIVE - git diff --word-diff=porcelain over both skill files yields zero removed-word lines, independently confirming the memhub task 72 reflow-drops-words hazard did not recur. CI: all six required checks pass and the run's head_sha is exactly cc509f66, not an earlier push. SECURITY: nothing security-relevant - documentation prose, a test-only helper, three version strings, no new dependencies, no boundary change.

THE DISCLOSED JUDGMENT CALL, RESOLVED AGAINST MY INSTRUCTION AND I ACCEPT THAT. I had told the executor to match each host file's voice because the two diverge in this passage; it wrote the new guidance identically in both instead. The reviewer agrees with the executor and says it would have made the same call: the new text contains no host-specific vocabulary - no 'Task result', no spawn-versus-dispatch, no host tool references - so it needed no per-host adaptation, and the divergent sentences were correctly left untouched in both files. It measured wrap width at 48-69 characters against surrounding paragraphs of  … [truncated by orch] — commit `cc509f6631088e9960f86ca368202a88c710fd50` (2026-07-28T23:37:22Z)
- **required-ci** — passing — scripts (windows-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass — commit `cc509f6631088e9960f86ca368202a88c710fd50` (2026-07-28T23:37:26Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Close task 87. Both hosts' orch-delivery skill must tell the Architect that a verification describing the branch as a whole goes false on the next push and has to be resubmitted on every review cycle, name the replace-by-name upsert as the mechanism that supersedes the stale text, and establish a literal name prefix marking which entries are branch-scoped. Pin the new guidance with a drift assertion sourced once and consumed by both hosts, because an unpinned prose section is not defended by the suite. Bump the plugin version so the change is installable and cannot collide with released tag v0.5.6.",
  "acceptance_criteria": [
    "Both adapters/claude/skills/orch-delivery/SKILL.md and adapters/codex/skills/orch-delivery/SKILL.md, in their review step, state that a verification whose text describes the branch as a whole - commit counts, file counts, diff totals, or scope claims - becomes false as soon as the executor pushes a fix commit, and must be resubmitted on every subsequent review cycle.",
    "Both skill files state the mechanism that makes resubmission work: verification entries are replace-by-name upserts, so submitting the same name again on orch run review re-stamps that entry at the live head and supersedes its stale text.",
    "Both skill files document the literal name prefix 'branch-scope:' as the convention marking a verification as branch-scoped and therefore resubmit-on-every-cycle, and both state that this prefix does not collide with the engine-owned names required-ci, merge, abandoned, and review-cycle-\u003cn\u003e.",
    "Deleting the new guidance from either host's skill file makes go test ./... fail. The assertion producing that failure has exactly one source in the module and is consumed by both adapters/claude/plugin_test.go and adapters/codex/plugin_test.go, so the two hosts cannot drift apart.",
    "Every site that declares or asserts the plugin version declares 0.5.7, and no tracked file still contains the string 0.5.5: adapters/claude/.claude-plugin/plugin.json, adapters/codex/.codex-plugin/plugin.json, .claude-plugin/marketplace.json, adapters/claude/plugin_test.go, and adapters/codex/plugin_test.go.",
    "go test ./..., go vet ./..., and gofmt -l . are all clean, with gofmt -l . producing no output."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:dd23c00b6bd5",
  "verifications": [
    {
      "name": "go test ./...",
      "command": "go test ./...",
      "result": "pass",
      "detail": "CORRECTED ON REVIEW CYCLE 1, superseding the pr-open text of this entry, which said 24 packages with tests and 3 with none. The reviewer re-ran the suite independently from a git archive export at commit cc509f6631088e9960f86ca368202a88c710fd50: 22 packages with tests all report ok, 3 report [no test files], 25 packages total per go list ./... | wc -l. Exit 0, no failures. The executor's earlier arithmetic was wrong by two and its 24+3 exceeded the module's package count; the pass/fail substance was correct in both accounts.",
      "commit_oid": "cc509f6631088e9960f86ca368202a88c710fd50",
      "at": "2026-07-28T23:37:21Z"
    },
    {
      "name": "go vet ./...",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Run by the executor in the issue-108 worktree at commit cc509f6. No output, so clean.",
      "commit_oid": "cc509f6631088e9960f86ca368202a88c710fd50",
      "at": "2026-07-28T23:26:32Z"
    },
    {
      "name": "gofmt -l .",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Run by the executor in the issue-108 worktree at commit cc509f6. No output, so no file is unformatted.",
      "commit_oid": "cc509f6631088e9960f86ca368202a88c710fd50",
      "at": "2026-07-28T23:26:32Z"
    },
    {
      "name": "criterion 4 - pin proven non-vacuous by two-sided mutation",
      "command": "delete the new guidance paragraph from each host SKILL.md in a scratch copy outside the repository, then go test ./...",
      "result": "pass",
      "detail": "The executor copied the worktree (minus .git) to a scratch directory OUTSIDE the repository and mutated only that copy. Deleting the guidance from adapters/claude/skills/orch-delivery/SKILL.md failed TestDeliverySkillHasBranchScopeVerificationGuidance at plugin_test.go:344 in package adapters/claude, reporting four missing-phrase errors, the first naming the phrase 'describes the branch as a whole - commit counts, file counts, diff totals, or scope claims - becomes false as soon as the executor pushes a fix commit, and must be resubmitted on every subsequent review cycle'. Restoring that file and instead deleting the same paragraph from adapters/codex/skills/orch-delivery/SKILL.md failed the same way in package adapters/codex at plugin_test.go:283, with the same four messages. Both failures trace to the single shared assertion internal/adaptertest.CheckBranchScopeVerificationGuidance over branchScopeGuidancePhrases, which is the 'exactly one source consumed by both hosts' the criterion requires. The scratch copy was deleted afterward. This matters because memhub fact 45 established by mutation at commit 3548a04 that a green suite was previously ZERO evidence about prose in these files.",
      "commit_oid": "cc509f6631088e9960f86ca368202a88c710fd50",
      "at": "2026-07-28T23:26:32Z"
    },
    {
      "name": "criterion 4 - the pin's stated non-coverage",
      "command": "read the doc comment above branchScopeGuidancePhrases in internal/adaptertest/adaptertest.go",
      "result": "pass",
      "detail": "The pin asserts four literal phrases, compared through NormalizeWhitespace on both sides: (1) the branch-describing-text-goes-false-on-push instruction; (2) 'verification entries are replace-by-name upserts: submitting the same name again on orch run review re-stamps that entry at the live head and supersedes its stale text'; (3) 'Prefix such an entry's name with branch-scope: to mark it as branch-scoped'; (4) 'this prefix does not collide with the engine-owned names required-ci, merge, abandoned, and review-cycle-\u003cn\u003e'. The doc comment states the non-coverage explicitly, per the PR #92 reviewer's recommendation recorded as memhub task 84: the pins guard against these phrases being DELETED, not against an unpinned sentence being reworded, nor against the paragraph's meaning drifting while the pinned phrases survive verbatim. NormalizeWhitespace makes the match reflow-tolerant, not semantics-aware. This is a deliberately partial pin and says so.",
      "commit_oid": "cc509f6631088e9960f86ca368202a88c710fd50",
      "at": "2026-07-28T23:26:32Z"
    },
    {
      "name": "criterion 5 - plugin version bump, verified by the Architect",
      "command": "git grep -n \"0\\.5\\.5\" cc509f6 ; git grep -n \"0\\.5\\.7\" cc509f6",
      "result": "pass",
      "detail": "Verified by the Architect independently of the executor's report, reading the tree at commit cc509f6 rather than a worktree. The 0.5.5 search returns nothing, so the negative half of the criterion holds. The 0.5.7 search returns all five required sites, seven lines in total: .claude-plugin/marketplace.json:6; adapters/claude/.claude-plugin/plugin.json:4; adapters/claude/plugin_test.go:81 and :82; adapters/codex/.codex-plugin/plugin.json:4; adapters/codex/plugin_test.go:82 and :83. 0.5.7 rather than 0.5.6 because tag v0.5.6 is already released with adapters/ declaring 0.5.5, so reusing 0.5.6 would name content absent from that tag - the same-version-different-bytes trap recorded as memhub task 65.",
      "commit_oid": "cc509f6631088e9960f86ca368202a88c710fd50",
      "at": "2026-07-28T23:26:32Z"
    },
    {
      "name": "prose edit is purely additive",
      "command": "git diff --word-diff --ignore-all-space -- adapters/claude/skills/orch-delivery/SKILL.md adapters/codex/skills/orch-delivery/SKILL.md",
      "result": "pass",
      "detail": "Showed only {+insertion+} markers and no [-removal-] markers across both skill files, so no word was dropped from the surrounding prose. This check exists because memhub task 72 records two occurrences in a single PR of a prose reflow silently dropping words while every gate stayed green; the executor was instructed to keep the diff additive and not reflow surrounding text.",
      "commit_oid": "cc509f6631088e9960f86ca368202a88c710fd50",
      "at": "2026-07-28T23:26:32Z"
    },
    {
      "name": "branch-scope: architect scope audit",
      "command": "git log --oneline main..cc509f6 \u0026\u0026 git diff --stat main..cc509f6",
      "result": "pass",
      "detail": "BRANCH-SCOPED ENTRY - describes the whole branch and must be resubmitted on every review cycle if the branch moves. Verified by the Architect at commit cc509f6: 1 commit ahead of main, 8 files changed, +77/-7. Breakdown: .claude-plugin/marketplace.json +1/-1; adapters/claude/.claude-plugin/plugin.json +1/-1; adapters/claude/plugin_test.go +6/-2; adapters/claude/skills/orch-delivery/SKILL.md +11/-0; adapters/codex/.codex-plugin/plugin.json +1/-1; adapters/codex/plugin_test.go +6/-2; adapters/codex/skills/orch-delivery/SKILL.md +11/-0; internal/adaptertest/adaptertest.go +40/-0. This matches the approved scope: the two skill files carry the new guidance, adaptertest holds the single shared pin, both plugin_test.go files consume it and carry the version assertion, and the three manifests carry the bump. Nothing outside adapters/ and internal/adaptertest is touched.",
      "commit_oid": "cc509f6631088e9960f86ca368202a88c710fd50",
      "at": "2026-07-28T23:26:32Z"
    },
    {
      "name": "executor judgment call worth reviewer attention",
      "command": "n/a - disclosure, not a check",
      "result": "n/a",
      "detail": "The Architect's working notes told the executor that the two host skill files diverge in wording in this passage (Claude says 'its Task result actually gives you', Codex says 'its own reporting actually gives you') and to match each file's existing voice. The executor instead wrote the new guidance IDENTICALLY in both files, reasoning that the text is wholly new rather than a rewrite of the divergent sentences, and that identical text keeps the shared pin simple. It did not touch either divergent sentence. The Architect considers this defensible and better than the instruction given, but is surfacing it rather than burying it: the reviewer should confirm the identical text reads correctly in the Codex file's voice and wrap width, since that was the reason for the original instruction.",
      "commit_oid": "cc509f6631088e9960f86ca368202a88c710fd50",
      "at": "2026-07-28T23:26:32Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "VERDICT: approve. BLOCKING FINDINGS: none. NON-BLOCKING FINDINGS (4, all follow-up grade): (1) This record's 'go test ./...' entry said 24 packages with tests, 3 with none; the actual count at this commit is 22 with tests, 3 without, 25 total, and 24+3 exceeds the package count. CORRECTED IN PLACE on this cycle by resubmitting that entry under the same name, so no false claim survives to the merge candidate. (2) The 'branch-scope:' prefix is documented only at the review step, but the entry is BORN at pr-open. The reviewer proved by probe that an entry first submitted at pr-open as 'architect scope audit' and later resubmitted as 'branch-scope: architect scope audit' does NOT replace - the names differ, setVerification appends, and the stale unprefixed entry persists forever. Criterion 1 deliberately scoped the guidance to the review step, so this is not a miss against the approved criteria, but pr-open needs one clause; filing as a follow-up task. (3) CheckBranchScopeVerificationGuidance reads the whole SKILL.md rather than the review step, so the phrases relocated to another section would still pass, despite the doc comment saying 'the review step must state'. Identical to the sibling CheckRoutedSelectionCue, so a pattern rather than a regression; the non-coverage paragraph could name it. (4) 'verification entries are replace-by-name upserts' is true of caller-supplied entries but not of the engine's own review-cycle-\u003cn\u003e entries, which are appended at internal/run/review.go:152. In context the immediately preceding sentence establishes those names are engine-owned and caller-rejected, so it does not mislead.\n\nALL SIX CRITERIA MET, each verified by the reviewer independently in a git archive export outside the repository; it accepted no executor transcript. Criterion 2's claim is TRUE about the engine: review.go:148-151 stamps caller verifications with pr.HeadRefOid, the head the engine read itself rather than a request field, then runs setVerification per entry, and manifestbody.go:99-107 replaces on exact name match and appends only when absent. Confirmed empirically by probe: resubmitting the same name held the count at 2, replaced STALE with FRESH, and re-stamped commit_oid to the new head. Criterion 3's non-collision claim is TRUE and was probed adversarially: the rejection logic at manifestbody.go:142-168 is an exact-match map for required-ci/merge/abandoned plus the ANCHORED regex ^review-cycle-[0-9]+$, so no prefixed name can trip it - branch-scope:required-ci, branch-scope: required-ci, branch-scope:merge, branch-scope:abandoned, branch-scope:review-cycle-1 and branch-scope: review-cycle-12 were all accepted while the five bare names were all rejected as a control. The prefix is also safe downstream: Verification.Name has no charset validation beyond non-empty, and mdText passes a colon through untouched.\n\nCRITERION 4 REPRODUCED, NOT INHERITED. Deleting the guidance from the Claude skill alone failed at plugin_test.go:344 with adapters/codex still ok; restoring and deleting from the Codex skill alone failed at plugin_test.go:283 with adapters/claude still ok. Exactly one source: branchScopeGuidancePhrases and CheckBranchScopeVerificationGuidance are defined only in internal/adaptertest/adaptertest.go and consumed by both hosts' plugin_test.go. THE VACUITY CHECK PASSES, and this was the specific risk with a NormalizeWhitespace pin: each single-host deletion reported ALL FOUR phrases missing, which is direct proof that no pinned phrase normalizes to something already present elsewhere in that file. The normalization is load-bearing right now rather than hypothetically - 'replace-by-name upserts' is hard-wrapped across four lines in the SKILL.md, so the pin passes only because normalizeWhitespace works.\n\nCRLF AND EM-DASH SAFETY, three independent grounds: .gitattributes pins *.md and *.go to eol=lf and the blob measures 0 CR bytes; normalizeWhitespace is strings.Join(strings.Fields(s), \" \") and strings.Fields splits on \\r, so CR is eliminated from both sides regardless; and test (windows-latest) and test (macos-latest) both ran go test ./... at this exact SHA and passed, which is direct execution evidence that the U+2014 em dashes and backtick spans matched against a real Windows checkout.\n\nCRITERION 5 re-derived by the reviewer: 0.5.5 and 0.5.6 both return nothing at cc509f6, 0.5.7 returns seven lines across exactly the five required files, and TestMarketplaceEntryConsistency independently defends manifest/marketplace agreement. It also verified the 0.5.7-not-0.5.6 reasoning at source: git show v0.5.6:adapters/claude/.claude-plugin/plugin.json declares 0.5.5, so 0.5.6 is already spent on different content. CRITERION 6: go build, go vet, gofmt -l and go test all clean in the export.\n\nSCOPE: 1 commit, 8 files, +77/-7, confirmed by --numstat arithmetic; nothing outside adapters/ and internal/adaptertest; go.mod and go.sum untouched. The prose edit is PURELY ADDITIVE - git diff --word-diff=porcelain over both skill files yields zero removed-word lines, independently confirming the memhub task 72 reflow-drops-words hazard did not recur. CI: all six required checks pass and the run's head_sha is exactly cc509f66, not an earlier push. SECURITY: nothing security-relevant - documentation prose, a test-only helper, three version strings, no new dependencies, no boundary change.\n\nTHE DISCLOSED JUDGMENT CALL, RESOLVED AGAINST MY INSTRUCTION AND I ACCEPT THAT. I had told the executor to match each host file's voice because the two diverge in this passage; it wrote the new guidance identically in both instead. The reviewer agrees with the executor and says it would have made the same call: the new text contains no host-specific vocabulary - no 'Task result', no spawn-versus-dispatch, no host tool references - so it needed no per-host adaptation, and the divergent sentences were correctly left untouched in both files. It measured wrap width at 48-69 characters against surrounding paragraphs of  … [truncated by orch]",
      "commit_oid": "cc509f6631088e9960f86ca368202a88c710fd50",
      "at": "2026-07-28T23:37:22Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "scripts (windows-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "cc509f6631088e9960f86ca368202a88c710fd50",
      "at": "2026-07-28T23:37:26Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->