### PR TITLE
Return a wrong acceptance criterion to the human

### DIFF
--- a/adapters/claude/agents/orch-reviewer-safe.md
+++ b/adapters/claude/agents/orch-reviewer-safe.md
@@ -49,7 +49,10 @@ control-flow step, or a validity notion the change had to invent in
 order to satisfy the wording is the usual case. Do not redesign the
 criterion yourself, and do not approve a change you believe is wrong
 because it matches what the issue asked for — the Architect takes a
-wrong criterion back to the human.
+wrong criterion back to the human. Mark it `wrong acceptance criterion`
+and state the rejected criterion and reason in the consolidated report
+so the Architect can surface the rejected criterion and reason to the
+human.
 
 Before you request a change that adds code, establish that the added
 code needs to exist at all. "This case is unhandled" is a finding only

--- a/adapters/claude/agents/orch-reviewer.md
+++ b/adapters/claude/agents/orch-reviewer.md
@@ -41,7 +41,10 @@ control-flow step, or a validity notion the change had to invent in
 order to satisfy the wording is the usual case. Do not redesign the
 criterion yourself, and do not approve a change you believe is wrong
 because it matches what the issue asked for — the Architect takes a
-wrong criterion back to the human.
+wrong criterion back to the human. Mark it `wrong acceptance criterion`
+and state the rejected criterion and reason in the consolidated report
+so the Architect can surface the rejected criterion and reason to the
+human.
 
 Before you request a change that adds code, establish that the added
 code needs to exist at all. "This case is unhandled" is a finding only

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -391,37 +391,40 @@ func TestDeliverySkillHasBranchScopeVerificationGuidance(t *testing.T) {
 	adaptertest.CheckBranchScopeVerificationGuidance(t, deliverySkillPath)
 }
 
-// The three statements that keep a wrong acceptance criterion
-// reachable: the plan-construction rule that a criterion states an
-// observable outcome rather than the mechanism its author imagines,
-// the reviewer's standing to reject a criterion instead of grading
-// conformance to it, and the necessity test a reviewer must apply
-// before asking for more code. Each phrase is pinned without its
-// surrounding punctuation or em dashes, so rewording around a
-// statement stays possible while deleting the statement fails the
-// test.
+// These statements keep a wrong acceptance criterion reachable and route
+// it to the human rather than through the ordinary executor fix cycle.
+// Each phrase is pinned without its surrounding punctuation or em dashes,
+// so a prose reflow stays possible while deleting the statement fails.
 const observableOutcomeCriterionGuidance = "An acceptance criterion describes an observable outcome, and never names a function, a control-flow step, or a validity notion the change is expected to introduce"
 const reviewerWrongCriterionGuidance = "You may return `request-changes` on the ground that an acceptance criterion is itself wrong"
 const reviewerAddedCodeNecessityGuidance = "Before you request a change that adds code, establish that the added code needs to exist at all"
+const reviewerWrongCriterionHumanGuidance = "Mark it `wrong acceptance criterion` and state the rejected criterion and reason in the consolidated report so the Architect can surface the rejected criterion and reason to the human"
+const wrongCriterionEscalationGuidance = "A `request-changes` report with a `wrong acceptance criterion` is not an executor fix cycle"
+const wrongCriterionEscalationTrigger = "call `orch run escalate` with `trigger` `architectural-ambiguity`"
+const wrongCriterionHumanGuidance = "surface the rejected criterion and reason to the human"
+const codeFindingFixCycleGuidance = "A `request-changes` based on a code finding resumes the same executor in the **same worktree** on the same branch: it fixes and pushes, then a **fresh** reviewer is spawned"
 
-// TestDeliverySkillAndReviewersHaveWrongCriterionGuidance checks each
-// of the three statements in the file that owns it: the first in the
-// delivery skill's PlanDoc construction guidance, the other two in both
-// reviewer agent definitions. Like
-// TestReviewerReportsCoverageAndBlockingVerdict above, the reviewer
-// files are addressed by stem rather than through agentRoster, whose
-// job is the tools/model frontmatter. Comparison runs on
-// whitespace-normalized text on both sides, so a statement the markdown
-// hard-wraps still matches.
+// TestDeliverySkillAndReviewersHaveWrongCriterionGuidance checks the
+// Delivery escalation/fix-cycle split and both reviewer definitions. Like
+// TestReviewerReportsCoverageAndBlockingVerdict above, the reviewer files
+// are addressed by stem rather than through agentRoster, whose job is the
+// tools/model frontmatter. Comparison ignores hard wraps.
 func TestDeliverySkillAndReviewersHaveWrongCriterionGuidance(t *testing.T) {
 	data, err := os.ReadFile(deliverySkillPath)
 	if err != nil {
 		t.Fatalf("read %s: %v", deliverySkillPath, err)
 	}
 	skill := adaptertest.NormalizeWhitespace(string(data))
-	if !strings.Contains(skill, adaptertest.NormalizeWhitespace(observableOutcomeCriterionGuidance)) {
-		t.Errorf("%s does not contain the observable-outcome criterion guidance %q",
-			deliverySkillPath, observableOutcomeCriterionGuidance)
+	for _, phrase := range []string{
+		observableOutcomeCriterionGuidance,
+		wrongCriterionEscalationGuidance,
+		wrongCriterionEscalationTrigger,
+		wrongCriterionHumanGuidance,
+		codeFindingFixCycleGuidance,
+	} {
+		if !strings.Contains(skill, adaptertest.NormalizeWhitespace(phrase)) {
+			t.Errorf("%s does not contain wrong-criterion guidance %q", deliverySkillPath, phrase)
+		}
 	}
 	for _, stem := range []string{"orch-reviewer", "orch-reviewer-safe"} {
 		t.Run(stem, func(t *testing.T) {
@@ -431,7 +434,7 @@ func TestDeliverySkillAndReviewersHaveWrongCriterionGuidance(t *testing.T) {
 				t.Fatalf("read %s: %v", path, err)
 			}
 			content := adaptertest.NormalizeWhitespace(string(data))
-			for _, phrase := range []string{reviewerWrongCriterionGuidance, reviewerAddedCodeNecessityGuidance} {
+			for _, phrase := range []string{reviewerWrongCriterionGuidance, reviewerAddedCodeNecessityGuidance, reviewerWrongCriterionHumanGuidance} {
 				if !strings.Contains(content, adaptertest.NormalizeWhitespace(phrase)) {
 					t.Errorf("%s: missing reviewer guidance %q", path, phrase)
 				}

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -328,14 +328,21 @@ in flight at once. For each issue:
    reviewer's own cost — only report what the reviewer subagent's
    Task result actually carries, including `total_tokens` when that
    is what it reports instead of the input/output/cache split.
-   `request-changes` loops the same executor in the **same worktree**
-   on the same branch: it fixes and pushes, then a **fresh** reviewer
-   is spawned (step 4) and `orch run review` is called again. Because
-   this is the only verb call on that cycle, `executor_usage` (same
-   optional shape as `usage`) carries the executor's fix-and-push
-   cost for the cycle just finished — report only what its Task
-   result actually gives you, never an estimate, and omit it when
-   there was no fix cycle (the first review after pr-open).
+    A `request-changes` report with a `wrong acceptance criterion` is not
+    an executor fix cycle. Record the review with `orch run review`, then,
+    before asking the executor to change anything, call `orch run escalate`
+    with `trigger` `architectural-ambiguity` and a `detail` that names the
+    rejected criterion and its reason. A `return-to-architect` result is
+    the needs-human outcome: surface the rejected criterion and reason to
+    the human and do not resume the executor. A `request-changes` based on
+    a code finding resumes the same executor in the **same worktree** on
+    the same branch: it fixes and pushes, then a **fresh** reviewer is
+    spawned (step 4) and `orch run review` is called again. Because this is
+    the only verb call on that cycle, `executor_usage` (same optional shape
+    as `usage`) carries the executor's fix-and-push cost for the cycle just
+    finished — report only what its Task result actually gives you, never an
+    estimate, and omit it when there was no fix cycle (the first review
+    after pr-open).
    `orch run pr-open` is not reachable a second time, so `verifications`
    is optional and takes pr-open's input shape — use it to carry
    evidence re-run on the fix commit (e.g. tests re-run before

--- a/adapters/codex/agents/orch-reviewer-safe.toml
+++ b/adapters/codex/agents/orch-reviewer-safe.toml
@@ -55,7 +55,10 @@ control-flow step, or a validity notion the change had to invent in
 order to satisfy the wording is the usual case. Do not redesign the
 criterion yourself, and do not approve a change you believe is wrong
 because it matches what the issue asked for — the Architect takes a
-wrong criterion back to the human.
+wrong criterion back to the human. Mark it `wrong acceptance criterion`
+and state the rejected criterion and reason in the consolidated report
+so the Architect can surface the rejected criterion and reason to the
+human.
 
 Before you request a change that adds code, establish that the added
 code needs to exist at all. "This case is unhandled" is a finding only

--- a/adapters/codex/agents/orch-reviewer.toml
+++ b/adapters/codex/agents/orch-reviewer.toml
@@ -47,7 +47,10 @@ control-flow step, or a validity notion the change had to invent in
 order to satisfy the wording is the usual case. Do not redesign the
 criterion yourself, and do not approve a change you believe is wrong
 because it matches what the issue asked for — the Architect takes a
-wrong criterion back to the human.
+wrong criterion back to the human. Mark it `wrong acceptance criterion`
+and state the rejected criterion and reason in the consolidated report
+so the Architect can surface the rejected criterion and reason to the
+human.
 
 Before you request a change that adds code, establish that the added
 code needs to exist at all. "This case is unhandled" is a finding only

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -283,36 +283,40 @@ func TestDeliverySkillHasBranchScopeVerificationGuidance(t *testing.T) {
 	adaptertest.CheckBranchScopeVerificationGuidance(t, deliverySkillPath)
 }
 
-// The three statements that keep a wrong acceptance criterion
-// reachable: the plan-construction rule that a criterion states an
-// observable outcome rather than the mechanism its author imagines,
-// the reviewer's standing to reject a criterion instead of grading
-// conformance to it, and the necessity test a reviewer must apply
-// before asking for more code. Each phrase is pinned without its
-// surrounding punctuation or em dashes, so rewording around a
-// statement stays possible while deleting the statement fails the
-// test.
+// These statements keep a wrong acceptance criterion reachable and route
+// it to the human rather than through the ordinary executor fix cycle.
+// Each phrase is pinned without its surrounding punctuation or em dashes,
+// so a prose reflow stays possible while deleting the statement fails.
 const observableOutcomeCriterionGuidance = "An acceptance criterion describes an observable outcome, and never names a function, a control-flow step, or a validity notion the change is expected to introduce"
 const reviewerWrongCriterionGuidance = "You may return `request-changes` on the ground that an acceptance criterion is itself wrong"
 const reviewerAddedCodeNecessityGuidance = "Before you request a change that adds code, establish that the added code needs to exist at all"
+const reviewerWrongCriterionHumanGuidance = "Mark it `wrong acceptance criterion` and state the rejected criterion and reason in the consolidated report so the Architect can surface the rejected criterion and reason to the human"
+const wrongCriterionEscalationGuidance = "A `request-changes` report with a `wrong acceptance criterion` is not an executor fix cycle"
+const wrongCriterionEscalationTrigger = "call `orch run escalate` with `trigger` `architectural-ambiguity`"
+const wrongCriterionHumanGuidance = "surface the rejected criterion and reason to the human"
+const codeFindingFixCycleGuidance = "A `request-changes` based on a code finding resumes the same executor with `followup_task` in the **same worktree** on the same branch: it fixes and pushes, then a **fresh** reviewer is dispatched"
 
-// TestDeliverySkillAndReviewersHaveWrongCriterionGuidance checks each
-// of the three statements in the file that owns it: the first in the
-// delivery skill's PlanDoc construction guidance, the other two in both
-// reviewer agent definitions. The agent files are decoded as TOML
-// rather than scanned raw, so a statement only counts when it is inside
-// developer_instructions — the field the agent actually receives.
-// Comparison runs on whitespace-normalized text on both sides, so a
-// statement the prose hard-wraps still matches.
+// TestDeliverySkillAndReviewersHaveWrongCriterionGuidance checks the
+// Delivery escalation/fix-cycle split and both reviewer definitions. The
+// agent files are decoded as TOML rather than scanned raw, so a statement
+// only counts when it is inside developer_instructions — the field the
+// agent actually receives. Comparison ignores hard wraps.
 func TestDeliverySkillAndReviewersHaveWrongCriterionGuidance(t *testing.T) {
 	data, err := os.ReadFile(deliverySkillPath)
 	if err != nil {
 		t.Fatalf("read %s: %v", deliverySkillPath, err)
 	}
 	skill := adaptertest.NormalizeWhitespace(string(data))
-	if !strings.Contains(skill, adaptertest.NormalizeWhitespace(observableOutcomeCriterionGuidance)) {
-		t.Errorf("%s does not contain the observable-outcome criterion guidance %q",
-			deliverySkillPath, observableOutcomeCriterionGuidance)
+	for _, phrase := range []string{
+		observableOutcomeCriterionGuidance,
+		wrongCriterionEscalationGuidance,
+		wrongCriterionEscalationTrigger,
+		wrongCriterionHumanGuidance,
+		codeFindingFixCycleGuidance,
+	} {
+		if !strings.Contains(skill, adaptertest.NormalizeWhitespace(phrase)) {
+			t.Errorf("%s does not contain wrong-criterion guidance %q", deliverySkillPath, phrase)
+		}
 	}
 	for _, stem := range []string{"orch-reviewer", "orch-reviewer-safe"} {
 		t.Run(stem, func(t *testing.T) {
@@ -322,7 +326,7 @@ func TestDeliverySkillAndReviewersHaveWrongCriterionGuidance(t *testing.T) {
 				t.Fatalf("decode %s: %v", path, err)
 			}
 			content := adaptertest.NormalizeWhitespace(a.DeveloperInstructions)
-			for _, phrase := range []string{reviewerWrongCriterionGuidance, reviewerAddedCodeNecessityGuidance} {
+			for _, phrase := range []string{reviewerWrongCriterionGuidance, reviewerAddedCodeNecessityGuidance, reviewerWrongCriterionHumanGuidance} {
 				if !strings.Contains(content, adaptertest.NormalizeWhitespace(phrase)) {
 					t.Errorf("%s: missing reviewer guidance %q", path, phrase)
 				}

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -337,8 +337,15 @@ When capture returns no total, omit the corresponding optional field.
      `usage` is optional (PRD §21), same rule as PR-open: every reviewer
      is fresh, so add only its full exact `{"total_tokens": N}` when
      available.
-    `request-changes` resumes the same executor with `followup_task` in
-    the **same worktree** on the same branch: it fixes and pushes, then a
+    A `request-changes` report with a `wrong acceptance criterion` is not
+    an executor fix cycle. Record the review with `orch run review`, then,
+    before asking the executor to change anything, call `orch run escalate`
+    with `trigger` `architectural-ambiguity` and a `detail` that names the
+    rejected criterion and its reason. A `return-to-architect` result is
+    the needs-human outcome: surface the rejected criterion and reason to
+    the human and do not resume the executor. A `request-changes` based on
+    a code finding resumes the same executor with `followup_task` in the
+    **same worktree** on the same branch: it fixes and pushes, then a
     **fresh** reviewer is dispatched (step 4) and `orch run review` is
     called again.
    Because this is the only verb call on that cycle, `executor_usage`


### PR DESCRIPTION
Delivers issue #149: Return a wrong acceptance criterion to the human

Closes #149

**Plan digest:** `sha256:760357306af0618f2294f2f3938916f693485dfec0a66981383cf8d296cc5f16`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** A reviewer can now reject an approved acceptance criterion as wrong, but Delivery currently treats that verdict as an ordinary request-changes cycle and sends the same executor back to work against the same bad plan. Make a wrong-criterion review stop before any executor fix cycle and surface the criterion and reason to the human on both hosts, while preserving the existing fix-and-re-review behavior for ordinary request-changes findings.

**Acceptance criteria:**
- On both hosts, a review that rejects an acceptance criterion as wrong reaches a needs-human outcome before the executor is asked to make another change.
- On both hosts, request-changes based on a code finding still resumes the same executor and then uses a fresh reviewer.
- The reviewer and Delivery guidance agree that the rejected criterion and the reason are surfaced to the human.
- A runnable adapter regression check fails if a wrong-criterion review is routed through the ordinary executor fix cycle again.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `gpt-5.6-terra` — effort `max` |
| Reviewer | `gpt-5.6-sol` — effort `xhigh` |
| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **adapter-tests** — pass — `go test ./adapters/codex ./adapters/claude` — Both adapter packages passed on commit 8b46811854eff23906e093ff56f350fdf77e3844. — commit `8b46811854eff23906e093ff56f350fdf77e3844` (2026-08-01T01:48:49Z)
- **go-test-all** — pass — `go test ./...` — All packages passed on commit 8b46811854eff23906e093ff56f350fdf77e3844; executor reported 66.5 seconds. — commit `8b46811854eff23906e093ff56f350fdf77e3844` (2026-08-01T01:48:49Z)
- **gofmt** — pass — `gofmt -l .` — No files listed on commit 8b46811854eff23906e093ff56f350fdf77e3844. — commit `8b46811854eff23906e093ff56f350fdf77e3844` (2026-08-01T01:48:49Z)
- **git-diff-check** — pass — `git diff --check` — No whitespace errors on commit 8b46811854eff23906e093ff56f350fdf77e3844. — commit `8b46811854eff23906e093ff56f350fdf77e3844` (2026-08-01T01:48:49Z)
- **branch-scope: files changed vs main** — pass — `git diff --name-only main...HEAD` — One commit changes only eight necessary host reviewer, Delivery-skill, and adapter-test files; no core or dependency change. — commit `8b46811854eff23906e093ff56f350fdf77e3844` (2026-08-01T01:53:33Z)
- **review-go-test-all** — pass — `go test ./...` — Independent reviewer ran all packages successfully on 8b46811854eff23906e093ff56f350fdf77e3844. — commit `8b46811854eff23906e093ff56f350fdf77e3844` (2026-08-01T01:53:33Z)
- **review-gofmt** — pass — `gofmt -l .` — Independent reviewer observed no output on the reviewed head. — commit `8b46811854eff23906e093ff56f350fdf77e3844` (2026-08-01T01:53:33Z)
- **review-adapter-guidance-tests** — pass — `go test ./adapters/codex ./adapters/claude -run TestDeliverySkillAndReviewersHaveWrongCriterionGuidance -count=1` — Both adapter regression checks passed uncached on the reviewed head. — commit `8b46811854eff23906e093ff56f350fdf77e3844` (2026-08-01T01:53:33Z)
- **review-engine-trace** — pass — `read Review and Escalate state transitions` — Review leaves the issue in in-review; Escalate accepts that phase; architectural-ambiguity returns return-to-architect, preserves the detail, and applies needs-human. — commit `8b46811854eff23906e093ff56f350fdf77e3844` (2026-08-01T01:53:33Z)
- **review-ci-checks** — pass — `gh pr checks 151` — All six CI jobs passed on the pinned head. — commit `8b46811854eff23906e093ff56f350fdf77e3844` (2026-08-01T01:53:33Z)
- **review-manifest-accuracy** — pass — `compare issue and PR audit record to repository and engine state` — Objective, criteria, routes, config revision, verification records, file count, and head OID match observed state. — commit `8b46811854eff23906e093ff56f350fdf77e3844` (2026-08-01T01:53:33Z)
- **review-cycle-1** — approve — Approved with no findings. Both hosts distinguish wrong-criterion reviews from ordinary code findings, record and escalate the former to return-to-architect/needs-human before executor follow-up, and preserve the same-executor/fresh-reviewer fix cycle for the latter. Tests, scope, CI, and manifest are accurate. — commit `8b46811854eff23906e093ff56f350fdf77e3844` (2026-08-01T01:53:34Z)
- **required-ci** — passing — scripts (ubuntu-latest)=pass, lint=pass, scripts (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass — commit `8b46811854eff23906e093ff56f350fdf77e3844` (2026-08-01T01:53:38Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "A reviewer can now reject an approved acceptance criterion as wrong, but Delivery currently treats that verdict as an ordinary request-changes cycle and sends the same executor back to work against the same bad plan. Make a wrong-criterion review stop before any executor fix cycle and surface the criterion and reason to the human on both hosts, while preserving the existing fix-and-re-review behavior for ordinary request-changes findings.",
  "acceptance_criteria": [
    "On both hosts, a review that rejects an acceptance criterion as wrong reaches a needs-human outcome before the executor is asked to make another change.",
    "On both hosts, request-changes based on a code finding still resumes the same executor and then uses a fresh reviewer.",
    "The reviewer and Delivery guidance agree that the rejected criterion and the reason are surfaced to the human.",
    "A runnable adapter regression check fails if a wrong-criterion review is routed through the ordinary executor fix cycle again."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "gpt-5.6-terra",
    "effort": "max"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "gpt-5.6-sol",
    "effort": "xhigh"
  },
  "effort_delivery": "parameter",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "adapter-tests",
      "command": "go test ./adapters/codex ./adapters/claude",
      "result": "pass",
      "detail": "Both adapter packages passed on commit 8b46811854eff23906e093ff56f350fdf77e3844.",
      "commit_oid": "8b46811854eff23906e093ff56f350fdf77e3844",
      "at": "2026-08-01T01:48:49Z"
    },
    {
      "name": "go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All packages passed on commit 8b46811854eff23906e093ff56f350fdf77e3844; executor reported 66.5 seconds.",
      "commit_oid": "8b46811854eff23906e093ff56f350fdf77e3844",
      "at": "2026-08-01T01:48:49Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No files listed on commit 8b46811854eff23906e093ff56f350fdf77e3844.",
      "commit_oid": "8b46811854eff23906e093ff56f350fdf77e3844",
      "at": "2026-08-01T01:48:49Z"
    },
    {
      "name": "git-diff-check",
      "command": "git diff --check",
      "result": "pass",
      "detail": "No whitespace errors on commit 8b46811854eff23906e093ff56f350fdf77e3844.",
      "commit_oid": "8b46811854eff23906e093ff56f350fdf77e3844",
      "at": "2026-08-01T01:48:49Z"
    },
    {
      "name": "branch-scope: files changed vs main",
      "command": "git diff --name-only main...HEAD",
      "result": "pass",
      "detail": "One commit changes only eight necessary host reviewer, Delivery-skill, and adapter-test files; no core or dependency change.",
      "commit_oid": "8b46811854eff23906e093ff56f350fdf77e3844",
      "at": "2026-08-01T01:53:33Z"
    },
    {
      "name": "review-go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Independent reviewer ran all packages successfully on 8b46811854eff23906e093ff56f350fdf77e3844.",
      "commit_oid": "8b46811854eff23906e093ff56f350fdf77e3844",
      "at": "2026-08-01T01:53:33Z"
    },
    {
      "name": "review-gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Independent reviewer observed no output on the reviewed head.",
      "commit_oid": "8b46811854eff23906e093ff56f350fdf77e3844",
      "at": "2026-08-01T01:53:33Z"
    },
    {
      "name": "review-adapter-guidance-tests",
      "command": "go test ./adapters/codex ./adapters/claude -run TestDeliverySkillAndReviewersHaveWrongCriterionGuidance -count=1",
      "result": "pass",
      "detail": "Both adapter regression checks passed uncached on the reviewed head.",
      "commit_oid": "8b46811854eff23906e093ff56f350fdf77e3844",
      "at": "2026-08-01T01:53:33Z"
    },
    {
      "name": "review-engine-trace",
      "command": "read Review and Escalate state transitions",
      "result": "pass",
      "detail": "Review leaves the issue in in-review; Escalate accepts that phase; architectural-ambiguity returns return-to-architect, preserves the detail, and applies needs-human.",
      "commit_oid": "8b46811854eff23906e093ff56f350fdf77e3844",
      "at": "2026-08-01T01:53:33Z"
    },
    {
      "name": "review-ci-checks",
      "command": "gh pr checks 151",
      "result": "pass",
      "detail": "All six CI jobs passed on the pinned head.",
      "commit_oid": "8b46811854eff23906e093ff56f350fdf77e3844",
      "at": "2026-08-01T01:53:33Z"
    },
    {
      "name": "review-manifest-accuracy",
      "command": "compare issue and PR audit record to repository and engine state",
      "result": "pass",
      "detail": "Objective, criteria, routes, config revision, verification records, file count, and head OID match observed state.",
      "commit_oid": "8b46811854eff23906e093ff56f350fdf77e3844",
      "at": "2026-08-01T01:53:33Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approved with no findings. Both hosts distinguish wrong-criterion reviews from ordinary code findings, record and escalate the former to return-to-architect/needs-human before executor follow-up, and preserve the same-executor/fresh-reviewer fix cycle for the latter. Tests, scope, CI, and manifest are accurate.",
      "commit_oid": "8b46811854eff23906e093ff56f350fdf77e3844",
      "at": "2026-08-01T01:53:34Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "scripts (ubuntu-latest)=pass, lint=pass, scripts (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass",
      "commit_oid": "8b46811854eff23906e093ff56f350fdf77e3844",
      "at": "2026-08-01T01:53:38Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->