### PR TITLE
Introduce branch-scope naming at pr-open, repair the criteria-verification paragraph, and resolve the Claude spawn-step plugin path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "kninetimmy" },
   "metadata": {
     "description": "Host adapters for the Orch development orchestrator",
-    "version": "0.5.7"
+    "version": "0.5.8"
   },
   "plugins": [
     {

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Claude Code host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -78,8 +78,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.7" {
-		t.Errorf("version = %q, want 0.5.7", m.Version)
+	if m.Version != "0.5.8" {
+		t.Errorf("version = %q, want 0.5.8", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -199,8 +199,8 @@ in flight at once. For each issue:
    when an escalation has rerouted the issue since dispatch, or
    `DispatchResult.executor.model` otherwise. Compare against the
    **installed** plugin copy: `~/.claude/plugins/installed_plugins.json`
-   resolves it — its `plugins["orch-claude@orch"]` object's
-   `installPath` member names the installed plugin's root (its
+   resolves it — its `plugins["orch-claude@orch"]` array's single
+   entry's `installPath` member names the installed plugin's root (its
    `agents/` subdirectory holds the copy to compare against), and its
    `version` and `gitCommitSha` members name exactly which build is
    installed — not this repository's `adapters/claude/agents/` copy,
@@ -281,8 +281,8 @@ in flight at once. For each issue:
    when an escalation has rerouted the issue since dispatch, or
    `DispatchResult.reviewer.model` otherwise. Compare against the
    **installed** plugin copy: `~/.claude/plugins/installed_plugins.json`
-   resolves it — its `plugins["orch-claude@orch"]` object's
-   `installPath` member names the installed plugin's root (its
+   resolves it — its `plugins["orch-claude@orch"]` array's single
+   entry's `installPath` member names the installed plugin's root (its
    `agents/` subdirectory holds the copy to compare against), and its
    `version` and `gitCommitSha` members name exactly which build is
    installed — not this repository's `adapters/claude/agents/` copy,

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -93,25 +93,29 @@ criterion asserts about the repository — a path, a file, a symbol,
 or a count — by running the command that checks it: `git ls-files`,
 `git check-ignore`, or a grep whose output you actually read. A
 count you have not confirmed this way belongs in the criterion as
-"every site", not a specific number like "the five sites" — a form
-an off-by-one cannot falsify. Read one issue's acceptance criteria
+"every site" — a form an off-by-one cannot falsify — not a specific
+number like "the five sites". Read one issue's acceptance criteria
 together as a set, not one at a time, and confirm that a single
 implementation can satisfy all of them simultaneously. Symbol
 visibility across a package boundary is a concrete way a set
-becomes contradictory — an unexported symbol one criterion requires
-while another criterion requires a different package to reach it is
-unsatisfiable by construction — so prefer a criterion stating the
-invariant actually wanted ("normalization logic has exactly one
-source in the module") over one prescribing the mechanism you
-imagine delivering it ("a single unexported function"); the
-invariant stays satisfiable however the executor structures the
-code. When a criterion is justified by a claim that something
-currently fails silently or passes while broken, run that failing
-case once yourself and read its actual outcome before writing the
-criterion — a mechanism that looks fragile can fail loudly on
-exactly the change you feared it would miss — and treat a memhub
-note or a prior finding you are relying on as a lead to verify, not
-evidence to inherit.
+becomes contradictory: a pair of requirements — one criterion
+needing a symbol unexported, another criterion needing a different
+package to reach it — is unsatisfiable by construction, so prefer a
+criterion stating the invariant actually wanted ("normalization
+logic has exactly one source in the module") over one prescribing
+the mechanism you imagine delivering it ("a single unexported
+function"); the invariant stays satisfiable however the executor
+structures the code. When a criterion is justified by a claim that
+something currently fails silently or passes while broken, run
+that failing case once yourself — in a scratch directory or
+throwaway clone outside the repository, never in this checkout
+where tracked-file changes are mechanically denied in Assist, the
+same convention this file already states for verb request JSON —
+and read its actual outcome before writing the criterion — a
+mechanism that looks fragile can fail loudly on exactly the change
+you feared it would miss — and treat a memhub note or a prior
+finding you are relying on as a lead to verify, not evidence to
+inherit.
 
 ## Plan gate
 
@@ -194,13 +198,17 @@ in flight at once. For each issue:
    **currently in force**: the most recent `EscalateResult.executor.model`
    when an escalation has rerouted the issue since dispatch, or
    `DispatchResult.executor.model` otherwise. Compare against the
-   **installed** plugin copy under the Claude Code plugin cache
-   (`~/.claude/plugins/cache/orch/orch-claude/<version>/agents/`), not
-   this repository's `adapters/claude/agents/` copy — a plugin version
-   behind head can still carry an older pin. **If the routed model
-   matches no installed agent's frontmatter, stop and tell the human —
-   never spawn a mismatched agent, and never report the routed
-   selection as if it ran.** Every spawn prompt opens with:
+   **installed** plugin copy: `~/.claude/plugins/installed_plugins.json`
+   resolves it — its `plugins["orch-claude@orch"]` object's
+   `installPath` member names the installed plugin's root (its
+   `agents/` subdirectory holds the copy to compare against), and its
+   `version` and `gitCommitSha` members name exactly which build is
+   installed — not this repository's `adapters/claude/agents/` copy,
+   since a plugin version behind head can still carry an older pin.
+   **If the routed model matches no installed agent's frontmatter,
+   stop and tell the human — never spawn a mismatched agent, and never
+   report the routed selection as if it ran.** Every spawn prompt
+   opens with:
 
    ```
    Routed selection: <model> @ <effort>
@@ -237,10 +245,19 @@ in flight at once. For each issue:
    At least one verification is required. The verification names
    `required-ci`, `merge`, `abandoned`, and `review-cycle-<n>` are
    engine-owned and are rejected with `ErrBadRequest` before any
-   mutation when supplied by a caller. `usage` is optional (PRD
-   §21) and is the executor's own cost: supply only the fields the
-   executor's Task result actually reports — token totals, duration,
-   and `total_tokens` when that is what it reports instead of the
+   mutation when supplied by a caller. A verification whose text
+   describes the branch as a whole — commit counts, file counts, diff
+   totals, or scope claims — must be named with the `branch-scope:`
+   prefix at this first submission, not on a later cycle: the `name`
+   is the identity `orch run review`'s replace-by-name upsert matches
+   on, so a prefix added later appends a second entry instead of
+   replacing the original, and the unprefixed original persists in the
+   audit record permanently. This prefix does not collide with the
+   engine-owned names `required-ci`, `merge`, `abandoned`, and
+   `review-cycle-<n>`. `usage` is optional (PRD §21) and is the
+   executor's own cost: supply only the fields the executor's Task
+   result actually reports — token totals, duration, and
+   `total_tokens` when that is what it reports instead of the
    input/output/cache split — never an estimate. Result carries
    `pr_number`, `pr_url`.
 
@@ -263,15 +280,18 @@ in flight at once. For each issue:
    **currently in force**: the most recent `EscalateResult.reviewer.model`
    when an escalation has rerouted the issue since dispatch, or
    `DispatchResult.reviewer.model` otherwise. Compare against the
-   **installed** plugin copy under the Claude Code plugin cache
-   (`~/.claude/plugins/cache/orch/orch-claude/<version>/agents/`), not
-   this repository's `adapters/claude/agents/` copy — a plugin version
-   behind head can still carry an older pin. **If the routed model
-   matches no installed agent's frontmatter, stop and tell the human —
-   never spawn a mismatched agent, and never report the routed
-   selection as if it ran.** `reviewed_head_oid` must be the PR's
-   **live** head OID at review time (e.g. via `gh pr view`), never a
-   cached value.
+   **installed** plugin copy: `~/.claude/plugins/installed_plugins.json`
+   resolves it — its `plugins["orch-claude@orch"]` object's
+   `installPath` member names the installed plugin's root (its
+   `agents/` subdirectory holds the copy to compare against), and its
+   `version` and `gitCommitSha` members name exactly which build is
+   installed — not this repository's `adapters/claude/agents/` copy,
+   since a plugin version behind head can still carry an older pin.
+   **If the routed model matches no installed agent's frontmatter,
+   stop and tell the human — never spawn a mismatched agent, and never
+   report the routed selection as if it ran.** `reviewed_head_oid`
+   must be the PR's **live** head OID at review time (e.g. via
+   `gh pr view`), never a cached value.
 
 5. **Review** — the reviewer produces **one consolidated report**
    (acceptance criteria, scope, correctness, tests, CI, security,
@@ -318,15 +338,17 @@ in flight at once. For each issue:
    A verification whose text describes the branch as a whole —
    commit counts, file counts, diff totals, or scope claims —
    becomes false as soon as the executor pushes a fix commit, and
-   must be resubmitted on every subsequent review cycle. This
-   works because verification entries are replace-by-name
-   upserts: submitting the same `name` again on `orch run review`
-   re-stamps that entry at the live head and supersedes its stale
-   text. Prefix such an entry's `name` with `branch-scope:` to mark
-   it as branch-scoped, and therefore resubmit-on-every-cycle; this
-   prefix does not collide with the engine-owned names `required-ci`,
-   `merge`, `abandoned`, and `review-cycle-<n>`.
-   `approve` continues.
+   must be resubmitted on every subsequent review cycle under the
+   same `branch-scope:`-prefixed `name` chosen at pr-open. This
+   works because caller-supplied verification entries are
+   replace-by-name upserts: submitting the same `name` again on
+   `orch run review` re-stamps that entry at the live head and
+   supersedes its stale text; the engine's own `review-cycle-<n>`
+   entries are appended, not replaced, each cycle. A reviewer's
+   non-blocking findings default to the backlog rather than into
+   the current fix cycle, and are folded into the current cycle
+   only when they sit inside text the blocking fix already
+   touches. `approve` continues.
 
 6. **CI** — `orch run ci` with
    `{"schema_version": 1, "issue_number": N}` records the honest

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Codex CLI host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -79,8 +79,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.7" {
-		t.Errorf("version = %q, want 0.5.7", m.Version)
+	if m.Version != "0.5.8" {
+		t.Errorf("version = %q, want 0.5.8", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -93,25 +93,29 @@ criterion asserts about the repository — a path, a file, a symbol,
 or a count — by running the command that checks it: `git ls-files`,
 `git check-ignore`, or a grep whose output you actually read. A
 count you have not confirmed this way belongs in the criterion as
-"every site", not a specific number like "the five sites" — a form
-an off-by-one cannot falsify. Read one issue's acceptance criteria
+"every site" — a form an off-by-one cannot falsify — not a specific
+number like "the five sites". Read one issue's acceptance criteria
 together as a set, not one at a time, and confirm that a single
 implementation can satisfy all of them simultaneously. Symbol
 visibility across a package boundary is a concrete way a set
-becomes contradictory — an unexported symbol one criterion requires
-while another criterion requires a different package to reach it is
-unsatisfiable by construction — so prefer a criterion stating the
-invariant actually wanted ("normalization logic has exactly one
-source in the module") over one prescribing the mechanism you
-imagine delivering it ("a single unexported function"); the
-invariant stays satisfiable however the executor structures the
-code. When a criterion is justified by a claim that something
-currently fails silently or passes while broken, run that failing
-case once yourself and read its actual outcome before writing the
-criterion — a mechanism that looks fragile can fail loudly on
-exactly the change you feared it would miss — and treat a memhub
-note or a prior finding you are relying on as a lead to verify, not
-evidence to inherit.
+becomes contradictory: a pair of requirements — one criterion
+needing a symbol unexported, another criterion needing a different
+package to reach it — is unsatisfiable by construction, so prefer a
+criterion stating the invariant actually wanted ("normalization
+logic has exactly one source in the module") over one prescribing
+the mechanism you imagine delivering it ("a single unexported
+function"); the invariant stays satisfiable however the executor
+structures the code. When a criterion is justified by a claim that
+something currently fails silently or passes while broken, run
+that failing case once yourself — in a scratch directory or
+throwaway clone outside the repository, never in this checkout
+where tracked-file changes are mechanically denied in Assist, the
+same convention this file already states for verb request JSON —
+and read its actual outcome before writing the criterion — a
+mechanism that looks fragile can fail loudly on exactly the change
+you feared it would miss — and treat a memhub note or a prior
+finding you are relying on as a lead to verify, not evidence to
+inherit.
 
 ## Plan gate
 
@@ -239,12 +243,21 @@ in flight at once. For each issue:
    At least one verification is required. The verification names
    `required-ci`, `merge`, `abandoned`, and `review-cycle-<n>` are
    engine-owned and are rejected with `ErrBadRequest` before any
-   mutation when supplied by a caller. `usage` is optional (PRD
-   §21) and is the executor's own cost: supply only the fields the
-   executor's own reporting actually gives you — token totals,
-   duration, and `total_tokens` when that is what it reports instead
-   of the input/output/cache split — never an estimate. Result
-   carries `pr_number`, `pr_url`.
+   mutation when supplied by a caller. A verification whose text
+   describes the branch as a whole — commit counts, file counts, diff
+   totals, or scope claims — must be named with the `branch-scope:`
+   prefix at this first submission, not on a later cycle: the `name`
+   is the identity `orch run review`'s replace-by-name upsert matches
+   on, so a prefix added later appends a second entry instead of
+   replacing the original, and the unprefixed original persists in the
+   audit record permanently. This prefix does not collide with the
+   engine-owned names `required-ci`, `merge`, `abandoned`, and
+   `review-cycle-<n>`. `usage` is optional (PRD §21) and is the
+   executor's own cost: supply only the fields the executor's own
+   reporting actually gives you — token totals, duration, and
+   `total_tokens` when that is what it reports instead of the
+   input/output/cache split — never an estimate. Result carries
+   `pr_number`, `pr_url`.
 
 4. **Dispatch the reviewer** — once the PR stops changing, dispatch
    `orch-reviewer` **fresh** (a new instance, not the executor
@@ -306,15 +319,17 @@ in flight at once. For each issue:
    A verification whose text describes the branch as a whole —
    commit counts, file counts, diff totals, or scope claims —
    becomes false as soon as the executor pushes a fix commit, and
-   must be resubmitted on every subsequent review cycle. This
-   works because verification entries are replace-by-name
-   upserts: submitting the same `name` again on `orch run review`
-   re-stamps that entry at the live head and supersedes its stale
-   text. Prefix such an entry's `name` with `branch-scope:` to mark
-   it as branch-scoped, and therefore resubmit-on-every-cycle; this
-   prefix does not collide with the engine-owned names `required-ci`,
-   `merge`, `abandoned`, and `review-cycle-<n>`.
-   `approve` continues.
+   must be resubmitted on every subsequent review cycle under the
+   same `branch-scope:`-prefixed `name` chosen at pr-open. This
+   works because caller-supplied verification entries are
+   replace-by-name upserts: submitting the same `name` again on
+   `orch run review` re-stamps that entry at the live head and
+   supersedes its stale text; the engine's own `review-cycle-<n>`
+   entries are appended, not replaced, each cycle. A reviewer's
+   non-blocking findings default to the backlog rather than into
+   the current fix cycle, and are folded into the current cycle
+   only when they sit inside text the blocking fix already
+   touches. `approve` continues.
 
 6. **CI** — `orch run ci` with
    `{"schema_version": 1, "issue_number": N}` records the honest

--- a/internal/adaptertest/adaptertest.go
+++ b/internal/adaptertest/adaptertest.go
@@ -312,16 +312,20 @@ func CheckRoutedSelectionCue(t *testing.T, skillPath string) {
 	}
 }
 
-// branchScopeGuidancePhrases are the exact phrases the review step of a
-// delivery skill must state about branch-scoped verifications (memhub
-// task 87): a verification whose text describes the branch as a
+// branchScopeGuidancePhrases are the exact phrases a delivery skill must
+// state about branch-scoped verifications (memhub task 87, extended by
+// task 105): a verification whose text describes the branch as a
 // whole — commit counts, file counts, diff totals, or scope claims —
 // goes false on the next push and must be resubmitted every review
-// cycle; the replace-by-name upsert is the mechanism that makes
-// resubmission supersede the stale entry instead of appending beside
-// it; and `branch-scope:` is the literal name-prefix convention for
-// marking such an entry, which does not collide with the four
-// engine-owned names.
+// cycle; `branch-scope:` is the literal name-prefix convention for
+// marking such an entry, and it must be chosen at pr-open — the
+// verification's first submission — because the `name` is the
+// identity a caller-supplied entry's replace-by-name upsert matches
+// on, so a prefix added only on a later cycle appends a second entry
+// instead of replacing the unprefixed original; the engine's own
+// `review-cycle-<n>` entries are the exception, appended rather than
+// replaced every cycle; and the `branch-scope:` prefix does not
+// collide with the engine-owned names.
 //
 // These phrases pin the presence of this instruction, not its
 // meaning: NormalizeWhitespace makes the comparison tolerant of a
@@ -330,18 +334,28 @@ func CheckRoutedSelectionCue(t *testing.T, skillPath string) {
 // these phrases, or drift the paragraph's overall sense while every
 // pinned phrase survives verbatim, without this check noticing. It
 // catches deletion of the guidance, not corruption of its meaning.
+// CheckBranchScopeVerificationGuidance also reads the entire skill
+// file, not any one section of it, so these phrases would still pass
+// if a skill relocated them out of the review step entirely — which is
+// exactly what task 105 did, moving the naming instruction to the
+// pr-open step where the name is first chosen; the check pins that the
+// words appear somewhere in the file, never that they appear at a
+// particular step.
 var branchScopeGuidancePhrases = []string{
+	"must be named with the `branch-scope:` prefix at this first submission, not on a later cycle",
+	"the `name` is the identity `orch run review`'s replace-by-name upsert matches on, so a prefix added later appends a second entry instead of replacing the original, and the unprefixed original persists in the audit record permanently",
+	"This prefix does not collide with the engine-owned names `required-ci`, `merge`, `abandoned`, and `review-cycle-<n>`",
 	"describes the branch as a whole — commit counts, file counts, diff totals, or scope claims — becomes false as soon as the executor pushes a fix commit, and must be resubmitted on every subsequent review cycle",
-	"verification entries are replace-by-name upserts: submitting the same `name` again on `orch run review` re-stamps that entry at the live head and supersedes its stale text",
-	"Prefix such an entry's `name` with `branch-scope:` to mark it as branch-scoped",
-	"this prefix does not collide with the engine-owned names `required-ci`, `merge`, `abandoned`, and `review-cycle-<n>`",
+	"caller-supplied verification entries are replace-by-name upserts: submitting the same `name` again on `orch run review` re-stamps that entry at the live head and supersedes its stale text",
+	"the engine's own `review-cycle-<n>` entries are appended, not replaced, each cycle",
 }
 
-// CheckBranchScopeVerificationGuidance pins deliverySkillPath's review
-// step against the exact branch-scope resubmission guidance above. The
-// comparison runs on whitespace-normalized text on both sides, so a
-// phrase a markdown reflow happens to hard-wrap across a line break
-// still counts as present.
+// CheckBranchScopeVerificationGuidance pins deliverySkillPath's entire
+// text against the exact branch-scope naming and resubmission guidance
+// above, wherever in the file each phrase appears. The comparison runs
+// on whitespace-normalized text on both sides, so a phrase a markdown
+// reflow happens to hard-wrap across a line break still counts as
+// present.
 func CheckBranchScopeVerificationGuidance(t *testing.T, deliverySkillPath string) {
 	t.Helper()
 	content := normalizeWhitespace(readFile(t, deliverySkillPath))


### PR DESCRIPTION
Delivers issue #112: Introduce branch-scope naming at pr-open, repair the criteria-verification paragraph, and resolve the Claude spawn-step plugin path

Closes #112

**Plan digest:** `sha256:7765529ed7f0b59c440482a3952d9d308a72d02598e56f75128289705718cbfb`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Close six recorded follow-ups against the two host orch-delivery skills in one pass, plus the plugin version bump they need in order to take effect.

The substantive change is WHERE branch-scoped verification names are introduced. PR #111 documented the `branch-scope:` prefix at the review step, but verification entries are first created at pr-open, and setVerification (internal/run/manifestbody.go:99-107) matches on exact name. So an entry submitted unprefixed at pr-open and later resubmitted prefixed at review appends a second entry rather than replacing it, and the stale unprefixed original persists in the audit record permanently. The guidance has to appear where the name is actually chosen, not one step after it.

That same passage contains a sentence that internal/adaptertest.branchScopeGuidancePhrases pins verbatim, so the pin must move together with the prose. The specific hazard to guard against: when the pin fails, the cheap way to make it pass is to shorten the pinned phrase until it matches again, which leaves the test green while quietly reducing what it protects. Acceptance criterion 4 forecloses that and requires the evidence in the audit record.

The remaining items are accuracy. Duty 3 of the criteria-verification paragraph tells the Architect to run a failing case but never says where; in Assist the guard denies exactly that mutation in the main checkout, so the duty reads as blocked when it is not, and the same file already establishes the technique (scratch file in the OS temp directory, outside the repository) for verb request JSON. Two prose defects sit in the same paragraph. Both Claude spawn steps name an unresolved plugin-cache path. And one policy addition routes a reviewer's non-blocking findings to the backlog instead of into fix cycles, which is the delivery-cost lever with the clearest evidence behind it.

NOTE ON CRITERION 9: the resolver file lives in the user's home directory, outside the repository and outside your worktree. Do not attempt to read it. Its shape was verified on the Architect's machine during planning and is given here so you do not need to: plugins["orch-claude@orch"] is a JSON object, NOT an array, carrying the members scope, installPath, version, installedAt, lastUpdated and gitCommitSha. Two prior memhub notes describe it as an array; they are wrong and that is why the shape is stated here.

**Acceptance criteria:**
- Step 3 (PR-open) of both hosts' orch-delivery SKILL.md states that a verification whose text describes the branch as a whole must be given its `branch-scope:` name prefix at the moment it is first submitted, and states the reason: the name is the identity that supersession matches on, so a prefix added on a later cycle appends a second entry instead of replacing the original.
- The sentence in both files describing verification entries as replace-by-name upserts is qualified to say that this describes caller-supplied entries, and that the engine's own `review-cycle-&lt;n&gt;` entries are appended rather than replaced.
- branchScopeGuidancePhrases in internal/adaptertest covers the pr-open guidance added by criterion 1, and every phrase in that slice is present in both hosts' shipped SKILL.md text as measured by CheckBranchScopeVerificationGuidance.
- Every phrase in branchScopeGuidancePhrases after the change is a complete claim carried by the shipped text rather than a fragment trimmed to make the suite pass, and the audit record carries evidence that each phrase is individually load-bearing: the unmodified tree passes `go test ./adapters/...`, and removing each phrase in turn from a scratch copy of the skill made outside the repository makes that same command fail naming the removed phrase.
- The doc comment above branchScopeGuidancePhrases states that the check reads the entire skill file, so the pinned phrases would still pass if they were relocated out of the review step.
- The third criteria-verification duty in the PlanDoc-construction section of both files names where the failing case is to be run - a scratch directory or throwaway clone outside the repository - consistent with the convention the same file already states for verb request JSON.
- Two prose defects in the criteria-verification paragraph of both files are repaired: the appositive "a form an off-by-one cannot falsify" attaches to the recommended "every site" form rather than to the rejected specific-count form, and the unsatisfiability claim is predicated on the pair of requirements rather than on a symbol.
- The criteria-verification paragraph is byte-identical between the two hosts' SKILL.md files after the change.
- Both spawn steps in the Claude host's orch-delivery SKILL.md name ~/.claude/plugins/installed_plugins.json as the resolver for the installed agent definitions and name the installPath, version and gitCommitSha members of its plugins["orch-claude@orch"] object, replacing the unresolved &lt;version&gt; cache path. The Codex host's file is left unchanged by this criterion, because it names the installed TOMLs as the authority and states no path.
- The review step of both files states that a reviewer's non-blocking findings default to the backlog rather than into the current fix cycle, and are folded into the current cycle only when they sit inside text the blocking fix already touches.
- The plugin version declared in adapters/claude/.claude-plugin/plugin.json, in adapters/codex/.codex-plugin/plugin.json, and as metadata.version in .claude-plugin/marketplace.json is 0.5.8 in all three.

**Required tests:**
- `go test ./...`
- `gofmt -l .`
- `go vet ./...`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:dd23c00b6bd5` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **branch-scope: architect scope audit** — pass — `git rev-list --count origin/main..origin/orch/issue-112-introduce-branch-scope-naming-at-pr-open ; git diff --shortstat origin/main...origin/orch/issue-112-introduce-branch-scope-naming-at-pr-open` — CORRECTED AND RESTAMPED AT 170a9912. The prior text of this entry said '1 commit ahead of main' and went false when the fix commit landed; the cycle-2 reviewer caught it and correctly argued it was Architect work due this cycle rather than a backlog item, since routing it to the backlog would leave a false commit count in the permanent record. Current truth, re-verified by the Architect: 2 commits ahead of main (2ddf30a executor pass, 170a991 fix cycle), 8 files, +150/-99. The file count and line totals are unchanged from the previous stamp only by coincidence - the fix rewrote four lines that were already counted as insertions against main - so the commit count was the one figure that moved, and it is exactly the figure that was wrong. THIS IS THE FEATURE THIS PR SHIPS, EXERCISED ON ITS OWN RUN: the entry carries the branch-scope: prefix chosen at pr-open, so resubmitting the same name replaces the stale text in place instead of appending a second entry beside it. Files unchanged: .claude-plugin/marketplace.json; adapters/claude/.claude-plugin/plugin.json; adapters/claude/plugin_test.go; adapters/claude/skills/orch-delivery/SKILL.md; adapters/codex/.codex-plugin/plugin.json; adapters/codex/plugin_test.go; adapters/codex/skills/orch-delivery/SKILL.md; internal/adaptertest/adaptertest.go. — commit `170a9912a6a5bc0222b14c80effba00dc2e5e4c2` (2026-07-29T01:18:53Z)
- **branch-scope: pin phrases audited for weakening** — pass — `git diff origin/main...origin/orch/issue-112-introduce-branch-scope-naming-at-pr-open -- internal/adaptertest/adaptertest.go` — Restamped at 170a9912; claim unchanged and still true. branchScopeGuidancePhrases 4 phrases to 6, no phrase shortened or generalized to make the failing suite pass. The fix cycle did not touch this file at all - the cycle-2 reviewer confirmed internal/adaptertest/adaptertest.go carries blob OID 9748fd50 at BOTH 2ddf30a and 170a991, which is stronger evidence than an empty diff because it rules out a change-and-revert within the delta. The fix brief instructed the executor to stop and report rather than adjust any pin if one covered the edited passage; none did, and none was touched. — commit `170a9912a6a5bc0222b14c80effba00dc2e5e4c2` (2026-07-29T01:18:53Z)
- **pin non-vacuity mutation proof** — pass — `go test ./adapters/... with each of the 6 branchScopeGuidancePhrases removed in turn from a scratch copy of SKILL.md made outside the repository` — Executor-run, output reported in full and reproducible by the reviewer. Unmodified scratch copy passes (ok adapters/claude, ok adapters/codex). Removing each of the 6 phrases individually makes go test ./adapters/... FAIL at plugin_test.go:344 naming exactly the removed phrase; each mutation was restored before the next, and the restored tree re-passed with -count=1. This establishes every phrase in the slice is individually load-bearing rather than decorative. — commit `2ddf30a41de3c397d759601de9a07e83f97c8ed6` (2026-07-29T00:50:19Z)
- **executor required tests** — pass — `go test ./... ; gofmt -l . ; go vet ./...` — All three pass at the pushed head, go test run twice including -count=1; gofmt -l . and go vet ./... both silent. SCOPE LIMIT, stated so the record is honest: memhub fact 45 records that the PlanDoc-construction section of both SKILL.md files is entirely unpinned - a garbage sentinel there leaves go test ./... and all six required CI checks green. Acceptance criteria 6, 7 and 8 land in exactly that section, so this passing suite is NOT evidence for them. Criterion 8 was checked instead by extracting the paragraph from both files and comparing byte-for-byte; criteria 6 and 7 rest on a reading of the shipped prose. — commit `2ddf30a41de3c397d759601de9a07e83f97c8ed6` (2026-07-29T00:50:19Z)
- **architect correction: installed_plugins.json shape** — fail — `[System.Text.Json.JsonDocument]::Parse((Get-Content ~/.claude/plugins/installed_plugins.json -Raw)).RootElement.GetProperty('plugins').GetProperty('orch-claude@orch').ValueKind` — CORRECTION OF THIS RECORD'S OWN NOTE ON CRITERION 9, issued by the Architect after the reviewer disputed it. The note asserts that plugins["orch-claude@orch"] is a JSON object and not an array, and that two prior memhub notes describing it as an array are wrong. That assertion is FALSE and the memhub records are correct. Re-verified from raw bytes: the key is followed by '[' and the .NET JSON parser reports ValueKind=Array, GetArrayLength()=1; the members scope, installPath, version, installedAt, lastUpdated and gitCommitSha sit on element [0]. HOW THE ERROR WAS MADE, recorded so it is not repeated: the planning-time check piped the value through PowerShell's ConvertTo-Json, and the PowerShell pipeline unrolls a single-element array into its element, so a one-entry array serializes as a bare object. The command looked like a direct shape verification and was not one. Correct memhub records overruled in error: fact 41, task 58 (which explicitly closes 'Verify the JSON shape before writing it into the skill'), task 65, task 76. — commit `2ddf30a41de3c397d759601de9a07e83f97c8ed6` (2026-07-29T01:04:27Z)
- **review-cycle-1** — request-changes — Ten of eleven criteria met and independently verified, including criterion 4 - the reviewer reproduced the pin non-vacuity proof two-sidedly and confirmed no pinned phrase was weakened. One blocker. Criterion 9 ships a factually wrong description of the resolver it exists to make resolvable: the shipped Claude spawn-step text calls plugins["orch-claude@orch"] an object with an installPath member, but it is a JSON array of length 1 whose element carries those members. An Architect following the sentence literally indexes an array as an object and resolves nothing. The error originates in the Architect's planning, not the executor, which complied with criterion 9 as written; the criterion itself says object. The audit record compounds it, asserting the wrong shape as verified fact and dismissing four correct memhub records (fact 41, tasks 58, 65, 76) as wrong. Five non-blocking findings are routed to the backlog, not this fix cycle. — commit `2ddf30a41de3c397d759601de9a07e83f97c8ed6` (2026-07-29T01:04:28Z)
- **criterion 9 resolver resolves end to end** — pass — `read ~/.claude/plugins/installed_plugins.json ; follow plugins["orch-claude@orch"][0].installPath to its agents/ subdirectory ; read orch-reviewer.md frontmatter` — Reviewer-run, independently of the Architect's corrected claim. plugins["orch-claude@orch"] is a JSON array of length 1; three sibling keys share that shape, so it is the file's schema rather than an accident of this key. Following the shipped instruction: installPath resolves to an existing directory, its agents/ subdirectory holds the five orch-* definitions, and orch-reviewer.md carries model: claude-opus-5 - the exact comparison the spawn step exists to enable. The unresolvable-pointer failure that criterion 9 was written to eliminate is genuinely eliminated. Criterion 9 is judged on factual truth rather than on its own literal wording, per the human-approved deviation: the criterion says object, the file is an array, and the shipped text says array. — commit `170a9912a6a5bc0222b14c80effba00dc2e5e4c2` (2026-07-29T01:18:53Z)
- **review-cycle-2** — approve — Cycle-2 reviewer (fresh instance, brief scoped to the delta by Architect cost decision, with explicit authority to widen) confirms the cycle-1 blocker is closed. It established the true array shape from the file itself rather than accepting the Architect's claim, then verified the corrected text resolves end to end: installPath points at an existing directory whose agents/ subdirectory holds the five definitions, and orch-reviewer.md carries model claude-opus-5 - the exact comparison the spawn step asks for. Delta integrity confirmed by blob OID rather than diff absence: every file except the Claude skill is byte-identical across the delta, so no pin was touched. The reviewer widened twice on its own judgement - to adapters/claude/plugin_test.go, finding frontmatterMatchRuleSentence pins the same paragraph though not the edited sentence, and repo-wide to confirm the false shape survives nowhere - and re-checked criteria 6, 7, 8 and 11 undisturbed. All six required checks SUCCESS at this exact SHA. No blocking findings. Its first non-blocking item was correctly routed to the Architect rather than the backlog: the branch-scope scope-audit entry had gone stale on the fix push, and is corrected in this cycle's resubmission below. — commit `170a9912a6a5bc0222b14c80effba00dc2e5e4c2` (2026-07-29T01:18:54Z)
- **required-ci** — passing — test (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `170a9912a6a5bc0222b14c80effba00dc2e5e4c2` (2026-07-29T01:19:08Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Close six recorded follow-ups against the two host orch-delivery skills in one pass, plus the plugin version bump they need in order to take effect.\n\nThe substantive change is WHERE branch-scoped verification names are introduced. PR #111 documented the `branch-scope:` prefix at the review step, but verification entries are first created at pr-open, and setVerification (internal/run/manifestbody.go:99-107) matches on exact name. So an entry submitted unprefixed at pr-open and later resubmitted prefixed at review appends a second entry rather than replacing it, and the stale unprefixed original persists in the audit record permanently. The guidance has to appear where the name is actually chosen, not one step after it.\n\nThat same passage contains a sentence that internal/adaptertest.branchScopeGuidancePhrases pins verbatim, so the pin must move together with the prose. The specific hazard to guard against: when the pin fails, the cheap way to make it pass is to shorten the pinned phrase until it matches again, which leaves the test green while quietly reducing what it protects. Acceptance criterion 4 forecloses that and requires the evidence in the audit record.\n\nThe remaining items are accuracy. Duty 3 of the criteria-verification paragraph tells the Architect to run a failing case but never says where; in Assist the guard denies exactly that mutation in the main checkout, so the duty reads as blocked when it is not, and the same file already establishes the technique (scratch file in the OS temp directory, outside the repository) for verb request JSON. Two prose defects sit in the same paragraph. Both Claude spawn steps name an unresolved plugin-cache path. And one policy addition routes a reviewer's non-blocking findings to the backlog instead of into fix cycles, which is the delivery-cost lever with the clearest evidence behind it.\n\nNOTE ON CRITERION 9: the resolver file lives in the user's home directory, outside the repository and outside your worktree. Do not attempt to read it. Its shape was verified on the Architect's machine during planning and is given here so you do not need to: plugins[\"orch-claude@orch\"] is a JSON object, NOT an array, carrying the members scope, installPath, version, installedAt, lastUpdated and gitCommitSha. Two prior memhub notes describe it as an array; they are wrong and that is why the shape is stated here.",
  "acceptance_criteria": [
    "Step 3 (PR-open) of both hosts' orch-delivery SKILL.md states that a verification whose text describes the branch as a whole must be given its `branch-scope:` name prefix at the moment it is first submitted, and states the reason: the name is the identity that supersession matches on, so a prefix added on a later cycle appends a second entry instead of replacing the original.",
    "The sentence in both files describing verification entries as replace-by-name upserts is qualified to say that this describes caller-supplied entries, and that the engine's own `review-cycle-\u003cn\u003e` entries are appended rather than replaced.",
    "branchScopeGuidancePhrases in internal/adaptertest covers the pr-open guidance added by criterion 1, and every phrase in that slice is present in both hosts' shipped SKILL.md text as measured by CheckBranchScopeVerificationGuidance.",
    "Every phrase in branchScopeGuidancePhrases after the change is a complete claim carried by the shipped text rather than a fragment trimmed to make the suite pass, and the audit record carries evidence that each phrase is individually load-bearing: the unmodified tree passes `go test ./adapters/...`, and removing each phrase in turn from a scratch copy of the skill made outside the repository makes that same command fail naming the removed phrase.",
    "The doc comment above branchScopeGuidancePhrases states that the check reads the entire skill file, so the pinned phrases would still pass if they were relocated out of the review step.",
    "The third criteria-verification duty in the PlanDoc-construction section of both files names where the failing case is to be run - a scratch directory or throwaway clone outside the repository - consistent with the convention the same file already states for verb request JSON.",
    "Two prose defects in the criteria-verification paragraph of both files are repaired: the appositive \"a form an off-by-one cannot falsify\" attaches to the recommended \"every site\" form rather than to the rejected specific-count form, and the unsatisfiability claim is predicated on the pair of requirements rather than on a symbol.",
    "The criteria-verification paragraph is byte-identical between the two hosts' SKILL.md files after the change.",
    "Both spawn steps in the Claude host's orch-delivery SKILL.md name ~/.claude/plugins/installed_plugins.json as the resolver for the installed agent definitions and name the installPath, version and gitCommitSha members of its plugins[\"orch-claude@orch\"] object, replacing the unresolved \u003cversion\u003e cache path. The Codex host's file is left unchanged by this criterion, because it names the installed TOMLs as the authority and states no path.",
    "The review step of both files states that a reviewer's non-blocking findings default to the backlog rather than into the current fix cycle, and are folded into the current cycle only when they sit inside text the blocking fix already touches.",
    "The plugin version declared in adapters/claude/.claude-plugin/plugin.json, in adapters/codex/.codex-plugin/plugin.json, and as metadata.version in .claude-plugin/marketplace.json is 0.5.8 in all three."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l .",
    "go vet ./..."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:dd23c00b6bd5",
  "verifications": [
    {
      "name": "branch-scope: architect scope audit",
      "command": "git rev-list --count origin/main..origin/orch/issue-112-introduce-branch-scope-naming-at-pr-open ; git diff --shortstat origin/main...origin/orch/issue-112-introduce-branch-scope-naming-at-pr-open",
      "result": "pass",
      "detail": "CORRECTED AND RESTAMPED AT 170a9912. The prior text of this entry said '1 commit ahead of main' and went false when the fix commit landed; the cycle-2 reviewer caught it and correctly argued it was Architect work due this cycle rather than a backlog item, since routing it to the backlog would leave a false commit count in the permanent record. Current truth, re-verified by the Architect: 2 commits ahead of main (2ddf30a executor pass, 170a991 fix cycle), 8 files, +150/-99. The file count and line totals are unchanged from the previous stamp only by coincidence - the fix rewrote four lines that were already counted as insertions against main - so the commit count was the one figure that moved, and it is exactly the figure that was wrong. THIS IS THE FEATURE THIS PR SHIPS, EXERCISED ON ITS OWN RUN: the entry carries the branch-scope: prefix chosen at pr-open, so resubmitting the same name replaces the stale text in place instead of appending a second entry beside it. Files unchanged: .claude-plugin/marketplace.json; adapters/claude/.claude-plugin/plugin.json; adapters/claude/plugin_test.go; adapters/claude/skills/orch-delivery/SKILL.md; adapters/codex/.codex-plugin/plugin.json; adapters/codex/plugin_test.go; adapters/codex/skills/orch-delivery/SKILL.md; internal/adaptertest/adaptertest.go.",
      "commit_oid": "170a9912a6a5bc0222b14c80effba00dc2e5e4c2",
      "at": "2026-07-29T01:18:53Z"
    },
    {
      "name": "branch-scope: pin phrases audited for weakening",
      "command": "git diff origin/main...origin/orch/issue-112-introduce-branch-scope-naming-at-pr-open -- internal/adaptertest/adaptertest.go",
      "result": "pass",
      "detail": "Restamped at 170a9912; claim unchanged and still true. branchScopeGuidancePhrases 4 phrases to 6, no phrase shortened or generalized to make the failing suite pass. The fix cycle did not touch this file at all - the cycle-2 reviewer confirmed internal/adaptertest/adaptertest.go carries blob OID 9748fd50 at BOTH 2ddf30a and 170a991, which is stronger evidence than an empty diff because it rules out a change-and-revert within the delta. The fix brief instructed the executor to stop and report rather than adjust any pin if one covered the edited passage; none did, and none was touched.",
      "commit_oid": "170a9912a6a5bc0222b14c80effba00dc2e5e4c2",
      "at": "2026-07-29T01:18:53Z"
    },
    {
      "name": "pin non-vacuity mutation proof",
      "command": "go test ./adapters/... with each of the 6 branchScopeGuidancePhrases removed in turn from a scratch copy of SKILL.md made outside the repository",
      "result": "pass",
      "detail": "Executor-run, output reported in full and reproducible by the reviewer. Unmodified scratch copy passes (ok adapters/claude, ok adapters/codex). Removing each of the 6 phrases individually makes go test ./adapters/... FAIL at plugin_test.go:344 naming exactly the removed phrase; each mutation was restored before the next, and the restored tree re-passed with -count=1. This establishes every phrase in the slice is individually load-bearing rather than decorative.",
      "commit_oid": "2ddf30a41de3c397d759601de9a07e83f97c8ed6",
      "at": "2026-07-29T00:50:19Z"
    },
    {
      "name": "executor required tests",
      "command": "go test ./... ; gofmt -l . ; go vet ./...",
      "result": "pass",
      "detail": "All three pass at the pushed head, go test run twice including -count=1; gofmt -l . and go vet ./... both silent. SCOPE LIMIT, stated so the record is honest: memhub fact 45 records that the PlanDoc-construction section of both SKILL.md files is entirely unpinned - a garbage sentinel there leaves go test ./... and all six required CI checks green. Acceptance criteria 6, 7 and 8 land in exactly that section, so this passing suite is NOT evidence for them. Criterion 8 was checked instead by extracting the paragraph from both files and comparing byte-for-byte; criteria 6 and 7 rest on a reading of the shipped prose.",
      "commit_oid": "2ddf30a41de3c397d759601de9a07e83f97c8ed6",
      "at": "2026-07-29T00:50:19Z"
    },
    {
      "name": "architect correction: installed_plugins.json shape",
      "command": "[System.Text.Json.JsonDocument]::Parse((Get-Content ~/.claude/plugins/installed_plugins.json -Raw)).RootElement.GetProperty('plugins').GetProperty('orch-claude@orch').ValueKind",
      "result": "fail",
      "detail": "CORRECTION OF THIS RECORD'S OWN NOTE ON CRITERION 9, issued by the Architect after the reviewer disputed it. The note asserts that plugins[\"orch-claude@orch\"] is a JSON object and not an array, and that two prior memhub notes describing it as an array are wrong. That assertion is FALSE and the memhub records are correct. Re-verified from raw bytes: the key is followed by '[' and the .NET JSON parser reports ValueKind=Array, GetArrayLength()=1; the members scope, installPath, version, installedAt, lastUpdated and gitCommitSha sit on element [0]. HOW THE ERROR WAS MADE, recorded so it is not repeated: the planning-time check piped the value through PowerShell's ConvertTo-Json, and the PowerShell pipeline unrolls a single-element array into its element, so a one-entry array serializes as a bare object. The command looked like a direct shape verification and was not one. Correct memhub records overruled in error: fact 41, task 58 (which explicitly closes 'Verify the JSON shape before writing it into the skill'), task 65, task 76.",
      "commit_oid": "2ddf30a41de3c397d759601de9a07e83f97c8ed6",
      "at": "2026-07-29T01:04:27Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "Ten of eleven criteria met and independently verified, including criterion 4 - the reviewer reproduced the pin non-vacuity proof two-sidedly and confirmed no pinned phrase was weakened. One blocker. Criterion 9 ships a factually wrong description of the resolver it exists to make resolvable: the shipped Claude spawn-step text calls plugins[\"orch-claude@orch\"] an object with an installPath member, but it is a JSON array of length 1 whose element carries those members. An Architect following the sentence literally indexes an array as an object and resolves nothing. The error originates in the Architect's planning, not the executor, which complied with criterion 9 as written; the criterion itself says object. The audit record compounds it, asserting the wrong shape as verified fact and dismissing four correct memhub records (fact 41, tasks 58, 65, 76) as wrong. Five non-blocking findings are routed to the backlog, not this fix cycle.",
      "commit_oid": "2ddf30a41de3c397d759601de9a07e83f97c8ed6",
      "at": "2026-07-29T01:04:28Z"
    },
    {
      "name": "criterion 9 resolver resolves end to end",
      "command": "read ~/.claude/plugins/installed_plugins.json ; follow plugins[\"orch-claude@orch\"][0].installPath to its agents/ subdirectory ; read orch-reviewer.md frontmatter",
      "result": "pass",
      "detail": "Reviewer-run, independently of the Architect's corrected claim. plugins[\"orch-claude@orch\"] is a JSON array of length 1; three sibling keys share that shape, so it is the file's schema rather than an accident of this key. Following the shipped instruction: installPath resolves to an existing directory, its agents/ subdirectory holds the five orch-* definitions, and orch-reviewer.md carries model: claude-opus-5 - the exact comparison the spawn step exists to enable. The unresolvable-pointer failure that criterion 9 was written to eliminate is genuinely eliminated. Criterion 9 is judged on factual truth rather than on its own literal wording, per the human-approved deviation: the criterion says object, the file is an array, and the shipped text says array.",
      "commit_oid": "170a9912a6a5bc0222b14c80effba00dc2e5e4c2",
      "at": "2026-07-29T01:18:53Z"
    },
    {
      "name": "review-cycle-2",
      "result": "approve",
      "detail": "Cycle-2 reviewer (fresh instance, brief scoped to the delta by Architect cost decision, with explicit authority to widen) confirms the cycle-1 blocker is closed. It established the true array shape from the file itself rather than accepting the Architect's claim, then verified the corrected text resolves end to end: installPath points at an existing directory whose agents/ subdirectory holds the five definitions, and orch-reviewer.md carries model claude-opus-5 - the exact comparison the spawn step asks for. Delta integrity confirmed by blob OID rather than diff absence: every file except the Claude skill is byte-identical across the delta, so no pin was touched. The reviewer widened twice on its own judgement - to adapters/claude/plugin_test.go, finding frontmatterMatchRuleSentence pins the same paragraph though not the edited sentence, and repo-wide to confirm the false shape survives nowhere - and re-checked criteria 6, 7, 8 and 11 undisturbed. All six required checks SUCCESS at this exact SHA. No blocking findings. Its first non-blocking item was correctly routed to the Architect rather than the backlog: the branch-scope scope-audit entry had gone stale on the fix push, and is corrected in this cycle's resubmission below.",
      "commit_oid": "170a9912a6a5bc0222b14c80effba00dc2e5e4c2",
      "at": "2026-07-29T01:18:54Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "170a9912a6a5bc0222b14c80effba00dc2e5e4c2",
      "at": "2026-07-29T01:19:08Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->