### PR TITLE
Update orch configuration

### DIFF
--- a/.orchestrator/config.toml
+++ b/.orchestrator/config.toml
@@ -3,7 +3,7 @@
 # a Delivery PR.
 
 schema_version  = 1
-config_revision = "sha256:ed9116916df7"
+config_revision = "sha256:c44cf6cd007e"
 
 [concurrency]
 max_subagents = 3
@@ -43,23 +43,23 @@ effort = "medium"
 
 [hosts.codex.roles.architect]
 model  = "gpt-5.6-sol"
-effort = "high"
+effort = "xhigh"
 
 [hosts.codex.roles.scout]
-model  = "gpt-5.6-terra"
-effort = "high"
+model  = "gpt-5.6-luna"
+effort = "max"
 
 [hosts.codex.roles.implementer]
 model  = "gpt-5.6-terra"
-effort = "high"
+effort = "max"
 
 [hosts.codex.roles.specialist]
 model  = "gpt-5.6-sol"
-effort = "high"
+effort = "max"
 
 [hosts.codex.roles.reviewer]
 model  = "gpt-5.6-sol"
-effort = "high"
+effort = "xhigh"
 
 [hosts.codex.roles.review_downgrade]
 model  = "gpt-5.6-sol"


### PR DESCRIPTION
## Detection

- claude_cli: yes
- codex_cli: yes
- gh: yes
- git: yes
- git_root: C:/Users/Kninetimmy/Orch
- memhub_cli: yes
- memhub_detail: 
- memhub_healthy: yes

## Configuration

**Config revision:** `sha256:c44cf6cd007e`

```toml
# Orch configuration (PRD §17). Generated by `orch init`; change it through
# `orch configure`, not by hand — canonical configuration changes go through
# a Delivery PR.

schema_version  = 1
config_revision = "sha256:c44cf6cd007e"

[concurrency]
max_subagents = 3

[merge]
strategy = "squash"

[memhub]
mode = "best-effort"

[metrics]
enabled = true

[hosts.claude.roles.architect]
model  = "claude-fable-5"
effort = "high"

[hosts.claude.roles.scout]
model  = "claude-opus-5"
effort = "low"

[hosts.claude.roles.implementer]
model  = "claude-opus-5"
effort = "medium"

[hosts.claude.roles.specialist]
model  = "claude-opus-5"
effort = "high"

[hosts.claude.roles.reviewer]
model  = "claude-opus-5"
effort = "high"

[hosts.claude.roles.review_downgrade]
model  = "claude-opus-5"
effort = "medium"

[hosts.codex.roles.architect]
model  = "gpt-5.6-sol"
effort = "xhigh"

[hosts.codex.roles.scout]
model  = "gpt-5.6-luna"
effort = "max"

[hosts.codex.roles.implementer]
model  = "gpt-5.6-terra"
effort = "max"

[hosts.codex.roles.specialist]
model  = "gpt-5.6-sol"
effort = "max"

[hosts.codex.roles.reviewer]
model  = "gpt-5.6-sol"
effort = "xhigh"

[hosts.codex.roles.review_downgrade]
model  = "gpt-5.6-sol"
effort = "medium"
```

## Configuration diff

```diff
@@ -3,7 +3,7 @@
 # a Delivery PR.
 
 schema_version  = 1
-config_revision = "sha256:ed9116916df7"
+config_revision = "sha256:c44cf6cd007e"
 
 [concurrency]
 max_subagents = 3
@@ -43,23 +43,23 @@
 
 [hosts.codex.roles.architect]
 model  = "gpt-5.6-sol"
-effort = "high"
+effort = "xhigh"
 
 [hosts.codex.roles.scout]
-model  = "gpt-5.6-terra"
-effort = "high"
+model  = "gpt-5.6-luna"
+effort = "max"
 
 [hosts.codex.roles.implementer]
 model  = "gpt-5.6-terra"
-effort = "high"
+effort = "max"
 
 [hosts.codex.roles.specialist]
 model  = "gpt-5.6-sol"
-effort = "high"
+effort = "max"
 
 [hosts.codex.roles.reviewer]
 model  = "gpt-5.6-sol"
-effort = "high"
+effort = "xhigh"
 
 [hosts.codex.roles.review_downgrade]
 model  = "gpt-5.6-sol"
```

## Instruction files

- `CLAUDE.md` (existed: true)
- `AGENTS.md` (existed: true)

## .gitignore additions

_none_

## Validations

- config.Load: pass
- config.Revision: pass
- instructions:CLAUDE.md: pass
- instructions:AGENTS.md: pass
- gitignore: pass

Closes #128

```json
{
  "summary": {
    "config_toml": "# Orch configuration (PRD §17). Generated by `orch init`; change it through\n# `orch configure`, not by hand — canonical configuration changes go through\n# a Delivery PR.\n\nschema_version  = 1\nconfig_revision = \"sha256:c44cf6cd007e\"\n\n[concurrency]\nmax_subagents = 3\n\n[merge]\nstrategy = \"squash\"\n\n[memhub]\nmode = \"best-effort\"\n\n[metrics]\nenabled = true\n\n[hosts.claude.roles.architect]\nmodel  = \"claude-fable-5\"\neffort = \"high\"\n\n[hosts.claude.roles.scout]\nmodel  = \"claude-opus-5\"\neffort = \"low\"\n\n[hosts.claude.roles.implementer]\nmodel  = \"claude-opus-5\"\neffort = \"medium\"\n\n[hosts.claude.roles.specialist]\nmodel  = \"claude-opus-5\"\neffort = \"high\"\n\n[hosts.claude.roles.reviewer]\nmodel  = \"claude-opus-5\"\neffort = \"high\"\n\n[hosts.claude.roles.review_downgrade]\nmodel  = \"claude-opus-5\"\neffort = \"medium\"\n\n[hosts.codex.roles.architect]\nmodel  = \"gpt-5.6-sol\"\neffort = \"xhigh\"\n\n[hosts.codex.roles.scout]\nmodel  = \"gpt-5.6-luna\"\neffort = \"max\"\n\n[hosts.codex.roles.implementer]\nmodel  = \"gpt-5.6-terra\"\neffort = \"max\"\n\n[hosts.codex.roles.specialist]\nmodel  = \"gpt-5.6-sol\"\neffort = \"max\"\n\n[hosts.codex.roles.reviewer]\nmodel  = \"gpt-5.6-sol\"\neffort = \"xhigh\"\n\n[hosts.codex.roles.review_downgrade]\nmodel  = \"gpt-5.6-sol\"\neffort = \"medium\"\n",
    "config_revision": "sha256:c44cf6cd007e",
    "files": [
      {
        "path": "CLAUDE.md",
        "existed": true,
        "new_content": "# Orch\n\nA cross-host development orchestrator for the Codex CLI and Claude Code CLI.\n\n## Session Continuity\n\nmemhub is the source of truth at `.memhub/project.sqlite`. The rendered files\nunder `.memhub/rendered/` are the local human-readable view — generated from\nthe DB and gitignored by default. Re-render after `/wrap-up` with\n`memhub render`. Read PROJECT.md at session start before acting.\n\n## Build / test / run\n\nShared core is Go (module `github.com/kninetimmy/orch`, Go 1.26+).\n\n- Build:  `go build ./...`\n- Test:   `go test ./...`\n- Vet:    `go vet ./...`\n- Format: `gofmt -w .` (CI fails on unformatted files)\n- Run:    `go run ./cmd/orch status` (or `doctor`, `help`)\n\nHost adapters under `adapters/` are non-Go artifacts (not implemented yet).\n\n\u003c!-- orchestrator:managed:start version=1 --\u003e\nThis file is partially managed by Orch (see `.orchestrator/config.toml`).\n- In **Assist** mode, tracked-file changes are mechanically denied; a mutating\n  request triggers read-only planning instead.\n- In **Delivery** mode, work happens in an isolated per-issue worktree, never in\n  this checkout directly.\n- Model/effort routing, concurrency, and host plugin setup live in\n  `.orchestrator/config.toml` — edit that file, not this block.\n- Orch upgrades this block through Delivery. Do not hand-edit it; a hand edit\n  blocks the next install/upgrade until reverted or removed.\n\u003c!-- orchestrator:managed:end --\u003e"
      },
      {
        "path": "AGENTS.md",
        "existed": true,
        "new_content": "# Orch\n\nA cross-host development orchestrator for the Codex CLI and Claude Code CLI.\n\n## Session Continuity\n\nmemhub is the source of truth at `.memhub/project.sqlite`. The rendered files\nunder `.memhub/rendered/` are the local human-readable view — generated from\nthe DB and gitignored by default. Re-render after `/wrap-up` with\n`memhub render`. Read PROJECT.md at session start before acting.\n\n## Build / test / run\n\nShared core is Go (module `github.com/kninetimmy/orch`, Go 1.26+).\n\n- Build:  `go build ./...`\n- Test:   `go test ./...`\n- Vet:    `go vet ./...`\n- Format: `gofmt -w .` (CI fails on unformatted files)\n- Run:    `go run ./cmd/orch status` (or `doctor`, `help`)\n\nHost adapters under `adapters/` are non-Go artifacts (not implemented yet).\n\n\u003c!-- orchestrator:managed:start version=1 --\u003e\nThis file is partially managed by Orch (see `.orchestrator/config.toml`).\n- In **Assist** mode, tracked-file changes are mechanically denied; a mutating\n  request triggers read-only planning instead.\n- In **Delivery** mode, work happens in an isolated per-issue worktree, never in\n  this checkout directly.\n- Model/effort routing, concurrency, and host plugin setup live in\n  `.orchestrator/config.toml` — edit that file, not this block.\n- Orch upgrades this block through Delivery. Do not hand-edit it; a hand edit\n  blocks the next install/upgrade until reverted or removed.\n\u003c!-- orchestrator:managed:end --\u003e"
      }
    ],
    "config_diff": "@@ -3,7 +3,7 @@\n # a Delivery PR.\n \n schema_version  = 1\n-config_revision = \"sha256:ed9116916df7\"\n+config_revision = \"sha256:c44cf6cd007e\"\n \n [concurrency]\n max_subagents = 3\n@@ -43,23 +43,23 @@\n \n [hosts.codex.roles.architect]\n model  = \"gpt-5.6-sol\"\n-effort = \"high\"\n+effort = \"xhigh\"\n \n [hosts.codex.roles.scout]\n-model  = \"gpt-5.6-terra\"\n-effort = \"high\"\n+model  = \"gpt-5.6-luna\"\n+effort = \"max\"\n \n [hosts.codex.roles.implementer]\n model  = \"gpt-5.6-terra\"\n-effort = \"high\"\n+effort = \"max\"\n \n [hosts.codex.roles.specialist]\n model  = \"gpt-5.6-sol\"\n-effort = \"high\"\n+effort = \"max\"\n \n [hosts.codex.roles.reviewer]\n model  = \"gpt-5.6-sol\"\n-effort = \"high\"\n+effort = \"xhigh\"\n \n [hosts.codex.roles.review_downgrade]\n model  = \"gpt-5.6-sol\"\n"
  },
  "detection": {
    "claude_cli": "yes",
    "codex_cli": "yes",
    "gh": "yes",
    "git": "yes",
    "git_root": "C:/Users/Kninetimmy/Orch",
    "memhub_cli": "yes",
    "memhub_detail": "",
    "memhub_healthy": "yes"
  },
  "bootstrap_ready": true
}
```
