### PR TITLE
Report and refuse on stale rendered Codex agent definitions

### DIFF
--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -11,8 +11,10 @@
 package agents
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -165,6 +167,38 @@ func Write(repoRoot string, files []File) error {
 		}
 	}
 	return nil
+}
+
+// Stale reports which of the files Write would put in repoRoot's Dir
+// for h are absent or differ from what Render produces now, as
+// repo-relative slash-form paths in roleFiles order, or nil when every
+// file matches. The rendered output is a machine-local artifact git
+// never carries, so nothing else notices when it falls behind the
+// build's canonical text or the effective configuration; this is the
+// module's single implementation of that comparison, shared by `orch
+// doctor`'s check and the codex-host activation preflight. A file that
+// exists but cannot be read is an error, not a stale file: the caller
+// fails closed either way, and the read error says more.
+func Stale(repoRoot string, h *config.Host) ([]string, error) {
+	files, err := Render(h)
+	if err != nil {
+		return nil, err
+	}
+	dir := filepath.Join(repoRoot, filepath.FromSlash(Dir))
+	var stale []string
+	for _, f := range files {
+		rel := Dir + "/" + f.Name + ".toml"
+		got, err := os.ReadFile(filepath.Join(dir, f.Name+".toml"))
+		switch {
+		case errors.Is(err, fs.ErrNotExist):
+			stale = append(stale, rel)
+		case err != nil:
+			return nil, fmt.Errorf("read %s: %w", rel, err)
+		case !bytes.Equal(got, f.Content):
+			stale = append(stale, rel)
+		}
+	}
+	return stale, nil
 }
 
 func writeAtomic(path, dir string, data []byte) error {

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -1,4 +1,8 @@
-package agents
+// Package agents_test is an external test package on purpose: its
+// adaptertest fixture imports internal/run, which imports this package
+// for the activation preflight, so an in-package test would be an
+// import cycle.
+package agents_test
 
 import (
 	"os"
@@ -10,6 +14,7 @@ import (
 
 	"github.com/kninetimmy/orch/adapters/codex"
 	"github.com/kninetimmy/orch/internal/adaptertest"
+	"github.com/kninetimmy/orch/internal/agents"
 	"github.com/kninetimmy/orch/internal/config"
 )
 
@@ -39,7 +44,7 @@ func defaultCodexHost() *config.Host {
 // Render itself uses, since that embed is the single canonical
 // source — see adapters/codex/embed.go).
 func TestRenderDefaultProfileByteIdenticalToShipped(t *testing.T) {
-	files, err := Render(defaultCodexHost())
+	files, err := agents.Render(defaultCodexHost())
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -60,7 +65,7 @@ func TestRenderDefaultProfileByteIdenticalToShipped(t *testing.T) {
 // TestRenderOrderAndNames pins the exact five file stems Render
 // produces, in order.
 func TestRenderOrderAndNames(t *testing.T) {
-	files, err := Render(defaultCodexHost())
+	files, err := agents.Render(defaultCodexHost())
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -99,7 +104,7 @@ func TestRenderOverrideSubstitution(t *testing.T) {
 		Reviewer:        config.RoleProfile{Model: "gpt-9000-ultra", Effort: "medium"},
 		ReviewDowngrade: config.RoleProfile{Model: "gpt-9000", Effort: "high"},
 	}}
-	files, err := Render(h)
+	files, err := agents.Render(h)
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -155,8 +160,8 @@ func TestRenderOverrideSubstitution(t *testing.T) {
 }
 
 func TestRenderNilHostFailsClosed(t *testing.T) {
-	if _, err := Render(nil); err == nil {
-		t.Error("Render(nil) succeeded, want an error")
+	if _, err := agents.Render(nil); err == nil {
+		t.Error("agents.Render(nil) succeeded, want an error")
 	}
 }
 
@@ -164,7 +169,7 @@ func TestRenderNilHostFailsClosed(t *testing.T) {
 // package documents: a rendered file must never introduce a carriage
 // return the shipped source did not already contain.
 func TestRenderNoTrailingCR(t *testing.T) {
-	files, err := Render(defaultCodexHost())
+	files, err := agents.Render(defaultCodexHost())
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -177,15 +182,15 @@ func TestRenderNoTrailingCR(t *testing.T) {
 
 func TestWriteCreatesDirectoryAndFiles(t *testing.T) {
 	root := t.TempDir()
-	files, err := Render(defaultCodexHost())
+	files, err := agents.Render(defaultCodexHost())
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
-	if err := Write(root, files); err != nil {
+	if err := agents.Write(root, files); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 
-	dir := filepath.Join(root, filepath.FromSlash(Dir))
+	dir := filepath.Join(root, filepath.FromSlash(agents.Dir))
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatalf("ReadDir: %v", err)
@@ -215,7 +220,7 @@ func TestWriteCreatesDirectoryAndFiles(t *testing.T) {
 // content rather than leaving it or appending to it.
 func TestWriteOverwritesExisting(t *testing.T) {
 	root := t.TempDir()
-	dir := filepath.Join(root, filepath.FromSlash(Dir))
+	dir := filepath.Join(root, filepath.FromSlash(agents.Dir))
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -224,11 +229,11 @@ func TestWriteOverwritesExisting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	files, err := Render(defaultCodexHost())
+	files, err := agents.Render(defaultCodexHost())
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
-	if err := Write(root, files); err != nil {
+	if err := agents.Write(root, files); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 
@@ -238,5 +243,78 @@ func TestWriteOverwritesExisting(t *testing.T) {
 	}
 	if strings.Contains(string(got), "stale content") {
 		t.Error("stale content survived Write")
+	}
+}
+
+// TestStale covers the three states doctor and the codex activation
+// preflight both distinguish: every file absent, every file matching,
+// and one file edited under them.
+func TestStale(t *testing.T) {
+	root := t.TempDir()
+	h := defaultCodexHost()
+
+	stale, err := agents.Stale(root, h)
+	if err != nil {
+		t.Fatalf("Stale: %v", err)
+	}
+	want := []string{
+		agents.Dir + "/orch-scout.toml",
+		agents.Dir + "/orch-implementer.toml",
+		agents.Dir + "/orch-specialist.toml",
+		agents.Dir + "/orch-reviewer.toml",
+		agents.Dir + "/orch-reviewer-safe.toml",
+	}
+	if strings.Join(stale, ",") != strings.Join(want, ",") {
+		t.Errorf("Stale on an empty repo = %v, want all five files %v", stale, want)
+	}
+
+	files, err := agents.Render(h)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if err := agents.Write(root, files); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	stale, err = agents.Stale(root, h)
+	if err != nil {
+		t.Fatalf("Stale: %v", err)
+	}
+	if len(stale) != 0 {
+		t.Errorf("Stale right after Write = %v, want none", stale)
+	}
+
+	edited := filepath.Join(root, filepath.FromSlash(agents.Dir), "orch-reviewer.toml")
+	if err := os.WriteFile(edited, append(files[3].Content, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stale, err = agents.Stale(root, h)
+	if err != nil {
+		t.Fatalf("Stale: %v", err)
+	}
+	if len(stale) != 1 || stale[0] != agents.Dir+"/orch-reviewer.toml" {
+		t.Errorf("Stale after an edit = %v, want only orch-reviewer.toml", stale)
+	}
+}
+
+// TestStaleConfigurationChange proves a roles change alone — the same
+// build, the same files on disk — makes them stale.
+func TestStaleConfigurationChange(t *testing.T) {
+	root := t.TempDir()
+	files, err := agents.Render(defaultCodexHost())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if err := agents.Write(root, files); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	h := defaultCodexHost()
+	h.Roles.Reviewer = config.RoleProfile{Model: "gpt-9000-ultra", Effort: "low"}
+	stale, err := agents.Stale(root, h)
+	if err != nil {
+		t.Fatalf("Stale: %v", err)
+	}
+	if len(stale) != 1 || stale[0] != agents.Dir+"/orch-reviewer.toml" {
+		t.Errorf("Stale after a reviewer roles change = %v, want only orch-reviewer.toml", stale)
 	}
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/kninetimmy/orch/internal/agents"
 	"github.com/kninetimmy/orch/internal/config"
 	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/gitops"
@@ -101,6 +102,22 @@ func runDoctor(env Env) error {
 			check("metrics .gitignore", fmt.Errorf("metrics is enabled but %s is missing from .gitignore; run `orch configure` to add it", metrics.GitignoreLine))
 		default:
 			check("metrics .gitignore", nil)
+		}
+	}
+
+	// Rendered codex agent files (only meaningful, and only checked,
+	// when hosts.codex is in the effective configuration): the files a
+	// Codex session actually loads are machine-local, so a build upgrade
+	// or a roles change leaves them silently behind until doctor says so.
+	if cfgErr == nil && cfg.Hosts.Codex != nil {
+		stale, staleErr := agents.Stale(env.RepoRoot, cfg.Hosts.Codex)
+		switch {
+		case staleErr != nil:
+			check("codex agent files", staleErr)
+		case len(stale) > 0:
+			check("codex agent files", fmt.Errorf("absent or out of date: %s; run `orch render-agents` to regenerate them", strings.Join(stale, ", ")))
+		default:
+			check("codex agent files", nil)
 		}
 	}
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kninetimmy/orch/internal/agents"
 	"github.com/kninetimmy/orch/internal/lockfile"
 	"github.com/kninetimmy/orch/internal/state"
 )
@@ -453,5 +454,77 @@ func TestDoctorPolicyViolatingLocalOverrideFails(t *testing.T) {
 	}
 	if !strings.Contains(out, "schema_version") {
 		t.Errorf("stdout missing policy-violation detail:\n%s", out)
+	}
+}
+
+// TestDoctorNoCodexHostSkipsCheck proves a repository without
+// hosts.codex in its effective configuration gets no codex agent files
+// check line at all — validTOML is claude-only, so every other doctor
+// test in this file covers the same ground.
+func TestDoctorNoCodexHostSkipsCheck(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	if strings.Contains(stdout.String(), "codex agent files") {
+		t.Errorf("stdout carries a codex agent files check though hosts.codex is absent:\n%s", stdout.String())
+	}
+}
+
+// TestDoctorCodexAgentsAbsentFails proves doctor fails closed, naming
+// every missing file and the command that repairs them, when
+// hosts.codex is configured but `orch render-agents` never ran.
+func TestDoctorCodexAgentsAbsentFails(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validCodexTOML)
+	if code := Run([]string{"doctor"}, env); code != ExitError {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitError, stdout.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "FAIL  codex agent files") {
+		t.Errorf("stdout missing the codex agent files failure:\n%s", out)
+	}
+	for _, name := range renderedAgentFiles {
+		if !strings.Contains(out, agents.Dir+"/"+name+".toml") {
+			t.Errorf("stdout does not name %s:\n%s", name, out)
+		}
+	}
+	if !strings.Contains(out, "orch render-agents") {
+		t.Errorf("stdout does not name the repairing command:\n%s", out)
+	}
+}
+
+// TestDoctorCodexAgentsCurrentPasses proves the check passes right
+// after a render, and fails again naming only the file that drifts when
+// one is edited under it.
+func TestDoctorCodexAgentsCurrentPasses(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validCodexTOML)
+	if code := Run([]string{"render-agents"}, env); code != ExitOK {
+		t.Fatalf("render-agents exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	stdout.Reset()
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "ok    codex agent files") {
+		t.Errorf("stdout missing the passing codex agent files check:\n%s", stdout.String())
+	}
+
+	edited := filepath.Join(env.RepoRoot, filepath.FromSlash(agents.Dir), "orch-reviewer.toml")
+	if err := os.WriteFile(edited, []byte("hand-edited\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	if code := Run([]string{"doctor"}, env); code != ExitError {
+		t.Fatalf("exit = %d, want %d after an edit\n%s", code, ExitError, stdout.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, agents.Dir+"/orch-reviewer.toml") {
+		t.Errorf("stdout does not name the edited file:\n%s", out)
+	}
+	if strings.Contains(out, agents.Dir+"/orch-scout.toml") {
+		t.Errorf("stdout names an untouched file:\n%s", out)
 	}
 }

--- a/internal/run/activate.go
+++ b/internal/run/activate.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kninetimmy/orch/internal/agents"
 	"github.com/kninetimmy/orch/internal/config"
 	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/gitops"
@@ -114,7 +115,8 @@ func wrapAfterEnter(err error) error {
 //
 //   - Phase 1 (pure validation): decode/validate the plan and its
 //     approval, derive routing and labels for every issue.
-//   - Phase 2 (read-only preflights): Assist+no-lock, clean primary
+//   - Phase 2 (read-only preflights): Assist+no-lock, the rendered
+//     codex agent files current on a codex-host plan, clean primary
 //     checkout, authenticated GitHub remote, primary on the default
 //     branch (F4), every plan-declared area label existing in the
 //     repository (area labels are repository-defined per PRD §13, so
@@ -180,6 +182,20 @@ func Activate(ctx context.Context, env Env, reqJSON []byte) (*ActivationResult, 
 	// Phase 2: read-only preflights.
 	if err := requireAssistNoLock(env.RepoRoot); err != nil {
 		return nil, err
+	}
+	if plan.Host == "codex" {
+		// The agent definitions a Codex session loads are machine-local
+		// (`orch render-agents` output, never carried by git), so a build
+		// upgrade or a roles change leaves them behind with nothing to
+		// notice. Dispatching from stale definitions runs the whole wave
+		// on older instructions, so refuse before anything is created.
+		stale, err := agents.Stale(env.RepoRoot, cfg.Hosts.Codex)
+		if err != nil {
+			return nil, err
+		}
+		if len(stale) > 0 {
+			return nil, fmt.Errorf("%w: %s; run `orch render-agents` in the primary checkout, then resubmit", ErrAgentsStale, strings.Join(stale, ", "))
+		}
 	}
 	git, err := gitops.Open(ctx, env.Runner, env.RepoRoot)
 	if err != nil {

--- a/internal/run/activate_test.go
+++ b/internal/run/activate_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kninetimmy/orch/internal/agents"
+	"github.com/kninetimmy/orch/internal/config"
 	"github.com/kninetimmy/orch/internal/execx"
 	"github.com/kninetimmy/orch/internal/execx/execxtest"
 	"github.com/kninetimmy/orch/internal/ghops"
@@ -654,5 +656,182 @@ func TestActivateBranchExistsMidRun(t *testing.T) {
 	}
 	if st.Run.Issues[1].Phase != state.PhaseIssueCreated {
 		t.Errorf("issue b phase = %s, want issue-created (worktree add failed)", st.Run.Issues[1].Phase)
+	}
+}
+
+// testConfigTOMLCodex is testConfigTOML with the codex host enabled at
+// the PRD §10 codex defaults, for the rendered-agent preflight.
+const testConfigTOMLCodex = testConfigTOML + `
+[hosts.codex.roles.architect]
+model  = "gpt-5.6-sol"
+effort = "xhigh"
+
+[hosts.codex.roles.scout]
+model  = "gpt-5.6-luna"
+effort = "max"
+
+[hosts.codex.roles.implementer]
+model  = "gpt-5.6-terra"
+effort = "max"
+
+[hosts.codex.roles.specialist]
+model  = "gpt-5.6-sol"
+effort = "max"
+
+[hosts.codex.roles.reviewer]
+model  = "gpt-5.6-sol"
+effort = "xhigh"
+
+[hosts.codex.roles.review_downgrade]
+model  = "gpt-5.6-sol"
+effort = "high"
+`
+
+// codexPlanJSON is a minimal single-issue plan on the codex host,
+// passing Validate against testConfigTOMLCodex.
+func codexPlanJSON() string {
+	return `{
+  "schema_version": 1,
+  "host": "codex",
+  "title": "Codex plan",
+  "issues": [
+    {
+      "id": "a",
+      "title": "Issue A",
+      "objective": "Do A",
+      "acceptance_criteria": ["A works"],
+      "type": "feature",
+      "facts": {"read_only": false},
+      "wave": 1,
+      "required_tests": ["go test ./..."],
+      "usage_class": "light"
+    }
+  ]
+}`
+}
+
+// newCodexActivateRepo builds a sandbox repo with the codex host
+// enabled and .codex/ git-ignored (the rendered agent files are
+// machine-local, so a real codex repository ignores them).
+func newCodexActivateRepo(t *testing.T) string {
+	t.Helper()
+	return newActivateRepoWithConfigAndIgnore(t, testConfigTOMLCodex, fullGitignore+"/.codex/\n")
+}
+
+// renderAgentFiles writes the current rendered agent files into root,
+// the state `orch render-agents` leaves behind.
+func renderAgentFiles(t *testing.T, root string) {
+	t.Helper()
+	cfg, err := config.Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files, err := agents.Render(cfg.Hosts.Codex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := agents.Write(root, files); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestActivateCodexStaleAgentsLeavesNothing proves a codex-host plan is
+// refused before anything is created when the rendered agent files are
+// absent: the empty script asserts activation never even reached gh.
+func TestActivateCodexStaleAgentsLeavesNothing(t *testing.T) {
+	root := newCodexActivateRepo(t)
+	script := &execxtest.Script{T: t}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	_, err := Activate(context.Background(), env, activationJSON(t, codexPlanJSON()))
+	if !errors.Is(err, ErrAgentsStale) {
+		t.Fatalf("err = %v, want ErrAgentsStale", err)
+	}
+	if !strings.Contains(err.Error(), agents.Dir+"/orch-reviewer.toml") {
+		t.Errorf("err = %v, want each absent file named", err)
+	}
+	if !strings.Contains(err.Error(), "orch render-agents") {
+		t.Errorf("err = %v, want the repairing command named", err)
+	}
+	script.AssertExhausted()
+	assertNoDeliveryState(t, root)
+}
+
+// TestActivateCodexEditedAgentFileRefused proves a rendered file edited
+// under the run is refused just like an absent one, naming only it.
+func TestActivateCodexEditedAgentFileRefused(t *testing.T) {
+	root := newCodexActivateRepo(t)
+	renderAgentFiles(t, root)
+	edited := filepath.Join(root, filepath.FromSlash(agents.Dir), "orch-scout.toml")
+	if err := os.WriteFile(edited, []byte("hand-edited\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	script := &execxtest.Script{T: t}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	_, err := Activate(context.Background(), env, activationJSON(t, codexPlanJSON()))
+	if !errors.Is(err, ErrAgentsStale) {
+		t.Fatalf("err = %v, want ErrAgentsStale", err)
+	}
+	if !strings.Contains(err.Error(), agents.Dir+"/orch-scout.toml") {
+		t.Errorf("err = %v, want the edited file named", err)
+	}
+	if strings.Contains(err.Error(), agents.Dir+"/orch-reviewer.toml") {
+		t.Errorf("err = %v, want the untouched files unnamed", err)
+	}
+	script.AssertExhausted()
+	assertNoDeliveryState(t, root)
+}
+
+// TestActivateCodexCurrentAgentsProceeds proves the preflight passes on
+// files that match the effective configuration — the check compares
+// against the plan's own host, not some other one.
+func TestActivateCodexCurrentAgentsProceeds(t *testing.T) {
+	root := newCodexActivateRepo(t)
+	renderAgentFiles(t, root)
+	calls := append(fullTaxonomyScript(),
+		ghIssueCreateCall("Issue A", []string{"ready", "feature", "implementer", "standard"}, 1),
+	)
+	script := &execxtest.Script{T: t, Calls: calls}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	result, err := Activate(context.Background(), env, activationJSON(t, codexPlanJSON()))
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	script.AssertExhausted()
+	if len(result.Issues) != 1 || result.Issues[0].Number != 1 {
+		t.Errorf("Issues = %+v, want one issue #1", result.Issues)
+	}
+}
+
+// TestActivateNonCodexIgnoresStaleAgents proves a plan on another host
+// is unaffected by rendered agent files that differ (the absent case is
+// what every other claude activation test in this file already runs
+// against): the preflight is keyed on the plan's host, not on the
+// files.
+func TestActivateNonCodexIgnoresStaleAgents(t *testing.T) {
+	root := newActivateRepoWithIgnore(t, fullGitignore+"/.codex/\n")
+	dir := filepath.Join(root, filepath.FromSlash(agents.Dir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "orch-scout.toml"), []byte("hand-edited\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	calls := append(fullTaxonomyScript(),
+		ghIssueCreateCall("Issue A", []string{"ready", "feature", "implementer", "standard"}, 1),
+	)
+	script := &execxtest.Script{T: t, Calls: calls}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	claudePlan := strings.Replace(codexPlanJSON(), `"host": "codex"`, `"host": "claude"`, 1)
+	result, err := Activate(context.Background(), env, activationJSON(t, claudePlan))
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	script.AssertExhausted()
+	if len(result.Issues) != 1 || result.Issues[0].Number != 1 {
+		t.Errorf("Issues = %+v, want one issue #1", result.Issues)
 	}
 }

--- a/internal/run/errors.go
+++ b/internal/run/errors.go
@@ -24,6 +24,12 @@ var (
 	// repository-defined (PRD §13), so activation never creates them —
 	// it fails closed before any mutation instead.
 	ErrAreaLabelMissing = errors.New("plan-declared area labels do not exist in the repository")
+	// ErrAgentsStale reports that a codex-host activation found the
+	// rendered agent definitions a Codex session loads absent or no
+	// longer equal to what the build and the effective configuration
+	// produce: those files are machine-local, so dispatching from them
+	// would run reviewers and implementers on older instructions.
+	ErrAgentsStale = errors.New("rendered codex agent files are absent or out of date")
 	// ErrMemhubRequired reports that config.Memhub.Mode is "required"
 	// and the memhub probe failed or could not run (PRD §20: fail
 	// closed rather than proceed without memory).


### PR DESCRIPTION
Delivers issue #153: Report and refuse on stale rendered Codex agent definitions

Closes #153

**Plan digest:** `sha256:b295dff5d34e850c8ce0d923a9fbfd0cec12902c1dffd23b86cfb7afcf01c7cc`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** The Codex agent definitions a Codex session loads are written by `orch render-agents` from the canonical text embedded in the build, into a machine-local directory that git never carries. When that directory falls behind the build, nothing reports it: `orch doctor` passes every check and a Delivery run dispatches reviewers running older instructions. Make that mismatch a visible failing check, and make it stop a Codex-host run before any issue or worktree is created.

**Acceptance criteria:**
- `orch doctor` reports a failing check, naming each file that differs, when any file `orch render-agents` writes is absent or differs from the content the effective configuration produces.
- `orch doctor` reports that check as passing when every such file matches, and does not report the check at all when hosts.codex is absent from the effective configuration.
- `orch run activate` refuses, before it creates any issue or worktree, when the submitted plan's host is codex and any file `orch render-agents` writes is absent or differs, and the refusal names the command that repairs it.
- `orch run activate` on a plan whose host is not codex succeeds regardless of whether those files are absent or differ.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **go-test-all** — pass — `go test ./...` — Executor reported all packages ok with no failures on commit 9d72095. — commit `9d720959fa343fda07cf9118feadcac92a82c053` (2026-08-01T02:56:06Z)
- **gofmt** — pass — `gofmt -l .` — Executor reported no output on commit 9d72095. — commit `9d720959fa343fda07cf9118feadcac92a82c053` (2026-08-01T02:56:06Z)
- **go-vet** — pass — `go vet ./...` — Executor reported no diagnostics on commit 9d72095. — commit `9d720959fa343fda07cf9118feadcac92a82c053` (2026-08-01T02:56:06Z)
- **go-build** — pass — `go build ./...` — Executor reported the build succeeded on commit 9d72095. — commit `9d720959fa343fda07cf9118feadcac92a82c053` (2026-08-01T02:56:06Z)
- **branch-scope: commits and files vs main** — pass — `git log --oneline main..HEAD; git diff --name-only main...HEAD; git diff --shortstat main...HEAD` — Architect re-ran these at the reviewed head: one commit 9d72095, seven files, 417 insertions and 14 deletions, every file under internal/. Unchanged since pr-open; no fix commit has been pushed. — commit `9d720959fa343fda07cf9118feadcac92a82c053` (2026-08-01T03:05:21Z)
- **review-go-test-all** — pass — `go test ./...` — Reviewer ran all packages on the reviewed head; all passed. — commit `9d720959fa343fda07cf9118feadcac92a82c053` (2026-08-01T03:05:21Z)
- **review-gofmt** — pass — `gofmt -l .` — Reviewer observed no output on the reviewed head. — commit `9d720959fa343fda07cf9118feadcac92a82c053` (2026-08-01T03:05:21Z)
- **review-go-vet** — pass — `go vet ./...` — Reviewer observed no diagnostics on the reviewed head. — commit `9d720959fa343fda07cf9118feadcac92a82c053` (2026-08-01T03:05:21Z)
- **review-ci-checks** — pass — `gh pr checks 157` — Reviewer observed 6 of 6 CI jobs passing on the reviewed head. — commit `9d720959fa343fda07cf9118feadcac92a82c053` (2026-08-01T03:05:21Z)
- **review-gitignore-trace** — pass — `read internal/interview/summary.go gitignoreLines and this repository's .gitignore` — Architect confirmed directly: gitignoreLines returns only the four .orchestrator entries plus .orchestrator/metrics/, with no .codex line for init or configure; this repository's /.codex/ line carries a hand-written comment and came from PR #115, not from any orch command. — commit `9d720959fa343fda07cf9118feadcac92a82c053` (2026-08-01T03:05:21Z)
- **review-user-global-docs** — pass — `grep -n 'codex/agents' README.md adapters/codex/README.md` — Architect confirmed directly: README.md lines 126-128 and adapters/codex/README.md line 103 both document a user-global agent directory as a supported install destination. — commit `9d720959fa343fda07cf9118feadcac92a82c053` (2026-08-01T03:05:21Z)
- **review-cycle-1** — request-changes — request-changes on two independent grounds, one of which is a wrong acceptance criterion. GROUND 1, blocks criterion 3: the refusal names `orch render-agents` as the repair, but in a repository orch itself initialized, running it does not repair the activation. internal/interview/summary.go's gitignoreLines proposes only .orchestrator/ entries plus .orchestrator/metrics/ and never a .codex/ line, for either `orch init` or `orch configure`. So render-agents writes five untracked files, gitops.RequireClean runs immediately after the new preflight, and the resubmit trades an ErrAgentsStale refusal for an ErrNotClean one telling the user to commit or stash machine-local generated files. The PR concedes this in its own fixture, which appends /.codex/ to a fullGitignore that deliberately lacks it. This repository's own /.codex/ line was hand-added by a human with an explanatory comment, not proposed by any orch command. The codebase already names and solves this exact failure class for metrics: metricsGitignoreLine is proposed unconditionally precisely so a later write cannot be the first time the line appears. GROUND 2, WRONG ACCEPTANCE CRITERION, criterion 1: the criterion pins validity to the byte-state of one path, the repository-local render destination, while the objective's stated harm is that a Codex session loads older instructions. README.md install step 4b and adapters/codex/README.md step 4 both document a user-global agent directory as a supported destination, and agents.Stale reads only the repository-local one, so a correctly installed and fully current user-global setup is reported as broken: doctor FAILs and every codex plan is refused permanently, with adapters/codex/README.md step 6 sending that user to `orch doctor` as the next step after the step offering the option. No conforming implementation could avoid that false failure, so this is not fixable inside the criterion. The human must decide whether the user-global layout is still supported (the criterion's location notion is then wrong) or is being dropped (an explicit decision, and both READMEs need updating). Recorded decision 55 says render-agents is deliberately project-local, which is the tension the criterion made load-bearing. Non-blocking findings for the backlog: criterion 4's test uses a claude-only configuration so the both-hosts-configured case is unpinned; agents.Stale does not notice orphaned files a newer build no longer renders; `orch doctor` run inside a Delivery worktree would report the codex check failing. The reviewer cleared three leads I gave it: the preflight placement leaves no partial state, the import cycle forcing the test-package conversion is real, and the omitted adapter and README wording is correctly omitted under the necessity test. — commit `9d720959fa343fda07cf9118feadcac92a82c053` (2026-08-01T03:05:22Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "The Codex agent definitions a Codex session loads are written by `orch render-agents` from the canonical text embedded in the build, into a machine-local directory that git never carries. When that directory falls behind the build, nothing reports it: `orch doctor` passes every check and a Delivery run dispatches reviewers running older instructions. Make that mismatch a visible failing check, and make it stop a Codex-host run before any issue or worktree is created.",
  "acceptance_criteria": [
    "`orch doctor` reports a failing check, naming each file that differs, when any file `orch render-agents` writes is absent or differs from the content the effective configuration produces.",
    "`orch doctor` reports that check as passing when every such file matches, and does not report the check at all when hosts.codex is absent from the effective configuration.",
    "`orch run activate` refuses, before it creates any issue or worktree, when the submitted plan's host is codex and any file `orch render-agents` writes is absent or differs, and the refusal names the command that repairs it.",
    "`orch run activate` on a plan whose host is not codex succeeds regardless of whether those files are absent or differ."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Executor reported all packages ok with no failures on commit 9d72095.",
      "commit_oid": "9d720959fa343fda07cf9118feadcac92a82c053",
      "at": "2026-08-01T02:56:06Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Executor reported no output on commit 9d72095.",
      "commit_oid": "9d720959fa343fda07cf9118feadcac92a82c053",
      "at": "2026-08-01T02:56:06Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Executor reported no diagnostics on commit 9d72095.",
      "commit_oid": "9d720959fa343fda07cf9118feadcac92a82c053",
      "at": "2026-08-01T02:56:06Z"
    },
    {
      "name": "go-build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "Executor reported the build succeeded on commit 9d72095.",
      "commit_oid": "9d720959fa343fda07cf9118feadcac92a82c053",
      "at": "2026-08-01T02:56:06Z"
    },
    {
      "name": "branch-scope: commits and files vs main",
      "command": "git log --oneline main..HEAD; git diff --name-only main...HEAD; git diff --shortstat main...HEAD",
      "result": "pass",
      "detail": "Architect re-ran these at the reviewed head: one commit 9d72095, seven files, 417 insertions and 14 deletions, every file under internal/. Unchanged since pr-open; no fix commit has been pushed.",
      "commit_oid": "9d720959fa343fda07cf9118feadcac92a82c053",
      "at": "2026-08-01T03:05:21Z"
    },
    {
      "name": "review-go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Reviewer ran all packages on the reviewed head; all passed.",
      "commit_oid": "9d720959fa343fda07cf9118feadcac92a82c053",
      "at": "2026-08-01T03:05:21Z"
    },
    {
      "name": "review-gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Reviewer observed no output on the reviewed head.",
      "commit_oid": "9d720959fa343fda07cf9118feadcac92a82c053",
      "at": "2026-08-01T03:05:21Z"
    },
    {
      "name": "review-go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Reviewer observed no diagnostics on the reviewed head.",
      "commit_oid": "9d720959fa343fda07cf9118feadcac92a82c053",
      "at": "2026-08-01T03:05:21Z"
    },
    {
      "name": "review-ci-checks",
      "command": "gh pr checks 157",
      "result": "pass",
      "detail": "Reviewer observed 6 of 6 CI jobs passing on the reviewed head.",
      "commit_oid": "9d720959fa343fda07cf9118feadcac92a82c053",
      "at": "2026-08-01T03:05:21Z"
    },
    {
      "name": "review-gitignore-trace",
      "command": "read internal/interview/summary.go gitignoreLines and this repository's .gitignore",
      "result": "pass",
      "detail": "Architect confirmed directly: gitignoreLines returns only the four .orchestrator entries plus .orchestrator/metrics/, with no .codex line for init or configure; this repository's /.codex/ line carries a hand-written comment and came from PR #115, not from any orch command.",
      "commit_oid": "9d720959fa343fda07cf9118feadcac92a82c053",
      "at": "2026-08-01T03:05:21Z"
    },
    {
      "name": "review-user-global-docs",
      "command": "grep -n 'codex/agents' README.md adapters/codex/README.md",
      "result": "pass",
      "detail": "Architect confirmed directly: README.md lines 126-128 and adapters/codex/README.md line 103 both document a user-global agent directory as a supported install destination.",
      "commit_oid": "9d720959fa343fda07cf9118feadcac92a82c053",
      "at": "2026-08-01T03:05:21Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "request-changes on two independent grounds, one of which is a wrong acceptance criterion. GROUND 1, blocks criterion 3: the refusal names `orch render-agents` as the repair, but in a repository orch itself initialized, running it does not repair the activation. internal/interview/summary.go's gitignoreLines proposes only .orchestrator/ entries plus .orchestrator/metrics/ and never a .codex/ line, for either `orch init` or `orch configure`. So render-agents writes five untracked files, gitops.RequireClean runs immediately after the new preflight, and the resubmit trades an ErrAgentsStale refusal for an ErrNotClean one telling the user to commit or stash machine-local generated files. The PR concedes this in its own fixture, which appends /.codex/ to a fullGitignore that deliberately lacks it. This repository's own /.codex/ line was hand-added by a human with an explanatory comment, not proposed by any orch command. The codebase already names and solves this exact failure class for metrics: metricsGitignoreLine is proposed unconditionally precisely so a later write cannot be the first time the line appears. GROUND 2, WRONG ACCEPTANCE CRITERION, criterion 1: the criterion pins validity to the byte-state of one path, the repository-local render destination, while the objective's stated harm is that a Codex session loads older instructions. README.md install step 4b and adapters/codex/README.md step 4 both document a user-global agent directory as a supported destination, and agents.Stale reads only the repository-local one, so a correctly installed and fully current user-global setup is reported as broken: doctor FAILs and every codex plan is refused permanently, with adapters/codex/README.md step 6 sending that user to `orch doctor` as the next step after the step offering the option. No conforming implementation could avoid that false failure, so this is not fixable inside the criterion. The human must decide whether the user-global layout is still supported (the criterion's location notion is then wrong) or is being dropped (an explicit decision, and both READMEs need updating). Recorded decision 55 says render-agents is deliberately project-local, which is the tension the criterion made load-bearing. Non-blocking findings for the backlog: criterion 4's test uses a claude-only configuration so the both-hosts-configured case is unpinned; agents.Stale does not notice orphaned files a newer build no longer renders; `orch doctor` run inside a Delivery worktree would report the codex check failing. The reviewer cleared three leads I gave it: the preflight placement leaves no partial state, the import cycle forcing the test-package conversion is real, and the omitted adapter and README wording is correctly omitted under the necessity test.",
      "commit_oid": "9d720959fa343fda07cf9118feadcac92a82c053",
      "at": "2026-08-01T03:05:22Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->