### PR TITLE
Let a reviewer reject a wrong acceptance criterion, and stop criteria prescribing mechanisms

### DIFF
--- a/adapters/claude/agents/orch-reviewer-safe.md
+++ b/adapters/claude/agents/orch-reviewer-safe.md
@@ -36,6 +36,28 @@ review must catch. Apply the same scrutiny `orch-reviewer` would.
 - **Manifest accuracy** — does the issue/PR's audit record (routed
   selection, verifications) match what actually happened?
 
+## When a criterion is itself wrong
+
+You meet the finished code. The executor met the acceptance criteria
+before any code existed, which is exactly when a wrong criterion is
+still invisible — so the criteria are reviewable too, not a fixed
+standard you only measure against. You may return `request-changes` on
+the ground that an acceptance criterion is itself wrong: name the
+criterion, say why it is wrong, and say so plainly instead of grading
+whether the PR conforms to it. A criterion that names a function, a
+control-flow step, or a validity notion the change had to invent in
+order to satisfy the wording is the usual case. Do not redesign the
+criterion yourself, and do not approve a change you believe is wrong
+because it matches what the issue asked for — the Architect takes a
+wrong criterion back to the human.
+
+Before you request a change that adds code, establish that the added
+code needs to exist at all. "This case is unhandled" is a finding only
+once you can say what breaks without the handling; absent that, the
+missing code is the correct outcome and not a gap to fill. A request
+you have not held to that test is how review grows a change past the
+issue that asked for it.
+
 ## How you look
 
 Your `Bash` access is for **read-only** investigation only: `git diff`,

--- a/adapters/claude/agents/orch-reviewer-safe.md
+++ b/adapters/claude/agents/orch-reviewer-safe.md
@@ -77,8 +77,9 @@ or falls under some bar. Give each finding a severity and a
 confidence.
 
 Decide the verdict after the findings are listed, as a separate
-judgment: `request-changes` applies only when a finding blocks an
-acceptance criterion. A non-blocking finding stays in the report
+judgment: `request-changes` applies on exactly two grounds — a finding
+blocks an acceptance criterion, or an acceptance criterion is itself
+wrong in the sense above. A finding that is neither stays in the report
 without by itself forcing another review cycle.
 
 Produce **one consolidated report** per review cycle — do not report

--- a/adapters/claude/agents/orch-reviewer.md
+++ b/adapters/claude/agents/orch-reviewer.md
@@ -69,8 +69,9 @@ or falls under some bar. Give each finding a severity and a
 confidence.
 
 Decide the verdict after the findings are listed, as a separate
-judgment: `request-changes` applies only when a finding blocks an
-acceptance criterion. A non-blocking finding stays in the report
+judgment: `request-changes` applies on exactly two grounds — a finding
+blocks an acceptance criterion, or an acceptance criterion is itself
+wrong in the sense above. A finding that is neither stays in the report
 without by itself forcing another review cycle.
 
 Produce **one consolidated report** per review cycle — do not report

--- a/adapters/claude/agents/orch-reviewer.md
+++ b/adapters/claude/agents/orch-reviewer.md
@@ -28,6 +28,28 @@ criteria in your prompt.
 - **Manifest accuracy** — does the issue/PR's audit record (routed
   selection, verifications) match what actually happened?
 
+## When a criterion is itself wrong
+
+You meet the finished code. The executor met the acceptance criteria
+before any code existed, which is exactly when a wrong criterion is
+still invisible — so the criteria are reviewable too, not a fixed
+standard you only measure against. You may return `request-changes` on
+the ground that an acceptance criterion is itself wrong: name the
+criterion, say why it is wrong, and say so plainly instead of grading
+whether the PR conforms to it. A criterion that names a function, a
+control-flow step, or a validity notion the change had to invent in
+order to satisfy the wording is the usual case. Do not redesign the
+criterion yourself, and do not approve a change you believe is wrong
+because it matches what the issue asked for — the Architect takes a
+wrong criterion back to the human.
+
+Before you request a change that adds code, establish that the added
+code needs to exist at all. "This case is unhandled" is a finding only
+once you can say what breaks without the handling; absent that, the
+missing code is the correct outcome and not a gap to fill. A request
+you have not held to that test is how review grows a change past the
+issue that asked for it.
+
 ## How you look
 
 Your `Bash` access is for **read-only** investigation only: `git diff`,

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -317,12 +317,17 @@ func TestAgentFrontmatter(t *testing.T) {
 // are the two prose anchors the reviewer agents' "## Report" section
 // must carry: the finding stage is about coverage, not a severity
 // filter, and the approve/request-changes verdict is a separate
-// judgment that turns only on findings blocking an acceptance
-// criterion. Neither anchor includes the backtick-quoted
-// `request-changes` token itself, so a formatting change around that
-// token doesn't make this check brittle.
+// judgment turning on a closed pair of grounds. The verdict anchor
+// enumerates both grounds rather than only the blocking one (its
+// original issue #117 form): a wrong-criterion finding does not block
+// an acceptance criterion — it rejects one — so an exclusive blocking
+// rule would foreclose the very verdict the "When a criterion is
+// itself wrong" section grants, and a reviewer reading the file in
+// order would take the later rule and approve. Neither anchor includes
+// the backtick-quoted `request-changes` token itself, so a formatting
+// change around that token doesn't make this check brittle.
 const reviewerCoverageInstruction = "this stage is about coverage, not filtering"
-const reviewerBlockingVerdictInstruction = "applies only when a finding blocks an acceptance criterion"
+const reviewerBlockingVerdictInstruction = "applies on exactly two grounds — a finding blocks an acceptance criterion, or an acceptance criterion is itself wrong"
 
 // TestReviewerReportsCoverageAndBlockingVerdict checks the two reviewer
 // agent files directly by stem, not via agentRoster: agentRoster is a

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -386,6 +386,55 @@ func TestDeliverySkillHasBranchScopeVerificationGuidance(t *testing.T) {
 	adaptertest.CheckBranchScopeVerificationGuidance(t, deliverySkillPath)
 }
 
+// The three statements that keep a wrong acceptance criterion
+// reachable: the plan-construction rule that a criterion states an
+// observable outcome rather than the mechanism its author imagines,
+// the reviewer's standing to reject a criterion instead of grading
+// conformance to it, and the necessity test a reviewer must apply
+// before asking for more code. Each phrase is pinned without its
+// surrounding punctuation or em dashes, so rewording around a
+// statement stays possible while deleting the statement fails the
+// test.
+const observableOutcomeCriterionGuidance = "An acceptance criterion describes an observable outcome, and never names a function, a control-flow step, or a validity notion the change is expected to introduce"
+const reviewerWrongCriterionGuidance = "You may return `request-changes` on the ground that an acceptance criterion is itself wrong"
+const reviewerAddedCodeNecessityGuidance = "Before you request a change that adds code, establish that the added code needs to exist at all"
+
+// TestDeliverySkillAndReviewersHaveWrongCriterionGuidance checks each
+// of the three statements in the file that owns it: the first in the
+// delivery skill's PlanDoc construction guidance, the other two in both
+// reviewer agent definitions. Like
+// TestReviewerReportsCoverageAndBlockingVerdict above, the reviewer
+// files are addressed by stem rather than through agentRoster, whose
+// job is the tools/model frontmatter. Comparison runs on
+// whitespace-normalized text on both sides, so a statement the markdown
+// hard-wraps still matches.
+func TestDeliverySkillAndReviewersHaveWrongCriterionGuidance(t *testing.T) {
+	data, err := os.ReadFile(deliverySkillPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", deliverySkillPath, err)
+	}
+	skill := adaptertest.NormalizeWhitespace(string(data))
+	if !strings.Contains(skill, adaptertest.NormalizeWhitespace(observableOutcomeCriterionGuidance)) {
+		t.Errorf("%s does not contain the observable-outcome criterion guidance %q",
+			deliverySkillPath, observableOutcomeCriterionGuidance)
+	}
+	for _, stem := range []string{"orch-reviewer", "orch-reviewer-safe"} {
+		t.Run(stem, func(t *testing.T) {
+			path := filepath.Join("agents", stem+".md")
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			content := adaptertest.NormalizeWhitespace(string(data))
+			for _, phrase := range []string{reviewerWrongCriterionGuidance, reviewerAddedCodeNecessityGuidance} {
+				if !strings.Contains(content, adaptertest.NormalizeWhitespace(phrase)) {
+					t.Errorf("%s: missing reviewer guidance %q", path, phrase)
+				}
+			}
+		})
+	}
+}
+
 // frontmatterMatchRuleSentence is the exact phrase
 // orch-delivery/SKILL.md must state: Claude Code's Task tool model
 // parameter is a coarse tier-alias enum (sonnet/opus/haiku/fable), so

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -83,6 +83,14 @@ the exact command that gates the change (`go test ./...`, `gofmt -l .`);
 it is not an invitation for comprehensive coverage, just the check this
 change must pass.
 
+An acceptance criterion describes an observable outcome, and never
+names a function, a control-flow step, or a validity notion the change
+is expected to introduce. Naming one that does not exist yet hands the
+executor a design to invent in order to satisfy the wording, and every
+later review then grades how completely that invention was built rather
+than whether it needed to exist at all — state what must be true once
+the issue is done, and leave the mechanism to the executor.
+
 Plan text must never reference machine-local or gitignored paths such
 as `.memhub/`, `.orchestrator/state.json`, or
 `.orchestrator/config.local.toml` — an executor sees only the committed

--- a/adapters/codex/agents/orch-reviewer-safe.toml
+++ b/adapters/codex/agents/orch-reviewer-safe.toml
@@ -42,6 +42,28 @@ change tracked files. Your job is to judge the change, not to fix it.
 - Manifest accuracy — does the issue/PR's audit record (routed
   selection, verifications) match what actually happened?
 
+## When a criterion is itself wrong
+
+You meet the finished code. The executor met the acceptance criteria
+before any code existed, which is exactly when a wrong criterion is
+still invisible — so the criteria are reviewable too, not a fixed
+standard you only measure against. You may return `request-changes` on
+the ground that an acceptance criterion is itself wrong: name the
+criterion, say why it is wrong, and say so plainly instead of grading
+whether the PR conforms to it. A criterion that names a function, a
+control-flow step, or a validity notion the change had to invent in
+order to satisfy the wording is the usual case. Do not redesign the
+criterion yourself, and do not approve a change you believe is wrong
+because it matches what the issue asked for — the Architect takes a
+wrong criterion back to the human.
+
+Before you request a change that adds code, establish that the added
+code needs to exist at all. "This case is unhandled" is a finding only
+once you can say what breaks without the handling; absent that, the
+missing code is the correct outcome and not a gap to fill. A request
+you have not held to that test is how review grows a change past the
+issue that asked for it.
+
 ## How you look
 
 Investigate read-only: `git diff`, `git log`, `gh pr view`, `gh pr

--- a/adapters/codex/agents/orch-reviewer.toml
+++ b/adapters/codex/agents/orch-reviewer.toml
@@ -34,6 +34,28 @@ change tracked files. Your job is to judge the change, not to fix it.
 - Manifest accuracy — does the issue/PR's audit record (routed
   selection, verifications) match what actually happened?
 
+## When a criterion is itself wrong
+
+You meet the finished code. The executor met the acceptance criteria
+before any code existed, which is exactly when a wrong criterion is
+still invisible — so the criteria are reviewable too, not a fixed
+standard you only measure against. You may return `request-changes` on
+the ground that an acceptance criterion is itself wrong: name the
+criterion, say why it is wrong, and say so plainly instead of grading
+whether the PR conforms to it. A criterion that names a function, a
+control-flow step, or a validity notion the change had to invent in
+order to satisfy the wording is the usual case. Do not redesign the
+criterion yourself, and do not approve a change you believe is wrong
+because it matches what the issue asked for — the Architect takes a
+wrong criterion back to the human.
+
+Before you request a change that adds code, establish that the added
+code needs to exist at all. "This case is unhandled" is a finding only
+once you can say what breaks without the handling; absent that, the
+missing code is the correct outcome and not a gap to fill. A request
+you have not held to that test is how review grows a change past the
+issue that asked for it.
+
 ## How you look
 
 Investigate read-only: `git diff`, `git log`, `gh pr view`, `gh pr

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -283,6 +283,54 @@ func TestDeliverySkillHasBranchScopeVerificationGuidance(t *testing.T) {
 	adaptertest.CheckBranchScopeVerificationGuidance(t, deliverySkillPath)
 }
 
+// The three statements that keep a wrong acceptance criterion
+// reachable: the plan-construction rule that a criterion states an
+// observable outcome rather than the mechanism its author imagines,
+// the reviewer's standing to reject a criterion instead of grading
+// conformance to it, and the necessity test a reviewer must apply
+// before asking for more code. Each phrase is pinned without its
+// surrounding punctuation or em dashes, so rewording around a
+// statement stays possible while deleting the statement fails the
+// test.
+const observableOutcomeCriterionGuidance = "An acceptance criterion describes an observable outcome, and never names a function, a control-flow step, or a validity notion the change is expected to introduce"
+const reviewerWrongCriterionGuidance = "You may return `request-changes` on the ground that an acceptance criterion is itself wrong"
+const reviewerAddedCodeNecessityGuidance = "Before you request a change that adds code, establish that the added code needs to exist at all"
+
+// TestDeliverySkillAndReviewersHaveWrongCriterionGuidance checks each
+// of the three statements in the file that owns it: the first in the
+// delivery skill's PlanDoc construction guidance, the other two in both
+// reviewer agent definitions. The agent files are decoded as TOML
+// rather than scanned raw, so a statement only counts when it is inside
+// developer_instructions — the field the agent actually receives.
+// Comparison runs on whitespace-normalized text on both sides, so a
+// statement the prose hard-wraps still matches.
+func TestDeliverySkillAndReviewersHaveWrongCriterionGuidance(t *testing.T) {
+	data, err := os.ReadFile(deliverySkillPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", deliverySkillPath, err)
+	}
+	skill := adaptertest.NormalizeWhitespace(string(data))
+	if !strings.Contains(skill, adaptertest.NormalizeWhitespace(observableOutcomeCriterionGuidance)) {
+		t.Errorf("%s does not contain the observable-outcome criterion guidance %q",
+			deliverySkillPath, observableOutcomeCriterionGuidance)
+	}
+	for _, stem := range []string{"orch-reviewer", "orch-reviewer-safe"} {
+		t.Run(stem, func(t *testing.T) {
+			path := filepath.Join("agents", stem+".toml")
+			var a agentTOML
+			if _, err := toml.DecodeFile(path, &a); err != nil {
+				t.Fatalf("decode %s: %v", path, err)
+			}
+			content := adaptertest.NormalizeWhitespace(a.DeveloperInstructions)
+			for _, phrase := range []string{reviewerWrongCriterionGuidance, reviewerAddedCodeNecessityGuidance} {
+				if !strings.Contains(content, adaptertest.NormalizeWhitespace(phrase)) {
+					t.Errorf("%s: missing reviewer guidance %q", path, phrase)
+				}
+			}
+		})
+	}
+}
+
 // TestDeliverySkillPinsCodexChildUsageMapping keeps the adapter's optional
 // exact-usage capture scoped to the completed task that produced it: the
 // initial executor and fresh reviewer use full totals, while a resumed fix

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -83,6 +83,14 @@ the exact command that gates the change (`go test ./...`, `gofmt -l .`);
 it is not an invitation for comprehensive coverage, just the check this
 change must pass.
 
+An acceptance criterion describes an observable outcome, and never
+names a function, a control-flow step, or a validity notion the change
+is expected to introduce. Naming one that does not exist yet hands the
+executor a design to invent in order to satisfy the wording, and every
+later review then grades how completely that invention was built rather
+than whether it needed to exist at all — state what must be true once
+the issue is done, and leave the mechanism to the executor.
+
 Plan text must never reference machine-local or gitignored paths such
 as `.memhub/`, `.orchestrator/state.json`, or
 `.orchestrator/config.local.toml` — an executor sees only the committed


### PR DESCRIPTION
Delivers issue #146: Let a reviewer reject a wrong acceptance criterion, and stop criteria prescribing mechanisms

Closes #146

**Plan digest:** `sha256:6bc7e7c9989ad5176362837aa91396aa1d5283b5bee5ae669ab54a8aa4351829`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Three review cycles on issue #143 each confirmed the change matched its acceptance criteria while those criteria specified the wrong behavior, and the resulting defect merged as 8e09458. Two structural gaps made that outcome unreachable by review. First, that issue's acceptance criterion 1 named a function, its control flow, and a validity notion that did not exist in the codebase yet, so the executor had to invent a metadata classifier to satisfy the wording and every later cycle graded that classifier's completeness rather than its necessity: it grew from about 27 lines in the first commit to about 110 lines in the merged result, entirely at reviewer request across two request-changes cycles. Second, orch-reviewer and orch-reviewer-safe on both hosts are told to check whether the PR satisfies every criterion the issue listed, and are given no way to say a criterion is wrong. orch-specialist already carries that escape hatch, but the executor meets the contract before any code exists, while the reviewer meets the finished code, which is exactly when a bad contract becomes visible. Third, and closely related, a reviewer requesting added code today applies no test of whether that code should exist at all. Close all three gaps in the committed adapter sources for both hosts. These files are the source for the installed plugins rather than the live copies, so the change takes effect only after the next release and plugin install.

**Acceptance criteria:**
- The plan-construction guidance in both adapters/claude/skills/orch-delivery/SKILL.md and adapters/codex/skills/orch-delivery/SKILL.md states that an acceptance criterion describes an observable outcome and never names a function, a control-flow step, or a validity notion the change is expected to introduce.
- Each of adapters/claude/agents/orch-reviewer.md, adapters/claude/agents/orch-reviewer-safe.md, adapters/codex/agents/orch-reviewer.toml and adapters/codex/agents/orch-reviewer-safe.toml states that a reviewer may return request-changes on the ground that an acceptance criterion is itself wrong, naming the criterion and the reason, instead of grading conformance to it.
- Each of the four reviewer definitions named above states that before requesting a change that adds code, the reviewer must first establish that the added code needs to exist at all.
- A test in each of adapters/claude and adapters/codex fails if any of the three guidance statements above is removed from the file it belongs to, following the existing TestDeliverySkillHas naming and assertion pattern in those packages.
- No file outside adapters/claude/ and adapters/codex/ changes.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.

**Escalations:** _none_

**Verification:**
- **go-test-all** — pass — `go test ./...` — All packages pass on head f84f495, re-run in a scratch clone outside the repository. — commit `f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1` (2026-08-01T01:03:01Z)
- **gofmt** — pass — `gofmt -l .` — No output on head f84f495. — commit `f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1` (2026-08-01T01:03:01Z)
- **branch-scope: files changed vs main** — pass — `git diff --name-only main...HEAD` — Resubmitted at head f84f495: 8 files, all under adapters/claude/ or adapters/codex/; the cycle-2 fix added no new file. Supersedes the entry stamped at the now-superseded commit 049ae86. — commit `f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1` (2026-08-01T01:03:01Z)
- **prose-reflow-check** — pass — `git diff --word-diff --ignore-all-space main...HEAD -- adapters/claude/skills/orch-delivery/SKILL.md adapters/codex/skills/orch-delivery/SKILL.md adapters/claude/agents adapters/codex/agents` — Zero [-word-] removal markers on commit 049ae86. All six prose edits are pure insertions of whole paragraphs or sections; no existing paragraph was rewrapped. — commit `049ae8659b97baaec15e292583d2f0610622e92f` (2026-08-01T00:40:45Z)
- **guidance-statement-mutation-check** — pass — `per-site loop deleting the whole blank-line-delimited paragraph containing each statement, asserting the paragraph is gone, running the full adapter package test, then git checkout --` — Corrected and re-stamped at head f84f495: 12 of 12 sites caught at whole-paragraph granularity, zero NOT-CAUGHT. Supersedes the pr-open entry, which reported 10 sites and did not disclose that it used the weaker single-line deletion. — commit `f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1` (2026-08-01T01:03:01Z)
- **review-go-test-all** — pass — `go test ./...` — All packages pass on reviewed head 049ae86, re-run in a scratch clone outside the repository. — commit `049ae8659b97baaec15e292583d2f0610622e92f` (2026-08-01T00:50:39Z)
- **review-go-build** — pass — `go build ./...` — Clean on reviewed head 049ae86. — commit `049ae8659b97baaec15e292583d2f0610622e92f` (2026-08-01T00:50:39Z)
- **review-go-vet** — pass — `go vet ./...` — Clean on reviewed head 049ae86. — commit `049ae8659b97baaec15e292583d2f0610622e92f` (2026-08-01T00:50:39Z)
- **review-gofmt** — pass — `gofmt -l .` — No output on reviewed head 049ae86. — commit `049ae8659b97baaec15e292583d2f0610622e92f` (2026-08-01T00:50:39Z)
- **review-guidance-mutation-loop** — pass — `delete each guidance paragraph from each owning file, then run the new pinning test per adapter package` — Reviewer independently reproduced all 10 sites caught on reviewed head 049ae86, confirming acceptance criterion 4. — commit `049ae8659b97baaec15e292583d2f0610622e92f` (2026-08-01T00:50:39Z)
- **review-verdict-rule-conflict** — fail — `grep -n "applies only when a finding blocks" adapters/claude/agents/orch-reviewer.md adapters/claude/agents/orch-reviewer-safe.md adapters/claude/plugin_test.go` — The exclusive-verdict rule exists at orch-reviewer.md line 50 and orch-reviewer-safe.md line 58 and is pinned at plugin_test.go line 325, contradicting the grant this PR adds to the same two files. This is the blocking finding. The Codex definitions do not carry the rule. — commit `049ae8659b97baaec15e292583d2f0610622e92f` (2026-08-01T00:50:39Z)
- **review-cycle-1** — request-changes — Request changes on one blocking finding. Criteria 1, 3, 4 and 5 are met and independently reproduced, including a 10-site paragraph-deletion mutation loop where all 10 sites were caught. Criterion 2 is not effectively met on the Claude host: the new section grants the reviewer the request-changes verdict when an acceptance criterion is itself wrong, but the section later in the same file that decides verdicts states that request-changes applies only when a finding blocks an acceptance criterion. A wrong-criterion finding does not block a criterion by the new text own definition, so under the exclusive rule a reviewer files it as non-blocking and approves, which is exactly the issue 143 failure mode this issue exists to prevent. Both statements are now test-locked in opposition: plugin_test.go pins the exclusive rule from issue 117 and this PR pins the contradicting grant. Verified against main at adapters/claude/agents/orch-reviewer.md line 50, orch-reviewer-safe.md line 58 and adapters/claude/plugin_test.go line 325. The Codex definitions carry no exclusive-verdict rule and are sound, so the defect is confined to the host this repository routes to. The wording itself is correct and does not collapse into the weaker report-the-ambiguity clause orch-specialist already has. Six non-blocking findings recorded: the criterion-wrong verdict has no defined destination in the orchestration skill, since request-changes loops the same executor back to re-satisfy the same wrong criterion and nothing routes it to escalate, which the reviewer recommends as a follow-up issue rather than folding into this fix; the Claude test reads the raw markdown while the Codex test decodes TOML and only counts text inside developer_instructions, the Codex approach being stronger; the pinned phrases cover the leading clause of each statement rather than the whole statement; a manifest nit that the mutation-check detail does not state deletion granularity; the test name deviating from the TestDeliverySkillHas prefix, judged reasonable; and the plugin version not being bumped, consistent with the objective. Security: nothing, prose and test only. Scope clean at 8 files all under the two adapter directories. — commit `049ae8659b97baaec15e292583d2f0610622e92f` (2026-08-01T00:50:40Z)
- **review-verdict-rule-reconciled** — pass — `read the When a criterion is itself wrong and Report sections in all four reviewer definitions and compare their line numbers` — The grant precedes the verdict rule in all four files (31/63, 39/71, 37/67, 45/75) and the two now give the same answer on the same input. The in the sense above referent is unambiguous. — commit `f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1` (2026-08-01T01:03:01Z)
- **review-issue-117-protection-intact** — pass — `read commit 985efe2 rationale and compare against the reworded rule` — Both of issue 117 intents survive: the coverage-only finding stage anchor is untouched, and a finding on neither ground still does not force a review cycle. The widening is exactly the one ground criterion 2 mandates. — commit `f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1` (2026-08-01T01:03:01Z)
- **review-anchor-pins-both-grounds** — pass — `probe the modified reviewerBlockingVerdictInstruction against TestReviewerReportsCoverageAndBlockingVerdict by reverting to the exclusive wording, then by dropping the blocking ground` — Both probes caught, confirming each ground is individually load-bearing in the anchor. — commit `f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1` (2026-08-01T01:03:01Z)
- **review-codex-definitions-untouched** — pass — `git show --stat f84f495` — Exactly three files, all under adapters/claude/. The Codex reviewer definitions are byte-identical to cycle 1 and carry no exclusive-verdict rule. — commit `f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1` (2026-08-01T01:03:01Z)
- **review-cycle-2** — approve — Approved at head f84f495. The cycle 1 blocker is closed on its merits and verified independently rather than inherited. Ordering and referent check out: the When a criterion is itself wrong section precedes Report in all four reviewer definitions, at lines 31 vs 63, 39 vs 71, 37 vs 67 and 45 vs 75, and the phrase in the sense above has exactly one candidate referent because the section heading and body both use the literal phrase an acceptance criterion is itself wrong. Issue 117 protection was checked against commit 985efe2 rationale rather than the executor claim: 117 had two intents, a coverage-only finding stage whose anchor is untouched here, and keeping non-blocking findings out of the review-cycle count, which the reword preserves verbatim in effect. The widening is exactly the one ground criterion 2 mandates. The modified anchor was probed two ways against TestReviewerReportsCoverageAndBlockingVerdict, reverting to the exclusive 117 wording and dropping the blocking ground while keeping only wrong-criterion, and both were caught, so both grounds are load-bearing. Codex definitions confirmed untouched: the fix commit lists exactly three files, all under adapters/claude/. The executor disclosed self-correction was independently reproduced: 12 of 12 sites caught at whole-paragraph granularity, zero NOT-CAUGHT, tree clean afterwards. All five acceptance criteria met, all six CI checks pass, scope exactly the two adapter directories. The reviewer explicitly judged no acceptance criterion wrong, noting criterion 4 names an existing pattern already in the tree rather than a mechanism the change had to invent. Eight findings, all non-blocking, and the reviewer deliberately declined to convert three of them into change requests on the ground that the added prose or test would not clear the necessity test this PR itself introduces. Recorded: the delivery skill now states the mechanism-prescription rule twice, as a new absolute near an older weaker preference clause about 25 lines apart; the in the sense above cross-reference is pinned by no test so a future section reorder would dangle it silently; terminology drift between the reviewer files residual category and the delivery skill non-blocking wording, the same seam as the routing gap already carried as a follow-up; and request-changes remaining a closed enumeration that excludes a severe defect touching no acceptance criterion, which is pre-existing and out of scope but named as the kind of thing this stage should surface. Security: nothing, prose and test files only. — commit `f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1` (2026-08-01T01:03:02Z)
- **required-ci** — passing — scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (windows-latest)=pass — commit `f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1` (2026-08-01T01:03:06Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Three review cycles on issue #143 each confirmed the change matched its acceptance criteria while those criteria specified the wrong behavior, and the resulting defect merged as 8e09458. Two structural gaps made that outcome unreachable by review. First, that issue's acceptance criterion 1 named a function, its control flow, and a validity notion that did not exist in the codebase yet, so the executor had to invent a metadata classifier to satisfy the wording and every later cycle graded that classifier's completeness rather than its necessity: it grew from about 27 lines in the first commit to about 110 lines in the merged result, entirely at reviewer request across two request-changes cycles. Second, orch-reviewer and orch-reviewer-safe on both hosts are told to check whether the PR satisfies every criterion the issue listed, and are given no way to say a criterion is wrong. orch-specialist already carries that escape hatch, but the executor meets the contract before any code exists, while the reviewer meets the finished code, which is exactly when a bad contract becomes visible. Third, and closely related, a reviewer requesting added code today applies no test of whether that code should exist at all. Close all three gaps in the committed adapter sources for both hosts. These files are the source for the installed plugins rather than the live copies, so the change takes effect only after the next release and plugin install.",
  "acceptance_criteria": [
    "The plan-construction guidance in both adapters/claude/skills/orch-delivery/SKILL.md and adapters/codex/skills/orch-delivery/SKILL.md states that an acceptance criterion describes an observable outcome and never names a function, a control-flow step, or a validity notion the change is expected to introduce.",
    "Each of adapters/claude/agents/orch-reviewer.md, adapters/claude/agents/orch-reviewer-safe.md, adapters/codex/agents/orch-reviewer.toml and adapters/codex/agents/orch-reviewer-safe.toml states that a reviewer may return request-changes on the ground that an acceptance criterion is itself wrong, naming the criterion and the reason, instead of grading conformance to it.",
    "Each of the four reviewer definitions named above states that before requesting a change that adds code, the reviewer must first establish that the added code needs to exist at all.",
    "A test in each of adapters/claude and adapters/codex fails if any of the three guidance statements above is removed from the file it belongs to, following the existing TestDeliverySkillHas naming and assertion pattern in those packages.",
    "No file outside adapters/claude/ and adapters/codex/ changes."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All packages pass on head f84f495, re-run in a scratch clone outside the repository.",
      "commit_oid": "f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1",
      "at": "2026-08-01T01:03:01Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No output on head f84f495.",
      "commit_oid": "f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1",
      "at": "2026-08-01T01:03:01Z"
    },
    {
      "name": "branch-scope: files changed vs main",
      "command": "git diff --name-only main...HEAD",
      "result": "pass",
      "detail": "Resubmitted at head f84f495: 8 files, all under adapters/claude/ or adapters/codex/; the cycle-2 fix added no new file. Supersedes the entry stamped at the now-superseded commit 049ae86.",
      "commit_oid": "f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1",
      "at": "2026-08-01T01:03:01Z"
    },
    {
      "name": "prose-reflow-check",
      "command": "git diff --word-diff --ignore-all-space main...HEAD -- adapters/claude/skills/orch-delivery/SKILL.md adapters/codex/skills/orch-delivery/SKILL.md adapters/claude/agents adapters/codex/agents",
      "result": "pass",
      "detail": "Zero [-word-] removal markers on commit 049ae86. All six prose edits are pure insertions of whole paragraphs or sections; no existing paragraph was rewrapped.",
      "commit_oid": "049ae8659b97baaec15e292583d2f0610622e92f",
      "at": "2026-08-01T00:40:45Z"
    },
    {
      "name": "guidance-statement-mutation-check",
      "command": "per-site loop deleting the whole blank-line-delimited paragraph containing each statement, asserting the paragraph is gone, running the full adapter package test, then git checkout --",
      "result": "pass",
      "detail": "Corrected and re-stamped at head f84f495: 12 of 12 sites caught at whole-paragraph granularity, zero NOT-CAUGHT. Supersedes the pr-open entry, which reported 10 sites and did not disclose that it used the weaker single-line deletion.",
      "commit_oid": "f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1",
      "at": "2026-08-01T01:03:01Z"
    },
    {
      "name": "review-go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All packages pass on reviewed head 049ae86, re-run in a scratch clone outside the repository.",
      "commit_oid": "049ae8659b97baaec15e292583d2f0610622e92f",
      "at": "2026-08-01T00:50:39Z"
    },
    {
      "name": "review-go-build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "Clean on reviewed head 049ae86.",
      "commit_oid": "049ae8659b97baaec15e292583d2f0610622e92f",
      "at": "2026-08-01T00:50:39Z"
    },
    {
      "name": "review-go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Clean on reviewed head 049ae86.",
      "commit_oid": "049ae8659b97baaec15e292583d2f0610622e92f",
      "at": "2026-08-01T00:50:39Z"
    },
    {
      "name": "review-gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No output on reviewed head 049ae86.",
      "commit_oid": "049ae8659b97baaec15e292583d2f0610622e92f",
      "at": "2026-08-01T00:50:39Z"
    },
    {
      "name": "review-guidance-mutation-loop",
      "command": "delete each guidance paragraph from each owning file, then run the new pinning test per adapter package",
      "result": "pass",
      "detail": "Reviewer independently reproduced all 10 sites caught on reviewed head 049ae86, confirming acceptance criterion 4.",
      "commit_oid": "049ae8659b97baaec15e292583d2f0610622e92f",
      "at": "2026-08-01T00:50:39Z"
    },
    {
      "name": "review-verdict-rule-conflict",
      "command": "grep -n \"applies only when a finding blocks\" adapters/claude/agents/orch-reviewer.md adapters/claude/agents/orch-reviewer-safe.md adapters/claude/plugin_test.go",
      "result": "fail",
      "detail": "The exclusive-verdict rule exists at orch-reviewer.md line 50 and orch-reviewer-safe.md line 58 and is pinned at plugin_test.go line 325, contradicting the grant this PR adds to the same two files. This is the blocking finding. The Codex definitions do not carry the rule.",
      "commit_oid": "049ae8659b97baaec15e292583d2f0610622e92f",
      "at": "2026-08-01T00:50:39Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "Request changes on one blocking finding. Criteria 1, 3, 4 and 5 are met and independently reproduced, including a 10-site paragraph-deletion mutation loop where all 10 sites were caught. Criterion 2 is not effectively met on the Claude host: the new section grants the reviewer the request-changes verdict when an acceptance criterion is itself wrong, but the section later in the same file that decides verdicts states that request-changes applies only when a finding blocks an acceptance criterion. A wrong-criterion finding does not block a criterion by the new text own definition, so under the exclusive rule a reviewer files it as non-blocking and approves, which is exactly the issue 143 failure mode this issue exists to prevent. Both statements are now test-locked in opposition: plugin_test.go pins the exclusive rule from issue 117 and this PR pins the contradicting grant. Verified against main at adapters/claude/agents/orch-reviewer.md line 50, orch-reviewer-safe.md line 58 and adapters/claude/plugin_test.go line 325. The Codex definitions carry no exclusive-verdict rule and are sound, so the defect is confined to the host this repository routes to. The wording itself is correct and does not collapse into the weaker report-the-ambiguity clause orch-specialist already has. Six non-blocking findings recorded: the criterion-wrong verdict has no defined destination in the orchestration skill, since request-changes loops the same executor back to re-satisfy the same wrong criterion and nothing routes it to escalate, which the reviewer recommends as a follow-up issue rather than folding into this fix; the Claude test reads the raw markdown while the Codex test decodes TOML and only counts text inside developer_instructions, the Codex approach being stronger; the pinned phrases cover the leading clause of each statement rather than the whole statement; a manifest nit that the mutation-check detail does not state deletion granularity; the test name deviating from the TestDeliverySkillHas prefix, judged reasonable; and the plugin version not being bumped, consistent with the objective. Security: nothing, prose and test only. Scope clean at 8 files all under the two adapter directories.",
      "commit_oid": "049ae8659b97baaec15e292583d2f0610622e92f",
      "at": "2026-08-01T00:50:40Z"
    },
    {
      "name": "review-verdict-rule-reconciled",
      "command": "read the When a criterion is itself wrong and Report sections in all four reviewer definitions and compare their line numbers",
      "result": "pass",
      "detail": "The grant precedes the verdict rule in all four files (31/63, 39/71, 37/67, 45/75) and the two now give the same answer on the same input. The in the sense above referent is unambiguous.",
      "commit_oid": "f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1",
      "at": "2026-08-01T01:03:01Z"
    },
    {
      "name": "review-issue-117-protection-intact",
      "command": "read commit 985efe2 rationale and compare against the reworded rule",
      "result": "pass",
      "detail": "Both of issue 117 intents survive: the coverage-only finding stage anchor is untouched, and a finding on neither ground still does not force a review cycle. The widening is exactly the one ground criterion 2 mandates.",
      "commit_oid": "f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1",
      "at": "2026-08-01T01:03:01Z"
    },
    {
      "name": "review-anchor-pins-both-grounds",
      "command": "probe the modified reviewerBlockingVerdictInstruction against TestReviewerReportsCoverageAndBlockingVerdict by reverting to the exclusive wording, then by dropping the blocking ground",
      "result": "pass",
      "detail": "Both probes caught, confirming each ground is individually load-bearing in the anchor.",
      "commit_oid": "f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1",
      "at": "2026-08-01T01:03:01Z"
    },
    {
      "name": "review-codex-definitions-untouched",
      "command": "git show --stat f84f495",
      "result": "pass",
      "detail": "Exactly three files, all under adapters/claude/. The Codex reviewer definitions are byte-identical to cycle 1 and carry no exclusive-verdict rule.",
      "commit_oid": "f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1",
      "at": "2026-08-01T01:03:01Z"
    },
    {
      "name": "review-cycle-2",
      "result": "approve",
      "detail": "Approved at head f84f495. The cycle 1 blocker is closed on its merits and verified independently rather than inherited. Ordering and referent check out: the When a criterion is itself wrong section precedes Report in all four reviewer definitions, at lines 31 vs 63, 39 vs 71, 37 vs 67 and 45 vs 75, and the phrase in the sense above has exactly one candidate referent because the section heading and body both use the literal phrase an acceptance criterion is itself wrong. Issue 117 protection was checked against commit 985efe2 rationale rather than the executor claim: 117 had two intents, a coverage-only finding stage whose anchor is untouched here, and keeping non-blocking findings out of the review-cycle count, which the reword preserves verbatim in effect. The widening is exactly the one ground criterion 2 mandates. The modified anchor was probed two ways against TestReviewerReportsCoverageAndBlockingVerdict, reverting to the exclusive 117 wording and dropping the blocking ground while keeping only wrong-criterion, and both were caught, so both grounds are load-bearing. Codex definitions confirmed untouched: the fix commit lists exactly three files, all under adapters/claude/. The executor disclosed self-correction was independently reproduced: 12 of 12 sites caught at whole-paragraph granularity, zero NOT-CAUGHT, tree clean afterwards. All five acceptance criteria met, all six CI checks pass, scope exactly the two adapter directories. The reviewer explicitly judged no acceptance criterion wrong, noting criterion 4 names an existing pattern already in the tree rather than a mechanism the change had to invent. Eight findings, all non-blocking, and the reviewer deliberately declined to convert three of them into change requests on the ground that the added prose or test would not clear the necessity test this PR itself introduces. Recorded: the delivery skill now states the mechanism-prescription rule twice, as a new absolute near an older weaker preference clause about 25 lines apart; the in the sense above cross-reference is pinned by no test so a future section reorder would dangle it silently; terminology drift between the reviewer files residual category and the delivery skill non-blocking wording, the same seam as the routing gap already carried as a follow-up; and request-changes remaining a closed enumeration that excludes a severe defect touching no acceptance criterion, which is pre-existing and out of scope but named as the kind of thing this stage should surface. Security: nothing, prose and test files only.",
      "commit_oid": "f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1",
      "at": "2026-08-01T01:03:02Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (windows-latest)=pass",
      "commit_oid": "f84f4954a47e4e8ea74e974efb2c4d6fe427d1e1",
      "at": "2026-08-01T01:03:06Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->