### PR TITLE
Bump the adapter version to 0.5.9

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "kninetimmy" },
   "metadata": {
     "description": "Host adapters for the Orch development orchestrator",
-    "version": "0.5.8"
+    "version": "0.5.9"
   },
   "plugins": [
     {

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Claude Code host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -78,8 +78,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.8" {
-		t.Errorf("version = %q, want 0.5.8", m.Version)
+	if m.Version != "0.5.9" {
+		t.Errorf("version = %q, want 0.5.9", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Codex CLI host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -79,8 +79,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.8" {
-		t.Errorf("version = %q, want 0.5.8", m.Version)
+	if m.Version != "0.5.9" {
+		t.Errorf("version = %q, want 0.5.9", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")


### PR DESCRIPTION
Delivers issue #140: Bump the adapter version to 0.5.9

Closes #140

**Plan digest:** `sha256:2ac24aab76eaf5230273e2fb7c025d9951d5ca49f5f33b6ec18312b66263958b`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Make the token-accounting adapter bytes installable under a new unambiguous plugin version after the content change has merged.

**Acceptance criteria:**
- Both host plugin manifests, the shared marketplace metadata, and every exact version test pin agree on 0.5.9.
- The version-only change contains no adapter content or unrelated edits.

**Required tests:**
- `go test ./...`
- `git diff --check`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `gpt-5.6-terra` — effort `max` |
| Reviewer | `gpt-5.6-sol` — effort `medium` |
| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **go-test-all** — pass — `go test ./...` — All Go packages passed on pinned head 2ee03f5. — commit `2ee03f5ad5702b5bf2a65cc08a91685a28d7e510` (2026-07-31T22:02:11Z)
- **git-diff-check** — pass — `git diff --check origin/main...HEAD` — No whitespace errors. — commit `2ee03f5ad5702b5bf2a65cc08a91685a28d7e510` (2026-07-31T22:02:11Z)
- **branch-scope:version-surfaces-only** — pass — `git diff --name-only origin/main...HEAD and repository-wide version search` — Exactly five intended version files changed; every relevant surface and exact pin is 0.5.9 and no 0.5.8 remains. — commit `2ee03f5ad5702b5bf2a65cc08a91685a28d7e510` (2026-07-31T22:02:11Z)
- **review-cycle-1** — approve — Pinned head 2ee03f5 satisfies both criteria. The single-commit diff changes only the shared marketplace version, both host manifest versions, and both exact test pins from 0.5.8 to 0.5.9; no adapter content or unrelated files changed. Repository search found no remaining 0.5.8 version surface, all tests and six CI checks pass, the audit record is accurate, and there are no blocking or non-blocking findings. — commit `2ee03f5ad5702b5bf2a65cc08a91685a28d7e510` (2026-07-31T22:02:13Z)
- **required-ci** — passing — test (windows-latest)=pass, test (ubuntu-latest)=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass, test (macos-latest)=pass, lint=pass — commit `2ee03f5ad5702b5bf2a65cc08a91685a28d7e510` (2026-07-31T22:02:22Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Make the token-accounting adapter bytes installable under a new unambiguous plugin version after the content change has merged.",
  "acceptance_criteria": [
    "Both host plugin manifests, the shared marketplace metadata, and every exact version test pin agree on 0.5.9.",
    "The version-only change contains no adapter content or unrelated edits."
  ],
  "required_tests": [
    "go test ./...",
    "git diff --check"
  ],
  "role": "implementer",
  "executor": {
    "model": "gpt-5.6-terra",
    "effort": "max"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "gpt-5.6-sol",
    "effort": "medium"
  },
  "effort_delivery": "parameter",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All Go packages passed on pinned head 2ee03f5.",
      "commit_oid": "2ee03f5ad5702b5bf2a65cc08a91685a28d7e510",
      "at": "2026-07-31T22:02:11Z"
    },
    {
      "name": "git-diff-check",
      "command": "git diff --check origin/main...HEAD",
      "result": "pass",
      "detail": "No whitespace errors.",
      "commit_oid": "2ee03f5ad5702b5bf2a65cc08a91685a28d7e510",
      "at": "2026-07-31T22:02:11Z"
    },
    {
      "name": "branch-scope:version-surfaces-only",
      "command": "git diff --name-only origin/main...HEAD and repository-wide version search",
      "result": "pass",
      "detail": "Exactly five intended version files changed; every relevant surface and exact pin is 0.5.9 and no 0.5.8 remains.",
      "commit_oid": "2ee03f5ad5702b5bf2a65cc08a91685a28d7e510",
      "at": "2026-07-31T22:02:11Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Pinned head 2ee03f5 satisfies both criteria. The single-commit diff changes only the shared marketplace version, both host manifest versions, and both exact test pins from 0.5.8 to 0.5.9; no adapter content or unrelated files changed. Repository search found no remaining 0.5.8 version surface, all tests and six CI checks pass, the audit record is accurate, and there are no blocking or non-blocking findings.",
      "commit_oid": "2ee03f5ad5702b5bf2a65cc08a91685a28d7e510",
      "at": "2026-07-31T22:02:13Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, test (ubuntu-latest)=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass, test (macos-latest)=pass, lint=pass",
      "commit_oid": "2ee03f5ad5702b5bf2a65cc08a91685a28d7e510",
      "at": "2026-07-31T22:02:22Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->