### PR TITLE
Extend per-host reasoning-effort enums with a free-text interview surface

### DIFF
--- a/internal/config/renderlocal_test.go
+++ b/internal/config/renderlocal_test.go
@@ -52,7 +52,7 @@ func TestRenderLocalRejectsInvalidValues(t *testing.T) {
 		"concurrency.max_subagents":          "0",
 		"metrics.enabled":                    "maybe",
 		"hosts.claude.roles.architect.model": "has space",
-		"hosts.codex.roles.reviewer.effort":  "ultra",
+		"hosts.codex.roles.reviewer.effort":  "minimal",
 	}
 	for key, value := range tests {
 		t.Run(key, func(t *testing.T) {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -11,10 +11,13 @@ var mergeStrategies = map[string]bool{"squash": true, "rebase": true, "merge-com
 var memhubModes = map[string]bool{"required": true, "best-effort": true, "off": true}
 
 // effortsByHost lists the reasoning-effort levels each host accepts
-// (PRD §10 model tables).
+// (PRD §10 model tables; Codex CLI ReasoningEffort wire tokens,
+// lowercase, no separators). "none" and "minimal" exist in the Codex
+// enum but are deliberately excluded: no orch role should route below
+// low.
 var effortsByHost = map[string]map[string]bool{
-	"codex":  {"low": true, "medium": true, "high": true},
-	"claude": {"low": true, "medium": true, "high": true, "xhigh": true},
+	"codex":  {"low": true, "medium": true, "high": true, "xhigh": true, "max": true, "ultra": true},
+	"claude": {"low": true, "medium": true, "high": true, "xhigh": true, "max": true},
 }
 
 // validate collects every violation and reports them together in one
@@ -82,7 +85,7 @@ func validateHost(name string, h *Host, fail func(string, ...any)) {
 
 func effortList(host string) string {
 	if host == "claude" {
-		return "low, medium, high, xhigh"
+		return "low, medium, high, xhigh, max"
 	}
-	return "low, medium, high"
+	return "low, medium, high, xhigh, max, ultra"
 }

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// singleHostTOML renders the smallest schema_version=1 document that
+// enables host with all six roles pinned to effort, so Parse's real
+// validation can be exercised against one effort value at a time.
+func singleHostTOML(host, effort string) string {
+	var b strings.Builder
+	b.WriteString("schema_version  = 1\n")
+	b.WriteString(`config_revision = "r1"` + "\n\n")
+	b.WriteString("[memhub]\nmode = \"off\"\n")
+	model := "gpt-5.6-sol"
+	if host == "claude" {
+		model = "claude-opus-5"
+	}
+	for _, role := range roleOrder {
+		fmt.Fprintf(&b, "\n[hosts.%s.roles.%s]\nmodel  = %q\neffort = %q\n", host, role, model, effort)
+	}
+	return b.String()
+}
+
+// TestEffortDomainPerHost pins the effort levels each host's role
+// profiles accept and reject (issue #122): codex gains xhigh, max, and
+// ultra; claude gains max. "none" and "minimal" stay excluded from both
+// hosts, and "ultra" stays excluded from claude.
+func TestEffortDomainPerHost(t *testing.T) {
+	tests := []struct {
+		host    string
+		effort  string
+		wantErr bool
+	}{
+		{"codex", "low", false},
+		{"codex", "medium", false},
+		{"codex", "high", false},
+		{"codex", "xhigh", false},
+		{"codex", "max", false},
+		{"codex", "ultra", false},
+		{"codex", "minimal", true},
+		{"codex", "none", true},
+		{"claude", "low", false},
+		{"claude", "medium", false},
+		{"claude", "high", false},
+		{"claude", "xhigh", false},
+		{"claude", "max", false},
+		{"claude", "ultra", true},
+		{"claude", "minimal", true},
+		{"claude", "none", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.host+"/"+tt.effort, func(t *testing.T) {
+			_, err := Parse([]byte(singleHostTOML(tt.host, tt.effort)))
+			if tt.wantErr && err == nil {
+				t.Fatalf("Parse(%s effort=%s) succeeded, want error", tt.host, tt.effort)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("Parse(%s effort=%s): %v", tt.host, tt.effort, err)
+			}
+		})
+	}
+}
+
+// TestEffortListNamesFullAcceptedDomain pins effortList's error text to
+// name every value effortsByHost accepts for that host, so an
+// out-of-domain effort's validation error always tells the caller the
+// complete accepted list.
+func TestEffortListNamesFullAcceptedDomain(t *testing.T) {
+	for host, accepted := range effortsByHost {
+		list := effortList(host)
+		for effort := range accepted {
+			if !strings.Contains(list, effort) {
+				t.Errorf("effortList(%s) = %q, missing accepted value %q", host, list, effort)
+			}
+		}
+	}
+}

--- a/internal/interview/configurelocal.go
+++ b/internal/interview/configurelocal.go
@@ -498,12 +498,13 @@ func localRoleDocSpecs(host string, committed *config.Config, seeded map[string]
 			Default:  effectiveModel,
 		}
 		effortQ := question.Question{
-			ID:      effortKey,
-			Header:  rs.header,
-			Prompt:  fmt.Sprintf("%s reasoning effort (%s)", rs.label, hostLabel),
-			Kind:    question.KindSelect,
-			Options: effortOptionsLocal(host, cp.Effort, effectiveEffort),
-			Default: effectiveEffort,
+			ID:       effortKey,
+			Header:   rs.header,
+			Prompt:   fmt.Sprintf("%s reasoning effort (%s)", rs.label, hostLabel),
+			Kind:     question.KindSelect,
+			Options:  effortOptionsLocal(host, cp.Effort, effectiveEffort),
+			FreeText: true,
+			Default:  effectiveEffort,
 		}
 		docs = append(docs, docSpec{questions: []question.Question{modelQ, effortQ}})
 	}
@@ -526,11 +527,14 @@ func modelOptionsLocal(host, committedVal, effectiveVal string) []question.Optio
 	return opts
 }
 
-// effortOptionsLocal lists host's closed effort enum, marking
-// committedVal's option "(committed)" in its Label and effectiveVal
-// Recommended.
+// effortOptionsLocal lists host's offered effort subset
+// (effortsOffered), marking committedVal's option "(committed)" in its
+// Label and effectiveVal Recommended. Neither value need be among
+// these options — the question's FreeText escape hatch admits any
+// other value in host's full effort enum (hostEfforts), validated by
+// validEffort wherever a typed value is ingested.
 func effortOptionsLocal(host, committedVal, effectiveVal string) []question.Option {
-	efforts := hostEfforts[host]
+	efforts := effortsOffered(host)
 	opts := make([]question.Option, len(efforts))
 	for i, e := range efforts {
 		label := effortLabel(e)

--- a/internal/interview/configurelocal_test.go
+++ b/internal/interview/configurelocal_test.go
@@ -272,6 +272,51 @@ func answerLocalWithOverrides(t *testing.T, root string, overrides map[string]st
 	return question.Document{}, nil
 }
 
+// TestNextConfigureLocalRejectsOutOfDomainFreeTextEffort proves issue
+// #124 criterion 4 for configure-local: an effort value the effort
+// question's FreeText escape hatch admits past question.ValidateAnswer,
+// but internal/config would reject for that host, never reaches a
+// written config.local.toml — config.RenderLocal's own domain check
+// (inside materializeLocal) rejects it first, naming the host's full
+// accepted domain (effortList) in the returned error, mirroring
+// answerLocalWithOverrides' walk shape but stopping to inspect the
+// error instead of treating it as fatal.
+func TestNextConfigureLocalRejectsOutOfDomainFreeTextEffort(t *testing.T) {
+	root := t.TempDir()
+	writeCommittedConfigLocal(t, root)
+
+	effortKey := localRoleEffortID("codex", "architect")
+	overrides := map[string]string{idPickCodex: "yes", effortKey: "minimal"}
+	answers := map[string]string{}
+	var lastErr error
+	for i := 0; i < 100; i++ {
+		doc, err := NextConfigureLocal(answers, root)
+		if err != nil {
+			lastErr = err
+			break
+		}
+		if doc.Kind != question.DocQuestions {
+			t.Fatalf("expected an error before reaching a clean %q document", doc.Kind)
+		}
+		for _, q := range doc.Questions {
+			if v, ok := overrides[q.ID]; ok {
+				answers[q.ID] = v
+				continue
+			}
+			if q.Default == "" {
+				t.Fatalf("question %s has no default to answer with", q.ID)
+			}
+			answers[q.ID] = q.Default
+		}
+	}
+	if lastErr == nil {
+		t.Fatal("NextConfigureLocal succeeded, want an error for codex effort=minimal")
+	}
+	if !strings.Contains(lastErr.Error(), "low, medium, high, xhigh, max, ultra") {
+		t.Errorf("error %q does not name codex's full accepted effort domain", lastErr)
+	}
+}
+
 // TestNextConfigureLocalMetricsTrapBlocked proves configure-local
 // refuses, through the same summary-blocker mechanism the no-change
 // case uses, any change whose resulting effective configuration would

--- a/internal/interview/materialize_test.go
+++ b/internal/interview/materialize_test.go
@@ -86,6 +86,24 @@ func TestMaterializeFreeTextModelRejectsWhitespace(t *testing.T) {
 	}
 }
 
+// TestMaterializeRejectsOutOfDomainFreeTextEffort proves issue #124
+// criterion 4: an effort value the effort question's FreeText escape
+// hatch admits past question.ValidateAnswer, but internal/config would
+// reject for that host, never materializes into a config.Config —
+// materialize's own Render/Parse round-trip catches it, naming the
+// host's full accepted domain (effortList) in the returned error.
+func TestMaterializeRejectsOutOfDomainFreeTextEffort(t *testing.T) {
+	answers := fullAnswers()
+	answers[roleEffortID("codex", "architect")] = "minimal"
+	_, err := materialize(answers)
+	if err == nil {
+		t.Fatal("materialize succeeded, want an error for codex effort=minimal")
+	}
+	if !strings.Contains(err.Error(), "low, medium, high, xhigh, max, ultra") {
+		t.Errorf("error %q does not name codex's full accepted effort domain", err)
+	}
+}
+
 func TestMaterializeConcurrency(t *testing.T) {
 	tests := []struct {
 		value   string

--- a/internal/interview/sequence.go
+++ b/internal/interview/sequence.go
@@ -107,11 +107,36 @@ var hostModels = map[string][]string{
 	"claude": {"claude-opus-5", "claude-sonnet-5"},
 }
 
-// hostEfforts lists each host's closed effort enum, in the same order
-// validate.go's effortList documents.
+// hostEfforts lists each host's full closed effort enum — every value
+// internal/config's effortsByHost accepts for that host, in the same
+// order validate.go's effortList documents — not just the subset
+// offered as literal select options (effortsOffered). validEffort
+// (configurelocal.go) checks a typed value against this full list, so
+// it stays the single full-domain source of truth the interview owns.
 var hostEfforts = map[string][]string{
-	"codex":  {"low", "medium", "high"},
-	"claude": {"low", "medium", "high", "xhigh"},
+	"codex":  {"low", "medium", "high", "xhigh", "max", "ultra"},
+	"claude": {"low", "medium", "high", "xhigh", "max"},
+}
+
+// maxOfferedEfforts is the largest number of effort levels offered as
+// literal select options — question.SpecCheck's 2-4-option cap (a hard
+// ceiling mirroring the hosts' native dialog limits) leaves headroom
+// for the FreeText escape hatch to cover the rest.
+const maxOfferedEfforts = 4
+
+// effortsOffered returns the leading maxOfferedEfforts values of
+// host's full effort enum (hostEfforts) — the subset an effort
+// question offers as literal Options. Every level hostEfforts lists
+// beyond this subset remains expressible only through that question's
+// FreeText escape hatch, validated against hostEfforts' full domain
+// wherever a typed value is ingested (validEffort, and internal/config's
+// own Parse/RenderLocal round-trip checks).
+func effortsOffered(host string) []string {
+	efforts := hostEfforts[host]
+	if len(efforts) > maxOfferedEfforts {
+		return efforts[:maxOfferedEfforts]
+	}
+	return efforts
 }
 
 // hostLabels is each host key's human-readable display name.
@@ -242,12 +267,13 @@ func roleDocSpecs(host string, showExplain bool, defaults func(string) profile) 
 		}
 
 		effortQ := question.Question{
-			ID:      roleEffortID(host, rs.key),
-			Header:  rs.header,
-			Prompt:  fmt.Sprintf("%s reasoning effort (%s)", rs.label, hostLabel),
-			Kind:    question.KindSelect,
-			Options: effortOptions(host, def.effort),
-			Default: def.effort,
+			ID:       roleEffortID(host, rs.key),
+			Header:   rs.header,
+			Prompt:   fmt.Sprintf("%s reasoning effort (%s)", rs.label, hostLabel),
+			Kind:     question.KindSelect,
+			Options:  effortOptions(host, def.effort),
+			FreeText: true,
+			Default:  def.effort,
 		}
 
 		docs = append(docs, docSpec{questions: []question.Question{modelQ, effortQ}})
@@ -266,10 +292,13 @@ func modelOptions(host, def string) []question.Option {
 	return opts
 }
 
-// effortOptions lists host's closed effort enum, marking def as
-// Recommended.
+// effortOptions lists host's offered effort subset (effortsOffered),
+// marking def as Recommended. def need not be among these options —
+// the question's FreeText escape hatch admits any other value in
+// host's full effort enum (hostEfforts); SpecCheck permits a Default
+// outside Options exactly when FreeText is set.
 func effortOptions(host, def string) []question.Option {
-	efforts := hostEfforts[host]
+	efforts := effortsOffered(host)
 	opts := make([]question.Option, len(efforts))
 	for i, e := range efforts {
 		opts[i] = question.Option{Value: e, Label: effortLabel(e), Recommended: e == def}

--- a/internal/interview/sequence_test.go
+++ b/internal/interview/sequence_test.go
@@ -109,6 +109,51 @@ func TestSequenceQuestionsSpecCheck(t *testing.T) {
 	}
 }
 
+// TestHostEffortsAcceptedByConfig proves hostEfforts' full per-host
+// domain — the domain validEffort (configurelocal.go) checks a typed
+// free-text effort against — never names a value internal/config
+// itself would reject for that host (issue #124 criterion 5): every
+// value materializes into a config.toml that round-trips through
+// config.Render/config.Parse cleanly.
+func TestHostEffortsAcceptedByConfig(t *testing.T) {
+	for host, efforts := range hostEfforts {
+		for _, effort := range efforts {
+			t.Run(host+"/"+effort, func(t *testing.T) {
+				answers := fullAnswers()
+				for _, rs := range roleSpecs {
+					answers[roleEffortID(host, rs.key)] = effort
+				}
+				if _, err := materialize(answers); err != nil {
+					t.Fatalf("materialize(%s effort=%s): %v", host, effort, err)
+				}
+			})
+		}
+	}
+}
+
+// TestEffortsOfferedIsSubsetOfHostEfforts proves effortsOffered stays
+// within question.SpecCheck's 2-4-option cap and never offers a value
+// hostEfforts does not itself list for that host — combined with
+// TestHostEffortsAcceptedByConfig, this closes issue #124 criterion 5
+// for every interview-offered effort option too.
+func TestEffortsOfferedIsSubsetOfHostEfforts(t *testing.T) {
+	for host := range hostEfforts {
+		offered := effortsOffered(host)
+		if len(offered) < 2 || len(offered) > 4 {
+			t.Fatalf("effortsOffered(%s) = %v, want 2-4 options", host, offered)
+		}
+		full := map[string]bool{}
+		for _, e := range hostEfforts[host] {
+			full[e] = true
+		}
+		for _, e := range offered {
+			if !full[e] {
+				t.Errorf("effortsOffered(%s) offers %q, not in hostEfforts[%s]", host, e, host)
+			}
+		}
+	}
+}
+
 func TestRoleModelOptionsExcludeFableFive(t *testing.T) {
 	for _, host := range []string{"claude", "codex"} {
 		for _, m := range hostModels[host] {

--- a/internal/interview/testdata/transcript/step_02.json
+++ b/internal/interview/testdata/transcript/step_02.json
@@ -50,6 +50,7 @@
           "recommended": true
         }
       ],
+      "free_text": true,
       "default": "xhigh"
     }
   ]

--- a/internal/interview/testdata/transcript/step_03.json
+++ b/internal/interview/testdata/transcript/step_03.json
@@ -50,6 +50,7 @@
           "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "low"
     }
   ]

--- a/internal/interview/testdata/transcript/step_04.json
+++ b/internal/interview/testdata/transcript/step_04.json
@@ -50,6 +50,7 @@
           "recommended": true
         }
       ],
+      "free_text": true,
       "default": "xhigh"
     }
   ]

--- a/internal/interview/testdata/transcript/step_05.json
+++ b/internal/interview/testdata/transcript/step_05.json
@@ -50,6 +50,7 @@
           "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript/step_06.json
+++ b/internal/interview/testdata/transcript/step_06.json
@@ -50,6 +50,7 @@
           "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript/step_07.json
+++ b/internal/interview/testdata/transcript/step_07.json
@@ -50,6 +50,7 @@
           "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript/step_08.json
+++ b/internal/interview/testdata/transcript/step_08.json
@@ -43,8 +43,13 @@
           "value": "high",
           "label": "High",
           "recommended": true
+        },
+        {
+          "value": "xhigh",
+          "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript/step_09.json
+++ b/internal/interview/testdata/transcript/step_09.json
@@ -43,8 +43,13 @@
         {
           "value": "high",
           "label": "High"
+        },
+        {
+          "value": "xhigh",
+          "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "low"
     }
   ]

--- a/internal/interview/testdata/transcript/step_10.json
+++ b/internal/interview/testdata/transcript/step_10.json
@@ -43,8 +43,13 @@
           "value": "high",
           "label": "High",
           "recommended": true
+        },
+        {
+          "value": "xhigh",
+          "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript/step_11.json
+++ b/internal/interview/testdata/transcript/step_11.json
@@ -43,8 +43,13 @@
         {
           "value": "high",
           "label": "High"
+        },
+        {
+          "value": "xhigh",
+          "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "medium"
     }
   ]

--- a/internal/interview/testdata/transcript/step_12.json
+++ b/internal/interview/testdata/transcript/step_12.json
@@ -43,8 +43,13 @@
         {
           "value": "high",
           "label": "High"
+        },
+        {
+          "value": "xhigh",
+          "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "medium"
     }
   ]

--- a/internal/interview/testdata/transcript/step_13.json
+++ b/internal/interview/testdata/transcript/step_13.json
@@ -43,8 +43,13 @@
           "value": "high",
           "label": "High",
           "recommended": true
+        },
+        {
+          "value": "xhigh",
+          "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_03.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_03.json
@@ -43,8 +43,13 @@
           "value": "high",
           "label": "High",
           "recommended": true
+        },
+        {
+          "value": "xhigh",
+          "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_04.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_04.json
@@ -43,8 +43,13 @@
         {
           "value": "high",
           "label": "High"
+        },
+        {
+          "value": "xhigh",
+          "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "low"
     }
   ]

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_05.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_05.json
@@ -43,8 +43,13 @@
           "value": "high",
           "label": "High",
           "recommended": true
+        },
+        {
+          "value": "xhigh",
+          "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_06.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_06.json
@@ -43,8 +43,13 @@
         {
           "value": "high",
           "label": "High"
+        },
+        {
+          "value": "xhigh",
+          "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "medium"
     }
   ]

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_07.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_07.json
@@ -43,8 +43,13 @@
         {
           "value": "high",
           "label": "High"
+        },
+        {
+          "value": "xhigh",
+          "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "medium"
     }
   ]

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_08.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_08.json
@@ -43,8 +43,13 @@
           "value": "high",
           "label": "High",
           "recommended": true
+        },
+        {
+          "value": "xhigh",
+          "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript_configure/merge_and_model/step_02.json
+++ b/internal/interview/testdata/transcript_configure/merge_and_model/step_02.json
@@ -49,6 +49,7 @@
           "recommended": true
         }
       ],
+      "free_text": true,
       "default": "xhigh"
     }
   ]

--- a/internal/interview/testdata/transcript_configure/merge_and_model/step_03.json
+++ b/internal/interview/testdata/transcript_configure/merge_and_model/step_03.json
@@ -50,6 +50,7 @@
           "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "low"
     }
   ]

--- a/internal/interview/testdata/transcript_configure/merge_and_model/step_04.json
+++ b/internal/interview/testdata/transcript_configure/merge_and_model/step_04.json
@@ -50,6 +50,7 @@
           "recommended": true
         }
       ],
+      "free_text": true,
       "default": "xhigh"
     }
   ]

--- a/internal/interview/testdata/transcript_configure/merge_and_model/step_05.json
+++ b/internal/interview/testdata/transcript_configure/merge_and_model/step_05.json
@@ -49,6 +49,7 @@
           "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript_configure/merge_and_model/step_06.json
+++ b/internal/interview/testdata/transcript_configure/merge_and_model/step_06.json
@@ -49,6 +49,7 @@
           "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript_configure/merge_and_model/step_07.json
+++ b/internal/interview/testdata/transcript_configure/merge_and_model/step_07.json
@@ -50,6 +50,7 @@
           "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript_local/clear_all/step_02.json
+++ b/internal/interview/testdata/transcript_local/clear_all/step_02.json
@@ -53,6 +53,7 @@
           "recommended": true
         }
       ],
+      "free_text": true,
       "default": "xhigh"
     }
   ]

--- a/internal/interview/testdata/transcript_local/clear_all/step_03.json
+++ b/internal/interview/testdata/transcript_local/clear_all/step_03.json
@@ -53,6 +53,7 @@
           "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "low"
     }
   ]

--- a/internal/interview/testdata/transcript_local/clear_all/step_04.json
+++ b/internal/interview/testdata/transcript_local/clear_all/step_04.json
@@ -53,6 +53,7 @@
           "recommended": true
         }
       ],
+      "free_text": true,
       "default": "xhigh"
     }
   ]

--- a/internal/interview/testdata/transcript_local/clear_all/step_05.json
+++ b/internal/interview/testdata/transcript_local/clear_all/step_05.json
@@ -52,6 +52,7 @@
           "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript_local/clear_all/step_06.json
+++ b/internal/interview/testdata/transcript_local/clear_all/step_06.json
@@ -52,6 +52,7 @@
           "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript_local/clear_all/step_07.json
+++ b/internal/interview/testdata/transcript_local/clear_all/step_07.json
@@ -53,6 +53,7 @@
           "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript_local/flagship/step_02.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_02.json
@@ -53,6 +53,7 @@
           "recommended": true
         }
       ],
+      "free_text": true,
       "default": "xhigh"
     }
   ]

--- a/internal/interview/testdata/transcript_local/flagship/step_03.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_03.json
@@ -53,6 +53,7 @@
           "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "low"
     }
   ]

--- a/internal/interview/testdata/transcript_local/flagship/step_04.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_04.json
@@ -53,6 +53,7 @@
           "recommended": true
         }
       ],
+      "free_text": true,
       "default": "xhigh"
     }
   ]

--- a/internal/interview/testdata/transcript_local/flagship/step_05.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_05.json
@@ -52,6 +52,7 @@
           "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript_local/flagship/step_06.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_06.json
@@ -52,6 +52,7 @@
           "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript_local/flagship/step_07.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_07.json
@@ -53,6 +53,7 @@
           "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript_local/flagship/step_08.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_08.json
@@ -43,8 +43,13 @@
           "value": "high",
           "label": "High (committed)",
           "recommended": true
+        },
+        {
+          "value": "xhigh",
+          "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript_local/flagship/step_09.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_09.json
@@ -43,8 +43,13 @@
         {
           "value": "high",
           "label": "High"
+        },
+        {
+          "value": "xhigh",
+          "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "low"
     }
   ]

--- a/internal/interview/testdata/transcript_local/flagship/step_10.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_10.json
@@ -43,8 +43,13 @@
           "value": "high",
           "label": "High (committed)",
           "recommended": true
+        },
+        {
+          "value": "xhigh",
+          "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]

--- a/internal/interview/testdata/transcript_local/flagship/step_11.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_11.json
@@ -43,8 +43,13 @@
         {
           "value": "high",
           "label": "High"
+        },
+        {
+          "value": "xhigh",
+          "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "medium"
     }
   ]

--- a/internal/interview/testdata/transcript_local/flagship/step_12.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_12.json
@@ -43,8 +43,13 @@
         {
           "value": "high",
           "label": "High"
+        },
+        {
+          "value": "xhigh",
+          "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "medium"
     }
   ]

--- a/internal/interview/testdata/transcript_local/flagship/step_13.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_13.json
@@ -43,8 +43,13 @@
           "value": "high",
           "label": "High (committed)",
           "recommended": true
+        },
+        {
+          "value": "xhigh",
+          "label": "Extra high"
         }
       ],
+      "free_text": true,
       "default": "high"
     }
   ]


### PR DESCRIPTION
Delivers issue #124: Extend per-host reasoning-effort enums with a free-text interview surface

Closes #124

**Plan digest:** `sha256:5b9fd3392c74f72b135ee20e0b45d459205bfafb8a31c10f8441529ea6b4f8ce`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** internal/config validation accepts the effort levels the host CLIs actually support - codex gains xhigh, max, and ultra (Codex CLI ReasoningEffort wire tokens, lowercase, no separators); claude gains max; none and minimal stay excluded deliberately (no orch role routes below low) - and the interview surfaces the widened domains within the 2-4 select-option cap by adopting the free-text-select pattern the model questions already use: each effort question offers at most 4 levels from its host's accepted domain and sets free_text so the remaining levels are typed, with typed values validated against the full accepted domain. Enum sites: effortsByHost and effortList in internal/config/validate.go, hostEfforts in internal/interview/sequence.go (shared by init, configure, and configure-local via effortOptions, effortOptionsLocal, and validEffort).

**Acceptance criteria:**
- internal/config accepts a codex role effort of xhigh, max, and ultra, and a claude role effort of max; it rejects minimal and none for both hosts and still rejects ultra for claude.
- The validation error text for an out-of-domain effort names the full accepted list for that host.
- Every effort question offers between 2 and 4 options, every offered option is a value internal/config accepts for that host, xhigh keeps the label 'Extra high', and the question permits free-text entry so every accepted value not offered as an option remains expressible.
- An effort value supplied via free text that internal/config would reject for that host never reaches a written config.toml or config.local.toml: it is surfaced to the human as a re-ask or a blocking validation message naming the host's accepted domain.
- A test fails if any interview-offered effort option, or any value the interview's own effort validation accepts, is not accepted by internal/config for that host.
- The existing invalid fixture asserting ultra is not a valid claude effort still passes unchanged.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-sonnet-5` — effort `xhigh` |
| Reviewer | `claude-opus-5` — effort `xhigh` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:dd23c00b6bd5` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — All 24 packages ok, including internal/config and internal/interview with the new domain-parity, subset, and free-text rejection tests. — commit `94634f44a03ea25e1d1b930940bcb6f31b641ac0` (2026-07-31T15:07:22Z)
- **go-vet** — pass — `go vet ./...` — No findings. — commit `94634f44a03ea25e1d1b930940bcb6f31b641ac0` (2026-07-31T15:07:22Z)
- **gofmt** — pass — `gofmt -l .` — No files listed. — commit `94634f44a03ea25e1d1b930940bcb6f31b641ac0` (2026-07-31T15:07:22Z)
- **go-build** — pass — `go build ./...` — Clean build, no output. — commit `94634f44a03ea25e1d1b930940bcb6f31b641ac0` (2026-07-31T15:07:22Z)
- **branch-scope: word-diff-prose-check** — pass — `git diff --word-diff --ignore-all-space -- internal/config/validate.go internal/interview/sequence.go internal/interview/configurelocal.go` — Every removal marker corresponds to an intentional value/wording change; no unintended word drops. Branch is one commit (94634f4): config enum widening + free-text-select interview surface + 44 regenerated golden transcripts. — commit `94634f44a03ea25e1d1b930940bcb6f31b641ac0` (2026-07-31T15:07:22Z)
- **review-cycle-1** — approve — All six acceptance criteria met with evidence; criterion-5 non-vacuity proven by three reverted mutations (adding ultra to claude hostEfforts, raising maxOfferedEfforts to 5, removing FreeText all fail the suite); the 2-4 option cap verified unraised; required tests reproduced green in a disposable clone and CI 6/6 pass at head; scope clean at one commit (8 source/test files + 42 regenerated golden transcripts). Non-blocking findings filed as follow-ups: README.md:317 still documents the pre-widening effort domain (out of this issue's scoped sites), and TestEffortListNamesFullAcceptedDomain's substring check cannot detect 'high' dropping from the error text (proven by mutation) - recommend token-set comparison; also a stale '#122' comment in validate_test.go:28. Cosmetic manifest discrepancies noted: '24 packages' vs actual 22 ok + 3 no-test-files, '44 transcripts' vs actual 42, and the word-diff check covered 3 of the 8 changed source files. — commit `94634f44a03ea25e1d1b930940bcb6f31b641ac0` (2026-07-31T15:18:36Z)
- **required-ci** — passing — test (windows-latest)=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (windows-latest)=pass, test (macos-latest)=pass — commit `94634f44a03ea25e1d1b930940bcb6f31b641ac0` (2026-07-31T15:18:41Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "internal/config validation accepts the effort levels the host CLIs actually support - codex gains xhigh, max, and ultra (Codex CLI ReasoningEffort wire tokens, lowercase, no separators); claude gains max; none and minimal stay excluded deliberately (no orch role routes below low) - and the interview surfaces the widened domains within the 2-4 select-option cap by adopting the free-text-select pattern the model questions already use: each effort question offers at most 4 levels from its host's accepted domain and sets free_text so the remaining levels are typed, with typed values validated against the full accepted domain. Enum sites: effortsByHost and effortList in internal/config/validate.go, hostEfforts in internal/interview/sequence.go (shared by init, configure, and configure-local via effortOptions, effortOptionsLocal, and validEffort).",
  "acceptance_criteria": [
    "internal/config accepts a codex role effort of xhigh, max, and ultra, and a claude role effort of max; it rejects minimal and none for both hosts and still rejects ultra for claude.",
    "The validation error text for an out-of-domain effort names the full accepted list for that host.",
    "Every effort question offers between 2 and 4 options, every offered option is a value internal/config accepts for that host, xhigh keeps the label 'Extra high', and the question permits free-text entry so every accepted value not offered as an option remains expressible.",
    "An effort value supplied via free text that internal/config would reject for that host never reaches a written config.toml or config.local.toml: it is surfaced to the human as a re-ask or a blocking validation message naming the host's accepted domain.",
    "A test fails if any interview-offered effort option, or any value the interview's own effort validation accepts, is not accepted by internal/config for that host.",
    "The existing invalid fixture asserting ultra is not a valid claude effort still passes unchanged."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-sonnet-5",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "xhigh"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:dd23c00b6bd5",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All 24 packages ok, including internal/config and internal/interview with the new domain-parity, subset, and free-text rejection tests.",
      "commit_oid": "94634f44a03ea25e1d1b930940bcb6f31b641ac0",
      "at": "2026-07-31T15:07:22Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "No findings.",
      "commit_oid": "94634f44a03ea25e1d1b930940bcb6f31b641ac0",
      "at": "2026-07-31T15:07:22Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No files listed.",
      "commit_oid": "94634f44a03ea25e1d1b930940bcb6f31b641ac0",
      "at": "2026-07-31T15:07:22Z"
    },
    {
      "name": "go-build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "Clean build, no output.",
      "commit_oid": "94634f44a03ea25e1d1b930940bcb6f31b641ac0",
      "at": "2026-07-31T15:07:22Z"
    },
    {
      "name": "branch-scope: word-diff-prose-check",
      "command": "git diff --word-diff --ignore-all-space -- internal/config/validate.go internal/interview/sequence.go internal/interview/configurelocal.go",
      "result": "pass",
      "detail": "Every removal marker corresponds to an intentional value/wording change; no unintended word drops. Branch is one commit (94634f4): config enum widening + free-text-select interview surface + 44 regenerated golden transcripts.",
      "commit_oid": "94634f44a03ea25e1d1b930940bcb6f31b641ac0",
      "at": "2026-07-31T15:07:22Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "All six acceptance criteria met with evidence; criterion-5 non-vacuity proven by three reverted mutations (adding ultra to claude hostEfforts, raising maxOfferedEfforts to 5, removing FreeText all fail the suite); the 2-4 option cap verified unraised; required tests reproduced green in a disposable clone and CI 6/6 pass at head; scope clean at one commit (8 source/test files + 42 regenerated golden transcripts). Non-blocking findings filed as follow-ups: README.md:317 still documents the pre-widening effort domain (out of this issue's scoped sites), and TestEffortListNamesFullAcceptedDomain's substring check cannot detect 'high' dropping from the error text (proven by mutation) - recommend token-set comparison; also a stale '#122' comment in validate_test.go:28. Cosmetic manifest discrepancies noted: '24 packages' vs actual 22 ok + 3 no-test-files, '44 transcripts' vs actual 42, and the word-diff check covered 3 of the 8 changed source files.",
      "commit_oid": "94634f44a03ea25e1d1b930940bcb6f31b641ac0",
      "at": "2026-07-31T15:18:36Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (windows-latest)=pass, test (macos-latest)=pass",
      "commit_oid": "94634f44a03ea25e1d1b930940bcb6f31b641ac0",
      "at": "2026-07-31T15:18:41Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->