### PR TITLE
Bump adapter version to 0.5.10

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "kninetimmy" },
   "metadata": {
     "description": "Host adapters for the Orch development orchestrator",
-    "version": "0.5.9"
+    "version": "0.5.10"
   },
   "plugins": [
     {

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Claude Code host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -78,8 +78,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.9" {
-		t.Errorf("version = %q, want 0.5.9", m.Version)
+	if m.Version != "0.5.10" {
+		t.Errorf("version = %q, want 0.5.10", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Codex CLI host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -79,8 +79,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.9" {
-		t.Errorf("version = %q, want 0.5.9", m.Version)
+	if m.Version != "0.5.10" {
+		t.Errorf("version = %q, want 0.5.10", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")


### PR DESCRIPTION
Delivers issue #150: Bump adapter version to 0.5.10

Closes #150

**Plan digest:** `sha256:760357306af0618f2294f2f3938916f693485dfec0a66981383cf8d296cc5f16`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Adapter content changed after the 0.5.9 version bump, so 0.5.9 now identifies two different plugin byte sets. Assign the completed adapter content a fresh 0.5.10 identity, with this bump landing after every other release change.

**Acceptance criteria:**
- The repository marketplace metadata and both host plugin manifests report version 0.5.10.
- Both adapter manifest checks expect version 0.5.10 and pass.
- The change contains only the version identity updates needed for 0.5.10.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `gpt-5.6-terra` — effort `max` |
| Reviewer | `gpt-5.6-sol` — effort `medium` |
| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **go-test-all** — pass — `go test ./...` — Independent reviewer ran all packages successfully on the pinned head. — commit `bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f` (2026-08-01T02:03:25Z)
- **gofmt** — pass — `gofmt -l .` — Independent reviewer observed no files listed. — commit `bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f` (2026-08-01T02:03:25Z)
- **git-diff-check** — pass — `git diff --check origin/main...HEAD` — No whitespace errors in the reviewed PR diff. — commit `bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f` (2026-08-01T02:03:25Z)
- **branch-scope: files changed vs main** — pass — `git diff --name-only origin/main...HEAD` — Correction: exactly five files changed: marketplace metadata, both host plugin manifests, and both adapter manifest tests. The pr-open command used stale local main at 695b044 and misleadingly included already-merged PR #151 files; origin/main is 5a91e487, matching GitHub's PR base. GitHub metadata and HEAD^..HEAD confirm the same five files and +7/-7. — commit `bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f` (2026-08-01T02:03:25Z)
- **pinned-head** — pass — `git rev-parse HEAD` — Reviewed head is bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f and its sole parent is GitHub base 5a91e487244e6bfab4b8b4da7186ef203c85180c. — commit `bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f` (2026-08-01T02:03:25Z)
- **adapter-version-identity** — pass — `rg -n --hidden --glob !.git 0.5.(9|10) .` — All seven relevant version literals are 0.5.10; no 0.5.9 remains. — commit `bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f` (2026-08-01T02:03:25Z)
- **github-ci** — pass — `gh pr checks 152 --repo kninetimmy/orch` — All six checks passed: lint; scripts on Ubuntu and Windows; tests on Ubuntu, Windows, and macOS. — commit `bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f` (2026-08-01T02:03:25Z)
- **review-cycle-1** — approve — Approved with no findings. Marketplace metadata, both host manifests, and both manifest checks use 0.5.10; the diff contains only seven literal replacements across the five intended identity files. Required tests and all six CI jobs pass. The stale-local-main scope record is corrected by the replacement verification in this review. — commit `bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f` (2026-08-01T02:03:26Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, scripts (windows-latest)=pass, test (windows-latest)=pass, lint=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass — commit `bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f` (2026-08-01T02:03:31Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Adapter content changed after the 0.5.9 version bump, so 0.5.9 now identifies two different plugin byte sets. Assign the completed adapter content a fresh 0.5.10 identity, with this bump landing after every other release change.",
  "acceptance_criteria": [
    "The repository marketplace metadata and both host plugin manifests report version 0.5.10.",
    "Both adapter manifest checks expect version 0.5.10 and pass.",
    "The change contains only the version identity updates needed for 0.5.10."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "gpt-5.6-terra",
    "effort": "max"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "gpt-5.6-sol",
    "effort": "medium"
  },
  "effort_delivery": "parameter",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Independent reviewer ran all packages successfully on the pinned head.",
      "commit_oid": "bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f",
      "at": "2026-08-01T02:03:25Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Independent reviewer observed no files listed.",
      "commit_oid": "bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f",
      "at": "2026-08-01T02:03:25Z"
    },
    {
      "name": "git-diff-check",
      "command": "git diff --check origin/main...HEAD",
      "result": "pass",
      "detail": "No whitespace errors in the reviewed PR diff.",
      "commit_oid": "bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f",
      "at": "2026-08-01T02:03:25Z"
    },
    {
      "name": "branch-scope: files changed vs main",
      "command": "git diff --name-only origin/main...HEAD",
      "result": "pass",
      "detail": "Correction: exactly five files changed: marketplace metadata, both host plugin manifests, and both adapter manifest tests. The pr-open command used stale local main at 695b044 and misleadingly included already-merged PR #151 files; origin/main is 5a91e487, matching GitHub's PR base. GitHub metadata and HEAD^..HEAD confirm the same five files and +7/-7.",
      "commit_oid": "bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f",
      "at": "2026-08-01T02:03:25Z"
    },
    {
      "name": "pinned-head",
      "command": "git rev-parse HEAD",
      "result": "pass",
      "detail": "Reviewed head is bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f and its sole parent is GitHub base 5a91e487244e6bfab4b8b4da7186ef203c85180c.",
      "commit_oid": "bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f",
      "at": "2026-08-01T02:03:25Z"
    },
    {
      "name": "adapter-version-identity",
      "command": "rg -n --hidden --glob !.git 0.5.(9|10) .",
      "result": "pass",
      "detail": "All seven relevant version literals are 0.5.10; no 0.5.9 remains.",
      "commit_oid": "bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f",
      "at": "2026-08-01T02:03:25Z"
    },
    {
      "name": "github-ci",
      "command": "gh pr checks 152 --repo kninetimmy/orch",
      "result": "pass",
      "detail": "All six checks passed: lint; scripts on Ubuntu and Windows; tests on Ubuntu, Windows, and macOS.",
      "commit_oid": "bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f",
      "at": "2026-08-01T02:03:25Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approved with no findings. Marketplace metadata, both host manifests, and both manifest checks use 0.5.10; the diff contains only seven literal replacements across the five intended identity files. Required tests and all six CI jobs pass. The stale-local-main scope record is corrected by the replacement verification in this review.",
      "commit_oid": "bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f",
      "at": "2026-08-01T02:03:26Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, scripts (windows-latest)=pass, test (windows-latest)=pass, lint=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "bbf5e8ef5612662adbb34fb8fee48a3e6ce7449f",
      "at": "2026-08-01T02:03:31Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->