### PR TITLE
Rewrite README.md user-first with badges and SVG diagrams; refresh stale facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Orch
 
-*Your coding agent doesn't choose its own model, and it doesn't write outside the box you gave it.*
+*Your coding agent doesn't choose its own model, and it puts mechanical bounds on what it may write.*
 
 <p align="center">
   <img src="https://img.shields.io/badge/License-MIT-2E7D32?style=flat&logo=opensourceinitiative&logoColor=white" alt="License: MIT"/>
@@ -29,13 +29,13 @@ The payoff: cheap, fast models handle read-only exploration and mechanical work,
 
 ## What you actually get
 
-- **Nothing writes by default.** Assist mode mechanically denies every write to a file git does not ignore — not a convention the agent is asked to honor, but a decision `orch guard` makes before the write happens.
+- **Read-only by default.** Assist mode mechanically denies every write to a file git does not ignore — not a convention the agent is asked to honor, but a decision `orch guard` makes before the write happens.
 - **You route the model, not the agent.** Six roles — architect, scout, implementer, specialist, reviewer, and a cheaper review downgrade — each pin an exact model version and effort level you choose, so a cheap model handles read-only work and a frontier model is spent only where the plan calls for it.
 - **Every issue gets its own worktree.** Delivery work happens on its own branch, in its own isolated git worktree, never in your primary checkout.
 - **A separate dispatch reviews the work.** The pull request is reviewed in a dispatch separate from the one that wrote it — never the same run marking its own homework.
 - **You hold the merge gate.** Nothing lands on your default branch until you approve it, and the merge fails closed if the pull request moved after your approval.
 - **Every issue and PR carries an audit record.** The exact model, the effort, how the host actually delivered that effort, and the routing rationale are recorded on the issue and mirrored onto its pull request.
-- **Works with the CLI you already use.** Claude Code and Codex CLI are both first-class hosts, so you keep working in the agent you already have.
+- **Works with the CLI you already use.** Orch works with both [Claude Code](adapters/claude/README.md) and [Codex CLI](adapters/codex/README.md), so you keep working in the agent you already have.
 
 ---
 
@@ -497,8 +497,9 @@ next release rather than the current one.
 - Worktree containment no longer fails open on a `.gitignore` whose
   blank line survives as an empty pattern — a CRLF blank line, or a
   whitespace-only line under LF — because `RequireIgnored` now queries
-  a concrete sentinel path instead of a bare trailing-slash directory
-  query, and an empty pattern can never match a non-empty basename —
+  two structurally dissimilar child probe paths and requires both to
+  come back ignored, instead of a bare trailing-slash directory query,
+  and an empty pattern can never match a non-empty basename —
   [#106](https://github.com/kninetimmy/orch/pull/106)
 - The metrics ignore line in `.gitignore` is now proposed
   unconditionally instead of only when metrics is enabled, closing a

--- a/README.md
+++ b/README.md
@@ -1,23 +1,49 @@
 # Orch
 
-Orch is a development orchestrator for the Claude Code CLI and the
-Codex CLI. You keep working in the agent you already use. Orch sits
-underneath it and takes over two decisions you would otherwise be
-trusting the agent to make on its own: which model does a given piece
-of work, and what that agent is allowed to write.
+*Your coding agent doesn't choose its own model, and it doesn't write outside the box you gave it.*
 
-**Two modes.** A repository running Orch is in exactly one of two
-states. **Assist** is the default and is read-only: the agent can read
-anything, search, explain and plan, but a write to a file git does not
-ignore is refused. **Delivery** is entered only for a plan you have
-read and approved. Each task in that plan becomes a GitHub issue, a
-branch, and its own git worktree; the work happens there, lands as a
-pull request, is reviewed by a separate agent, runs CI, and waits for
-you to approve the merge. When every task is merged or abandoned, the
-run's last step puts the repository back in Assist.
+<p align="center">
+  <img src="https://img.shields.io/badge/License-MIT-2E7D32?style=flat&logo=opensourceinitiative&logoColor=white" alt="License: MIT"/>
+  <img src="https://img.shields.io/badge/Go-1.26%2B-00ADD8?style=flat&logo=go&logoColor=white" alt="Go 1.26+"/>
+  <img src="https://img.shields.io/badge/Release-v0.5.7-24292F?style=flat&logo=github&logoColor=white" alt="Release: v0.5.7"/>
+  <br/>
+  <img src="https://img.shields.io/badge/Platform-Linux%20%C2%B7%20macOS%20%C2%B7%20Windows-607D8B?style=flat" alt="Platform: Linux, macOS, Windows"/>
+  <img src="https://img.shields.io/badge/Hosts-Claude%20Code%20%C2%B7%20Codex%20CLI-6E56CF?style=flat" alt="Hosts: Claude Code and Codex CLI"/>
+</p>
 
-**Six roles.** Delivery work is split across roles, and you pin each
-one to an exact model version and reasoning-effort level:
+---
+
+Left to itself, a coding agent picks its own model for every task, and it can write to any file it can reach. That's fine until the model is wrong for the job — too expensive for something trivial, or too weak for something that actually matters — or until a change lands somewhere you didn't intend it to.
+
+Orch sits underneath the CLI you already use (Claude Code or Codex CLI) and takes over those two decisions. By default it puts the repository in **Assist**: a mechanical, read-only mode where the agent can look around, search, explain and plan, but a write to a file git does not ignore is refused before it happens. When you approve a plan, Orch enters **Delivery**: each task becomes a GitHub issue with its own isolated git worktree, gets implemented there, is reviewed by a separate agent dispatch, runs CI, and is merged only after you approve it. Which model handles which job is not the agent's call either — you route it, per role, to an exact model version and effort level.
+
+The payoff: cheap, fast models handle read-only exploration and mechanical work, a frontier model gets spent only where the plan calls for it, and every change that lands is auditable and gated by a human at the one step that matters — the merge.
+
+<br>
+
+<p align="center">
+  <img src="docs/images/orch-overview.svg" alt="Orch system overview: you and your host CLI, the orch binary naming the guard, routing, and run engine, and GitHub" width="920"/>
+</p>
+
+---
+
+## What you actually get
+
+- **Nothing writes by default.** Assist mode mechanically denies every write to a file git does not ignore — not a convention the agent is asked to honor, but a decision `orch guard` makes before the write happens.
+- **You route the model, not the agent.** Six roles — architect, scout, implementer, specialist, reviewer, and a cheaper review downgrade — each pin an exact model version and effort level you choose, so a cheap model handles read-only work and a frontier model is spent only where the plan calls for it.
+- **Every issue gets its own worktree.** Delivery work happens on its own branch, in its own isolated git worktree, never in your primary checkout.
+- **A separate dispatch reviews the work.** The pull request is reviewed in a dispatch separate from the one that wrote it — never the same run marking its own homework.
+- **You hold the merge gate.** Nothing lands on your default branch until you approve it, and the merge fails closed if the pull request moved after your approval.
+- **Every issue and PR carries an audit record.** The exact model, the effort, how the host actually delivered that effort, and the routing rationale are recorded on the issue and mirrored onto its pull request.
+- **Works with the CLI you already use.** Claude Code and Codex CLI are both first-class hosts, so you keep working in the agent you already have.
+
+---
+
+## How it works
+
+**Two modes.** A repository running Orch is in exactly one of two states. **Assist** is the default and is read-only: the agent can read anything, search, explain and plan, but a write to a file git does not ignore is refused. **Delivery** is entered only for a plan you have read and approved. Each task in that plan becomes a GitHub issue, a branch, and its own git worktree; the work happens there, lands as a pull request, is reviewed by a separate agent, runs CI, and waits for you to approve the merge. When every task is merged or abandoned, the run's last step puts the repository back in Assist.
+
+**Six roles.** Delivery work is split across roles, and you pin each one to an exact model version and reasoning-effort level:
 
 | Role | What it does |
 |---|---|
@@ -28,60 +54,23 @@ one to an exact model version and reasoning-effort level:
 | Reviewer | Reviews the pull request in a separate dispatch from the one that wrote it |
 | Review downgrade | A cheaper reviewer, allowed only when the plan affirms all four of mechanical, low-risk, fully specified, unsurprising |
 
-Which role gets an issue is derived from the issue's own facts by a
-deterministic table, not chosen by the model that will run it. The
-reviewer is always a separate dispatch and never the session that wrote
-the code, but it is often not a different model: the shipped defaults
-put the specialist and the reviewer on one model, and the implementer
-and the downgraded reviewer on another. Any specialist run and any
-downgraded review therefore has the same model on both sides. For a
-specialist run the effort matches too, on either host; only a Claude
-downgrade drops it.
+Which role gets an issue is derived from the issue's own facts by a deterministic table, not chosen by the model that will run it. The reviewer is always a separate dispatch and never the session that wrote the code, but it is often not a different model: the shipped defaults put the specialist and the reviewer on one model, and the implementer and the downgraded reviewer on another. Any specialist run and any downgraded review therefore has the same model on both sides. For a specialist run the effort matches too, on either host; only a Claude downgrade drops it.
 
-**The guard.** None of the above is an instruction the agent is asked
-to honor. Both host adapters wire the CLI's pre-write hook to `orch
-guard`, a subcommand of the same binary, which is consulted before the
-agent writes a file and answers allow or deny. In Assist it denies
-every write to a file git does not ignore. In Delivery it allows a
-write only inside a worktree registered to the running plan, on that
-worktree's registered branch, in a phase where writing is allowed.
-Git internals are never writable, and neither is the orchestrator
-state your session is running against. It fails closed: anything it
-cannot establish is a denial. What it enforces is containment — it
-cannot tell which role is writing, and a file written by a shell
-command never reaches it at all (see
-[Known issues](#known-issues-and-limitations)).
+**The guard.** None of the above is an instruction the agent is asked to honor. Both host adapters wire the CLI's pre-write hook to `orch guard`, a subcommand of the same binary, which is consulted before the agent writes a file and answers allow or deny. In Assist it denies every write to a file git does not ignore. In Delivery it allows a write only inside a worktree registered to the running plan, on that worktree's registered branch, in a phase where writing is allowed. Git internals are never writable, and neither is the orchestrator state your session is running against. It fails closed: anything it cannot establish is a denial. What it enforces is containment — it cannot tell which role is writing, and a file written by a shell command never reaches it at all (see [Known issues](#known-issues-and-limitations)).
 
 Concretely, asking for a change goes like this:
 
-1. You describe what you want. The Architect plans it in Assist and
-   shows you the plan: one issue per task, each carrying the model,
-   effort and reviewer it will get and why.
+1. You describe what you want. The Architect plans it in Assist and shows you the plan: one issue per task, each carrying the model, effort and reviewer it will get and why.
 2. You approve it or send it back. Approving is what enters Delivery.
-3. Each issue gets a branch and a worktree. An implementer or a
-   specialist does the work there and pushes.
+3. Each issue gets a branch and a worktree. An implementer or a specialist does the work there and pushes.
 4. A reviewer reviews the pull request. CI runs.
-5. You approve the merge, and it runs against GitHub pinned to the
-   commit that approval names — it fails closed if the pull request
-   moved after that.
+5. You approve the merge, and it runs against GitHub pinned to the commit that approval names — it fails closed if the pull request moved after that.
 
 The full product definition lives in [ORCH-PRD.md](ORCH-PRD.md).
 
 ## Status
 
-Early software. What can be stated as fact: 9 tagged releases (v0.1.0
-through v0.5.4) and 65 merged pull requests, 28 of which carry an Orch
-audit record in their body — every merge from PR #40 through PR #97
-except #50, which `orch configure` delivered in its own format. Since
-PR #40, this repository has been built through the pipeline described
-above: a plan gate, an isolated worktree per issue, a review dispatched
-separately from the work, CI, and a merge that fails closed unless it
-carries an approval pinned to the commit `merge-report` recorded.
-
-In 12 of those 28 the reviewer ran the same model as the executor — 6
-specialist runs and 6 downgraded reviews, both of which the shipped
-defaults put on one model. The reviewer's independence is a separate
-dispatch against the pull request, not a different model.
+Early software. What can be stated as fact: 12 tagged releases (v0.1.0 through v0.5.7) and 75 merged pull requests, 37 of which carry an Orch audit record in their body — every merge from PR #40 through PR #117 except #50 and #103, both of which `orch configure` delivered in its own body format. Since PR #40, this repository has been built through the pipeline described above: a plan gate, an isolated worktree per issue, a review dispatched separately from the work, CI, and a merge that fails closed unless it carries an approval pinned to the commit `merge-report` recorded.
 
 All of that evidence comes from one repository: this one.
 
@@ -112,7 +101,7 @@ on this machine. Work in a scratch directory, not in one of my projects.
 
 2. Confirm that `orch` resolves on PATH and that `orch status` prints a
    release version on its first line — a line beginning `orch:` and giving
-   a release tag such as v0.5.4. Run it from anywhere: outside an
+   a release tag such as v0.5.7. Run it from anywhere: outside an
    initialized repository it prints that version line first and then exits
    non-zero saying the repository is not initialized, which is expected
    here. On Windows the installer adds its install directory to my user
@@ -201,7 +190,7 @@ your OS and architecture, verify its SHA-256 against the release's
 `SHA256SUMS` **before** installing, and fail closed on any mismatch.
 
 Linux / macOS — installs to `~/.local/bin` (override with
-`ORCH_INSTALL_DIR`); pin a version with `ORCH_VERSION=v0.5.4`:
+`ORCH_INSTALL_DIR`); pin a version with `ORCH_VERSION=v0.5.7`:
 
 ```sh
 curl -fsSLO https://raw.githubusercontent.com/kninetimmy/orch/main/install.sh
@@ -211,7 +200,7 @@ sh install.sh
 
 Windows (PowerShell) — installs to `%LOCALAPPDATA%\Programs\orch` and
 appends that directory to your user `PATH`; skip the `PATH` change with
-`-NoPathUpdate`, pin a version with `-Version v0.5.4`:
+`-NoPathUpdate`, pin a version with `-Version v0.5.7`:
 
 ```powershell
 iwr https://raw.githubusercontent.com/kninetimmy/orch/main/install.ps1 -OutFile install.ps1
@@ -281,23 +270,28 @@ go install github.com/kninetimmy/orch/cmd/orch@latest
 
 ## Day to day
 
-These are the commands `orch help` lists for you:
+`orch help` lists every command, human and plumbing, in one place:
 
 ```text
-orch init             Interview and bootstrap this repository
-orch status           Show mode and configuration summary
-orch doctor           Check environment and configuration health
-orch configure        Interview and deliver committed configuration changes
-orch configure-local  Interview and apply machine-local overrides
-orch resume           Reconcile an interrupted Delivery run against GitHub and continue
-orch abort            Stop dispatch and return to Assist
-orch metrics          Show local metrics
-orch render-agents    Render the five Codex agent TOMLs from configuration into .codex/agents/
+usage: orch <command>
+
+commands:
+  init             Interview and bootstrap this repository
+  status           Show mode and configuration summary
+  doctor           Check environment and configuration health
+  configure        Interview and deliver committed configuration changes
+  configure-local  Interview and apply machine-local overrides
+  resume           Reconcile an interrupted Delivery run against GitHub and continue
+  abort            Stop dispatch and return to Assist
+  metrics          Show local metrics
+  render-agents    Render the five Codex agent TOMLs from configuration into .codex/agents/
+  run              Adapter plumbing: Delivery run verbs (JSON stdin/stdout; not a human command)
+  guard            Adapter plumbing: pre-write enforcement for host hooks (not a human command)
+  hook             Adapter plumbing: host lifecycle-event verbs (not a human command)
 ```
 
-`orch run`, `orch guard` and `orch hook` also exist, but they are
-adapter plumbing: they read and write JSON, the host adapters drive
-them, and you never call them by hand.
+The last three rows — `run`, `guard`, `hook` — are what the host
+adapters call for you; you never invoke them by hand.
 
 On Claude Code the three interviews also have slash commands:
 `/orch:init`, `/orch:configure`, `/orch:configure-local`.
@@ -496,10 +490,23 @@ continue, or `orch abort` to end it.
 <details>
 <summary>Defects already corrected, newest first</summary>
 
-Everything here is merged on `main`. The top entry landed after v0.5.4
-was tagged, so it ships in the next release rather than the current
-one.
+Everything here is merged on `main`. v0.5.7 is the latest tagged
+release; PRs #113, #115, and #117 landed after it, so they ship in the
+next release rather than the current one.
 
+- Worktree containment no longer fails open on a `.gitignore` whose
+  blank line survives as an empty pattern — a CRLF blank line, or a
+  whitespace-only line under LF — because `RequireIgnored` now queries
+  a concrete sentinel path instead of a bare trailing-slash directory
+  query, and an empty pattern can never match a non-empty basename —
+  [#106](https://github.com/kninetimmy/orch/pull/106)
+- The metrics ignore line in `.gitignore` is now proposed
+  unconditionally instead of only when metrics is enabled, closing a
+  trap where turning metrics on before that line existed could leave
+  metrics output un-ignored; `orch configure-local` and `orch doctor`
+  now fail closed, naming the missing line, when metrics is enabled
+  without it —
+  [#107](https://github.com/kninetimmy/orch/pull/107)
 - Both adapters stopped claiming that per-agent tool whitelists make
   every read-only role unable to write; the shipped prose now matches
   what the guard actually enforces —
@@ -591,6 +598,12 @@ fail-closed loads), persisted after every sub-step, so a crash at any
 point is recoverable.
 
 ### The Delivery pipeline
+
+<br>
+
+<p align="center">
+  <img src="docs/images/delivery-pipeline.svg" alt="Delivery pipeline left to right: plan gate, activation, dispatch, implement, PR, review, CI, merge gate, cleanup" width="920"/>
+</p>
 
 A run starts at the **plan gate**: a schema-versioned plan document
 (issues, dependency waves, risk facts) is validated fail-closed, and a

--- a/docs/images/delivery-pipeline.svg
+++ b/docs/images/delivery-pipeline.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 300" width="1440" height="300" style="max-width:100%;display:block;">
+  <title>Orch Delivery pipeline, issue to merge</title>
+  <defs>
+    <marker id="dp-right" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#5a6480"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1440" height="300" rx="16" fill="#0c0e18"/>
+  <rect width="1440" height="300" rx="16" fill="none" stroke="#1e2435" stroke-width="1"/>
+
+  <text x="720" y="30" text-anchor="middle"
+        font-family="ui-sans-serif,system-ui,sans-serif" font-size="11"
+        fill="#5a6480" letter-spacing="1.4">DELIVERY PIPELINE &#8212; ISSUE TO MERGE</text>
+
+  <!-- ═══════════════════════════════════════════════════════ -->
+  <!-- Stage boxes, left to right                              -->
+  <!-- x: 25, 183, 341, 499, 657, 815, 973, 1131, 1289 (w=126) -->
+  <!-- ═══════════════════════════════════════════════════════ -->
+
+  <!-- 0: plan gate (human) -->
+  <rect x="25" y="54" width="126" height="110" rx="10" fill="#201208" stroke="#e0a458" stroke-width="1.4"/>
+  <text x="88" y="104" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" font-weight="700" fill="#e0a458">plan gate</text>
+  <text x="88" y="128" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#c8a878">you approve</text>
+
+  <!-- 1: activation -->
+  <rect x="183" y="54" width="126" height="110" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
+  <text x="246" y="104" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" fill="#c8d0e4">activate</text>
+  <text x="246" y="128" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#4a5470">issue + worktree</text>
+
+  <!-- 2: dispatch -->
+  <rect x="341" y="54" width="126" height="110" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
+  <text x="404" y="104" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" fill="#c8d0e4">dispatch</text>
+  <text x="404" y="128" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#4a5470">ff onto default</text>
+
+  <!-- 3: implement -->
+  <rect x="499" y="54" width="126" height="110" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
+  <text x="562" y="104" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" fill="#c8d0e4">implement</text>
+  <text x="562" y="128" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#4a5470">isolated worktree</text>
+
+  <!-- 4: PR -->
+  <rect x="657" y="54" width="126" height="110" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
+  <text x="720" y="104" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" fill="#c8d0e4">open PR</text>
+  <text x="720" y="128" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#4a5470">clean, ahead</text>
+
+  <!-- 5: independent review -->
+  <rect x="815" y="54" width="126" height="110" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
+  <text x="878" y="104" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" fill="#c8d0e4">review</text>
+  <text x="878" y="128" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#4a5470">separate dispatch</text>
+
+  <!-- 6: CI -->
+  <rect x="973" y="54" width="126" height="110" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
+  <text x="1036" y="104" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" fill="#c8d0e4">CI</text>
+  <text x="1036" y="128" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#4a5470">required checks</text>
+
+  <!-- 7: merge gate (human) -->
+  <rect x="1131" y="54" width="126" height="110" rx="10" fill="#201208" stroke="#e0a458" stroke-width="1.4"/>
+  <text x="1194" y="104" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" font-weight="700" fill="#e0a458">merge gate</text>
+  <text x="1194" y="128" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#c8a878">you approve</text>
+
+  <!-- 8: cleanup / complete -->
+  <rect x="1289" y="54" width="126" height="110" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
+  <text x="1352" y="104" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" fill="#c8d0e4">cleanup</text>
+  <text x="1352" y="128" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#4a5470">back to Assist</text>
+
+  <!-- ═══════════════════════════════════════════════════════ -->
+  <!-- Arrows between stages                                   -->
+  <!-- ═══════════════════════════════════════════════════════ -->
+  <line x1="151" y1="109" x2="183" y2="109" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
+  <line x1="309" y1="109" x2="341" y2="109" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
+  <line x1="467" y1="109" x2="499" y2="109" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
+  <line x1="625" y1="109" x2="657" y2="109" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
+  <line x1="783" y1="109" x2="815" y2="109" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
+  <line x1="941" y1="109" x2="973" y2="109" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
+  <line x1="1099" y1="109" x2="1131" y2="109" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
+  <line x1="1257" y1="109" x2="1289" y2="109" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
+
+  <!-- ═══════════════════════════════════════════════════════ -->
+  <!-- Legend                                                  -->
+  <!-- ═══════════════════════════════════════════════════════ -->
+  <rect x="500" y="222" width="16" height="16" rx="3" fill="#111521" stroke="#19e3ff" stroke-width="1.2"/>
+  <text x="524" y="234" text-anchor="start" font-family="ui-sans-serif,system-ui,sans-serif" font-size="10" fill="#8892ac">automated step</text>
+
+  <rect x="700" y="222" width="16" height="16" rx="3" fill="#201208" stroke="#e0a458" stroke-width="1.4"/>
+  <text x="724" y="234" text-anchor="start" font-family="ui-sans-serif,system-ui,sans-serif" font-size="10" fill="#e0a458">human approval gate</text>
+
+  <text x="720" y="270" text-anchor="middle"
+        font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#3a4560">on failure, an issue can escalate, block, or abandon instead of continuing (not shown)</text>
+</svg>

--- a/docs/images/delivery-pipeline.svg
+++ b/docs/images/delivery-pipeline.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 300" width="1440" height="300" style="max-width:100%;display:block;">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 340" width="1440" height="340" style="max-width:100%;display:block;">
   <title>Orch Delivery pipeline, issue to merge</title>
   <defs>
     <marker id="dp-right" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
@@ -7,8 +7,8 @@
   </defs>
 
   <!-- Background -->
-  <rect width="1440" height="300" rx="16" fill="#0c0e18"/>
-  <rect width="1440" height="300" rx="16" fill="none" stroke="#1e2435" stroke-width="1"/>
+  <rect width="1440" height="340" rx="16" fill="#0c0e18"/>
+  <rect width="1440" height="340" rx="16" fill="none" stroke="#1e2435" stroke-width="1"/>
 
   <text x="720" y="30" text-anchor="middle"
         font-family="ui-sans-serif,system-ui,sans-serif" font-size="11"
@@ -16,75 +16,87 @@
 
   <!-- ═══════════════════════════════════════════════════════ -->
   <!-- Stage boxes, left to right                              -->
-  <!-- x: 25, 183, 341, 499, 657, 815, 973, 1131, 1289 (w=126) -->
+  <!-- x: 18, 176, 334, 492, 650, 808, 966, 1124, 1282 (w=140)  -->
+  <!-- Rendered at width="920" in README (0.639x viewBox scale):-->
+  <!-- stage name 20px -> 12.8 effective; sub-label/footnote    -->
+  <!-- 15px -> 9.6 effective.                                   -->
   <!-- ═══════════════════════════════════════════════════════ -->
 
   <!-- 0: plan gate (human) -->
-  <rect x="25" y="54" width="126" height="110" rx="10" fill="#201208" stroke="#e0a458" stroke-width="1.4"/>
-  <text x="88" y="104" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" font-weight="700" fill="#e0a458">plan gate</text>
-  <text x="88" y="128" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#c8a878">you approve</text>
+  <rect x="18" y="54" width="140" height="150" rx="10" fill="#201208" stroke="#e0a458" stroke-width="1.4"/>
+  <text x="88" y="108" text-anchor="middle" font-family="ui-monospace,monospace" font-size="20" font-weight="700" fill="#e0a458">plan gate</text>
+  <text x="88" y="142" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" fill="#c8a878">you</text>
+  <text x="88" y="164" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" fill="#c8a878">approve</text>
 
   <!-- 1: activation -->
-  <rect x="183" y="54" width="126" height="110" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
-  <text x="246" y="104" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" fill="#c8d0e4">activate</text>
-  <text x="246" y="128" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#4a5470">issue + worktree</text>
+  <rect x="176" y="54" width="140" height="150" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
+  <text x="246" y="108" text-anchor="middle" font-family="ui-monospace,monospace" font-size="20" fill="#c8d0e4">activate</text>
+  <text x="246" y="142" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" fill="#8892ac">issue +</text>
+  <text x="246" y="164" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" fill="#8892ac">worktree</text>
 
   <!-- 2: dispatch -->
-  <rect x="341" y="54" width="126" height="110" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
-  <text x="404" y="104" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" fill="#c8d0e4">dispatch</text>
-  <text x="404" y="128" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#4a5470">ff onto default</text>
+  <rect x="334" y="54" width="140" height="150" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
+  <text x="404" y="108" text-anchor="middle" font-family="ui-monospace,monospace" font-size="20" fill="#c8d0e4">dispatch</text>
+  <text x="404" y="142" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" fill="#8892ac">ff onto</text>
+  <text x="404" y="164" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" fill="#8892ac">default</text>
 
   <!-- 3: implement -->
-  <rect x="499" y="54" width="126" height="110" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
-  <text x="562" y="104" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" fill="#c8d0e4">implement</text>
-  <text x="562" y="128" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#4a5470">isolated worktree</text>
+  <rect x="492" y="54" width="140" height="150" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
+  <text x="562" y="108" text-anchor="middle" font-family="ui-monospace,monospace" font-size="20" fill="#c8d0e4">implement</text>
+  <text x="562" y="142" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" fill="#8892ac">isolated</text>
+  <text x="562" y="164" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" fill="#8892ac">worktree</text>
 
   <!-- 4: PR -->
-  <rect x="657" y="54" width="126" height="110" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
-  <text x="720" y="104" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" fill="#c8d0e4">open PR</text>
-  <text x="720" y="128" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#4a5470">clean, ahead</text>
+  <rect x="650" y="54" width="140" height="150" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
+  <text x="720" y="108" text-anchor="middle" font-family="ui-monospace,monospace" font-size="20" fill="#c8d0e4">open PR</text>
+  <text x="720" y="142" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" fill="#8892ac">clean,</text>
+  <text x="720" y="164" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" fill="#8892ac">ahead</text>
 
   <!-- 5: independent review -->
-  <rect x="815" y="54" width="126" height="110" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
-  <text x="878" y="104" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" fill="#c8d0e4">review</text>
-  <text x="878" y="128" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#4a5470">separate dispatch</text>
+  <rect x="808" y="54" width="140" height="150" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
+  <text x="878" y="108" text-anchor="middle" font-family="ui-monospace,monospace" font-size="20" fill="#c8d0e4">review</text>
+  <text x="878" y="142" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" fill="#8892ac">separate</text>
+  <text x="878" y="164" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" fill="#8892ac">dispatch</text>
 
   <!-- 6: CI -->
-  <rect x="973" y="54" width="126" height="110" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
-  <text x="1036" y="104" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" fill="#c8d0e4">CI</text>
-  <text x="1036" y="128" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#4a5470">required checks</text>
+  <rect x="966" y="54" width="140" height="150" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
+  <text x="1036" y="108" text-anchor="middle" font-family="ui-monospace,monospace" font-size="20" fill="#c8d0e4">CI</text>
+  <text x="1036" y="142" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" fill="#8892ac">required</text>
+  <text x="1036" y="164" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" fill="#8892ac">checks</text>
 
   <!-- 7: merge gate (human) -->
-  <rect x="1131" y="54" width="126" height="110" rx="10" fill="#201208" stroke="#e0a458" stroke-width="1.4"/>
-  <text x="1194" y="104" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" font-weight="700" fill="#e0a458">merge gate</text>
-  <text x="1194" y="128" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#c8a878">you approve</text>
+  <rect x="1124" y="54" width="140" height="150" rx="10" fill="#201208" stroke="#e0a458" stroke-width="1.4"/>
+  <text x="1194" y="108" text-anchor="middle" font-family="ui-monospace,monospace" font-size="20" font-weight="700" fill="#e0a458">merge gate</text>
+  <text x="1194" y="142" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" fill="#c8a878">you</text>
+  <text x="1194" y="164" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" fill="#c8a878">approve</text>
 
   <!-- 8: cleanup / complete -->
-  <rect x="1289" y="54" width="126" height="110" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
-  <text x="1352" y="104" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" fill="#c8d0e4">cleanup</text>
-  <text x="1352" y="128" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#4a5470">back to Assist</text>
+  <rect x="1282" y="54" width="140" height="150" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
+  <text x="1352" y="108" text-anchor="middle" font-family="ui-monospace,monospace" font-size="20" fill="#c8d0e4">cleanup</text>
+  <text x="1352" y="142" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" fill="#8892ac">back to</text>
+  <text x="1352" y="164" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" fill="#8892ac">Assist</text>
 
   <!-- ═══════════════════════════════════════════════════════ -->
   <!-- Arrows between stages                                   -->
   <!-- ═══════════════════════════════════════════════════════ -->
-  <line x1="151" y1="109" x2="183" y2="109" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
-  <line x1="309" y1="109" x2="341" y2="109" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
-  <line x1="467" y1="109" x2="499" y2="109" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
-  <line x1="625" y1="109" x2="657" y2="109" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
-  <line x1="783" y1="109" x2="815" y2="109" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
-  <line x1="941" y1="109" x2="973" y2="109" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
-  <line x1="1099" y1="109" x2="1131" y2="109" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
-  <line x1="1257" y1="109" x2="1289" y2="109" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
+  <line x1="158" y1="129" x2="176" y2="129" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
+  <line x1="316" y1="129" x2="334" y2="129" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
+  <line x1="474" y1="129" x2="492" y2="129" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
+  <line x1="632" y1="129" x2="650" y2="129" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
+  <line x1="790" y1="129" x2="808" y2="129" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
+  <line x1="948" y1="129" x2="966" y2="129" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
+  <line x1="1106" y1="129" x2="1124" y2="129" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
+  <line x1="1264" y1="129" x2="1282" y2="129" stroke="#5a6480" stroke-width="1.5" marker-end="url(#dp-right)"/>
 
   <!-- ═══════════════════════════════════════════════════════ -->
   <!-- Legend                                                  -->
   <!-- ═══════════════════════════════════════════════════════ -->
-  <rect x="500" y="222" width="16" height="16" rx="3" fill="#111521" stroke="#19e3ff" stroke-width="1.2"/>
-  <text x="524" y="234" text-anchor="start" font-family="ui-sans-serif,system-ui,sans-serif" font-size="10" fill="#8892ac">automated step</text>
+  <rect x="500" y="262" width="16" height="16" rx="3" fill="#111521" stroke="#19e3ff" stroke-width="1.2"/>
+  <text x="524" y="274" text-anchor="start" font-family="ui-sans-serif,system-ui,sans-serif" font-size="10" fill="#8892ac">automated step</text>
 
-  <rect x="700" y="222" width="16" height="16" rx="3" fill="#201208" stroke="#e0a458" stroke-width="1.4"/>
-  <text x="724" y="234" text-anchor="start" font-family="ui-sans-serif,system-ui,sans-serif" font-size="10" fill="#e0a458">human approval gate</text>
+  <rect x="700" y="262" width="16" height="16" rx="3" fill="#201208" stroke="#e0a458" stroke-width="1.4"/>
+  <text x="724" y="274" text-anchor="start" font-family="ui-sans-serif,system-ui,sans-serif" font-size="10" fill="#e0a458">human approval gate</text>
 
-  <text x="720" y="270" text-anchor="middle"
-        font-family="ui-sans-serif,system-ui,sans-serif" font-size="9" fill="#3a4560">on failure, an issue can escalate, block, or abandon instead of continuing (not shown)</text>
+  <text x="720" y="310" text-anchor="middle"
+        font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" fill="#3a4560">on failure, an issue can escalate, block, or abandon instead of continuing (not shown)</text>
 </svg>

--- a/docs/images/orch-overview.svg
+++ b/docs/images/orch-overview.svg
@@ -50,7 +50,7 @@
   <line x1="280" y1="124" x2="248" y2="124" stroke="#19e3ff" stroke-width="1.4"
         stroke-dasharray="4,3" opacity="0.5" marker-end="url(#oa-right-cyan-dim)"/>
   <text x="264" y="139" text-anchor="middle"
-        font-family="ui-sans-serif,system-ui,sans-serif" font-size="9.5" fill="#19e3ff" opacity="0.5">context</text>
+        font-family="ui-sans-serif,system-ui,sans-serif" font-size="9.5" fill="#19e3ff" opacity="0.5">ctx</text>
 
   <!-- ═══════════════════════════════════════════════════════ -->
   <!-- MIDDLE BOX: orch                                        -->

--- a/docs/images/orch-overview.svg
+++ b/docs/images/orch-overview.svg
@@ -1,0 +1,120 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 320" width="1000" height="320" style="max-width:100%;display:block;">
+  <title>Orch system overview</title>
+  <defs>
+    <marker id="oa-right-cyan" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#19e3ff"/>
+    </marker>
+    <marker id="oa-right-cyan-dim" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#19e3ff" opacity="0.45"/>
+    </marker>
+    <marker id="oa-right-green" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#1fe88a"/>
+    </marker>
+    <marker id="oa-right-green-dim" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#1fe88a" opacity="0.4"/>
+    </marker>
+  </defs>
+
+  <!-- Main background -->
+  <rect width="1000" height="320" rx="14" fill="#0c0e18"/>
+  <rect width="1000" height="320" rx="14" fill="none" stroke="#1e2435" stroke-width="1"/>
+
+  <!-- ═══════════════════════════════════════════════════════ -->
+  <!-- LEFT BOX: You & your host CLI                           -->
+  <!-- ═══════════════════════════════════════════════════════ -->
+  <rect x="18" y="18" width="230" height="284" rx="10" fill="#111521" stroke="#242c3e" stroke-width="1"/>
+
+  <text x="133" y="44" text-anchor="middle"
+        font-family="ui-sans-serif,system-ui,sans-serif" font-size="10.5"
+        fill="#5a6480" letter-spacing="1.1">YOU &amp; YOUR HOST CLI</text>
+
+  <rect x="34" y="58" width="198" height="34" rx="7" fill="#161c2c" stroke="#2a3248" stroke-width="1"/>
+  <text x="54" y="80" font-family="ui-monospace,monospace" font-size="13" fill="#c8d0e4">&#9000;  you (terminal)</text>
+
+  <rect x="34" y="100" width="198" height="34" rx="7" fill="#161c2c" stroke="#19e3ff" stroke-width="1" opacity="0.85"/>
+  <text x="54" y="122" font-family="ui-monospace,monospace" font-size="13" fill="#19e3ff">&#9678;  Claude Code</text>
+
+  <rect x="34" y="142" width="198" height="34" rx="7" fill="#161c2c" stroke="#a45cff" stroke-width="1" opacity="0.85"/>
+  <text x="54" y="164" font-family="ui-monospace,monospace" font-size="13" fill="#a45cff">&#9673;  Codex CLI</text>
+
+  <text x="133" y="286" text-anchor="middle"
+        font-family="ui-sans-serif,system-ui,sans-serif" font-size="10" fill="#4a5470">you plan &#183; approve &#183; merge</text>
+
+  <!-- ═══════════════════════════════════════════════════════ -->
+  <!-- ARROWS: left ↔ middle                                   -->
+  <!-- ═══════════════════════════════════════════════════════ -->
+  <line x1="248" y1="100" x2="280" y2="100" stroke="#19e3ff" stroke-width="1.6" marker-end="url(#oa-right-cyan)"/>
+  <text x="264" y="95" text-anchor="middle"
+        font-family="ui-sans-serif,system-ui,sans-serif" font-size="9.5" fill="#19e3ff">write</text>
+
+  <line x1="280" y1="124" x2="248" y2="124" stroke="#19e3ff" stroke-width="1.4"
+        stroke-dasharray="4,3" opacity="0.5" marker-end="url(#oa-right-cyan-dim)"/>
+  <text x="264" y="139" text-anchor="middle"
+        font-family="ui-sans-serif,system-ui,sans-serif" font-size="9.5" fill="#19e3ff" opacity="0.5">context</text>
+
+  <!-- ═══════════════════════════════════════════════════════ -->
+  <!-- MIDDLE BOX: orch                                        -->
+  <!-- ═══════════════════════════════════════════════════════ -->
+  <rect x="280" y="8" width="340" height="304" rx="10" fill="#111521" stroke="#19e3ff" stroke-width="1" opacity="0.7"/>
+
+  <text x="450" y="44" text-anchor="middle"
+        font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" font-weight="700"
+        fill="#19e3ff" letter-spacing="2">orch</text>
+
+  <rect x="298" y="64" width="304" height="46" rx="8" fill="#0d1420" stroke="#19e3ff" stroke-width="1" opacity="0.8"/>
+  <text x="450" y="84" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" fill="#c8d0e4">guard</text>
+  <text x="450" y="100" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9.5" fill="#4a5470">pre-write enforcement, fail closed</text>
+
+  <rect x="298" y="122" width="304" height="46" rx="8" fill="#0d1420" stroke="#a45cff" stroke-width="1" opacity="0.8"/>
+  <text x="450" y="142" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" fill="#c8d0e4">routing</text>
+  <text x="450" y="158" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9.5" fill="#4a5470">role &#8594; model, a deterministic table</text>
+
+  <rect x="298" y="180" width="304" height="54" rx="8" fill="#0a1220" stroke="#1fe88a" stroke-width="1" opacity="0.8"/>
+  <text x="450" y="202" text-anchor="middle" font-family="ui-monospace,monospace" font-size="13" fill="#c8d0e4">run engine</text>
+  <text x="450" y="220" text-anchor="middle" font-family="ui-sans-serif,system-ui,sans-serif" font-size="9.5" fill="#4a5470">plan gate &#8594; dispatch &#8594; merge gate</text>
+
+  <text x="450" y="282" text-anchor="middle"
+        font-family="ui-sans-serif,system-ui,sans-serif" font-size="10" fill="#4a5470">one binary: contain, route, deliver</text>
+
+  <!-- ═══════════════════════════════════════════════════════ -->
+  <!-- ARROWS: middle ↔ right                                  -->
+  <!-- ═══════════════════════════════════════════════════════ -->
+  <line x1="620" y1="100" x2="652" y2="100" stroke="#1fe88a" stroke-width="1.6" marker-end="url(#oa-right-green)"/>
+  <text x="636" y="95" text-anchor="middle"
+        font-family="ui-sans-serif,system-ui,sans-serif" font-size="9.5" fill="#1fe88a">push</text>
+
+  <line x1="652" y1="124" x2="620" y2="124" stroke="#1fe88a" stroke-width="1.4"
+        stroke-dasharray="4,3" opacity="0.45" marker-end="url(#oa-right-green-dim)"/>
+  <text x="636" y="139" text-anchor="middle"
+        font-family="ui-sans-serif,system-ui,sans-serif" font-size="9.5" fill="#1fe88a" opacity="0.45">status</text>
+
+  <!-- ═══════════════════════════════════════════════════════ -->
+  <!-- RIGHT BOX: GitHub                                       -->
+  <!-- ═══════════════════════════════════════════════════════ -->
+  <rect x="652" y="18" width="330" height="284" rx="10" fill="#111521" stroke="#242c3e" stroke-width="1"/>
+
+  <text x="817" y="44" text-anchor="middle"
+        font-family="ui-sans-serif,system-ui,sans-serif" font-size="10.5"
+        fill="#5a6480" letter-spacing="1.1">GITHUB</text>
+
+  <rect x="668" y="60" width="298" height="28" rx="6" fill="#0b1118" stroke="#242c3e" stroke-width="1"/>
+  <text x="817" y="79" text-anchor="middle" font-family="ui-monospace,monospace" font-size="11.5" fill="#c8d0e4">issue</text>
+
+  <rect x="668" y="96" width="298" height="28" rx="6" fill="#0b1118" stroke="#19e3ff" stroke-width="1" opacity="0.9"/>
+  <text x="817" y="115" text-anchor="middle" font-family="ui-monospace,monospace" font-size="11.5" fill="#19e3ff">branch + worktree</text>
+
+  <rect x="668" y="132" width="298" height="28" rx="6" fill="#0b1118" stroke="#1fe88a" stroke-width="1" opacity="0.9"/>
+  <text x="817" y="151" text-anchor="middle" font-family="ui-monospace,monospace" font-size="11.5" fill="#1fe88a">PR</text>
+
+  <rect x="668" y="168" width="298" height="28" rx="6" fill="#0b1118" stroke="#a45cff" stroke-width="1" opacity="0.9"/>
+  <text x="817" y="187" text-anchor="middle" font-family="ui-monospace,monospace" font-size="11.5" fill="#a45cff">review</text>
+
+  <rect x="668" y="204" width="298" height="28" rx="6" fill="#0b1118" stroke="#1fe88a" stroke-width="1" opacity="0.6"/>
+  <text x="817" y="223" text-anchor="middle" font-family="ui-monospace,monospace" font-size="11.5" fill="#1fe88a" opacity="0.85">CI</text>
+
+  <rect x="668" y="240" width="298" height="28" rx="6" fill="#201208" stroke="#e0a458" stroke-width="1.2"/>
+  <text x="817" y="259" text-anchor="middle" font-family="ui-monospace,monospace" font-size="11.5" fill="#e0a458">merge</text>
+
+  <text x="817" y="286" text-anchor="middle"
+        font-family="ui-sans-serif,system-ui,sans-serif" font-size="10" fill="#4a5470">one audit record, issue &#8594; PR</text>
+</svg>


### PR DESCRIPTION
Delivers issue #118: Rewrite README.md user-first with badges and SVG diagrams; refresh stale facts

Closes #118

**Plan digest:** `sha256:0a9fe807a88d976ba7fb13b118abfb38f889943921307705346c1d007bb8f277`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Restructure README.md so a reader with no knowledge of Orch immediately sees what it does and the value it provides, in the visual style of a modern OSS README: a one-line tagline, a centered block of static shields.io badges, a plain-language introduction, a user-benefit bullet list, and two new hand-authored dark-theme SVG diagrams committed under docs/images/ that explain the system and the Delivery workflow visually. Update all out-of-date facts to the verified current values given in the acceptance criteria. Preserve the existing substantive content (install prompt and details, day-to-day commands, settings, memhub integration, known issues, fixed list, under-the-hood) reorganized beneath the new top matter; content may be condensed or reordered but no behavioral claim about Orch may be introduced that is not in the current README or verified against the code, and no existing behavioral claim may be strengthened.

**Acceptance criteria:**
- README.md opens with the project title, a one-line tagline, and a centered block of static img.shields.io badges that includes at minimum: license MIT, Go 1.26+, platform (Linux / macOS / Windows), and hosts (Claude Code / Codex CLI). All badges are static badge URLs; none depends on CI or external state.
- Immediately after the badge block, an introduction of one to three short paragraphs written for a reader with no prior knowledge of Orch: the problem (an agent left to itself picks its own model for every task and can write anywhere it likes), what Orch does about it (mechanical read-only Assist mode, per-role model routing, and a Delivery pipeline of issue -&gt; isolated worktree -&gt; PR -&gt; independent review -&gt; CI -&gt; human-approved merge), and why that is valuable (cheaper models where they suffice, a frontier model only where it matters, and every change auditable and human-gated) - in plain language, with no Orch-specific vocabulary used before it is explained.
- A user-benefit bullet section near the top (heading of the form 'What you actually get' or equivalent) whose bullets each lead with a bolded benefit phrase followed by one or two plain-language sentences, covering at least: enforced read-only default, model routing you control per role, isolated per-issue worktrees, independent review, human merge gate, full audit record on every issue and PR, and works with both Claude Code and Codex CLI.
- Two new SVG files exist at docs/images/orch-overview.svg and docs/images/delivery-pipeline.svg and each is referenced from README.md via a plain img tag or markdown image whose relative path resolves from the repository root. orch-overview.svg shows the system at a glance: you and your host CLI (Claude Code / Codex CLI) on one side, the orch binary in the middle (naming the guard, routing, and the run engine), and GitHub on the other side (issue, branch + worktree, PR, review, CI, merge). delivery-pipeline.svg shows the Delivery flow left to right: plan gate (human approves) -&gt; activation -&gt; dispatch -&gt; implement in worktree -&gt; PR -&gt; independent review -&gt; CI -&gt; merge gate (human approves) -&gt; cleanup/complete, and visually distinguishes the two human gates from the automated steps.
- Both SVGs are self-contained hand-authored vector graphics: valid XML, no external fonts, images, scripts, or CSS references, using only inline attributes/styles and generic font-family stacks (system-ui/sans-serif and monospace), sized via a viewBox with a width that renders legibly on GitHub. The two share one visual language: dark rounded panel background, rounded node boxes, arrow markers, and a small consistent accent palette.
- Every stale fact is corrected to these values, verified 2026-07-30 against git and GitHub (re-verify with `git tag` and a `gh pr list --state merged` body scan for the literal 'orch:manifest:begin' if repeating): 12 tagged releases, v0.1.0 through v0.5.7; 75 merged pull requests; 37 of them carrying an Orch audit record - every merge from PR #40 through PR #117 except #50 and #103, both of which `orch configure` delivered in its own body format; and every version-pin example in the install instructions references v0.5.7.
- The Fixed section gains entries for the worktree-containment empty-pattern fail-open fix (PR #106) and the metrics/.gitignore self-blocking trap closure (PR #107), and its release framing states that v0.5.7 is the latest tag with PRs #113, #115, and #117 landed after it (shipping in the next release).
- The rewritten README still contains, in some order: the agent-paste install prompt and the install-by-hand details, an 'orch help'-derived command list that matches the output of `go run ./cmd/orch help` at HEAD (including the three plumbing rows run/guard/hook it now prints), the settings tables (config.toml vs config.local.toml split, the role/model defaults table), the memhub integration section, the Known issues section, and the Under the hood material; each may be condensed, reworded, or moved into collapsible details blocks, but none is dropped entirely.
- No behavioral claim about Orch appears in the new README that is neither present in the pre-change README nor verified against the repository's code or command output during implementation, and no behavioral claim present in the pre-change README is strengthened (a hedged or qualified claim stays hedged; known limitations stay stated).
- Markdown integrity: every intra-document anchor link resolves to a heading in the document, all code fences are balanced, and both image references point at the committed SVG paths.

**Required tests:**
- `go build ./...`
- `git diff --name-only $(git merge-base HEAD origin/main) HEAD -- lists exactly: README.md, docs/images/delivery-pipeline.svg, docs/images/orch-overview.svg`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:dd23c00b6bd5` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **go-build** — pass — `go build ./...` — Re-run by the cycle-2 reviewer at d8cf68f: build OK, go vet OK, gofmt -l clean (branch changes no Go files). — commit `d8cf68f7ecbb4311688633cf92e4931338599b73` (2026-07-31T03:04:22Z)
- **branch-scope: diff-file-list** — pass — `git diff --name-only $(git merge-base HEAD origin/main) HEAD` — At d8cf68f the branch diff lists exactly README.md, docs/images/delivery-pipeline.svg, docs/images/orch-overview.svg - the three files the plan permits; zero .go files change on the branch. Independently confirmed by the cycle-2 reviewer. — commit `d8cf68f7ecbb4311688633cf92e4931338599b73` (2026-07-31T03:04:22Z)
- **markdown-integrity** — pass — `ad-hoc Python check over README.md` — Code fences balanced (18, even count); the one intra-document anchor link (#known-issues-and-limitations) resolves to its heading; both image references point at the committed SVG paths. — commit `098bb157b0741833da8f421839d27b288a4ef1e9` (2026-07-31T02:36:57Z)
- **svg-well-formed** — pass — `python3 -c "import xml.dom.minidom as m; m.parse(...)" on both SVGs` — docs/images/orch-overview.svg and docs/images/delivery-pipeline.svg both parse as well-formed XML; no external fonts, images, scripts, or CSS references. — commit `098bb157b0741833da8f421839d27b288a4ef1e9` (2026-07-31T02:36:57Z)
- **stale-facts-reverified** — pass — `git tag; gh pr list --state merged; gh pr view 106/107` — Executor independently re-verified criterion 6 before writing: 12 tags v0.1.0-v0.5.7; 75 merged PRs; merged PRs #40-#117 minus #50/#103 = 37 audit records; PR #106/#107 merge timestamps precede the v0.5.7 tag so only #113/#115/#117 land after it. — commit `098bb157b0741833da8f421839d27b288a4ef1e9` (2026-07-31T02:36:57Z)
- **review-cycle-1** — request-changes — Full cycle-1 audit. Nine of ten criteria pass, independently re-verified: badges/intro/benefit bullets as specified; both SVGs well-formed, self-contained, correct content; stale facts re-derived from git/gh (12 tags v0.1.0-v0.5.7, 75 merged PRs, 37 audit records = merged #40-#117 minus #50/#103, with prose-only #8 explaining the 38th raw marker hit); Fixed entries for #106/#107 accurate with release framing confirmed via git tag --contains; help block byte-identical to HEAD output; scope exactly the three permitted files; all 6 CI checks green; manifest accurate. BLOCKING (criterion 5): delivery-pipeline.svg is authored at viewBox 1440 units but referenced at width=920 (0.639x downscale), rendering stage sub-labels (9px -&gt; 5.75px effective at 2.42:1 contrast) and the footnote illegible in a headless-Edge render at 920px; remedy is a ~920-1000 unit re-layout or larger/lighter text at 1440. Non-blocking findings recorded: two unhedged absolutes in new top matter (tagline and 'Nothing writes by default.'), new 'first-class hosts' parity phrasing, #106 Fixed entry says a single sentinel probe where the commit ships two dissimilar probes, 'context' arrow label overhangs panel borders in orch-overview.svg, static release badge needs manual bumps (required by criterion 1), mixed line-wrap conventions, and the deliberate drop of the stale 12-of-28 same-model statistic (qualitative version preserved verbatim). — commit `098bb157b0741833da8f421839d27b288a4ef1e9` (2026-07-31T02:46:50Z)
- **review-cycle-2** — approve — Cycle-2 delta review at d8cf68f: the cycle-1 blocking finding (delivery-pipeline.svg illegible at width=920) is genuinely closed - verified arithmetically (stage names 12.78 effective px, sub-labels 9.58 at 6.19:1 contrast) and by headless-Edge renders of pre- and post-fix files at 920px/1x, with geometry (canvas 300-&gt;340, boxes 140x150, no overflow or overlap) checked coordinate by coordinate. The #106 Fixed entry now correctly states the two-dissimilar-probes-both-required mechanism (verified against internal/gitops/checks.go), the ctx label clears its gap, and all three Architect-directed rewordings are weaker-or-equal so criterion 9 holds, with both new adapter links resolving. No regression: branch diff is exactly the three permitted files with zero .go changes, both SVGs remain well-formed and self-contained, fences/anchors/links all resolve, go build/vet/gofmt clean, CI 6/6 green at the reviewed head. Non-blocking notes recorded: the reworded tagline's 'it' now reads as the agent bounding itself (inverted pitch, line 3), the footnote kept its 2.02:1 fill and diagram title/legend their pre-fix sizes (legible in render; below WCAG), inter-box arrows reduced to bare arrowheads (~4.5 visible units), and the manifest's branch-scope entry was stamped at 098bb15 and is resubmitted at this head with this review. — commit `d8cf68f7ecbb4311688633cf92e4931338599b73` (2026-07-31T03:04:23Z)
- **required-ci** — passing — test (windows-latest)=pass, lint=pass, test (macos-latest)=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, scripts (ubuntu-latest)=pass — commit `d8cf68f7ecbb4311688633cf92e4931338599b73` (2026-07-31T03:04:37Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Restructure README.md so a reader with no knowledge of Orch immediately sees what it does and the value it provides, in the visual style of a modern OSS README: a one-line tagline, a centered block of static shields.io badges, a plain-language introduction, a user-benefit bullet list, and two new hand-authored dark-theme SVG diagrams committed under docs/images/ that explain the system and the Delivery workflow visually. Update all out-of-date facts to the verified current values given in the acceptance criteria. Preserve the existing substantive content (install prompt and details, day-to-day commands, settings, memhub integration, known issues, fixed list, under-the-hood) reorganized beneath the new top matter; content may be condensed or reordered but no behavioral claim about Orch may be introduced that is not in the current README or verified against the code, and no existing behavioral claim may be strengthened.",
  "acceptance_criteria": [
    "README.md opens with the project title, a one-line tagline, and a centered block of static img.shields.io badges that includes at minimum: license MIT, Go 1.26+, platform (Linux / macOS / Windows), and hosts (Claude Code / Codex CLI). All badges are static badge URLs; none depends on CI or external state.",
    "Immediately after the badge block, an introduction of one to three short paragraphs written for a reader with no prior knowledge of Orch: the problem (an agent left to itself picks its own model for every task and can write anywhere it likes), what Orch does about it (mechanical read-only Assist mode, per-role model routing, and a Delivery pipeline of issue -\u003e isolated worktree -\u003e PR -\u003e independent review -\u003e CI -\u003e human-approved merge), and why that is valuable (cheaper models where they suffice, a frontier model only where it matters, and every change auditable and human-gated) - in plain language, with no Orch-specific vocabulary used before it is explained.",
    "A user-benefit bullet section near the top (heading of the form 'What you actually get' or equivalent) whose bullets each lead with a bolded benefit phrase followed by one or two plain-language sentences, covering at least: enforced read-only default, model routing you control per role, isolated per-issue worktrees, independent review, human merge gate, full audit record on every issue and PR, and works with both Claude Code and Codex CLI.",
    "Two new SVG files exist at docs/images/orch-overview.svg and docs/images/delivery-pipeline.svg and each is referenced from README.md via a plain img tag or markdown image whose relative path resolves from the repository root. orch-overview.svg shows the system at a glance: you and your host CLI (Claude Code / Codex CLI) on one side, the orch binary in the middle (naming the guard, routing, and the run engine), and GitHub on the other side (issue, branch + worktree, PR, review, CI, merge). delivery-pipeline.svg shows the Delivery flow left to right: plan gate (human approves) -\u003e activation -\u003e dispatch -\u003e implement in worktree -\u003e PR -\u003e independent review -\u003e CI -\u003e merge gate (human approves) -\u003e cleanup/complete, and visually distinguishes the two human gates from the automated steps.",
    "Both SVGs are self-contained hand-authored vector graphics: valid XML, no external fonts, images, scripts, or CSS references, using only inline attributes/styles and generic font-family stacks (system-ui/sans-serif and monospace), sized via a viewBox with a width that renders legibly on GitHub. The two share one visual language: dark rounded panel background, rounded node boxes, arrow markers, and a small consistent accent palette.",
    "Every stale fact is corrected to these values, verified 2026-07-30 against git and GitHub (re-verify with `git tag` and a `gh pr list --state merged` body scan for the literal 'orch:manifest:begin' if repeating): 12 tagged releases, v0.1.0 through v0.5.7; 75 merged pull requests; 37 of them carrying an Orch audit record - every merge from PR #40 through PR #117 except #50 and #103, both of which `orch configure` delivered in its own body format; and every version-pin example in the install instructions references v0.5.7.",
    "The Fixed section gains entries for the worktree-containment empty-pattern fail-open fix (PR #106) and the metrics/.gitignore self-blocking trap closure (PR #107), and its release framing states that v0.5.7 is the latest tag with PRs #113, #115, and #117 landed after it (shipping in the next release).",
    "The rewritten README still contains, in some order: the agent-paste install prompt and the install-by-hand details, an 'orch help'-derived command list that matches the output of `go run ./cmd/orch help` at HEAD (including the three plumbing rows run/guard/hook it now prints), the settings tables (config.toml vs config.local.toml split, the role/model defaults table), the memhub integration section, the Known issues section, and the Under the hood material; each may be condensed, reworded, or moved into collapsible details blocks, but none is dropped entirely.",
    "No behavioral claim about Orch appears in the new README that is neither present in the pre-change README nor verified against the repository's code or command output during implementation, and no behavioral claim present in the pre-change README is strengthened (a hedged or qualified claim stays hedged; known limitations stay stated).",
    "Markdown integrity: every intra-document anchor link resolves to a heading in the document, all code fences are balanced, and both image references point at the committed SVG paths."
  ],
  "required_tests": [
    "go build ./...",
    "git diff --name-only $(git merge-base HEAD origin/main) HEAD -- lists exactly: README.md, docs/images/delivery-pipeline.svg, docs/images/orch-overview.svg"
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:dd23c00b6bd5",
  "verifications": [
    {
      "name": "go-build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "Re-run by the cycle-2 reviewer at d8cf68f: build OK, go vet OK, gofmt -l clean (branch changes no Go files).",
      "commit_oid": "d8cf68f7ecbb4311688633cf92e4931338599b73",
      "at": "2026-07-31T03:04:22Z"
    },
    {
      "name": "branch-scope: diff-file-list",
      "command": "git diff --name-only $(git merge-base HEAD origin/main) HEAD",
      "result": "pass",
      "detail": "At d8cf68f the branch diff lists exactly README.md, docs/images/delivery-pipeline.svg, docs/images/orch-overview.svg - the three files the plan permits; zero .go files change on the branch. Independently confirmed by the cycle-2 reviewer.",
      "commit_oid": "d8cf68f7ecbb4311688633cf92e4931338599b73",
      "at": "2026-07-31T03:04:22Z"
    },
    {
      "name": "markdown-integrity",
      "command": "ad-hoc Python check over README.md",
      "result": "pass",
      "detail": "Code fences balanced (18, even count); the one intra-document anchor link (#known-issues-and-limitations) resolves to its heading; both image references point at the committed SVG paths.",
      "commit_oid": "098bb157b0741833da8f421839d27b288a4ef1e9",
      "at": "2026-07-31T02:36:57Z"
    },
    {
      "name": "svg-well-formed",
      "command": "python3 -c \"import xml.dom.minidom as m; m.parse(...)\" on both SVGs",
      "result": "pass",
      "detail": "docs/images/orch-overview.svg and docs/images/delivery-pipeline.svg both parse as well-formed XML; no external fonts, images, scripts, or CSS references.",
      "commit_oid": "098bb157b0741833da8f421839d27b288a4ef1e9",
      "at": "2026-07-31T02:36:57Z"
    },
    {
      "name": "stale-facts-reverified",
      "command": "git tag; gh pr list --state merged; gh pr view 106/107",
      "result": "pass",
      "detail": "Executor independently re-verified criterion 6 before writing: 12 tags v0.1.0-v0.5.7; 75 merged PRs; merged PRs #40-#117 minus #50/#103 = 37 audit records; PR #106/#107 merge timestamps precede the v0.5.7 tag so only #113/#115/#117 land after it.",
      "commit_oid": "098bb157b0741833da8f421839d27b288a4ef1e9",
      "at": "2026-07-31T02:36:57Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "Full cycle-1 audit. Nine of ten criteria pass, independently re-verified: badges/intro/benefit bullets as specified; both SVGs well-formed, self-contained, correct content; stale facts re-derived from git/gh (12 tags v0.1.0-v0.5.7, 75 merged PRs, 37 audit records = merged #40-#117 minus #50/#103, with prose-only #8 explaining the 38th raw marker hit); Fixed entries for #106/#107 accurate with release framing confirmed via git tag --contains; help block byte-identical to HEAD output; scope exactly the three permitted files; all 6 CI checks green; manifest accurate. BLOCKING (criterion 5): delivery-pipeline.svg is authored at viewBox 1440 units but referenced at width=920 (0.639x downscale), rendering stage sub-labels (9px -\u003e 5.75px effective at 2.42:1 contrast) and the footnote illegible in a headless-Edge render at 920px; remedy is a ~920-1000 unit re-layout or larger/lighter text at 1440. Non-blocking findings recorded: two unhedged absolutes in new top matter (tagline and 'Nothing writes by default.'), new 'first-class hosts' parity phrasing, #106 Fixed entry says a single sentinel probe where the commit ships two dissimilar probes, 'context' arrow label overhangs panel borders in orch-overview.svg, static release badge needs manual bumps (required by criterion 1), mixed line-wrap conventions, and the deliberate drop of the stale 12-of-28 same-model statistic (qualitative version preserved verbatim).",
      "commit_oid": "098bb157b0741833da8f421839d27b288a4ef1e9",
      "at": "2026-07-31T02:46:50Z"
    },
    {
      "name": "review-cycle-2",
      "result": "approve",
      "detail": "Cycle-2 delta review at d8cf68f: the cycle-1 blocking finding (delivery-pipeline.svg illegible at width=920) is genuinely closed - verified arithmetically (stage names 12.78 effective px, sub-labels 9.58 at 6.19:1 contrast) and by headless-Edge renders of pre- and post-fix files at 920px/1x, with geometry (canvas 300-\u003e340, boxes 140x150, no overflow or overlap) checked coordinate by coordinate. The #106 Fixed entry now correctly states the two-dissimilar-probes-both-required mechanism (verified against internal/gitops/checks.go), the ctx label clears its gap, and all three Architect-directed rewordings are weaker-or-equal so criterion 9 holds, with both new adapter links resolving. No regression: branch diff is exactly the three permitted files with zero .go changes, both SVGs remain well-formed and self-contained, fences/anchors/links all resolve, go build/vet/gofmt clean, CI 6/6 green at the reviewed head. Non-blocking notes recorded: the reworded tagline's 'it' now reads as the agent bounding itself (inverted pitch, line 3), the footnote kept its 2.02:1 fill and diagram title/legend their pre-fix sizes (legible in render; below WCAG), inter-box arrows reduced to bare arrowheads (~4.5 visible units), and the manifest's branch-scope entry was stamped at 098bb15 and is resubmitted at this head with this review.",
      "commit_oid": "d8cf68f7ecbb4311688633cf92e4931338599b73",
      "at": "2026-07-31T03:04:23Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, lint=pass, test (macos-latest)=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "d8cf68f7ecbb4311688633cf92e4931338599b73",
      "at": "2026-07-31T03:04:37Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->