### PR TITLE
Isolate unrelated Codex rollout corruption

### DIFF
--- a/internal/cli/hook_test.go
+++ b/internal/cli/hook_test.go
@@ -225,7 +225,7 @@ func TestHookCodexSubagentUsageReportsExactChildTotalOrDelta(t *testing.T) {
 		t.Fatal(err)
 	}
 	rollout := strings.Join([]string{
-		`{"type":"session_meta","payload":{"id":"child","session_id":"parent","parent_thread_id":"parent","thread_source":"subagent","agent_path":"/root/task","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent"}}}}}`,
+		`{"type":"session_meta","payload":{"id":"child","session_id":"parent","parent_thread_id":"parent","thread_source":"subagent","agent_path":"/root/task","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent","depth":1}}}}}`,
 		`{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"total_tokens":782763}}}}`,
 		`{"type":"event_msg","payload":{"type":"task_complete"}}`,
 	}, "\n")

--- a/internal/codexusage/capture.go
+++ b/internal/codexusage/capture.go
@@ -163,30 +163,76 @@ func rolloutTotal(path, parentThreadID, taskIdentity string) (int64, bool, bool,
 }
 
 func validSessionMeta(meta sessionMeta) bool {
-	if meta.ID == "" {
+	sourceParent, threadSpawn, valid := parseSessionSource(meta.Source)
+	if meta.ID == "" || !valid {
 		return false
 	}
-	if meta.ThreadSource != "subagent" {
-		var source string
-		return meta.ParentThreadID == "" &&
-			(meta.AgentPath == "" || meta.AgentPath == "/root") &&
-			(meta.SessionID == "" || meta.SessionID == meta.ID) &&
-			json.Unmarshal(meta.Source, &source) == nil &&
-			source != ""
+	if !threadSpawn {
+		return true
+	}
+	return meta.ThreadSource == "subagent" &&
+		meta.SessionID != "" &&
+		meta.ParentThreadID != "" &&
+		meta.AgentPath != "" &&
+		meta.ID != meta.SessionID &&
+		meta.SessionID == meta.ParentThreadID &&
+		meta.ParentThreadID == sourceParent
+}
+
+func parseSessionSource(raw json.RawMessage) (string, bool, bool) {
+	if len(raw) == 0 {
+		return "", false, true
 	}
 
-	if meta.SessionID == "" ||
-		meta.ParentThreadID == "" ||
-		meta.AgentPath == "" ||
-		meta.ID == meta.SessionID {
-		return false
+	var source any
+	if err := json.Unmarshal(raw, &source); err != nil {
+		return "", false, false
 	}
-	var source subagentSource
-	if err := json.Unmarshal(meta.Source, &source); err != nil {
-		return false
+	switch source := source.(type) {
+	case string:
+		switch source {
+		case "custom", "internal", "subagent":
+			return "", false, false
+		default:
+			return "", false, true
+		}
+	case map[string]any:
+		if len(source) != 1 {
+			return "", false, false
+		}
+		for kind, payload := range source {
+			switch kind {
+			case "custom":
+				_, valid := payload.(string)
+				return "", false, valid
+			case "internal":
+				internal, valid := payload.(string)
+				return "", false, valid && internal == "memory_consolidation"
+			case "subagent":
+				switch payload := payload.(type) {
+				case string:
+					return "", false, payload == "review" ||
+						payload == "compact" ||
+						payload == "memory_consolidation"
+				case map[string]any:
+					if len(payload) != 1 {
+						return "", false, false
+					}
+					if other, ok := payload["other"]; ok {
+						_, valid := other.(string)
+						return "", false, valid
+					}
+					spawn, ok := payload["thread_spawn"].(map[string]any)
+					if !ok {
+						return "", false, false
+					}
+					parent, valid := spawn["parent_thread_id"].(string)
+					return parent, true, valid && parent != ""
+				}
+			}
+		}
 	}
-	return meta.SessionID == meta.ParentThreadID &&
-		meta.ParentThreadID == source.Subagent.ThreadSpawn.ParentThreadID
+	return "", false, false
 }
 
 func matches(meta sessionMeta, parentThreadID, taskIdentity string) bool {

--- a/internal/codexusage/capture.go
+++ b/internal/codexusage/capture.go
@@ -86,7 +86,12 @@ type sessionMeta struct {
 type subagentSource struct {
 	Subagent struct {
 		ThreadSpawn struct {
-			ParentThreadID string `json:"parent_thread_id"`
+			ParentThreadID string  `json:"parent_thread_id"`
+			Depth          *int32  `json:"depth"`
+			AgentPath      *string `json:"agent_path"`
+			AgentNickname  *string `json:"agent_nickname"`
+			AgentRole      *string `json:"agent_role"`
+			AgentType      *string `json:"agent_type"`
 		} `json:"thread_spawn"`
 	} `json:"subagent"`
 }
@@ -226,13 +231,51 @@ func parseSessionSource(raw json.RawMessage) (string, bool, bool) {
 					if !ok {
 						return "", false, false
 					}
-					parent, valid := spawn["parent_thread_id"].(string)
-					return parent, true, valid && parent != ""
+					_, hasAgentRole := spawn["agent_role"]
+					_, hasAgentType := spawn["agent_type"]
+					if hasAgentRole && hasAgentType {
+						return "", false, false
+					}
+
+					var typed subagentSource
+					if err := json.Unmarshal(raw, &typed); err != nil {
+						return "", false, false
+					}
+					threadSpawn := typed.Subagent.ThreadSpawn
+					if threadSpawn.ParentThreadID == "" || threadSpawn.Depth == nil {
+						return "", false, false
+					}
+					if threadSpawn.AgentPath != nil && !validAgentPath(*threadSpawn.AgentPath) {
+						return "", false, false
+					}
+					return threadSpawn.ParentThreadID, true, true
 				}
 			}
 		}
 	}
 	return "", false, false
+}
+
+func validAgentPath(path string) bool {
+	if path == "/morpheus" || path == "/root" {
+		return true
+	}
+	if !strings.HasPrefix(path, "/root/") || strings.HasSuffix(path, "/") {
+		return false
+	}
+	for _, segment := range strings.Split(strings.TrimPrefix(path, "/root/"), "/") {
+		if segment == "" || segment == "root" || segment == "." || segment == ".." {
+			return false
+		}
+		for _, char := range segment {
+			if (char < 'a' || char > 'z') &&
+				(char < '0' || char > '9') &&
+				char != '_' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func matches(meta sessionMeta, parentThreadID, taskIdentity string) bool {

--- a/internal/codexusage/capture.go
+++ b/internal/codexusage/capture.go
@@ -134,7 +134,13 @@ func rolloutTotal(path, parentThreadID, taskIdentity string) (int64, bool, bool,
 			if err := json.Unmarshal(current.Payload, &meta); err != nil {
 				return 0, false, false, err
 			}
+			if !validSessionMeta(meta) {
+				return 0, false, false, errInvalidRollout
+			}
 			matched = matches(meta, parentThreadID, taskIdentity)
+			if !matched {
+				return 0, false, false, nil
+			}
 			continue
 		}
 		if matched {
@@ -145,12 +151,42 @@ func rolloutTotal(path, parentThreadID, taskIdentity string) (int64, bool, bool,
 	if err := scanner.Err(); err != nil {
 		return 0, false, false, err
 	}
+	if !seenMeta {
+		return 0, false, false, errInvalidRollout
+	}
 	if !matched {
 		return 0, false, false, nil
 	}
 
 	total, valid := finalTotal(previous, last)
 	return total, true, valid, nil
+}
+
+func validSessionMeta(meta sessionMeta) bool {
+	if meta.ID == "" {
+		return false
+	}
+	if meta.ThreadSource != "subagent" {
+		var source string
+		return meta.ParentThreadID == "" &&
+			(meta.AgentPath == "" || meta.AgentPath == "/root") &&
+			(meta.SessionID == "" || meta.SessionID == meta.ID) &&
+			json.Unmarshal(meta.Source, &source) == nil &&
+			source != ""
+	}
+
+	if meta.SessionID == "" ||
+		meta.ParentThreadID == "" ||
+		meta.AgentPath == "" ||
+		meta.ID == meta.SessionID {
+		return false
+	}
+	var source subagentSource
+	if err := json.Unmarshal(meta.Source, &source); err != nil {
+		return false
+	}
+	return meta.SessionID == meta.ParentThreadID &&
+		meta.ParentThreadID == source.Subagent.ThreadSpawn.ParentThreadID
 }
 
 func matches(meta sessionMeta, parentThreadID, taskIdentity string) bool {

--- a/internal/codexusage/capture_test.go
+++ b/internal/codexusage/capture_test.go
@@ -85,6 +85,71 @@ func TestTotalTokensIsolatesOnlyIdentifiedNonMatchingCorruption(t *testing.T) {
 	}
 }
 
+func TestTotalTokensValidatesThreadSpawnSource(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		source    string
+		available bool
+	}{
+		{
+			name:      "complete",
+			source:    `{"subagent":{"thread_spawn":{"parent_thread_id":"parent-139","depth":1,"agent_path":"/root/task","agent_nickname":"worker","agent_role":"default"}}}`,
+			available: true,
+		},
+		{
+			name:      "agent type alias",
+			source:    `{"subagent":{"thread_spawn":{"parent_thread_id":"parent-139","depth":1,"agent_type":"default"}}}`,
+			available: true,
+		},
+		{
+			name:   "missing depth",
+			source: `{"subagent":{"thread_spawn":{"parent_thread_id":"parent-139"}}}`,
+		},
+		{
+			name:   "wrong typed depth",
+			source: `{"subagent":{"thread_spawn":{"parent_thread_id":"parent-139","depth":"1"}}}`,
+		},
+		{
+			name:   "wrong typed agent path",
+			source: `{"subagent":{"thread_spawn":{"parent_thread_id":"parent-139","depth":1,"agent_path":1}}}`,
+		},
+		{
+			name:   "invalid agent path",
+			source: `{"subagent":{"thread_spawn":{"parent_thread_id":"parent-139","depth":1,"agent_path":"/root/Bad"}}}`,
+		},
+		{
+			name:   "wrong typed agent nickname",
+			source: `{"subagent":{"thread_spawn":{"parent_thread_id":"parent-139","depth":1,"agent_nickname":true}}}`,
+		},
+		{
+			name:   "wrong typed agent role",
+			source: `{"subagent":{"thread_spawn":{"parent_thread_id":"parent-139","depth":1,"agent_role":[]}}}`,
+		},
+		{
+			name:   "duplicate agent role alias",
+			source: `{"subagent":{"thread_spawn":{"parent_thread_id":"parent-139","depth":1,"agent_role":"default","agent_type":"default"}}}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			rollout := `{"type":"session_meta","payload":{"id":"child-executor","session_id":"parent-139","parent_thread_id":"parent-139","thread_source":"subagent","agent_path":"/root/issue_139_executor","source":` + tc.source + "}}\n" +
+				"{\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"total_tokens\":782763}}}}\n" +
+				"{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_complete\"}}\n"
+			if err := os.WriteFile(filepath.Join(dir, "rollout.jsonl"), []byte(rollout), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			got, ok := TotalTokens(dir, parentThread, executorTask, nil)
+			if ok != tc.available {
+				t.Fatalf("TotalTokens availability = %t, want %t", ok, tc.available)
+			}
+			if ok && got != 782763 {
+				t.Errorf("total_tokens = %d, want 782763", got)
+			}
+		})
+	}
+}
+
 func TestTotalTokensReturnsExactResumeDelta(t *testing.T) {
 	for _, tc := range []struct {
 		name     string

--- a/internal/codexusage/capture_test.go
+++ b/internal/codexusage/capture_test.go
@@ -26,6 +26,51 @@ func TestTotalTokensSelectsOnlyExactCompletedChild(t *testing.T) {
 	}
 }
 
+func TestTotalTokensIsolatesOnlyIdentifiedNonMatchingCorruption(t *testing.T) {
+	exact, err := os.ReadFile(filepath.Join(fixture(t, "exact"), "executor.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	unrelated, err := os.ReadFile(filepath.Join(fixture(t, "exact"), "sibling.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		other []byte
+		ok    bool
+	}{
+		{
+			name:  "identified unrelated rollout",
+			other: append(unrelated, []byte("this is not json\n")...),
+			ok:    true,
+		},
+		{
+			name:  "unidentified rollout",
+			other: []byte("{\"type\":\"session_meta\",\"payload\":{}}\nthis is not json\n"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "exact.jsonl"), exact, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "other.jsonl"), tc.other, 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			got, ok := TotalTokens(dir, parentThread, executorTask, nil)
+			if ok != tc.ok {
+				t.Fatalf("TotalTokens availability = %t, want %t", ok, tc.ok)
+			}
+			if ok && got != 782763 {
+				t.Errorf("total_tokens = %d, want 782763", got)
+			}
+		})
+	}
+}
+
 func TestTotalTokensReturnsExactResumeDelta(t *testing.T) {
 	for _, tc := range []struct {
 		name     string

--- a/internal/codexusage/capture_test.go
+++ b/internal/codexusage/capture_test.go
@@ -47,8 +47,22 @@ func TestTotalTokensIsolatesOnlyIdentifiedNonMatchingCorruption(t *testing.T) {
 			ok:    true,
 		},
 		{
+			name:  "object-valued unrelated source",
+			other: []byte("{\"type\":\"session_meta\",\"payload\":{\"id\":\"review\",\"session_id\":\"review\",\"thread_source\":\"subagent\",\"source\":{\"subagent\":\"review\"}}}\nthis is not json\n"),
+			ok:    true,
+		},
+		{
+			name:  "defaulted unrelated source",
+			other: []byte("{\"type\":\"session_meta\",\"payload\":{\"id\":\"root\",\"session_id\":\"root\",\"thread_source\":\"user\"}}\nthis is not json\n"),
+			ok:    true,
+		},
+		{
 			name:  "unidentified rollout",
 			other: []byte("{\"type\":\"session_meta\",\"payload\":{}}\nthis is not json\n"),
+		},
+		{
+			name:  "malformed source",
+			other: []byte("{\"type\":\"session_meta\",\"payload\":{\"id\":\"unknown\",\"session_id\":\"parent-139\",\"parent_thread_id\":\"parent-139\",\"thread_source\":\"subagent\",\"agent_path\":\"/root/issue_139_executor\",\"source\":{\"subagent\":\"not-a-variant\"}}}\nthis is not json\n"),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/codexusage/testdata/exact/different-parent.jsonl
+++ b/internal/codexusage/testdata/exact/different-parent.jsonl
@@ -1,3 +1,3 @@
-{"type":"session_meta","payload":{"id":"other-executor","session_id":"other-parent","parent_thread_id":"other-parent","thread_source":"subagent","agent_path":"/root/issue_139_executor","source":{"subagent":{"thread_spawn":{"parent_thread_id":"other-parent"}}}}}
+{"type":"session_meta","payload":{"id":"other-executor","session_id":"other-parent","parent_thread_id":"other-parent","thread_source":"subagent","agent_path":"/root/issue_139_executor","source":{"subagent":{"thread_spawn":{"parent_thread_id":"other-parent","depth":1}}}}}
 {"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"total_tokens":444444}}}}
 {"type":"event_msg","payload":{"type":"task_complete"}}

--- a/internal/codexusage/testdata/exact/executor.jsonl
+++ b/internal/codexusage/testdata/exact/executor.jsonl
@@ -1,4 +1,4 @@
-{"type":"session_meta","payload":{"id":"child-executor","session_id":"parent-139","parent_thread_id":"parent-139","thread_source":"subagent","agent_path":"/root/issue_139_executor","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-139"}}}}}
+{"type":"session_meta","payload":{"id":"child-executor","session_id":"parent-139","parent_thread_id":"parent-139","thread_source":"subagent","agent_path":"/root/issue_139_executor","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-139","depth":1}}}}}
 {"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"total_tokens":782000}}}}
 {"type":"event_msg","payload":{"type":"task_complete"}}
 {"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"total_tokens":782763}}}}

--- a/internal/codexusage/testdata/exact/sibling.jsonl
+++ b/internal/codexusage/testdata/exact/sibling.jsonl
@@ -1,3 +1,3 @@
-{"type":"session_meta","payload":{"id":"child-reviewer","session_id":"parent-139","parent_thread_id":"parent-139","thread_source":"subagent","agent_path":"/root/issue_139_reviewer","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-139"}}}}}
+{"type":"session_meta","payload":{"id":"child-reviewer","session_id":"parent-139","parent_thread_id":"parent-139","thread_source":"subagent","agent_path":"/root/issue_139_reviewer","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-139","depth":1}}}}}
 {"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"total_tokens":1036235}}}}
 {"type":"event_msg","payload":{"type":"task_complete"}}

--- a/internal/codexusage/testdata/unavailable/executor.jsonl
+++ b/internal/codexusage/testdata/unavailable/executor.jsonl
@@ -1,3 +1,3 @@
-{"type":"session_meta","payload":{"id":"child-executor","session_id":"parent-139","parent_thread_id":"parent-139","thread_source":"subagent","agent_path":"/root/issue_139_executor","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-139"}}}}}
+{"type":"session_meta","payload":{"id":"child-executor","session_id":"parent-139","parent_thread_id":"parent-139","thread_source":"subagent","agent_path":"/root/issue_139_executor","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-139","depth":1}}}}}
 {"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"total_tokens":"not-a-number"}}}}
 {"type":"event_msg","payload":{"type":"task_complete"}}


### PR DESCRIPTION
Delivers issue #143: Isolate unrelated Codex rollout corruption

Closes #143

**Plan digest:** `sha256:46f084d454a980b2bdd5b75d7e218968322f0dd48025b8327c8b0ea2ab3a885d`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Make Codex usage capture ignore records after a valid non-matching session_meta without weakening the exact unique-attribution contract for unreadable, unidentified, matching, or ambiguous rollouts.

**Acceptance criteria:**
- After rolloutTotal parses a valid session_meta that does not match the requested parent thread and task identity, it returns a non-match without parsing later records, so a malformed or truncated tail in that identified unrelated rollout cannot suppress a unique valid match.
- A rollout that cannot be opened or identified from valid metadata, a malformed matching rollout, and multiple matching rollouts continue to make usage unavailable; the implementation never returns a total when unique attribution cannot be proven.
- A runnable regression test places one exact matching rollout beside a rollout with valid non-matching session_meta followed by malformed data and proves the exact total is returned, while the existing unavailable and ambiguity coverage remains passing.
- The implementation uses the Go standard library and existing repository facilities only.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `specialist` |
| Executor | `gpt-5.6-sol` — effort `max` |
| Reviewer | `gpt-5.6-sol` — effort `xhigh` |
| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to a specialist with a strong reviewer because risk domains (concurrency, data-integrity).

**Escalations:** _none_

**Verification:**
- **go-test-all** — pass — `go test ./...` — All Go packages passed on commit 570d31d. — commit `570d31dcb78502e298e8f26ad72c31bc68548a85` (2026-07-31T23:10:46Z)
- **go-vet** — pass — `go vet ./...` — Go vet passed on commit 570d31d. — commit `570d31dcb78502e298e8f26ad72c31bc68548a85` (2026-07-31T23:10:46Z)
- **gofmt** — pass — `gofmt -l .` — No output on commit 570d31d. — commit `570d31dcb78502e298e8f26ad72c31bc68548a85` (2026-07-31T23:10:46Z)
- **git-diff-check** — pass — `git diff --check` — No whitespace errors on commit 570d31d. — commit `570d31dcb78502e298e8f26ad72c31bc68548a85` (2026-07-31T23:10:46Z)
- **review-go-test-all** — pass — `go test ./...` — All Go packages passed on approved head 5a0456c. — commit `5a0456c02951c4c4f79a60ed8f6fda4331b0836d` (2026-07-31T23:54:12Z)
- **review-go-test-focused** — pass — `go test -count=1 ./internal/codexusage ./internal/cli` — Focused Codex usage and CLI tests passed uncached on approved head 5a0456c. — commit `5a0456c02951c4c4f79a60ed8f6fda4331b0836d` (2026-07-31T23:54:12Z)
- **review-go-vet** — pass — `go vet ./...` — Go vet passed on approved head 5a0456c. — commit `5a0456c02951c4c4f79a60ed8f6fda4331b0836d` (2026-07-31T23:54:12Z)
- **review-gofmt** — pass — `gofmt -l .` — No output on approved head 5a0456c. — commit `5a0456c02951c4c4f79a60ed8f6fda4331b0836d` (2026-07-31T23:54:12Z)
- **review-git-diff-check** — pass — `git diff --check origin/main...HEAD` — No whitespace errors on approved head 5a0456c. — commit `5a0456c02951c4c4f79a60ed8f6fda4331b0836d` (2026-07-31T23:54:12Z)
- **review-cycle-1** — request-changes — Request changes: the early return and fail-closed boundary are correct for tested fixtures, but the metadata classifier rejects valid Codex 0.146 object-valued and omitted SessionSource variants. Those authoritative non-matches can still suppress an exact match, violating acceptance criterion 1. Recognize the protocol's current valid non-matching source shapes and add an object-valued regression while preserving fail-closed handling for malformed or unidentified metadata. — commit `570d31dcb78502e298e8f26ad72c31bc68548a85` (2026-07-31T23:17:47Z)
- **review-cycle-2** — request-changes — Request changes: cycle 1's SessionSource coverage gap is resolved, but matching thread_spawn metadata is accepted after validating only a non-empty parent_thread_id. Codex 0.146 requires depth and typed optional fields; the existing synthetic CLI fixture omits depth yet returns an exact total, so malformed matching metadata can violate acceptance criterion 2. Validate the complete known thread_spawn payload and add missing/wrong-typed depth regressions while updating affected fixtures. — commit `c64432685b81be21650393da5e5cf1e90f86153a` (2026-07-31T23:35:01Z)
- **review-cycle-3** — approve — Approved: PR #144 satisfies every acceptance criterion. Early return occurs only after authoritative non-matching metadata; unreadable, unidentified, malformed matching, and ambiguous rollouts remain unavailable. Both prior Codex 0.146 protocol findings are resolved: all SessionSource/SubAgentSource shapes are handled, and thread_spawn depth, typed optionals, alias conflicts, and AgentPath syntax are validated. Scope is focused, stdlib-only, tests are meaningful, and no blocking or non-blocking findings remain. — commit `5a0456c02951c4c4f79a60ed8f6fda4331b0836d` (2026-07-31T23:54:13Z)
- **required-ci** — passing — lint=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, test (windows-latest)=pass, scripts (ubuntu-latest)=pass — commit `5a0456c02951c4c4f79a60ed8f6fda4331b0836d` (2026-07-31T23:54:23Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Make Codex usage capture ignore records after a valid non-matching session_meta without weakening the exact unique-attribution contract for unreadable, unidentified, matching, or ambiguous rollouts.",
  "acceptance_criteria": [
    "After rolloutTotal parses a valid session_meta that does not match the requested parent thread and task identity, it returns a non-match without parsing later records, so a malformed or truncated tail in that identified unrelated rollout cannot suppress a unique valid match.",
    "A rollout that cannot be opened or identified from valid metadata, a malformed matching rollout, and multiple matching rollouts continue to make usage unavailable; the implementation never returns a total when unique attribution cannot be proven.",
    "A runnable regression test places one exact matching rollout beside a rollout with valid non-matching session_meta followed by malformed data and proves the exact total is returned, while the existing unavailable and ambiguity coverage remains passing.",
    "The implementation uses the Go standard library and existing repository facilities only."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "specialist",
  "executor": {
    "model": "gpt-5.6-sol",
    "effort": "max"
  },
  "routing_rationale": "Routed to a specialist with a strong reviewer because risk domains (concurrency, data-integrity).",
  "reviewer": {
    "model": "gpt-5.6-sol",
    "effort": "xhigh"
  },
  "effort_delivery": "parameter",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All Go packages passed on commit 570d31d.",
      "commit_oid": "570d31dcb78502e298e8f26ad72c31bc68548a85",
      "at": "2026-07-31T23:10:46Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Go vet passed on commit 570d31d.",
      "commit_oid": "570d31dcb78502e298e8f26ad72c31bc68548a85",
      "at": "2026-07-31T23:10:46Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No output on commit 570d31d.",
      "commit_oid": "570d31dcb78502e298e8f26ad72c31bc68548a85",
      "at": "2026-07-31T23:10:46Z"
    },
    {
      "name": "git-diff-check",
      "command": "git diff --check",
      "result": "pass",
      "detail": "No whitespace errors on commit 570d31d.",
      "commit_oid": "570d31dcb78502e298e8f26ad72c31bc68548a85",
      "at": "2026-07-31T23:10:46Z"
    },
    {
      "name": "review-go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All Go packages passed on approved head 5a0456c.",
      "commit_oid": "5a0456c02951c4c4f79a60ed8f6fda4331b0836d",
      "at": "2026-07-31T23:54:12Z"
    },
    {
      "name": "review-go-test-focused",
      "command": "go test -count=1 ./internal/codexusage ./internal/cli",
      "result": "pass",
      "detail": "Focused Codex usage and CLI tests passed uncached on approved head 5a0456c.",
      "commit_oid": "5a0456c02951c4c4f79a60ed8f6fda4331b0836d",
      "at": "2026-07-31T23:54:12Z"
    },
    {
      "name": "review-go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Go vet passed on approved head 5a0456c.",
      "commit_oid": "5a0456c02951c4c4f79a60ed8f6fda4331b0836d",
      "at": "2026-07-31T23:54:12Z"
    },
    {
      "name": "review-gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No output on approved head 5a0456c.",
      "commit_oid": "5a0456c02951c4c4f79a60ed8f6fda4331b0836d",
      "at": "2026-07-31T23:54:12Z"
    },
    {
      "name": "review-git-diff-check",
      "command": "git diff --check origin/main...HEAD",
      "result": "pass",
      "detail": "No whitespace errors on approved head 5a0456c.",
      "commit_oid": "5a0456c02951c4c4f79a60ed8f6fda4331b0836d",
      "at": "2026-07-31T23:54:12Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "Request changes: the early return and fail-closed boundary are correct for tested fixtures, but the metadata classifier rejects valid Codex 0.146 object-valued and omitted SessionSource variants. Those authoritative non-matches can still suppress an exact match, violating acceptance criterion 1. Recognize the protocol's current valid non-matching source shapes and add an object-valued regression while preserving fail-closed handling for malformed or unidentified metadata.",
      "commit_oid": "570d31dcb78502e298e8f26ad72c31bc68548a85",
      "at": "2026-07-31T23:17:47Z"
    },
    {
      "name": "review-cycle-2",
      "result": "request-changes",
      "detail": "Request changes: cycle 1's SessionSource coverage gap is resolved, but matching thread_spawn metadata is accepted after validating only a non-empty parent_thread_id. Codex 0.146 requires depth and typed optional fields; the existing synthetic CLI fixture omits depth yet returns an exact total, so malformed matching metadata can violate acceptance criterion 2. Validate the complete known thread_spawn payload and add missing/wrong-typed depth regressions while updating affected fixtures.",
      "commit_oid": "c64432685b81be21650393da5e5cf1e90f86153a",
      "at": "2026-07-31T23:35:01Z"
    },
    {
      "name": "review-cycle-3",
      "result": "approve",
      "detail": "Approved: PR #144 satisfies every acceptance criterion. Early return occurs only after authoritative non-matching metadata; unreadable, unidentified, malformed matching, and ambiguous rollouts remain unavailable. Both prior Codex 0.146 protocol findings are resolved: all SessionSource/SubAgentSource shapes are handled, and thread_spawn depth, typed optionals, alias conflicts, and AgentPath syntax are validated. Scope is focused, stdlib-only, tests are meaningful, and no blocking or non-blocking findings remain.",
      "commit_oid": "5a0456c02951c4c4f79a60ed8f6fda4331b0836d",
      "at": "2026-07-31T23:54:13Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "lint=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, test (windows-latest)=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "5a0456c02951c4c4f79a60ed8f6fda4331b0836d",
      "at": "2026-07-31T23:54:23Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->