### PR TITLE
Refresh README allowed-effort domains and defaults-pairing prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The payoff: cheap, fast models handle read-only exploration and mechanical work,
 | Reviewer | Reviews the pull request in a separate dispatch from the one that wrote it |
 | Review downgrade | A cheaper reviewer, allowed only when the plan affirms all four of mechanical, low-risk, fully specified, unsurprising |
 
-Which role gets an issue is derived from the issue's own facts by a deterministic table, not chosen by the model that will run it. The reviewer is always a separate dispatch and never the session that wrote the code, but it is often not a different model: the shipped defaults put the specialist and the reviewer on one model, and the implementer and the downgraded reviewer on another. Any specialist run and any downgraded review therefore has the same model on both sides. For a specialist run the effort matches too, on either host; only a Claude downgrade drops it.
+Which role gets an issue is derived from the issue's own facts by a deterministic table, not chosen by the model that will run it. The reviewer is always a separate dispatch and never the session that wrote the code, but under the shipped defaults it is often not a different model: on Claude every role runs `claude-opus-5`, so both sides always match; on Codex the specialist and the reviewer share `gpt-5.6-sol` while the implementer runs `gpt-5.6-terra` and the downgraded reviewer `gpt-5.6-sol`, so a specialist run has the same model on both sides but a downgraded review pairs different ones. Effort is where the hosts diverge: a specialist run's reviewer matches the specialist's effort on Claude (high on both) but not on Codex (max executor, xhigh reviewer), and a downgraded review drops effort below the implementer's on Codex (max to high) but not on Claude (medium on both).
 
 **The guard.** None of the above is an instruction the agent is asked to honor. Both host adapters wire the CLI's pre-write hook to `orch guard`, a subcommand of the same binary, which is consulted before the agent writes a file and answers allow or deny. In Assist it denies every write to a file git does not ignore. In Delivery it allows a write only inside a worktree registered to the running plan, on that worktree's registered branch, in a phase where writing is allowed. Git internals are never writable, and neither is the orchestrator state your session is running against. It fails closed: anything it cannot establish is a denial. What it enforces is containment — it cannot tell which role is writing, and a file written by a shell command never reaches it at all (see [Known issues](#known-issues-and-limitations)).
 
@@ -314,7 +314,7 @@ local override can never weaken a shared workflow rule.
 |---|---|---|
 | `hosts.claude` / `hosts.codex` | enable a host by giving it a role table | no (committed) |
 | `hosts.<host>.roles.<role>.model` | exact model version string | yes |
-| `hosts.<host>.roles.<role>.effort` | `low` `medium` `high` (+ `xhigh` on claude) | yes |
+| `hosts.<host>.roles.<role>.effort` | `low` `medium` `high` `xhigh` `max` (+ `ultra` on codex) | yes |
 | `concurrency.max_subagents` | integer ≥ 1 (`3`) | yes |
 | `metrics.enabled` | `true` / `false` (`false` when omitted) | yes |
 | `merge.strategy` | `squash` `rebase` `merge-commit` (`squash`) | no (committed) |


### PR DESCRIPTION
Delivers issue #130: Refresh README allowed-effort domains and defaults-pairing prose

Closes #130

**Plan digest:** `sha256:93058af429354575ac239550695b59d4bf4373e418b9b8ff1e2d6b5a688c0921`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Update README.md so the configuration-reference effort row names the full widened per-host effort domains, and the 'How it decides' paragraph's claims about which default roles share models and efforts match the current section-10 default table.

**Acceptance criteria:**
- The configuration settings table row for hosts.&lt;host&gt;.roles.&lt;role&gt;.effort lists the full accepted domain per host as validated by internal/config/validate.go effortsByHost: low, medium, high, xhigh and max on both hosts, with ultra additionally accepted on codex only.
- The 'How it decides' paragraph's claims about the shipped defaults match internal/interview/sequence.go defaultProfiles: under the defaults every Claude role runs claude-opus-5; on Codex the specialist and reviewer share gpt-5.6-sol while the implementer runs gpt-5.6-terra and the downgraded reviewer gpt-5.6-sol, so a Codex downgraded review pairs different models; a default specialist run's reviewer matches the specialist's effort on Claude (high/high) but not on Codex (max executor, xhigh reviewer); and the review downgrade drops effort relative to the implementer on Codex (max to high) but not on Claude (medium on both).
- No line of README.md still states the pre-widening effort domain: a search for the old parenthetical '(+ `xhigh` on claude)' over README.md returns no matches.
- The section-10 defaults table in README.md (Role / Claude Code / Codex) is left byte-identical to its current state, which already matches defaultProfiles.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:c44cf6cd007e` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — 22 packages ok, 3 [no test files], exit 0. Includes internal/config (effortsByHost) and internal/interview (defaultProfiles verbatim assertion). — commit `4e01f0b0fdceb49d1adf4f5c68c7986fac9b8bbf` (2026-07-31T16:38:27Z)
- **gofmt-clean** — pass — `gofmt -l .` — Empty output, exit 0. — commit `4e01f0b0fdceb49d1adf4f5c68c7986fac9b8bbf` (2026-07-31T16:38:27Z)
- **stale-effort-domain-grep** — pass — ``rg '\(\+ `xhigh` on claude\)' README.md`` — No matches: the pre-widening parenthetical is gone from README.md (acceptance criterion 3). — commit `4e01f0b0fdceb49d1adf4f5c68c7986fac9b8bbf` (2026-07-31T16:38:27Z)
- **branch-scope: two-hunk-readme-only-diff** — pass — `git diff --stat fc7ae4a 4e01f0b; git log --oneline fc7ae4a..4e01f0b` — Re-verified by the reviewer at the reviewed head: README.md only, 2 insertions / 2 deletions, two hunks (lines ~57 and ~317), one commit ahead of base, README:73 untouched. — commit `4e01f0b0fdceb49d1adf4f5c68c7986fac9b8bbf` (2026-07-31T16:44:00Z)
- **reviewer-go-test-uncached** — pass — `go test -count=1 ./...` — Reviewer's own uncached run: exit 0, 22 packages ok, 3 [no test files]. gofmt -l . empty. — commit `4e01f0b0fdceb49d1adf4f5c68c7986fac9b8bbf` (2026-07-31T16:44:00Z)
- **reviewer-source-cross-read** — pass — `read internal/config/validate.go:13-21, internal/interview/sequence.go:64-98, internal/routing/decide.go:33-106` — All six prose clauses confirmed against defaultProfiles/effortsByHost/routing rows, including that a specialist run can never draw the downgraded reviewer (row order), so no clause is inverted or over-general. — commit `4e01f0b0fdceb49d1adf4f5c68c7986fac9b8bbf` (2026-07-31T16:44:00Z)
- **reviewer-section10-byte-identity** — pass — `git show fc7ae4a:README.md | sed -n '333,340p' | md5sum (vs 4e01f0b)` — Identical md5 7b84f90c94733a845ca66109b377461d on base and head: section-10 table byte-identical (criterion 4). Stale-domain grep exit 1, no matches (criterion 3). — commit `4e01f0b0fdceb49d1adf4f5c68c7986fac9b8bbf` (2026-07-31T16:44:00Z)
- **review-cycle-1** — approve — Approved on first pass. Every clause of the rewritten 'How it decides' paragraph and the widened effort row was verified against source (internal/config/validate.go effortsByHost, internal/interview/sequence.go defaultProfiles, internal/routing/decide.go) rather than against the criterion text; all four acceptance criteria met; diff confined to the two intended hunks with README:73 and the section-10 table untouched (byte-identical by md5); required tests re-run uncached and passing; 6/6 CI checks SUCCESS. Four non-blocking findings routed to backlog: 'specialist and reviewer share sol' could imply exclusivity (four codex roles run sol); line 57 is a dense ~830-char paragraph (consistent with file style); this repo's own config diverges from documented defaults in two scoped-out places (fable architect, codex downgrade medium); the effort row's parenthetical sits in a 'Values (default)' column where siblings use parentheses for defaults (pre-existing form). — commit `4e01f0b0fdceb49d1adf4f5c68c7986fac9b8bbf` (2026-07-31T16:44:01Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, test (macos-latest)=pass, test (windows-latest)=pass, scripts (windows-latest)=pass — commit `4e01f0b0fdceb49d1adf4f5c68c7986fac9b8bbf` (2026-07-31T16:44:06Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Update README.md so the configuration-reference effort row names the full widened per-host effort domains, and the 'How it decides' paragraph's claims about which default roles share models and efforts match the current section-10 default table.",
  "acceptance_criteria": [
    "The configuration settings table row for hosts.\u003chost\u003e.roles.\u003crole\u003e.effort lists the full accepted domain per host as validated by internal/config/validate.go effortsByHost: low, medium, high, xhigh and max on both hosts, with ultra additionally accepted on codex only.",
    "The 'How it decides' paragraph's claims about the shipped defaults match internal/interview/sequence.go defaultProfiles: under the defaults every Claude role runs claude-opus-5; on Codex the specialist and reviewer share gpt-5.6-sol while the implementer runs gpt-5.6-terra and the downgraded reviewer gpt-5.6-sol, so a Codex downgraded review pairs different models; a default specialist run's reviewer matches the specialist's effort on Claude (high/high) but not on Codex (max executor, xhigh reviewer); and the review downgrade drops effort relative to the implementer on Codex (max to high) but not on Claude (medium on both).",
    "No line of README.md still states the pre-widening effort domain: a search for the old parenthetical '(+ `xhigh` on claude)' over README.md returns no matches.",
    "The section-10 defaults table in README.md (Role / Claude Code / Codex) is left byte-identical to its current state, which already matches defaultProfiles."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:c44cf6cd007e",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "22 packages ok, 3 [no test files], exit 0. Includes internal/config (effortsByHost) and internal/interview (defaultProfiles verbatim assertion).",
      "commit_oid": "4e01f0b0fdceb49d1adf4f5c68c7986fac9b8bbf",
      "at": "2026-07-31T16:38:27Z"
    },
    {
      "name": "gofmt-clean",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Empty output, exit 0.",
      "commit_oid": "4e01f0b0fdceb49d1adf4f5c68c7986fac9b8bbf",
      "at": "2026-07-31T16:38:27Z"
    },
    {
      "name": "stale-effort-domain-grep",
      "command": "rg '\\(\\+ `xhigh` on claude\\)' README.md",
      "result": "pass",
      "detail": "No matches: the pre-widening parenthetical is gone from README.md (acceptance criterion 3).",
      "commit_oid": "4e01f0b0fdceb49d1adf4f5c68c7986fac9b8bbf",
      "at": "2026-07-31T16:38:27Z"
    },
    {
      "name": "branch-scope: two-hunk-readme-only-diff",
      "command": "git diff --stat fc7ae4a 4e01f0b; git log --oneline fc7ae4a..4e01f0b",
      "result": "pass",
      "detail": "Re-verified by the reviewer at the reviewed head: README.md only, 2 insertions / 2 deletions, two hunks (lines ~57 and ~317), one commit ahead of base, README:73 untouched.",
      "commit_oid": "4e01f0b0fdceb49d1adf4f5c68c7986fac9b8bbf",
      "at": "2026-07-31T16:44:00Z"
    },
    {
      "name": "reviewer-go-test-uncached",
      "command": "go test -count=1 ./...",
      "result": "pass",
      "detail": "Reviewer's own uncached run: exit 0, 22 packages ok, 3 [no test files]. gofmt -l . empty.",
      "commit_oid": "4e01f0b0fdceb49d1adf4f5c68c7986fac9b8bbf",
      "at": "2026-07-31T16:44:00Z"
    },
    {
      "name": "reviewer-source-cross-read",
      "command": "read internal/config/validate.go:13-21, internal/interview/sequence.go:64-98, internal/routing/decide.go:33-106",
      "result": "pass",
      "detail": "All six prose clauses confirmed against defaultProfiles/effortsByHost/routing rows, including that a specialist run can never draw the downgraded reviewer (row order), so no clause is inverted or over-general.",
      "commit_oid": "4e01f0b0fdceb49d1adf4f5c68c7986fac9b8bbf",
      "at": "2026-07-31T16:44:00Z"
    },
    {
      "name": "reviewer-section10-byte-identity",
      "command": "git show fc7ae4a:README.md | sed -n '333,340p' | md5sum (vs 4e01f0b)",
      "result": "pass",
      "detail": "Identical md5 7b84f90c94733a845ca66109b377461d on base and head: section-10 table byte-identical (criterion 4). Stale-domain grep exit 1, no matches (criterion 3).",
      "commit_oid": "4e01f0b0fdceb49d1adf4f5c68c7986fac9b8bbf",
      "at": "2026-07-31T16:44:00Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approved on first pass. Every clause of the rewritten 'How it decides' paragraph and the widened effort row was verified against source (internal/config/validate.go effortsByHost, internal/interview/sequence.go defaultProfiles, internal/routing/decide.go) rather than against the criterion text; all four acceptance criteria met; diff confined to the two intended hunks with README:73 and the section-10 table untouched (byte-identical by md5); required tests re-run uncached and passing; 6/6 CI checks SUCCESS. Four non-blocking findings routed to backlog: 'specialist and reviewer share sol' could imply exclusivity (four codex roles run sol); line 57 is a dense ~830-char paragraph (consistent with file style); this repo's own config diverges from documented defaults in two scoped-out places (fable architect, codex downgrade medium); the effort row's parenthetical sits in a 'Values (default)' column where siblings use parentheses for defaults (pre-existing form).",
      "commit_oid": "4e01f0b0fdceb49d1adf4f5c68c7986fac9b8bbf",
      "at": "2026-07-31T16:44:01Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, test (macos-latest)=pass, test (windows-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "4e01f0b0fdceb49d1adf4f5c68c7986fac9b8bbf",
      "at": "2026-07-31T16:44:06Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->