### PR TITLE
Make usage capture depend only on the rollout that actually matches

### DIFF
--- a/internal/codexusage/capture.go
+++ b/internal/codexusage/capture.go
@@ -20,7 +20,10 @@ var errInvalidRollout = errors.New("invalid Codex rollout")
 // sessionsRoot contains exactly one valid rollout for parentThreadID and
 // taskIdentity. When previousTotal is set, it returns the exact non-negative
 // difference from that earlier cumulative total. Every persistence or format
-// problem is unavailable rather than a best-effort attribution.
+// problem in a rollout that identifies itself as that child is unavailable
+// rather than a best-effort attribution; a rollout that does not identify
+// itself as that child is another session's business and cannot affect the
+// result, however malformed it is.
 func TotalTokens(sessionsRoot, parentThreadID, taskIdentity string, previousTotal *int64) (int64, bool) {
 	if strings.TrimSpace(parentThreadID) == "" || strings.TrimSpace(taskIdentity) == "" {
 		return 0, false
@@ -39,11 +42,8 @@ func TotalTokens(sessionsRoot, parentThreadID, taskIdentity string, previousTota
 			return nil
 		}
 
-		candidateTotal, matched, valid, err := rolloutTotal(path, parentThreadID, taskIdentity)
-		if err != nil {
-			return err
-		}
-		if !matched {
+		candidateTotal, candidate, valid := rolloutTotal(path, parentThreadID, taskIdentity)
+		if !candidate {
 			return nil
 		}
 		if !valid {
@@ -105,19 +105,23 @@ type event struct {
 	} `json:"info"`
 }
 
-// rolloutTotal parses one JSONL rollout. A candidate must be a child session
-// whose three persisted parent references and agent path exactly match.
-func rolloutTotal(path, parentThreadID, taskIdentity string) (int64, bool, bool, error) {
+// rolloutTotal parses one JSONL rollout and reports whether it is a candidate
+// for the requested child and, if so, whether it is wholly valid. A rollout
+// only becomes a candidate once its session metadata identifies it as that
+// child; until then any read or format failure means the file is unidentified,
+// so it is not this capture's rollout and is left out of the result entirely.
+// Once identified, every remaining check is fail-closed.
+func rolloutTotal(path, parentThreadID, taskIdentity string) (int64, bool, bool) {
 	f, err := os.Open(path)
 	if err != nil {
-		return 0, false, false, err
+		return 0, false, false
 	}
 	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 64*1024), maxJSONLRecord)
 
-	var seenMeta, matched bool
+	var identified bool
 	var previous, last record
 	for scanner.Scan() {
 		line := bytes.TrimSpace(scanner.Bytes())
@@ -127,44 +131,40 @@ func rolloutTotal(path, parentThreadID, taskIdentity string) (int64, bool, bool,
 
 		var current record
 		if err := json.Unmarshal(line, &current); err != nil {
-			return 0, false, false, err
+			return 0, identified, false
 		}
 		if current.Type == "session_meta" {
-			if seenMeta {
-				return 0, false, false, errInvalidRollout
+			if identified {
+				return 0, true, false
 			}
-			seenMeta = true
 
 			var meta sessionMeta
 			if err := json.Unmarshal(current.Payload, &meta); err != nil {
-				return 0, false, false, err
+				return 0, false, false
 			}
-			if !validSessionMeta(meta) {
-				return 0, false, false, errInvalidRollout
+			if !identifies(meta, parentThreadID, taskIdentity) {
+				return 0, false, false
 			}
-			matched = matches(meta, parentThreadID, taskIdentity)
-			if !matched {
-				return 0, false, false, nil
+			if !validSessionMeta(meta) || !sourceNamesParent(meta, parentThreadID) {
+				return 0, true, false
 			}
+			identified = true
 			continue
 		}
-		if matched {
+		if identified {
 			previous = last
 			last = current
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return 0, false, false, err
+		return 0, identified, false
 	}
-	if !seenMeta {
-		return 0, false, false, errInvalidRollout
-	}
-	if !matched {
-		return 0, false, false, nil
+	if !identified {
+		return 0, false, false
 	}
 
 	total, valid := finalTotal(previous, last)
-	return total, true, valid, nil
+	return total, true, valid
 }
 
 func validSessionMeta(meta sessionMeta) bool {
@@ -278,14 +278,22 @@ func validAgentPath(path string) bool {
 	return true
 }
 
-func matches(meta sessionMeta, parentThreadID, taskIdentity string) bool {
-	if meta.ID == "" || meta.ID == parentThreadID ||
-		meta.SessionID != parentThreadID ||
-		meta.ParentThreadID != parentThreadID ||
-		meta.ThreadSource != "subagent" ||
-		meta.AgentPath != taskIdentity {
-		return false
-	}
+// identifies reports whether a rollout's own id, its two persisted parent
+// references and its agent path name it as the requested child. This is the
+// only question a rollout has to answer before it can affect the result; the
+// remaining parent reference in its spawn source is validated afterwards.
+func identifies(meta sessionMeta, parentThreadID, taskIdentity string) bool {
+	return meta.ID != "" &&
+		meta.ID != parentThreadID &&
+		meta.SessionID == parentThreadID &&
+		meta.ParentThreadID == parentThreadID &&
+		meta.ThreadSource == "subagent" &&
+		meta.AgentPath == taskIdentity
+}
+
+// sourceNamesParent reports whether an identified rollout's spawn source agrees
+// with the parent references it identified itself by.
+func sourceNamesParent(meta sessionMeta, parentThreadID string) bool {
 	var source subagentSource
 	if err := json.Unmarshal(meta.Source, &source); err != nil {
 		return false

--- a/internal/codexusage/capture_test.go
+++ b/internal/codexusage/capture_test.go
@@ -106,7 +106,10 @@ func TestTotalTokensIsolatesUnrelatedRolloutCorruption(t *testing.T) {
 }
 
 // A rollout that does identify itself as the requested child is still checked
-// in full and still fails closed.
+// in full and still fails closed. Each broken rollout sits beside the exact
+// matching rollout, so unavailable can only mean the broken one poisoned a
+// capture that would otherwise have resolved: were it merely skipped as a
+// non-candidate, the exact total would still be reported.
 func TestTotalTokensFailsClosedForIdentifiedChild(t *testing.T) {
 	exact := exactRollout(t)
 
@@ -133,12 +136,15 @@ func TestTotalTokensFailsClosedForIdentifiedChild(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "exact.jsonl"), exact, 0o644); err != nil {
+				t.Fatal(err)
+			}
 			if err := os.WriteFile(filepath.Join(dir, "rollout.jsonl"), tc.rollout, 0o644); err != nil {
 				t.Fatal(err)
 			}
 
 			if _, ok := TotalTokens(dir, parentThread, executorTask, nil); ok {
-				t.Error("TotalTokens reported usage for an invalid identified child")
+				t.Error("TotalTokens reported usage despite an invalid identified child")
 			}
 		})
 	}

--- a/internal/codexusage/capture_test.go
+++ b/internal/codexusage/capture_test.go
@@ -26,11 +26,19 @@ func TestTotalTokensSelectsOnlyExactCompletedChild(t *testing.T) {
 	}
 }
 
-func TestTotalTokensIsolatesOnlyIdentifiedNonMatchingCorruption(t *testing.T) {
-	exact, err := os.ReadFile(filepath.Join(fixture(t, "exact"), "executor.jsonl"))
+func exactRollout(t *testing.T) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(fixture(t, "exact"), "executor.jsonl"))
 	if err != nil {
 		t.Fatal(err)
 	}
+	return data
+}
+
+// A rollout that does not identify itself as the requested child is another
+// session's business: nothing wrong with it may suppress the exact total.
+func TestTotalTokensIsolatesUnrelatedRolloutCorruption(t *testing.T) {
+	exact := exactRollout(t)
 	unrelated, err := os.ReadFile(filepath.Join(fixture(t, "exact"), "sibling.jsonl"))
 	if err != nil {
 		t.Fatal(err)
@@ -39,30 +47,42 @@ func TestTotalTokensIsolatesOnlyIdentifiedNonMatchingCorruption(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
 		other []byte
-		ok    bool
 	}{
 		{
-			name:  "identified unrelated rollout",
-			other: append(unrelated, []byte("this is not json\n")...),
-			ok:    true,
+			name:  "zero-byte rollout",
+			other: nil,
 		},
 		{
-			name:  "object-valued unrelated source",
-			other: []byte("{\"type\":\"session_meta\",\"payload\":{\"id\":\"review\",\"session_id\":\"review\",\"thread_source\":\"subagent\",\"source\":{\"subagent\":\"review\"}}}\nthis is not json\n"),
-			ok:    true,
+			name:  "no session metadata",
+			other: []byte("{\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\"}}\n"),
 		},
 		{
-			name:  "defaulted unrelated source",
-			other: []byte("{\"type\":\"session_meta\",\"payload\":{\"id\":\"root\",\"session_id\":\"root\",\"thread_source\":\"user\"}}\nthis is not json\n"),
-			ok:    true,
+			name:  "unparseable first line",
+			other: []byte("{\"type\":\"session_me"),
+		},
+		{
+			name:  "unrecognized session metadata shape",
+			other: []byte("{\"type\":\"session_meta\",\"payload\":{\"id\":\"other\",\"source\":{\"mcp\":\"gateway\"}}}\n"),
+		},
+		{
+			name:  "non-object session metadata payload",
+			other: []byte("{\"type\":\"session_meta\",\"payload\":\"other\"}\n"),
 		},
 		{
 			name:  "unidentified rollout",
 			other: []byte("{\"type\":\"session_meta\",\"payload\":{}}\nthis is not json\n"),
 		},
 		{
-			name:  "malformed source",
-			other: []byte("{\"type\":\"session_meta\",\"payload\":{\"id\":\"unknown\",\"session_id\":\"parent-139\",\"parent_thread_id\":\"parent-139\",\"thread_source\":\"subagent\",\"agent_path\":\"/root/issue_139_executor\",\"source\":{\"subagent\":\"not-a-variant\"}}}\nthis is not json\n"),
+			name:  "identified unrelated rollout",
+			other: append(unrelated, []byte("this is not json\n")...),
+		},
+		{
+			name:  "object-valued unrelated source",
+			other: []byte("{\"type\":\"session_meta\",\"payload\":{\"id\":\"review\",\"session_id\":\"review\",\"thread_source\":\"subagent\",\"source\":{\"subagent\":\"review\"}}}\nthis is not json\n"),
+		},
+		{
+			name:  "defaulted unrelated source",
+			other: []byte("{\"type\":\"session_meta\",\"payload\":{\"id\":\"root\",\"session_id\":\"root\",\"thread_source\":\"user\"}}\nthis is not json\n"),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -75,11 +95,50 @@ func TestTotalTokensIsolatesOnlyIdentifiedNonMatchingCorruption(t *testing.T) {
 			}
 
 			got, ok := TotalTokens(dir, parentThread, executorTask, nil)
-			if ok != tc.ok {
-				t.Fatalf("TotalTokens availability = %t, want %t", ok, tc.ok)
+			if !ok {
+				t.Fatal("TotalTokens reported unavailable")
 			}
-			if ok && got != 782763 {
+			if got != 782763 {
 				t.Errorf("total_tokens = %d, want 782763", got)
+			}
+		})
+	}
+}
+
+// A rollout that does identify itself as the requested child is still checked
+// in full and still fails closed.
+func TestTotalTokensFailsClosedForIdentifiedChild(t *testing.T) {
+	exact := exactRollout(t)
+
+	for _, tc := range []struct {
+		name    string
+		rollout []byte
+	}{
+		{
+			name:    "malformed record",
+			rollout: append(exactRollout(t), []byte("this is not json\n")...),
+		},
+		{
+			name:    "duplicate session metadata",
+			rollout: append(exactRollout(t), exact...),
+		},
+		{
+			name:    "malformed source",
+			rollout: []byte("{\"type\":\"session_meta\",\"payload\":{\"id\":\"unknown\",\"session_id\":\"parent-139\",\"parent_thread_id\":\"parent-139\",\"thread_source\":\"subagent\",\"agent_path\":\"/root/issue_139_executor\",\"source\":{\"subagent\":\"not-a-variant\"}}}\nthis is not json\n"),
+		},
+		{
+			name:    "missing source",
+			rollout: []byte("{\"type\":\"session_meta\",\"payload\":{\"id\":\"child-executor\",\"session_id\":\"parent-139\",\"parent_thread_id\":\"parent-139\",\"thread_source\":\"subagent\",\"agent_path\":\"/root/issue_139_executor\"}}\n"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "rollout.jsonl"), tc.rollout, 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, ok := TotalTokens(dir, parentThread, executorTask, nil); ok {
+				t.Error("TotalTokens reported usage for an invalid identified child")
 			}
 		})
 	}


### PR DESCRIPTION
Delivers issue #145: Make usage capture depend only on the rollout that actually matches

Closes #145

**Plan digest:** `sha256:6bc7e7c9989ad5176362837aa91396aa1d5283b5bee5ae669ab54a8aa4351829`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Codex usage capture currently reports unavailable for an entire Delivery run when any single unrelated rollout anywhere in the Codex sessions tree fails a metadata shape check. TotalTokens walks every .jsonl file under the sessions root and aborts the whole walk on the first error any file produces, so a file that has nothing to do with the requested child silently zeroes the measurement: a zero-byte rollout caught mid-creation, a rollout written by another project or another Codex version, or a rollout carrying a session-source shape the current code does not recognize. This was measured on 2026-07-31 against commit 8e09458 by running the package in a scratch directory outside this repository: seven distinct unrelated-neighbour cases each suppress an otherwise-exact capture that succeeded at the immediately preceding commit 04dc0bd. Make the outcome depend only on the rollout that actually matches. A rollout whose identity fields do not match the requested parent thread and task identity is not a candidate and must never affect the result, whatever else is wrong with it. A rollout that does match, and genuine ambiguity between two matching rollouts, must still make usage unavailable: exact unique attribution is unchanged. This narrows the rationale recorded for PR #144 rather than reversing it. That rationale kept unidentified rollouts fail-closed because blanket-skipping them could conceal another matching rollout and falsely claim uniqueness. That concern only bites for a file that is genuinely a second child and yet fails identification; a file whose identity fields do match is still fully validated and still fails closed here, so uniqueness is still proven before any total is returned. The cost that rationale accepted is far broader than the risk it avoids, and it is not observable in the way fail-closed implies: the result is the same empty JSON object an operator sees when there is simply no data, so an operator cannot tell a concealed-duplicate refusal from an unrelated file's schema quirk.

**Acceptance criteria:**
- With exactly one exact matching rollout present in the sessions tree, capture returns that rollout's exact total even when another rollout in the same tree is zero-byte, contains no session metadata, has an unparseable first line, or carries session metadata whose shape the implementation does not recognize.
- A rollout whose session metadata identifies it as the requested child still makes usage unavailable when its own records are malformed or its final cumulative total cannot be read exactly.
- Two rollouts that both identify as the requested child still make usage unavailable.
- A runnable regression test in internal/codexusage places one exact matching rollout beside each unrelated-neighbour case named in the first criterion and fails if any one of them suppresses the exact total.
- The existing resume-delta behavior and the existing unavailable and ambiguity coverage in internal/codexusage remain passing unchanged.
- The change uses the Go standard library and existing repository facilities only, and adds no new module dependency.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `specialist` |
| Executor | `claude-opus-5` — effort `high` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to a specialist with a strong reviewer because risk domains (data-integrity).

**Escalations:** _none_

**Verification:**
- **go-test-all** — pass — `go test ./...` — 23 test packages passed on head 89896a1, plus 3 packages with no test files, 0 failures. Corrects the count of 24 recorded at pr-open. — commit `89896a137b5161cb29e97a70ef0885c0d80b1d83` (2026-08-01T01:01:57Z)
- **go-vet** — pass — `go vet ./...` — No output on head 89896a1. — commit `89896a137b5161cb29e97a70ef0885c0d80b1d83` (2026-08-01T01:01:57Z)
- **gofmt** — pass — `gofmt -l .` — No files listed on head 89896a1. — commit `89896a137b5161cb29e97a70ef0885c0d80b1d83` (2026-08-01T01:01:57Z)
- **go-test-codexusage-verbose** — pass — `go test ./internal/codexusage/ -v` — 6 tests and 30 subtests passed on head 89896a1. Corrects the count of 28 subtests recorded at pr-open. — commit `89896a137b5161cb29e97a70ef0885c0d80b1d83` (2026-08-01T01:01:57Z)
- **architect-reproduction-vs-fix** — pass — `copy fixed capture.go plus the Architect blast_test.go reproduction into a scratch module outside the repository, then go test -run TestBlastRadius -v` — All 10 neighbour cases resolve on commit 21c5083, including the seven that commit 8e09458 suppressed. — commit `21c50839c1069ab73df1683e307e0c59444c2baa` (2026-08-01T00:41:03Z)
- **regression-test-proves-the-fix** — pass — `copy git show 8e09458:internal/codexusage/capture.go plus the new capture_test.go into a scratch module outside the repository, then go test ./...` — Check achieved its purpose: the new TestTotalTokensIsolatesUnrelatedRolloutCorruption fails 6 of 9 subtests against the pre-fix implementation, proving it is a real regression test rather than one that passes either way. — commit `21c50839c1069ab73df1683e307e0c59444c2baa` (2026-08-01T00:41:03Z)
- **prose-reflow-check** — pass — `git diff --word-diff --ignore-all-space -- internal/codexusage/capture.go` — No unintended [-word-] removal markers on commit 21c5083. Every removal marker is a deliberate rewrite of the rolloutTotal doc comment or a code removal for the dropped error return, seenMeta, and the matches guard inversion. — commit `21c50839c1069ab73df1683e307e0c59444c2baa` (2026-08-01T00:41:03Z)
- **review-go-test-all** — pass — `go test ./...` — 23 test packages green on reviewed head 21c5083. — commit `21c50839c1069ab73df1683e307e0c59444c2baa` (2026-08-01T00:49:04Z)
- **review-go-vet** — pass — `go vet ./...` — Clean on reviewed head 21c5083. — commit `21c50839c1069ab73df1683e307e0c59444c2baa` (2026-08-01T00:49:04Z)
- **review-gofmt** — pass — `gofmt -l .` — No output on reviewed head 21c5083. — commit `21c50839c1069ab73df1683e307e0c59444c2baa` (2026-08-01T00:49:04Z)
- **review-no-module-change** — pass — `git diff --name-only main...HEAD` — Two files, no go.mod or go.sum change on reviewed head 21c5083, satisfying acceptance criterion 6. — commit `21c50839c1069ab73df1683e307e0c59444c2baa` (2026-08-01T00:49:04Z)
- **review-fail-closed-mutation-check** — fail — `rewrite all four candidate-signalling returns in rolloutTotal to report not-a-candidate, then go test ./...` — Suite still passes with the entire fail-closed guarantee for identified children removed, proving TestTotalTokensFailsClosedForIdentifiedChild is non-discriminating in its solo-file configuration. This is the blocking finding. — commit `21c50839c1069ab73df1683e307e0c59444c2baa` (2026-08-01T00:49:04Z)
- **review-regression-test-proves-fix** — pass — `run the new capture_test.go against git show 8e09458:internal/codexusage/capture.go in a scratch module` — Fails 6 of 9 subtests against the pre-fix implementation and passes at head, confirming criterion 4. — commit `21c50839c1069ab73df1683e307e0c59444c2baa` (2026-08-01T00:49:04Z)
- **review-cycle-1** — request-changes — Request changes on one blocking finding, a test gap rather than a code defect. The implementation is correct: identification now gates candidacy, criterion 1 isolation is real (the new tests fail 6 of 9 subtests against pre-fix 8e09458), and the reviewer independently confirmed criterion 2 behavior by placing identified-but-broken rollouts beside the exact match in a scratch module. The blocker is that TestTotalTokensFailsClosedForIdentifiedChild writes its rollout as the only file in the temp directory, so candidate-and-invalid and not-a-candidate both yield unavailable and the assertion cannot distinguish them. Proven by mutation: rewriting all four candidate-signalling returns in rolloutTotal to report not-a-candidate deletes the entire fail-closed guarantee for identified children and go test ./... still passes. The deleted TestTotalTokensIsolatesOnlyIdentifiedNonMatchingCorruption held the one discriminating assertion, its malformed-source case placed the broken identified rollout beside exact.jsonl. This matters because the objective justifies narrowing PR 144 precisely on the claim that an identified child is still fully validated and still fails closed, and that claim is currently enforced by nothing. Remedy is a pure test change touching no production code: write the exact matching rollout as a second file in the same temp directory. Six non-blocking findings recorded and not requiring their own cycle: two inaccurate counts in the manifest verification details (23 test packages not 24, 30 subtests not 28, all results themselves accurate), the executor fail-closed claim being true but narrower than stated, validSessionMeta now near-redundant on the identified path, the accepted residual risk that an unidentifiable genuine second child is skipped, and os.Open failures now being silently skipped. The reviewer explicitly judged no acceptance criterion to be wrong, and found scope clean at two files with no drive-by edits. — commit `21c50839c1069ab73df1683e307e0c59444c2baa` (2026-08-01T00:49:05Z)
- **review-capture-go-unchanged-by-fix** — pass — `git rev-parse 21c5083:internal/codexusage/capture.go 89896a1:internal/codexusage/capture.go and git diff --stat 21c5083 89896a1` — Same blob b8c57e5591dd510ee3f661d95746bac84e1bf61d at both commits; only capture_test.go differs, +8/-2. The cycle-2 fix is test-only as claimed. — commit `89896a137b5161cb29e97a70ef0885c0d80b1d83` (2026-08-01T01:01:57Z)
- **review-fail-closed-mutation-recheck** — pass — `rewrite all four candidate-signalling returns in rolloutTotal to return 0, false, false, then go test ./internal/codexusage/ at both 21c5083 and 89896a1` — Fails all four subtests of TestTotalTokensFailsClosedForIdentifiedChild at 89896a1 and leaves the suite green at 21c5083. Cycle 1 blocking finding reproduced and confirmed closed. — commit `89896a137b5161cb29e97a70ef0885c0d80b1d83` (2026-08-01T01:01:57Z)
- **review-ci-check-runs-at-head** — pass — `GitHub check-runs API queried against head OID 89896a1` — All six required checks SUCCESS on the head OID: lint, scripts x2, test x3. Queried by OID rather than via gh pr checks. — commit `89896a137b5161cb29e97a70ef0885c0d80b1d83` (2026-08-01T01:01:57Z)
- **review-cycle-2** — approve — Approved at head 89896a1. Cycle 1 blocker is genuinely closed, verified by re-running the exact four-return mutation at both commits and getting opposite results: it fails all four subtests of TestTotalTokensFailsClosedForIdentifiedChild at 89896a1 and leaves the suite green at 21c5083. The fix is test-only, confirmed independently: capture.go is the same blob b8c57e5591dd510ee3f661d95746bac84e1bf61d at both commits and git diff --stat lists only capture_test.go at plus 8 minus 2. All six acceptance criteria met. Criterion 5 verified structurally: TestTotalTokensValidatesThreadSpawnSource, TestTotalTokensReturnsExactResumeDelta and TestTotalTokensUnavailable are byte-unchanged from 8e09458. The executor two self-corrections were checked and are accurate: 23 test packages and 6 tests with 30 subtests, and the newly closed fail-closed surface being validSessionMeta non-threadSpawn early exit, confirmed by the head test file failing 7 subtests against the pre-fix capture.go including FailsClosedForIdentifiedChild missing_source. All six required CI checks SUCCESS on the head OID via the check-runs API. Reviewer judged no acceptance criterion wrong and explicitly declined to request added code for two findings on the ground that neither is named by any criterion. Eight findings recorded, none blocking. The most significant is that sourceNamesParent is enforced by no test: neutering it leaves the suite green, because its only aimed subtest missing_source has no records so finalTotal rejects it anyway, and on the threadSpawn path validSessionMeta already enforces the same equality. It is load-bearing only for non-threadSpawn sources, where removal would report a total for an identified rollout carrying source subagent review, more permissive than both head and base. Closing it is two table rows. Second, criterion 2 second clause still rests on the solo-file testdata/unavailable fixture, structurally the same gap cycle 1 blocked on but pre-existing and protected by criterion 5. Third, the cycle-2 fix traded one mutation gap for a smaller one: the duplicate session metadata subtest now passes for the wrong reason because the added exact.jsonl makes matches greater than 1 produce unavailable regardless. Also recorded: the scanner.Err candidate flag is unexercised, directory-level WalkDir errors still abort the whole capture while os.Open failures are now skipped, and the move of the spawn-source check from candidacy into validation is a real behavior change no criterion enumerates. Scope clean at two files, exported signature unchanged, sole caller internal/cli/codexusage.go untouched. Nothing security-relevant. — commit `89896a137b5161cb29e97a70ef0885c0d80b1d83` (2026-08-01T01:01:59Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, lint=pass, test (windows-latest)=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `89896a137b5161cb29e97a70ef0885c0d80b1d83` (2026-08-01T01:02:03Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Codex usage capture currently reports unavailable for an entire Delivery run when any single unrelated rollout anywhere in the Codex sessions tree fails a metadata shape check. TotalTokens walks every .jsonl file under the sessions root and aborts the whole walk on the first error any file produces, so a file that has nothing to do with the requested child silently zeroes the measurement: a zero-byte rollout caught mid-creation, a rollout written by another project or another Codex version, or a rollout carrying a session-source shape the current code does not recognize. This was measured on 2026-07-31 against commit 8e09458 by running the package in a scratch directory outside this repository: seven distinct unrelated-neighbour cases each suppress an otherwise-exact capture that succeeded at the immediately preceding commit 04dc0bd. Make the outcome depend only on the rollout that actually matches. A rollout whose identity fields do not match the requested parent thread and task identity is not a candidate and must never affect the result, whatever else is wrong with it. A rollout that does match, and genuine ambiguity between two matching rollouts, must still make usage unavailable: exact unique attribution is unchanged. This narrows the rationale recorded for PR #144 rather than reversing it. That rationale kept unidentified rollouts fail-closed because blanket-skipping them could conceal another matching rollout and falsely claim uniqueness. That concern only bites for a file that is genuinely a second child and yet fails identification; a file whose identity fields do match is still fully validated and still fails closed here, so uniqueness is still proven before any total is returned. The cost that rationale accepted is far broader than the risk it avoids, and it is not observable in the way fail-closed implies: the result is the same empty JSON object an operator sees when there is simply no data, so an operator cannot tell a concealed-duplicate refusal from an unrelated file's schema quirk.",
  "acceptance_criteria": [
    "With exactly one exact matching rollout present in the sessions tree, capture returns that rollout's exact total even when another rollout in the same tree is zero-byte, contains no session metadata, has an unparseable first line, or carries session metadata whose shape the implementation does not recognize.",
    "A rollout whose session metadata identifies it as the requested child still makes usage unavailable when its own records are malformed or its final cumulative total cannot be read exactly.",
    "Two rollouts that both identify as the requested child still make usage unavailable.",
    "A runnable regression test in internal/codexusage places one exact matching rollout beside each unrelated-neighbour case named in the first criterion and fails if any one of them suppresses the exact total.",
    "The existing resume-delta behavior and the existing unavailable and ambiguity coverage in internal/codexusage remain passing unchanged.",
    "The change uses the Go standard library and existing repository facilities only, and adds no new module dependency."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "specialist",
  "executor": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "routing_rationale": "Routed to a specialist with a strong reviewer because risk domains (data-integrity).",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "23 test packages passed on head 89896a1, plus 3 packages with no test files, 0 failures. Corrects the count of 24 recorded at pr-open.",
      "commit_oid": "89896a137b5161cb29e97a70ef0885c0d80b1d83",
      "at": "2026-08-01T01:01:57Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "No output on head 89896a1.",
      "commit_oid": "89896a137b5161cb29e97a70ef0885c0d80b1d83",
      "at": "2026-08-01T01:01:57Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No files listed on head 89896a1.",
      "commit_oid": "89896a137b5161cb29e97a70ef0885c0d80b1d83",
      "at": "2026-08-01T01:01:57Z"
    },
    {
      "name": "go-test-codexusage-verbose",
      "command": "go test ./internal/codexusage/ -v",
      "result": "pass",
      "detail": "6 tests and 30 subtests passed on head 89896a1. Corrects the count of 28 subtests recorded at pr-open.",
      "commit_oid": "89896a137b5161cb29e97a70ef0885c0d80b1d83",
      "at": "2026-08-01T01:01:57Z"
    },
    {
      "name": "architect-reproduction-vs-fix",
      "command": "copy fixed capture.go plus the Architect blast_test.go reproduction into a scratch module outside the repository, then go test -run TestBlastRadius -v",
      "result": "pass",
      "detail": "All 10 neighbour cases resolve on commit 21c5083, including the seven that commit 8e09458 suppressed.",
      "commit_oid": "21c50839c1069ab73df1683e307e0c59444c2baa",
      "at": "2026-08-01T00:41:03Z"
    },
    {
      "name": "regression-test-proves-the-fix",
      "command": "copy git show 8e09458:internal/codexusage/capture.go plus the new capture_test.go into a scratch module outside the repository, then go test ./...",
      "result": "pass",
      "detail": "Check achieved its purpose: the new TestTotalTokensIsolatesUnrelatedRolloutCorruption fails 6 of 9 subtests against the pre-fix implementation, proving it is a real regression test rather than one that passes either way.",
      "commit_oid": "21c50839c1069ab73df1683e307e0c59444c2baa",
      "at": "2026-08-01T00:41:03Z"
    },
    {
      "name": "prose-reflow-check",
      "command": "git diff --word-diff --ignore-all-space -- internal/codexusage/capture.go",
      "result": "pass",
      "detail": "No unintended [-word-] removal markers on commit 21c5083. Every removal marker is a deliberate rewrite of the rolloutTotal doc comment or a code removal for the dropped error return, seenMeta, and the matches guard inversion.",
      "commit_oid": "21c50839c1069ab73df1683e307e0c59444c2baa",
      "at": "2026-08-01T00:41:03Z"
    },
    {
      "name": "review-go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "23 test packages green on reviewed head 21c5083.",
      "commit_oid": "21c50839c1069ab73df1683e307e0c59444c2baa",
      "at": "2026-08-01T00:49:04Z"
    },
    {
      "name": "review-go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Clean on reviewed head 21c5083.",
      "commit_oid": "21c50839c1069ab73df1683e307e0c59444c2baa",
      "at": "2026-08-01T00:49:04Z"
    },
    {
      "name": "review-gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No output on reviewed head 21c5083.",
      "commit_oid": "21c50839c1069ab73df1683e307e0c59444c2baa",
      "at": "2026-08-01T00:49:04Z"
    },
    {
      "name": "review-no-module-change",
      "command": "git diff --name-only main...HEAD",
      "result": "pass",
      "detail": "Two files, no go.mod or go.sum change on reviewed head 21c5083, satisfying acceptance criterion 6.",
      "commit_oid": "21c50839c1069ab73df1683e307e0c59444c2baa",
      "at": "2026-08-01T00:49:04Z"
    },
    {
      "name": "review-fail-closed-mutation-check",
      "command": "rewrite all four candidate-signalling returns in rolloutTotal to report not-a-candidate, then go test ./...",
      "result": "fail",
      "detail": "Suite still passes with the entire fail-closed guarantee for identified children removed, proving TestTotalTokensFailsClosedForIdentifiedChild is non-discriminating in its solo-file configuration. This is the blocking finding.",
      "commit_oid": "21c50839c1069ab73df1683e307e0c59444c2baa",
      "at": "2026-08-01T00:49:04Z"
    },
    {
      "name": "review-regression-test-proves-fix",
      "command": "run the new capture_test.go against git show 8e09458:internal/codexusage/capture.go in a scratch module",
      "result": "pass",
      "detail": "Fails 6 of 9 subtests against the pre-fix implementation and passes at head, confirming criterion 4.",
      "commit_oid": "21c50839c1069ab73df1683e307e0c59444c2baa",
      "at": "2026-08-01T00:49:04Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "Request changes on one blocking finding, a test gap rather than a code defect. The implementation is correct: identification now gates candidacy, criterion 1 isolation is real (the new tests fail 6 of 9 subtests against pre-fix 8e09458), and the reviewer independently confirmed criterion 2 behavior by placing identified-but-broken rollouts beside the exact match in a scratch module. The blocker is that TestTotalTokensFailsClosedForIdentifiedChild writes its rollout as the only file in the temp directory, so candidate-and-invalid and not-a-candidate both yield unavailable and the assertion cannot distinguish them. Proven by mutation: rewriting all four candidate-signalling returns in rolloutTotal to report not-a-candidate deletes the entire fail-closed guarantee for identified children and go test ./... still passes. The deleted TestTotalTokensIsolatesOnlyIdentifiedNonMatchingCorruption held the one discriminating assertion, its malformed-source case placed the broken identified rollout beside exact.jsonl. This matters because the objective justifies narrowing PR 144 precisely on the claim that an identified child is still fully validated and still fails closed, and that claim is currently enforced by nothing. Remedy is a pure test change touching no production code: write the exact matching rollout as a second file in the same temp directory. Six non-blocking findings recorded and not requiring their own cycle: two inaccurate counts in the manifest verification details (23 test packages not 24, 30 subtests not 28, all results themselves accurate), the executor fail-closed claim being true but narrower than stated, validSessionMeta now near-redundant on the identified path, the accepted residual risk that an unidentifiable genuine second child is skipped, and os.Open failures now being silently skipped. The reviewer explicitly judged no acceptance criterion to be wrong, and found scope clean at two files with no drive-by edits.",
      "commit_oid": "21c50839c1069ab73df1683e307e0c59444c2baa",
      "at": "2026-08-01T00:49:05Z"
    },
    {
      "name": "review-capture-go-unchanged-by-fix",
      "command": "git rev-parse 21c5083:internal/codexusage/capture.go 89896a1:internal/codexusage/capture.go and git diff --stat 21c5083 89896a1",
      "result": "pass",
      "detail": "Same blob b8c57e5591dd510ee3f661d95746bac84e1bf61d at both commits; only capture_test.go differs, +8/-2. The cycle-2 fix is test-only as claimed.",
      "commit_oid": "89896a137b5161cb29e97a70ef0885c0d80b1d83",
      "at": "2026-08-01T01:01:57Z"
    },
    {
      "name": "review-fail-closed-mutation-recheck",
      "command": "rewrite all four candidate-signalling returns in rolloutTotal to return 0, false, false, then go test ./internal/codexusage/ at both 21c5083 and 89896a1",
      "result": "pass",
      "detail": "Fails all four subtests of TestTotalTokensFailsClosedForIdentifiedChild at 89896a1 and leaves the suite green at 21c5083. Cycle 1 blocking finding reproduced and confirmed closed.",
      "commit_oid": "89896a137b5161cb29e97a70ef0885c0d80b1d83",
      "at": "2026-08-01T01:01:57Z"
    },
    {
      "name": "review-ci-check-runs-at-head",
      "command": "GitHub check-runs API queried against head OID 89896a1",
      "result": "pass",
      "detail": "All six required checks SUCCESS on the head OID: lint, scripts x2, test x3. Queried by OID rather than via gh pr checks.",
      "commit_oid": "89896a137b5161cb29e97a70ef0885c0d80b1d83",
      "at": "2026-08-01T01:01:57Z"
    },
    {
      "name": "review-cycle-2",
      "result": "approve",
      "detail": "Approved at head 89896a1. Cycle 1 blocker is genuinely closed, verified by re-running the exact four-return mutation at both commits and getting opposite results: it fails all four subtests of TestTotalTokensFailsClosedForIdentifiedChild at 89896a1 and leaves the suite green at 21c5083. The fix is test-only, confirmed independently: capture.go is the same blob b8c57e5591dd510ee3f661d95746bac84e1bf61d at both commits and git diff --stat lists only capture_test.go at plus 8 minus 2. All six acceptance criteria met. Criterion 5 verified structurally: TestTotalTokensValidatesThreadSpawnSource, TestTotalTokensReturnsExactResumeDelta and TestTotalTokensUnavailable are byte-unchanged from 8e09458. The executor two self-corrections were checked and are accurate: 23 test packages and 6 tests with 30 subtests, and the newly closed fail-closed surface being validSessionMeta non-threadSpawn early exit, confirmed by the head test file failing 7 subtests against the pre-fix capture.go including FailsClosedForIdentifiedChild missing_source. All six required CI checks SUCCESS on the head OID via the check-runs API. Reviewer judged no acceptance criterion wrong and explicitly declined to request added code for two findings on the ground that neither is named by any criterion. Eight findings recorded, none blocking. The most significant is that sourceNamesParent is enforced by no test: neutering it leaves the suite green, because its only aimed subtest missing_source has no records so finalTotal rejects it anyway, and on the threadSpawn path validSessionMeta already enforces the same equality. It is load-bearing only for non-threadSpawn sources, where removal would report a total for an identified rollout carrying source subagent review, more permissive than both head and base. Closing it is two table rows. Second, criterion 2 second clause still rests on the solo-file testdata/unavailable fixture, structurally the same gap cycle 1 blocked on but pre-existing and protected by criterion 5. Third, the cycle-2 fix traded one mutation gap for a smaller one: the duplicate session metadata subtest now passes for the wrong reason because the added exact.jsonl makes matches greater than 1 produce unavailable regardless. Also recorded: the scanner.Err candidate flag is unexercised, directory-level WalkDir errors still abort the whole capture while os.Open failures are now skipped, and the move of the spawn-source check from candidacy into validation is a real behavior change no criterion enumerates. Scope clean at two files, exported signature unchanged, sole caller internal/cli/codexusage.go untouched. Nothing security-relevant.",
      "commit_oid": "89896a137b5161cb29e97a70ef0885c0d80b1d83",
      "at": "2026-08-01T01:01:59Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, lint=pass, test (windows-latest)=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "89896a137b5161cb29e97a70ef0885c0d80b1d83",
      "at": "2026-08-01T01:02:03Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->