### PR TITLE
Add /.codex/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ coverage.html
 .orchestrator/delivery.lock
 .orchestrator/worktrees/
 .orchestrator/metrics/
+
+# Generated orch render-agents output (root-anchored: avoid matching testdata fixtures)
+/.codex/


### PR DESCRIPTION
Delivers issue #114: Add /.codex/ to .gitignore

Closes #114

**Plan digest:** `sha256:93a7dc1a2af337a081140cd60934a4572a5b1e0e8da01f36f15fb53d53a18d76`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Add a root-anchored /.codex/ ignore pattern to .gitignore so the generated output of `orch render-agents` stops showing up as untracked, without affecting any tracked path.

**Acceptance criteria:**
- `.gitignore` contains a root-anchored `/.codex/` pattern with a short comment identifying it as the generated `orch render-agents` output, placed alongside the existing Orch machine-local entries.
- `git status --porcelain` no longer lists `.codex/` as untracked.
- `git check-ignore -v .codex/agents/orch-scout.toml` reports the new pattern as the match.
- `adapters/codex/.codex-plugin/plugin.json` remains tracked and is NOT ignored (`git check-ignore` exits 1 for it), confirming the pattern does not catch `.codex-plugin`.
- `git ls-files` output is unchanged — no previously tracked file becomes ignored or is removed from the index.
- `.gitignore` keeps LF-only line endings, as pinned by `.gitattributes` (`.gitignore text eol=lf`), and contains no empty ignore pattern (gitops.RequireIgnored fails closed on those).
- No file other than `.gitignore` is modified.

**Required tests:**
- `git check-ignore -v .codex/agents/orch-scout.toml`
- `git status --porcelain`
- `git check-ignore adapters/codex/.codex-plugin/plugin.json || echo 'not ignored (expected)'`
- `git ls-files | grep -c codex`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-sonnet-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:dd23c00b6bd5` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **ignore pattern matches render target** — pass — `git check-ignore -v .codex/agents/orch-scout.toml` — .gitignore:23:/.codex/	.codex/agents/orch-scout.toml — commit `d4a2d3cde8ca3d8a0753438d3ef61c6b957c9c53` (2026-07-30T15:24:27Z)
- **clean tree / .codex not listed untracked** — pass — `git status --porcelain` — no output; with a temporary .codex/agents/orch-scout.toml fixture present, status showed only 'M .gitignore' and never listed .codex/ — commit `d4a2d3cde8ca3d8a0753438d3ef61c6b957c9c53` (2026-07-30T15:24:27Z)
- **codex-plugin path not caught by pattern** — pass — `git check-ignore adapters/codex/.codex-plugin/plugin.json || echo 'not ignored (expected)'` — not ignored (expected) — exit 1, adapters/codex/.codex-plugin/plugin.json remains tracked — commit `d4a2d3cde8ca3d8a0753438d3ef61c6b957c9c53` (2026-07-30T15:24:27Z)
- **tracked index unchanged** — pass — `git ls-files | grep -c codex` — 30 before and after; architect independently confirmed git diff origin/main touches only .gitignore (1 file, 3 insertions) — commit `d4a2d3cde8ca3d8a0753438d3ef61c6b957c9c53` (2026-07-30T15:24:27Z)
- **LF-only line endings preserved** — pass — `grep -c $'\r' .gitignore` — 0 CR bytes; added pattern /.codex/ is non-empty, so gitops.RequireIgnored's empty-pattern fail-closed path is unaffected — commit `d4a2d3cde8ca3d8a0753438d3ef61c6b957c9c53` (2026-07-30T15:24:27Z)
- **Go build/vet/test** — skip — `go build ./... && go vet ./... && go test ./...` — no Go toolchain installed on this machine (go: command not found); Go coverage is provided by GitHub Actions CI on this PR, not by the executor — commit `d4a2d3cde8ca3d8a0753438d3ef61c6b957c9c53` (2026-07-30T15:24:27Z)
- **review-cycle-1** — approve — Fresh reviewer independently reproduced every reported verification command-for-command. Diff is .gitignore only, +3 lines, 0 deletions — no scope creep. All seven acceptance criteria satisfied: pattern is genuinely root-anchored at .gitignore:23; check-ignore matches .codex/agents/orch-scout.toml via /.codex/; adapters/codex/.codex-plugin/plugin.json is not caught (exit 1) and stays tracked; git ls-files count unchanged at 30; LF-only preserved with 0 CR bytes; the non-empty pattern cannot trigger gitops.RequireIgnored's empty-pattern fail-closed path. Reviewer checked existing interview testdata for a literal .codex collision and found none, confirming root-anchoring is a forward-looking safeguard rather than a fix for a live bug. Manifest accuracy verified: the Go build/vet/test entry is honestly marked skip (no Go toolchain on this machine) rather than claimed as run. All 6 required CI checks green (lint, scripts ubuntu/windows, test ubuntu/macos/windows). The executor's repo-local git identity fix is not part of the tracked diff and did not affect committed content. No security surface. — commit `d4a2d3cde8ca3d8a0753438d3ef61c6b957c9c53` (2026-07-30T15:26:49Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, scripts (windows-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass — commit `d4a2d3cde8ca3d8a0753438d3ef61c6b957c9c53` (2026-07-30T15:27:19Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Add a root-anchored /.codex/ ignore pattern to .gitignore so the generated output of `orch render-agents` stops showing up as untracked, without affecting any tracked path.",
  "acceptance_criteria": [
    "`.gitignore` contains a root-anchored `/.codex/` pattern with a short comment identifying it as the generated `orch render-agents` output, placed alongside the existing Orch machine-local entries.",
    "`git status --porcelain` no longer lists `.codex/` as untracked.",
    "`git check-ignore -v .codex/agents/orch-scout.toml` reports the new pattern as the match.",
    "`adapters/codex/.codex-plugin/plugin.json` remains tracked and is NOT ignored (`git check-ignore` exits 1 for it), confirming the pattern does not catch `.codex-plugin`.",
    "`git ls-files` output is unchanged — no previously tracked file becomes ignored or is removed from the index.",
    "`.gitignore` keeps LF-only line endings, as pinned by `.gitattributes` (`.gitignore text eol=lf`), and contains no empty ignore pattern (gitops.RequireIgnored fails closed on those).",
    "No file other than `.gitignore` is modified."
  ],
  "required_tests": [
    "git check-ignore -v .codex/agents/orch-scout.toml",
    "git status --porcelain",
    "git check-ignore adapters/codex/.codex-plugin/plugin.json || echo 'not ignored (expected)'",
    "git ls-files | grep -c codex"
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "claude-sonnet-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:dd23c00b6bd5",
  "verifications": [
    {
      "name": "ignore pattern matches render target",
      "command": "git check-ignore -v .codex/agents/orch-scout.toml",
      "result": "pass",
      "detail": ".gitignore:23:/.codex/\t.codex/agents/orch-scout.toml",
      "commit_oid": "d4a2d3cde8ca3d8a0753438d3ef61c6b957c9c53",
      "at": "2026-07-30T15:24:27Z"
    },
    {
      "name": "clean tree / .codex not listed untracked",
      "command": "git status --porcelain",
      "result": "pass",
      "detail": "no output; with a temporary .codex/agents/orch-scout.toml fixture present, status showed only 'M .gitignore' and never listed .codex/",
      "commit_oid": "d4a2d3cde8ca3d8a0753438d3ef61c6b957c9c53",
      "at": "2026-07-30T15:24:27Z"
    },
    {
      "name": "codex-plugin path not caught by pattern",
      "command": "git check-ignore adapters/codex/.codex-plugin/plugin.json || echo 'not ignored (expected)'",
      "result": "pass",
      "detail": "not ignored (expected) — exit 1, adapters/codex/.codex-plugin/plugin.json remains tracked",
      "commit_oid": "d4a2d3cde8ca3d8a0753438d3ef61c6b957c9c53",
      "at": "2026-07-30T15:24:27Z"
    },
    {
      "name": "tracked index unchanged",
      "command": "git ls-files | grep -c codex",
      "result": "pass",
      "detail": "30 before and after; architect independently confirmed git diff origin/main touches only .gitignore (1 file, 3 insertions)",
      "commit_oid": "d4a2d3cde8ca3d8a0753438d3ef61c6b957c9c53",
      "at": "2026-07-30T15:24:27Z"
    },
    {
      "name": "LF-only line endings preserved",
      "command": "grep -c $'\\r' .gitignore",
      "result": "pass",
      "detail": "0 CR bytes; added pattern /.codex/ is non-empty, so gitops.RequireIgnored's empty-pattern fail-closed path is unaffected",
      "commit_oid": "d4a2d3cde8ca3d8a0753438d3ef61c6b957c9c53",
      "at": "2026-07-30T15:24:27Z"
    },
    {
      "name": "Go build/vet/test",
      "command": "go build ./... \u0026\u0026 go vet ./... \u0026\u0026 go test ./...",
      "result": "skip",
      "detail": "no Go toolchain installed on this machine (go: command not found); Go coverage is provided by GitHub Actions CI on this PR, not by the executor",
      "commit_oid": "d4a2d3cde8ca3d8a0753438d3ef61c6b957c9c53",
      "at": "2026-07-30T15:24:27Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Fresh reviewer independently reproduced every reported verification command-for-command. Diff is .gitignore only, +3 lines, 0 deletions — no scope creep. All seven acceptance criteria satisfied: pattern is genuinely root-anchored at .gitignore:23; check-ignore matches .codex/agents/orch-scout.toml via /.codex/; adapters/codex/.codex-plugin/plugin.json is not caught (exit 1) and stays tracked; git ls-files count unchanged at 30; LF-only preserved with 0 CR bytes; the non-empty pattern cannot trigger gitops.RequireIgnored's empty-pattern fail-closed path. Reviewer checked existing interview testdata for a literal .codex collision and found none, confirming root-anchoring is a forward-looking safeguard rather than a fix for a live bug. Manifest accuracy verified: the Go build/vet/test entry is honestly marked skip (no Go toolchain on this machine) rather than claimed as run. All 6 required CI checks green (lint, scripts ubuntu/windows, test ubuntu/macos/windows). The executor's repo-local git identity fix is not part of the tracked diff and did not affect committed content. No security surface.",
      "commit_oid": "d4a2d3cde8ca3d8a0753438d3ef61c6b957c9c53",
      "at": "2026-07-30T15:26:49Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, scripts (windows-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "d4a2d3cde8ca3d8a0753438d3ef61c6b957c9c53",
      "at": "2026-07-30T15:27:19Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->