### PR TITLE
Strengthen the total-tokens regression assertion against a derived-sum implementation

### DIFF
--- a/internal/cli/metrics_test.go
+++ b/internal/cli/metrics_test.go
@@ -67,7 +67,14 @@ func TestMetricsSummarizesFixtureRun(t *testing.T) {
 	env, stdout, _ := testEnv(t)
 	writeConfig(t, env.RepoRoot, validTOML)
 
-	usage := &metrics.Usage{InputTokens: 100, OutputTokens: 40, CacheReadTokens: 5, CacheCreationTokens: 2, TotalTokens: 147, DurationMS: 300}
+	// TotalTokens is deliberately not the sum of the four split fields
+	// (metrics.Usage documents it as independent: it is what a host
+	// reporting one aggregate with no split records). Keeping it apart
+	// is what makes the run-level "total 900" assertion below a real
+	// guard — a printRunSummary that summed the split fields instead of
+	// printing the accumulated TotalTokens would print 147 and fail,
+	// which is exactly the bug #135 fixed. Do not "correct" 900 to 147.
+	usage := &metrics.Usage{InputTokens: 100, OutputTokens: 40, CacheReadTokens: 5, CacheCreationTokens: 2, TotalTokens: 900, DurationMS: 300}
 	doc := metrics.Document{
 		SchemaVersion: metrics.SchemaVersion,
 		RunID:         "run-20260713T000000Z-aaaaaaaa",
@@ -96,7 +103,7 @@ func TestMetricsSummarizesFixtureRun(t *testing.T) {
 		"escalations: 0",
 		"reviews:     1 cycles; first-pass approve: 1 of 1 reviewed issues",
 		"ci:          passing: 1",
-		"usage:       input 100, output 40, cache read 5, cache creation 2, total 147, duration 300ms",
+		"usage:       input 100, output 40, cache read 5, cache creation 2, total 900, duration 300ms",
 		"usage reported on 1 of 7 events",
 	} {
 		if !strings.Contains(out, want) {


### PR DESCRIPTION
Delivers issue #137: Strengthen the total-tokens regression assertion against a derived-sum implementation

Closes #137

**Plan digest:** `sha256:f18acf67497ee1161e6f6313b4e727e4fad72e748c9b9c6f27d4527d46043339`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Make the run-level usage assertion in TestMetricsSummarizesFixtureRun fail when total is computed from the four split token fields instead of read from Usage.TotalTokens, without changing any shipped behavior.

**Acceptance criteria:**
- In TestMetricsSummarizesFixtureRun, the usage fixture's TotalTokens is not equal to the sum of its InputTokens, OutputTokens, CacheReadTokens and CacheCreationTokens, and the run-level usage assertion in that same test asserts the fixture's TotalTokens value.
- When printRunSummary's total argument in internal/cli/metrics.go is replaced by the sum of the four split token fields, go test ./internal/cli fails; this must be confirmed against a scratch copy outside the worktree and must not be left applied.
- internal/cli/metrics.go is byte-for-byte identical to its state on the base branch, so the branch changes test files only.

**Required tests:**
- `go test ./...`
- `gofmt -l internal/cli/metrics_test.go`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `medium` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **go-test-all** — pass — `go test ./...` — All 22 packages ok, including internal/cli in 2.605s; 3 packages reported no test files. — commit `c3390155155fffdedddc61f0c0ac0dac54d392e8` (2026-07-31T19:45:01Z)
- **gofmt** — pass — `gofmt -l internal/cli/metrics_test.go` — No output, exit 0; the changed file is formatted. — commit `c3390155155fffdedddc61f0c0ac0dac54d392e8` (2026-07-31T19:45:01Z)
- **go-vet** — pass — `go vet ./internal/cli` — No output. — commit `c3390155155fffdedddc61f0c0ac0dac54d392e8` (2026-07-31T19:45:01Z)
- **mutation-discriminates-derived-sum** — pass — `go test ./internal/cli (against a scratch copy outside the repo with printRunSummary's total argument replaced by s.usage.InputTokens+s.usage.OutputTokens+s.usage.CacheReadTokens+s.usage.CacheCreationTokens)` — Acceptance criterion 2. The mutated build FAILS as required: --- FAIL: TestMetricsSummarizesFixtureRun, output missing the run-level line with total 900, actual printed total 147. Run in a scratch copy created via git archive HEAD outside the repository and worktree, then deleted; the mutation was never applied inside the repo or the worktree. This is the check the equivalent assertion on PR #135 could not make, where TotalTokens equalled the split sum and the mutated build passed. — commit `c3390155155fffdedddc61f0c0ac0dac54d392e8` (2026-07-31T19:45:01Z)
- **fixture-total-not-derivable** — pass — `git diff main..HEAD -- internal/cli/metrics_test.go` — Acceptance criterion 1. Fixture TotalTokens is 900 while InputTokens+OutputTokens+CacheReadTokens+CacheCreationTokens is 100+40+5+2=147, so the two are no longer reconcilable, and the run-level assertion asserts total 900. A comment records why the two values must stay apart. — commit `c3390155155fffdedddc61f0c0ac0dac54d392e8` (2026-07-31T19:45:01Z)
- **branch-scope:test-only-change** — pass — `git diff --stat main FETCH_HEAD && git rev-parse main:internal/cli/metrics.go FETCH_HEAD:internal/cli/metrics.go` — Acceptance criterion 3. One file changed, internal/cli/metrics_test.go, 9 insertions and 2 deletions. internal/cli/metrics.go resolves to the identical blob e3da2f2033cc94c7da29ccb10478fa32c5476a4c on both main and the branch, so no shipped behavior changed. Verified independently by the Architect from the main checkout, not only reported by the executor. — commit `c3390155155fffdedddc61f0c0ac0dac54d392e8` (2026-07-31T19:45:01Z)
- **reviewer-go-test-all** — pass — `go test ./...` — Independent full suite on the head tree: 22 packages ok, 3 with no test files, internal/cli in 2.713s. — commit `c3390155155fffdedddc61f0c0ac0dac54d392e8` (2026-07-31T19:51:02Z)
- **reviewer-gofmt-tree** — pass — `gofmt -l .` — No output over the whole tree, broader than the required per-file check. — commit `c3390155155fffdedddc61f0c0ac0dac54d392e8` (2026-07-31T19:51:02Z)
- **reviewer-go-vet** — pass — `go vet ./internal/cli` — No output. — commit `c3390155155fffdedddc61f0c0ac0dac54d392e8` (2026-07-31T19:51:02Z)
- **reviewer-mutation-discriminates** — pass — `go test ./internal/cli (derived-sum mutation applied to a scratch copy of head, outside the repo and worktree)` — Independently reproduced acceptance criterion 2. Mutated build fails: TestMetricsSummarizesFixtureRun reports output missing the run-level total 900 line, with the actual line printing total 147. Scratch trees deleted afterward; both the main checkout and the issue-137 worktree left clean at the base blob. — commit `c3390155155fffdedddc61f0c0ac0dac54d392e8` (2026-07-31T19:51:02Z)
- **reviewer-mutation-base-control** — pass — `go test ./internal/cli (same derived-sum mutation applied to a scratch copy of main)` — Control experiment confirming the premise of the issue: on main the same mutation leaves internal/cli ok, so the pre-change fixture genuinely did not discriminate. This establishes the change adds real discrimination rather than churn. — commit `c3390155155fffdedddc61f0c0ac0dac54d392e8` (2026-07-31T19:51:02Z)
- **reviewer-metrics-go-blob-identity** — pass — `git rev-parse main:internal/cli/metrics.go <branch>:internal/cli/metrics.go` — Acceptance criterion 3 verified by blob identity rather than diff summary: both resolve to e3da2f2033cc94c7da29ccb10478fa32c5476a4c, and the extracted scratch copy content-hashes to the same blob. — commit `c3390155155fffdedddc61f0c0ac0dac54d392e8` (2026-07-31T19:51:02Z)
- **reviewer-manifest-accuracy** — pass — `gh pr view 138 and comparison against observed state` — All six recorded verifications reproduce against observation. Package counts, the mutation failure output including the actual total 147 value, and the branch-scope blob claim all match. Routed selection in the manifest matches the profile actually spawned. Head OID agrees across issue, PR body, and remote branch. — commit `c3390155155fffdedddc61f0c0ac0dac54d392e8` (2026-07-31T19:51:02Z)
- **review-cycle-1** — approve — Approved. All three acceptance criteria met and independently reproduced. AC1: fixture TotalTokens is 900 against a split sum of 147, and the run-level assertion carries the aligned label prefix that the per-event detail format can never satisfy, so it is unambiguous. AC2: the reviewer rebuilt the derived-sum mutation in a scratch copy outside the repo and confirmed it fails with the actual line printing total 147; critically, it also ran the same mutation against main and confirmed the old fixture did NOT discriminate, proving the change adds real discrimination rather than churn. AC3: internal/cli/metrics.go resolves to blob e3da2f2033cc94c7da29ccb10478fa32c5476a4c on both base and head. Required tests, gofmt over the whole tree, vet, and all six CI checks pass. Scope is one test file with no drive-by edits; no security surface; the audit manifest reproduces against observation on every entry. Two low-severity backlog findings, neither blocking and neither a failure of this issue's criteria: (1) run-level accumulation of TotalTokens is still unpinned - changing the += at metrics.go:194 to = leaves the whole suite green, because no fixture has two usage-carrying events with distinct TotalTokens; (2) the total 420 assertion at metrics_test.go:146 lands on the per-event detail line but is not pinned there, since it lacks a line-distinguishing prefix. — commit `c3390155155fffdedddc61f0c0ac0dac54d392e8` (2026-07-31T19:51:03Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass, test (macos-latest)=pass, lint=pass, test (windows-latest)=pass — commit `c3390155155fffdedddc61f0c0ac0dac54d392e8` (2026-07-31T19:51:08Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Make the run-level usage assertion in TestMetricsSummarizesFixtureRun fail when total is computed from the four split token fields instead of read from Usage.TotalTokens, without changing any shipped behavior.",
  "acceptance_criteria": [
    "In TestMetricsSummarizesFixtureRun, the usage fixture's TotalTokens is not equal to the sum of its InputTokens, OutputTokens, CacheReadTokens and CacheCreationTokens, and the run-level usage assertion in that same test asserts the fixture's TotalTokens value.",
    "When printRunSummary's total argument in internal/cli/metrics.go is replaced by the sum of the four split token fields, go test ./internal/cli fails; this must be confirmed against a scratch copy outside the worktree and must not be left applied.",
    "internal/cli/metrics.go is byte-for-byte identical to its state on the base branch, so the branch changes test files only."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l internal/cli/metrics_test.go"
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All 22 packages ok, including internal/cli in 2.605s; 3 packages reported no test files.",
      "commit_oid": "c3390155155fffdedddc61f0c0ac0dac54d392e8",
      "at": "2026-07-31T19:45:01Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l internal/cli/metrics_test.go",
      "result": "pass",
      "detail": "No output, exit 0; the changed file is formatted.",
      "commit_oid": "c3390155155fffdedddc61f0c0ac0dac54d392e8",
      "at": "2026-07-31T19:45:01Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./internal/cli",
      "result": "pass",
      "detail": "No output.",
      "commit_oid": "c3390155155fffdedddc61f0c0ac0dac54d392e8",
      "at": "2026-07-31T19:45:01Z"
    },
    {
      "name": "mutation-discriminates-derived-sum",
      "command": "go test ./internal/cli (against a scratch copy outside the repo with printRunSummary's total argument replaced by s.usage.InputTokens+s.usage.OutputTokens+s.usage.CacheReadTokens+s.usage.CacheCreationTokens)",
      "result": "pass",
      "detail": "Acceptance criterion 2. The mutated build FAILS as required: --- FAIL: TestMetricsSummarizesFixtureRun, output missing the run-level line with total 900, actual printed total 147. Run in a scratch copy created via git archive HEAD outside the repository and worktree, then deleted; the mutation was never applied inside the repo or the worktree. This is the check the equivalent assertion on PR #135 could not make, where TotalTokens equalled the split sum and the mutated build passed.",
      "commit_oid": "c3390155155fffdedddc61f0c0ac0dac54d392e8",
      "at": "2026-07-31T19:45:01Z"
    },
    {
      "name": "fixture-total-not-derivable",
      "command": "git diff main..HEAD -- internal/cli/metrics_test.go",
      "result": "pass",
      "detail": "Acceptance criterion 1. Fixture TotalTokens is 900 while InputTokens+OutputTokens+CacheReadTokens+CacheCreationTokens is 100+40+5+2=147, so the two are no longer reconcilable, and the run-level assertion asserts total 900. A comment records why the two values must stay apart.",
      "commit_oid": "c3390155155fffdedddc61f0c0ac0dac54d392e8",
      "at": "2026-07-31T19:45:01Z"
    },
    {
      "name": "branch-scope:test-only-change",
      "command": "git diff --stat main FETCH_HEAD \u0026\u0026 git rev-parse main:internal/cli/metrics.go FETCH_HEAD:internal/cli/metrics.go",
      "result": "pass",
      "detail": "Acceptance criterion 3. One file changed, internal/cli/metrics_test.go, 9 insertions and 2 deletions. internal/cli/metrics.go resolves to the identical blob e3da2f2033cc94c7da29ccb10478fa32c5476a4c on both main and the branch, so no shipped behavior changed. Verified independently by the Architect from the main checkout, not only reported by the executor.",
      "commit_oid": "c3390155155fffdedddc61f0c0ac0dac54d392e8",
      "at": "2026-07-31T19:45:01Z"
    },
    {
      "name": "reviewer-go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Independent full suite on the head tree: 22 packages ok, 3 with no test files, internal/cli in 2.713s.",
      "commit_oid": "c3390155155fffdedddc61f0c0ac0dac54d392e8",
      "at": "2026-07-31T19:51:02Z"
    },
    {
      "name": "reviewer-gofmt-tree",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No output over the whole tree, broader than the required per-file check.",
      "commit_oid": "c3390155155fffdedddc61f0c0ac0dac54d392e8",
      "at": "2026-07-31T19:51:02Z"
    },
    {
      "name": "reviewer-go-vet",
      "command": "go vet ./internal/cli",
      "result": "pass",
      "detail": "No output.",
      "commit_oid": "c3390155155fffdedddc61f0c0ac0dac54d392e8",
      "at": "2026-07-31T19:51:02Z"
    },
    {
      "name": "reviewer-mutation-discriminates",
      "command": "go test ./internal/cli (derived-sum mutation applied to a scratch copy of head, outside the repo and worktree)",
      "result": "pass",
      "detail": "Independently reproduced acceptance criterion 2. Mutated build fails: TestMetricsSummarizesFixtureRun reports output missing the run-level total 900 line, with the actual line printing total 147. Scratch trees deleted afterward; both the main checkout and the issue-137 worktree left clean at the base blob.",
      "commit_oid": "c3390155155fffdedddc61f0c0ac0dac54d392e8",
      "at": "2026-07-31T19:51:02Z"
    },
    {
      "name": "reviewer-mutation-base-control",
      "command": "go test ./internal/cli (same derived-sum mutation applied to a scratch copy of main)",
      "result": "pass",
      "detail": "Control experiment confirming the premise of the issue: on main the same mutation leaves internal/cli ok, so the pre-change fixture genuinely did not discriminate. This establishes the change adds real discrimination rather than churn.",
      "commit_oid": "c3390155155fffdedddc61f0c0ac0dac54d392e8",
      "at": "2026-07-31T19:51:02Z"
    },
    {
      "name": "reviewer-metrics-go-blob-identity",
      "command": "git rev-parse main:internal/cli/metrics.go \u003cbranch\u003e:internal/cli/metrics.go",
      "result": "pass",
      "detail": "Acceptance criterion 3 verified by blob identity rather than diff summary: both resolve to e3da2f2033cc94c7da29ccb10478fa32c5476a4c, and the extracted scratch copy content-hashes to the same blob.",
      "commit_oid": "c3390155155fffdedddc61f0c0ac0dac54d392e8",
      "at": "2026-07-31T19:51:02Z"
    },
    {
      "name": "reviewer-manifest-accuracy",
      "command": "gh pr view 138 and comparison against observed state",
      "result": "pass",
      "detail": "All six recorded verifications reproduce against observation. Package counts, the mutation failure output including the actual total 147 value, and the branch-scope blob claim all match. Routed selection in the manifest matches the profile actually spawned. Head OID agrees across issue, PR body, and remote branch.",
      "commit_oid": "c3390155155fffdedddc61f0c0ac0dac54d392e8",
      "at": "2026-07-31T19:51:02Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approved. All three acceptance criteria met and independently reproduced. AC1: fixture TotalTokens is 900 against a split sum of 147, and the run-level assertion carries the aligned label prefix that the per-event detail format can never satisfy, so it is unambiguous. AC2: the reviewer rebuilt the derived-sum mutation in a scratch copy outside the repo and confirmed it fails with the actual line printing total 147; critically, it also ran the same mutation against main and confirmed the old fixture did NOT discriminate, proving the change adds real discrimination rather than churn. AC3: internal/cli/metrics.go resolves to blob e3da2f2033cc94c7da29ccb10478fa32c5476a4c on both base and head. Required tests, gofmt over the whole tree, vet, and all six CI checks pass. Scope is one test file with no drive-by edits; no security surface; the audit manifest reproduces against observation on every entry. Two low-severity backlog findings, neither blocking and neither a failure of this issue's criteria: (1) run-level accumulation of TotalTokens is still unpinned - changing the += at metrics.go:194 to = leaves the whole suite green, because no fixture has two usage-carrying events with distinct TotalTokens; (2) the total 420 assertion at metrics_test.go:146 lands on the per-event detail line but is not pinned there, since it lacks a line-distinguishing prefix.",
      "commit_oid": "c3390155155fffdedddc61f0c0ac0dac54d392e8",
      "at": "2026-07-31T19:51:03Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass, test (macos-latest)=pass, lint=pass, test (windows-latest)=pass",
      "commit_oid": "c3390155155fffdedddc61f0c0ac0dac54d392e8",
      "at": "2026-07-31T19:51:08Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->