### PR TITLE
Report aggregate total tokens in metrics summaries

### DIFF
--- a/internal/cli/metrics.go
+++ b/internal/cli/metrics.go
@@ -254,8 +254,8 @@ func printRunSummary(w io.Writer, s runSummary) {
 	}
 
 	if s.usageEvents > 0 {
-		fmt.Fprintf(w, "usage:       input %d, output %d, cache read %d, cache creation %d, duration %dms\n",
-			s.usage.InputTokens, s.usage.OutputTokens, s.usage.CacheReadTokens, s.usage.CacheCreationTokens, s.usage.DurationMS)
+		fmt.Fprintf(w, "usage:       input %d, output %d, cache read %d, cache creation %d, total %d, duration %dms\n",
+			s.usage.InputTokens, s.usage.OutputTokens, s.usage.CacheReadTokens, s.usage.CacheCreationTokens, s.usage.TotalTokens, s.usage.DurationMS)
 		fmt.Fprintf(w, "             usage reported on %d of %d events\n", s.usageEvents, s.eventCount)
 		printUsageDetail(w, s.usageDetail)
 	}

--- a/internal/cli/metrics_test.go
+++ b/internal/cli/metrics_test.go
@@ -67,7 +67,7 @@ func TestMetricsSummarizesFixtureRun(t *testing.T) {
 	env, stdout, _ := testEnv(t)
 	writeConfig(t, env.RepoRoot, validTOML)
 
-	usage := &metrics.Usage{InputTokens: 100, OutputTokens: 40, CacheReadTokens: 5, CacheCreationTokens: 2, DurationMS: 300}
+	usage := &metrics.Usage{InputTokens: 100, OutputTokens: 40, CacheReadTokens: 5, CacheCreationTokens: 2, TotalTokens: 147, DurationMS: 300}
 	doc := metrics.Document{
 		SchemaVersion: metrics.SchemaVersion,
 		RunID:         "run-20260713T000000Z-aaaaaaaa",
@@ -96,7 +96,7 @@ func TestMetricsSummarizesFixtureRun(t *testing.T) {
 		"escalations: 0",
 		"reviews:     1 cycles; first-pass approve: 1 of 1 reviewed issues",
 		"ci:          passing: 1",
-		"usage:       input 100, output 40, cache read 5, cache creation 2, duration 300ms",
+		"usage:       input 100, output 40, cache read 5, cache creation 2, total 147, duration 300ms",
 		"usage reported on 1 of 7 events",
 	} {
 		if !strings.Contains(out, want) {


### PR DESCRIPTION
Delivers issue #134: Report aggregate total tokens in metrics summaries

Closes #134

**Plan digest:** `sha256:6b142efc42d7b99b4193be1127393e2ea80b638a12a22d0749f81ec87c2f3aad`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Include the already-accumulated total token count in each run-level usage summary without changing metrics collection or per-event reporting.

**Acceptance criteria:**
- The run-level usage line printed by orch metrics includes total &lt;N&gt; from the sum of every event's total_tokens, while preserving the existing input, output, cache-read, cache-creation, and duration values.
- A focused CLI regression test uses a nonzero total_tokens value and asserts it in the exact run-level usage summary, so per-event detail alone cannot satisfy the assertion.

**Required tests:**
- `go test ./...`
- `gofmt -l internal/cli/metrics.go internal/cli/metrics_test.go`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `gpt-5.6-terra` — effort `max` |
| Reviewer | `gpt-5.6-sol` — effort `medium` |
| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **focused-regression** — pass — `go test ./internal/cli -run '^TestMetricsSummarizesFixtureRun$' -count=1` — Focused regression passed in 0.458s. — commit `3f5d840c9cba58a3534bc0b35da232673e756486` (2026-07-31T18:52:08Z)
- **go-test-all** — pass — `go test ./...` — All packages passed in 98.8s. — commit `3f5d840c9cba58a3534bc0b35da232673e756486` (2026-07-31T18:52:08Z)
- **gofmt** — pass — `gofmt -l internal/cli/metrics.go internal/cli/metrics_test.go` — No output; both changed files are formatted. — commit `3f5d840c9cba58a3534bc0b35da232673e756486` (2026-07-31T18:52:08Z)
- **diff-check** — pass — `git diff --check` — No whitespace errors. — commit `3f5d840c9cba58a3534bc0b35da232673e756486` (2026-07-31T18:52:08Z)
- **branch-scope:changed-files** — pass — `git show --stat --oneline --summary 3f5d840c9cba58a3534bc0b35da232673e756486` — One commit; only internal/cli/metrics.go and internal/cli/metrics_test.go changed, with 4 insertions and 4 deletions. — commit `3f5d840c9cba58a3534bc0b35da232673e756486` (2026-07-31T18:57:59Z)
- **reviewer-focused-regression** — pass — `go test ./internal/cli -run '^TestMetricsSummarizesFixtureRun$' -count=1` — Independent focused test passed in 0.449s; exact run-level summary assertion is load-bearing. — commit `3f5d840c9cba58a3534bc0b35da232673e756486` (2026-07-31T18:57:59Z)
- **reviewer-go-test-all** — pass — `go test ./...` — Independent full suite passed in 99s. — commit `3f5d840c9cba58a3534bc0b35da232673e756486` (2026-07-31T18:57:59Z)
- **reviewer-gofmt** — pass — `gofmt -l internal/cli/metrics.go internal/cli/metrics_test.go` — No output. — commit `3f5d840c9cba58a3534bc0b35da232673e756486` (2026-07-31T18:57:59Z)
- **reviewer-diff-check** — pass — `git diff --check 19d0ca8fc6b7a05db8cd9ba8cc293fe5373f24ae 3f5d840c9cba58a3534bc0b35da232673e756486` — No whitespace errors. — commit `3f5d840c9cba58a3534bc0b35da232673e756486` (2026-07-31T18:57:59Z)
- **reviewer-ci** — pass — `gh pr checks 135 --repo kninetimmy/orch` — All six checks succeeded; merge state CLEAN. — commit `3f5d840c9cba58a3534bc0b35da232673e756486` (2026-07-31T18:57:59Z)
- **review-cycle-1** — approve — Approved with no findings. The run summary prints the already-aggregated TotalTokens while preserving existing usage fields; the focused nonzero-total assertion is specific to the full run-level usage line and cannot pass on per-event output. One commit changes only the two intended metrics files. Independent focused/full tests, formatting, diff checks, and all six live CI checks pass. No security boundary is affected, and the audit manifest matches the observed routing, head, scope, and verification evidence. — commit `3f5d840c9cba58a3534bc0b35da232673e756486` (2026-07-31T18:58:01Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, scripts (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (windows-latest)=pass — commit `3f5d840c9cba58a3534bc0b35da232673e756486` (2026-07-31T18:59:13Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Include the already-accumulated total token count in each run-level usage summary without changing metrics collection or per-event reporting.",
  "acceptance_criteria": [
    "The run-level usage line printed by orch metrics includes total \u003cN\u003e from the sum of every event's total_tokens, while preserving the existing input, output, cache-read, cache-creation, and duration values.",
    "A focused CLI regression test uses a nonzero total_tokens value and asserts it in the exact run-level usage summary, so per-event detail alone cannot satisfy the assertion."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l internal/cli/metrics.go internal/cli/metrics_test.go"
  ],
  "role": "implementer",
  "executor": {
    "model": "gpt-5.6-terra",
    "effort": "max"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "gpt-5.6-sol",
    "effort": "medium"
  },
  "effort_delivery": "parameter",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "focused-regression",
      "command": "go test ./internal/cli -run '^TestMetricsSummarizesFixtureRun$' -count=1",
      "result": "pass",
      "detail": "Focused regression passed in 0.458s.",
      "commit_oid": "3f5d840c9cba58a3534bc0b35da232673e756486",
      "at": "2026-07-31T18:52:08Z"
    },
    {
      "name": "go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All packages passed in 98.8s.",
      "commit_oid": "3f5d840c9cba58a3534bc0b35da232673e756486",
      "at": "2026-07-31T18:52:08Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l internal/cli/metrics.go internal/cli/metrics_test.go",
      "result": "pass",
      "detail": "No output; both changed files are formatted.",
      "commit_oid": "3f5d840c9cba58a3534bc0b35da232673e756486",
      "at": "2026-07-31T18:52:08Z"
    },
    {
      "name": "diff-check",
      "command": "git diff --check",
      "result": "pass",
      "detail": "No whitespace errors.",
      "commit_oid": "3f5d840c9cba58a3534bc0b35da232673e756486",
      "at": "2026-07-31T18:52:08Z"
    },
    {
      "name": "branch-scope:changed-files",
      "command": "git show --stat --oneline --summary 3f5d840c9cba58a3534bc0b35da232673e756486",
      "result": "pass",
      "detail": "One commit; only internal/cli/metrics.go and internal/cli/metrics_test.go changed, with 4 insertions and 4 deletions.",
      "commit_oid": "3f5d840c9cba58a3534bc0b35da232673e756486",
      "at": "2026-07-31T18:57:59Z"
    },
    {
      "name": "reviewer-focused-regression",
      "command": "go test ./internal/cli -run '^TestMetricsSummarizesFixtureRun$' -count=1",
      "result": "pass",
      "detail": "Independent focused test passed in 0.449s; exact run-level summary assertion is load-bearing.",
      "commit_oid": "3f5d840c9cba58a3534bc0b35da232673e756486",
      "at": "2026-07-31T18:57:59Z"
    },
    {
      "name": "reviewer-go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Independent full suite passed in 99s.",
      "commit_oid": "3f5d840c9cba58a3534bc0b35da232673e756486",
      "at": "2026-07-31T18:57:59Z"
    },
    {
      "name": "reviewer-gofmt",
      "command": "gofmt -l internal/cli/metrics.go internal/cli/metrics_test.go",
      "result": "pass",
      "detail": "No output.",
      "commit_oid": "3f5d840c9cba58a3534bc0b35da232673e756486",
      "at": "2026-07-31T18:57:59Z"
    },
    {
      "name": "reviewer-diff-check",
      "command": "git diff --check 19d0ca8fc6b7a05db8cd9ba8cc293fe5373f24ae 3f5d840c9cba58a3534bc0b35da232673e756486",
      "result": "pass",
      "detail": "No whitespace errors.",
      "commit_oid": "3f5d840c9cba58a3534bc0b35da232673e756486",
      "at": "2026-07-31T18:57:59Z"
    },
    {
      "name": "reviewer-ci",
      "command": "gh pr checks 135 --repo kninetimmy/orch",
      "result": "pass",
      "detail": "All six checks succeeded; merge state CLEAN.",
      "commit_oid": "3f5d840c9cba58a3534bc0b35da232673e756486",
      "at": "2026-07-31T18:57:59Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approved with no findings. The run summary prints the already-aggregated TotalTokens while preserving existing usage fields; the focused nonzero-total assertion is specific to the full run-level usage line and cannot pass on per-event output. One commit changes only the two intended metrics files. Independent focused/full tests, formatting, diff checks, and all six live CI checks pass. No security boundary is affected, and the audit manifest matches the observed routing, head, scope, and verification evidence.",
      "commit_oid": "3f5d840c9cba58a3534bc0b35da232673e756486",
      "at": "2026-07-31T18:58:01Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, scripts (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (windows-latest)=pass",
      "commit_oid": "3f5d840c9cba58a3534bc0b35da232673e756486",
      "at": "2026-07-31T18:59:13Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->