### PR TITLE
Reviewer reports every finding; only blocking findings drive request-changes

### DIFF
--- a/adapters/claude/agents/orch-reviewer-safe.md
+++ b/adapters/claude/agents/orch-reviewer-safe.md
@@ -47,10 +47,22 @@ sent back to the executor, not something you do yourself.
 
 ## Report
 
+List every finding your review turns up — this stage is about
+coverage, not filtering. Report low-severity findings and anything
+you are uncertain about; do not hold one back because it seems minor
+or falls under some bar. Give each finding a severity and a
+confidence.
+
+Decide the verdict after the findings are listed, as a separate
+judgment: `request-changes` applies only when a finding blocks an
+acceptance criterion. A non-blocking finding stays in the report
+without by itself forcing another review cycle.
+
 Produce **one consolidated report** per review cycle — do not report
 findings piecemeal across several messages. State a clear verdict
 (`approve` or `request-changes`) and the reasoning behind it, covering
-every area above that is relevant to this change.
+every area above that is relevant to this change. Size the report to
+the change under review — no filler, no restated boilerplate.
 
 A write denial from the pre-write guard is policy — report it to the
 Architect; do not work around it.

--- a/adapters/claude/agents/orch-reviewer.md
+++ b/adapters/claude/agents/orch-reviewer.md
@@ -40,10 +40,22 @@ sent back to the executor, not something you do yourself.
 
 ## Report
 
+List every finding your review turns up — this stage is about
+coverage, not filtering. Report low-severity findings and anything
+you are uncertain about; do not hold one back because it seems minor
+or falls under some bar. Give each finding a severity and a
+confidence.
+
+Decide the verdict after the findings are listed, as a separate
+judgment: `request-changes` applies only when a finding blocks an
+acceptance criterion. A non-blocking finding stays in the report
+without by itself forcing another review cycle.
+
 Produce **one consolidated report** per review cycle — do not report
 findings piecemeal across several messages. State a clear verdict
 (`approve` or `request-changes`) and the reasoning behind it, covering
-every area above that is relevant to this change.
+every area above that is relevant to this change. Size the report to
+the change under review — no filler, no restated boilerplate.
 
 A write denial from the pre-write guard is policy — report it to the
 Architect; do not work around it.

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -309,6 +309,44 @@ func TestAgentFrontmatter(t *testing.T) {
 	}
 }
 
+// reviewerCoverageInstruction and reviewerBlockingVerdictInstruction
+// are the two prose anchors the reviewer agents' "## Report" section
+// must carry: the finding stage is about coverage, not a severity
+// filter, and the approve/request-changes verdict is a separate
+// judgment that turns only on findings blocking an acceptance
+// criterion. Neither anchor includes the backtick-quoted
+// `request-changes` token itself, so a formatting change around that
+// token doesn't make this check brittle.
+const reviewerCoverageInstruction = "this stage is about coverage, not filtering"
+const reviewerBlockingVerdictInstruction = "applies only when a finding blocks an acceptance criterion"
+
+// TestReviewerReportsCoverageAndBlockingVerdict checks the two reviewer
+// agent files directly by stem, not via agentRoster: agentRoster is a
+// name-keyed map iterated by TestAgentFrontmatter, so a file it doesn't
+// list would go unchecked there, and a body-content assertion has
+// nothing to do with the tools/model fields that map exists for. This
+// mechanically guards the coverage-not-filtering and blocking-only-verdict
+// instructions instead of leaving them as prose a future reader must
+// re-verify by hand.
+func TestReviewerReportsCoverageAndBlockingVerdict(t *testing.T) {
+	for _, stem := range []string{"orch-reviewer", "orch-reviewer-safe"} {
+		t.Run(stem, func(t *testing.T) {
+			path := filepath.Join("agents", stem+".md")
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			content := adaptertest.NormalizeWhitespace(string(data))
+			if !strings.Contains(content, reviewerCoverageInstruction) {
+				t.Errorf("%s: missing coverage instruction %q", path, reviewerCoverageInstruction)
+			}
+			if !strings.Contains(content, reviewerBlockingVerdictInstruction) {
+				t.Errorf("%s: missing blocking-only verdict instruction %q", path, reviewerBlockingVerdictInstruction)
+			}
+		})
+	}
+}
+
 // skillGlob is the pattern every shared skill-drift check in this
 // package scans.
 const skillGlob = "skills/*/SKILL.md"


### PR DESCRIPTION
Delivers issue #116: Reviewer reports every finding; only blocking findings drive request-changes

Closes #116

**Plan digest:** `sha256:91a5543510b80f9963ff73cf737a3dc12aeb7d7f872cdc69745f920a22e43b48`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Revise the two Claude reviewer agent definitions, adapters/claude/agents/orch-reviewer.md and adapters/claude/agents/orch-reviewer-safe.md, so the reviewer's finding stage is explicitly about coverage rather than filtering, and the approve / request-changes decision is stated as a separate judgment made after the findings are listed. Keep every existing contract these files already carry: one consolidated report per review cycle, the exact verdict vocabulary approve and request-changes that orch run review accepts, the read-only tool posture, and the guard-denial-is-policy closing. Add a length instruction so the report is sized to the change under review rather than padded. Then add an assertion to the existing Claude plugin test so both instructions are mechanically guarded rather than left as prose a future reader must re-verify by hand. Do not modify the Codex reviewer TOMLs: this tuning derives from published prompting guidance for the Claude models these two files pin, and the host asymmetry is intentional.

**Acceptance criteria:**
- adapters/claude/agents/orch-reviewer.md and adapters/claude/agents/orch-reviewer-safe.md each instruct the reviewer to report every issue it finds, explicitly including low-severity findings and findings it is uncertain about, and each finding carries a severity and a confidence.
- Neither file contains an instruction to withhold, suppress, or omit a finding on the grounds that it is minor, low-severity, or below a bar.
- Each of the two files states that the approve / request-changes verdict is decided after the findings are listed, and that request-changes turns only on findings that block an acceptance criterion, so a non-blocking finding is recorded in the report without by itself forcing another review cycle.
- Each of the two files still requires one consolidated report per review cycle and still names the verdict values approve and request-changes verbatim, so the report remains valid input for orch run review.
- Each of the two files instructs the reviewer to size its report to the change under review and not to pad it with filler or restated boilerplate.
- Every section that exists in these two files before this change still exists after it: the opening you-did-not-write-this-change framing, the safe-downgrade paragraph in orch-reviewer-safe.md, the checked-areas list, the read-only How you look section, and the closing sentence that a pre-write guard denial is policy to report rather than work around.
- A test in adapters/claude/plugin_test.go fails if either reviewer file loses its coverage instruction or its blocking-only verdict instruction, and that test passes on the revised files.
- git diff on the merge commit shows no change to any file under adapters/codex/.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:dd23c00b6bd5` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively low-risk.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — All packages pass, including the new adapters/claude test TestReviewerReportsCoverageAndBlockingVerdict; its subtests /orch-reviewer and /orch-reviewer-safe both PASS. — commit `62c87a2dcb511ad7727c2eaeeb3f7e597beae66a` (2026-07-30T19:50:14Z)
- **gofmt** — pass — `gofmt -l .` — No output; no unformatted Go files. — commit `62c87a2dcb511ad7727c2eaeeb3f7e597beae66a` (2026-07-30T19:50:14Z)
- **guard-catches-regression** — pass — `Temporarily reverted adapters/claude/agents/orch-reviewer.md to its pre-change content, re-ran go test ./adapters/claude/..., then restored the file.` — Executor reports the new test failed with a clear message on the reverted file and passed again once restored, so the acceptance-criterion-7 guard is confirmed to actually catch a regression rather than merely passing on the current tree. — commit `62c87a2dcb511ad7727c2eaeeb3f7e597beae66a` (2026-07-30T19:50:14Z)
- **prose-reflow-word-diff** — pass — `git diff --word-diff --ignore-all-space -- adapters/claude/agents/orch-reviewer.md adapters/claude/agents/orch-reviewer-safe.md` — Every change is a pure insertion block; no [-word-] removal marker appears, so no word was dropped from the existing paragraphs. — commit `62c87a2dcb511ad7727c2eaeeb3f7e597beae66a` (2026-07-30T19:50:14Z)
- **branch-scope: codex-untouched** — pass — `git diff origin/main...62c87a2 -- adapters/codex/` — Empty across the whole branch. Independently re-confirmed by the cycle-1 reviewer against the extracted head tree. Acceptance criterion 8 holds. — commit `62c87a2dcb511ad7727c2eaeeb3f7e597beae66a` (2026-07-30T20:00:03Z)
- **branch-scope: change-size** — pass — `git diff origin/main...origin/orch/issue-116-reviewer-reports-every-finding-only-bloc --numstat` — CORRECTED, superseding the entry submitted at pr-open. 1 commit (62c87a2), 3 files, 64 insertions and 2 deletions total: adapters/claude/agents/orch-reviewer.md +13/-1, adapters/claude/agents/orch-reviewer-safe.md +13/-1, adapters/claude/plugin_test.go +38/-0. The pr-open entry said +14/-1 for each markdown file; that was the Architect misreading git diff --stat's total-changed-line count as an insertion count. Re-derived with --numstat, which reports insertions and deletions separately. Caught by the cycle-1 reviewer as finding 3. — commit `62c87a2dcb511ad7727c2eaeeb3f7e597beae66a` (2026-07-30T20:00:03Z)
- **reviewer-independent-toolchain** — pass — `git archive 62c87a2 into scratch, then go test ./... && gofmt -l . && go vet ./...` — Reviewer re-ran the toolchain against an extracted copy of the head tree rather than trusting the executor's report, leaving the main checkout untouched. All packages pass, gofmt clean, go vet clean. go vet was not a required test but was run anyway. — commit `62c87a2dcb511ad7727c2eaeeb3f7e597beae66a` (2026-07-30T20:00:03Z)
- **reviewer-mutation-test-of-guard** — pass — `Six mutations of the two reviewer .md files against the new TestReviewerReportsCoverageAndBlockingVerdict` — Reverting either file fails naming both anchors; deleting only the coverage paragraph fails on the coverage anchor alone; deleting only the verdict paragraph fails on the verdict anchor alone; reflowing the coverage sentence with different wrapping plus a tab still passes, confirming whitespace normalization is not brittle; renaming a reviewer file away fails loudly via t.Fatalf rather than skipping. Confirms the criterion-7 guard catches regressions rather than merely passing on the current tree. — commit `62c87a2dcb511ad7727c2eaeeb3f7e597beae66a` (2026-07-30T20:00:03Z)
- **review-cycle-1** — approve — Cycle 1 full audit, verdict approve. All eight acceptance criteria are satisfied; seven findings were raised and none blocks a criterion.

Independent verification: the reviewer extracted the head tree with git archive 62c87a2 into scratch and ran everything there, leaving the main checkout untouched. go test ./... passes for all packages including adapters/claude, gofmt -l . is clean, and go vet ./... is clean. All six required CI checks are green.

The criterion-7 guard was re-verified by mutation rather than inherited, since a guard that merely passes on the current tree would not satisfy the criterion. Six cases: reverting orch-reviewer.md to origin/main fails naming both anchors; reverting orch-reviewer-safe.md fails naming both anchors; deleting only the coverage paragraph fails on the coverage anchor alone; deleting only the verdict paragraph fails on the verdict anchor alone; reflowing the coverage sentence across different wrapping plus a tab still passes, confirming the whitespace normalization is not brittle; and renaming a reviewer file away fails loudly via t.Fatalf rather than silently skipping. The guard holds more strongly than the executor claimed.

Criterion 8 confirmed branch-wide: git diff origin/main...62c87a2 -- adapters/codex/ is empty. Word-diff confirms every markdown change is a pure insertion with no dropped word. Criteria 1 through 6 confirmed by reading both files at head: the only mention of minor-or-below-a-bar is inside the negated do-not-hold-one-back clause, the verdict tokens match VerdictApprove and VerdictRequestChanges in internal/run/review.go, and every section outside the single ## Report hunk per file is byte-identical. Scope is 3 files, all under adapters/claude/. Manifest accuracy: config_revision sha256:dd23c00b6bd5 matches the committed configuration and both routed selections match it.

On the substantive prose question the review was asked to weigh: the coverage-versus-verdict separation holds. Because request-changes applies ONLY WHEN a finding blocks an acceptance criterion is a necessary condition rather than a permission, it cannot be read as licensing request-changes on a non-blocking nit, and the ordering forecloses the aggregate-of-nits loophole that the following sentence's by-itself qualifier would otherwise leave open. Judged cycle-neutral, which was the cost constraint the criterion existed to protect.

Findings, all non-blocking. (1) medium/high: the verdict bar names only blocks-an-acceptance-criterion while the checked-areas list includes security, CI, tests, scope and manifest accuracy, so a security regression or failing required test not named by a criterion would read literally as reportable-but-approvable. The wording is verbatim from criterion 3, so shipping it was correct; a follow-up widening the bar to name required tests and security boundaries is the fix. (2) low/medium: the preserved How you look sentence, if the change needs a fix that is a request-changes verdict, is broader than the new bar; criterion 6 required preserving it, so this is correct scope. (3) low/high: an Architect manifest transcription error, corrected on this cycle by resubmitting the branch-scope: change-size entry. (4) low/medium: the criterion-5 length instruction is unguarded; only the two anchors criterion 7 named are pinned. (5) low/medium: anchors are substrings, so partial erosion of a pinned paragraph would pass, a standard limitation of prose pinning. (6) low/medium: no plugin version bump, left as a release-cadence call for the Architect; noted because the reviewer-spawn step compares the installed copy by version, so an installed 0.5.8 without this prose is indistinguishable from one with it. (7) low/low: the two new instructions trade against the fixed 6000-rune reviewDetailCap at internal/run/manifestbody.go:47, with the new size-to-the-change sentence acting as the counterweight.

Nothing security-relevant: no tool list, guard, or secret surface is touched, and the new test reads two constant paths via filepath.Join. The two known-stale items and the pre-existing agentRoster iteration shape were correctly left alone per the recorded deferral. — commit `62c87a2dcb511ad7727c2eaeeb3f7e597beae66a` (2026-07-30T20:00:04Z)
- **required-ci** — passing — test (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `62c87a2dcb511ad7727c2eaeeb3f7e597beae66a` (2026-07-30T20:00:14Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Revise the two Claude reviewer agent definitions, adapters/claude/agents/orch-reviewer.md and adapters/claude/agents/orch-reviewer-safe.md, so the reviewer's finding stage is explicitly about coverage rather than filtering, and the approve / request-changes decision is stated as a separate judgment made after the findings are listed. Keep every existing contract these files already carry: one consolidated report per review cycle, the exact verdict vocabulary approve and request-changes that orch run review accepts, the read-only tool posture, and the guard-denial-is-policy closing. Add a length instruction so the report is sized to the change under review rather than padded. Then add an assertion to the existing Claude plugin test so both instructions are mechanically guarded rather than left as prose a future reader must re-verify by hand. Do not modify the Codex reviewer TOMLs: this tuning derives from published prompting guidance for the Claude models these two files pin, and the host asymmetry is intentional.",
  "acceptance_criteria": [
    "adapters/claude/agents/orch-reviewer.md and adapters/claude/agents/orch-reviewer-safe.md each instruct the reviewer to report every issue it finds, explicitly including low-severity findings and findings it is uncertain about, and each finding carries a severity and a confidence.",
    "Neither file contains an instruction to withhold, suppress, or omit a finding on the grounds that it is minor, low-severity, or below a bar.",
    "Each of the two files states that the approve / request-changes verdict is decided after the findings are listed, and that request-changes turns only on findings that block an acceptance criterion, so a non-blocking finding is recorded in the report without by itself forcing another review cycle.",
    "Each of the two files still requires one consolidated report per review cycle and still names the verdict values approve and request-changes verbatim, so the report remains valid input for orch run review.",
    "Each of the two files instructs the reviewer to size its report to the change under review and not to pad it with filler or restated boilerplate.",
    "Every section that exists in these two files before this change still exists after it: the opening you-did-not-write-this-change framing, the safe-downgrade paragraph in orch-reviewer-safe.md, the checked-areas list, the read-only How you look section, and the closing sentence that a pre-write guard denial is policy to report rather than work around.",
    "A test in adapters/claude/plugin_test.go fails if either reviewer file loses its coverage instruction or its blocking-only verdict instruction, and that test passes on the revised files.",
    "git diff on the merge commit shows no change to any file under adapters/codex/."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively low-risk.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:dd23c00b6bd5",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All packages pass, including the new adapters/claude test TestReviewerReportsCoverageAndBlockingVerdict; its subtests /orch-reviewer and /orch-reviewer-safe both PASS.",
      "commit_oid": "62c87a2dcb511ad7727c2eaeeb3f7e597beae66a",
      "at": "2026-07-30T19:50:14Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No output; no unformatted Go files.",
      "commit_oid": "62c87a2dcb511ad7727c2eaeeb3f7e597beae66a",
      "at": "2026-07-30T19:50:14Z"
    },
    {
      "name": "guard-catches-regression",
      "command": "Temporarily reverted adapters/claude/agents/orch-reviewer.md to its pre-change content, re-ran go test ./adapters/claude/..., then restored the file.",
      "result": "pass",
      "detail": "Executor reports the new test failed with a clear message on the reverted file and passed again once restored, so the acceptance-criterion-7 guard is confirmed to actually catch a regression rather than merely passing on the current tree.",
      "commit_oid": "62c87a2dcb511ad7727c2eaeeb3f7e597beae66a",
      "at": "2026-07-30T19:50:14Z"
    },
    {
      "name": "prose-reflow-word-diff",
      "command": "git diff --word-diff --ignore-all-space -- adapters/claude/agents/orch-reviewer.md adapters/claude/agents/orch-reviewer-safe.md",
      "result": "pass",
      "detail": "Every change is a pure insertion block; no [-word-] removal marker appears, so no word was dropped from the existing paragraphs.",
      "commit_oid": "62c87a2dcb511ad7727c2eaeeb3f7e597beae66a",
      "at": "2026-07-30T19:50:14Z"
    },
    {
      "name": "branch-scope: codex-untouched",
      "command": "git diff origin/main...62c87a2 -- adapters/codex/",
      "result": "pass",
      "detail": "Empty across the whole branch. Independently re-confirmed by the cycle-1 reviewer against the extracted head tree. Acceptance criterion 8 holds.",
      "commit_oid": "62c87a2dcb511ad7727c2eaeeb3f7e597beae66a",
      "at": "2026-07-30T20:00:03Z"
    },
    {
      "name": "branch-scope: change-size",
      "command": "git diff origin/main...origin/orch/issue-116-reviewer-reports-every-finding-only-bloc --numstat",
      "result": "pass",
      "detail": "CORRECTED, superseding the entry submitted at pr-open. 1 commit (62c87a2), 3 files, 64 insertions and 2 deletions total: adapters/claude/agents/orch-reviewer.md +13/-1, adapters/claude/agents/orch-reviewer-safe.md +13/-1, adapters/claude/plugin_test.go +38/-0. The pr-open entry said +14/-1 for each markdown file; that was the Architect misreading git diff --stat's total-changed-line count as an insertion count. Re-derived with --numstat, which reports insertions and deletions separately. Caught by the cycle-1 reviewer as finding 3.",
      "commit_oid": "62c87a2dcb511ad7727c2eaeeb3f7e597beae66a",
      "at": "2026-07-30T20:00:03Z"
    },
    {
      "name": "reviewer-independent-toolchain",
      "command": "git archive 62c87a2 into scratch, then go test ./... \u0026\u0026 gofmt -l . \u0026\u0026 go vet ./...",
      "result": "pass",
      "detail": "Reviewer re-ran the toolchain against an extracted copy of the head tree rather than trusting the executor's report, leaving the main checkout untouched. All packages pass, gofmt clean, go vet clean. go vet was not a required test but was run anyway.",
      "commit_oid": "62c87a2dcb511ad7727c2eaeeb3f7e597beae66a",
      "at": "2026-07-30T20:00:03Z"
    },
    {
      "name": "reviewer-mutation-test-of-guard",
      "command": "Six mutations of the two reviewer .md files against the new TestReviewerReportsCoverageAndBlockingVerdict",
      "result": "pass",
      "detail": "Reverting either file fails naming both anchors; deleting only the coverage paragraph fails on the coverage anchor alone; deleting only the verdict paragraph fails on the verdict anchor alone; reflowing the coverage sentence with different wrapping plus a tab still passes, confirming whitespace normalization is not brittle; renaming a reviewer file away fails loudly via t.Fatalf rather than skipping. Confirms the criterion-7 guard catches regressions rather than merely passing on the current tree.",
      "commit_oid": "62c87a2dcb511ad7727c2eaeeb3f7e597beae66a",
      "at": "2026-07-30T20:00:03Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Cycle 1 full audit, verdict approve. All eight acceptance criteria are satisfied; seven findings were raised and none blocks a criterion.\n\nIndependent verification: the reviewer extracted the head tree with git archive 62c87a2 into scratch and ran everything there, leaving the main checkout untouched. go test ./... passes for all packages including adapters/claude, gofmt -l . is clean, and go vet ./... is clean. All six required CI checks are green.\n\nThe criterion-7 guard was re-verified by mutation rather than inherited, since a guard that merely passes on the current tree would not satisfy the criterion. Six cases: reverting orch-reviewer.md to origin/main fails naming both anchors; reverting orch-reviewer-safe.md fails naming both anchors; deleting only the coverage paragraph fails on the coverage anchor alone; deleting only the verdict paragraph fails on the verdict anchor alone; reflowing the coverage sentence across different wrapping plus a tab still passes, confirming the whitespace normalization is not brittle; and renaming a reviewer file away fails loudly via t.Fatalf rather than silently skipping. The guard holds more strongly than the executor claimed.\n\nCriterion 8 confirmed branch-wide: git diff origin/main...62c87a2 -- adapters/codex/ is empty. Word-diff confirms every markdown change is a pure insertion with no dropped word. Criteria 1 through 6 confirmed by reading both files at head: the only mention of minor-or-below-a-bar is inside the negated do-not-hold-one-back clause, the verdict tokens match VerdictApprove and VerdictRequestChanges in internal/run/review.go, and every section outside the single ## Report hunk per file is byte-identical. Scope is 3 files, all under adapters/claude/. Manifest accuracy: config_revision sha256:dd23c00b6bd5 matches the committed configuration and both routed selections match it.\n\nOn the substantive prose question the review was asked to weigh: the coverage-versus-verdict separation holds. Because request-changes applies ONLY WHEN a finding blocks an acceptance criterion is a necessary condition rather than a permission, it cannot be read as licensing request-changes on a non-blocking nit, and the ordering forecloses the aggregate-of-nits loophole that the following sentence's by-itself qualifier would otherwise leave open. Judged cycle-neutral, which was the cost constraint the criterion existed to protect.\n\nFindings, all non-blocking. (1) medium/high: the verdict bar names only blocks-an-acceptance-criterion while the checked-areas list includes security, CI, tests, scope and manifest accuracy, so a security regression or failing required test not named by a criterion would read literally as reportable-but-approvable. The wording is verbatim from criterion 3, so shipping it was correct; a follow-up widening the bar to name required tests and security boundaries is the fix. (2) low/medium: the preserved How you look sentence, if the change needs a fix that is a request-changes verdict, is broader than the new bar; criterion 6 required preserving it, so this is correct scope. (3) low/high: an Architect manifest transcription error, corrected on this cycle by resubmitting the branch-scope: change-size entry. (4) low/medium: the criterion-5 length instruction is unguarded; only the two anchors criterion 7 named are pinned. (5) low/medium: anchors are substrings, so partial erosion of a pinned paragraph would pass, a standard limitation of prose pinning. (6) low/medium: no plugin version bump, left as a release-cadence call for the Architect; noted because the reviewer-spawn step compares the installed copy by version, so an installed 0.5.8 without this prose is indistinguishable from one with it. (7) low/low: the two new instructions trade against the fixed 6000-rune reviewDetailCap at internal/run/manifestbody.go:47, with the new size-to-the-change sentence acting as the counterweight.\n\nNothing security-relevant: no tool list, guard, or secret surface is touched, and the new test reads two constant paths via filepath.Join. The two known-stale items and the pre-existing agentRoster iteration shape were correctly left alone per the recorded deferral.",
      "commit_oid": "62c87a2dcb511ad7727c2eaeeb3f7e597beae66a",
      "at": "2026-07-30T20:00:04Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "62c87a2dcb511ad7727c2eaeeb3f7e597beae66a",
      "at": "2026-07-30T20:00:14Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->