### PR TITLE
Require a judgment for every acceptance criterion, and let the engine block on a wrong one

### DIFF
--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -125,7 +125,7 @@ func TestRunLifecycleVerbsAreRouted(t *testing.T) {
 		"dispatch":        `{"schema_version":2,"issue_number":1}`,
 		"pr-open":         `{"schema_version":1,"issue_number":1,"verifications":[{"name":"t","result":"pass"}]}`,
 		"review-worktree": `{"schema_version":1,"issue_number":1,"head_oid":"0123456789abcdef0123456789abcdef01234567"}`,
-		"review":          `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"h","verdict":"approve","summary":"s","reviewer":{"model":"m","effort":"e"}}`,
+		"review":          `{"schema_version":2,"issue_number":1,"reviewed_head_oid":"h","verdict":"approve","summary":"s","reviewer":{"model":"m","effort":"e"},"judgments":[{"criterion":1,"judgment":"satisfied","reason":"r"}]}`,
 		"escalate":        `{"schema_version":1,"issue_number":1,"trigger":"architectural-ambiguity","detail":"x"}`,
 		"ci":              `{"schema_version":1,"issue_number":1}`,
 		"merge-report":    `{"schema_version":1,"issue_number":1}`,

--- a/internal/run/lifecycle.go
+++ b/internal/run/lifecycle.go
@@ -4,7 +4,7 @@
 //	dispatch         worktree-ready → dispatched
 //	pr-open          dispatched     → pr-open
 //	review-worktree  pr-open/in-review → same (git only, no state write)
-//	review           pr-open/in-review → in-review
+//	review           pr-open/in-review → in-review (blocked on a criterion judged wrong)
 //	escalate         dispatched/pr-open/in-review → reroute (same) or blocked
 //	ci               pr-open/in-review/awaiting-merge → same (manifest only)
 //	merge-report     in-review      → awaiting-merge

--- a/internal/run/lifecycle_test.go
+++ b/internal/run/lifecycle_test.go
@@ -33,6 +33,12 @@ func fixtureAcceptance() []string { return []string{"No data race under -race."}
 
 func fixtureTests() []string { return []string{"go test ./..."} }
 
+// fixtureJudgments is the judgments fragment every valid review request
+// in this package carries: one satisfied judgment for the single
+// acceptance criterion fixtureAcceptance holds, which is the coverage
+// checkJudgments requires of a fixture issue.
+const fixtureJudgments = `"judgments":[{"criterion":1,"judgment":"satisfied","reason":"-race is clean on the fix commit"}]`
+
 // baseManifestBody renders a minimal valid audit record on some prose, so
 // a scripted issue view returns a body manifest.Parse accepts.
 func baseManifestBody(t *testing.T) string {
@@ -281,14 +287,14 @@ func TestLifecycleWalk(t *testing.T) {
 	}
 
 	// review: request-changes.
-	runVerb(t, root, Review, `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"request-changes","summary":"fix things","reviewer":{"model":"claude-opus-4-8","effort":"high"}}`,
+	runVerb(t, root, Review, `{"schema_version":2,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"request-changes","summary":"fix things","reviewer":{"model":"claude-opus-4-8","effort":"high"},`+fixtureJudgments+`}`,
 		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-1"),
 		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghSetPRBodyCall(10),
 		ghSetStatusCall(1, ghops.StatusInProgress))
 	wantPhase(t, root, 1, state.PhaseInReview)
 
 	// review: approve (PR moved to a new head).
-	runVerb(t, root, Review, `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-2","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"}}`,
+	runVerb(t, root, Review, `{"schema_version":2,"issue_number":1,"reviewed_head_oid":"head-oid-2","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"},`+fixtureJudgments+`}`,
 		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-2"),
 		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghSetPRBodyCall(10))
 	wantPhase(t, root, 1, state.PhaseInReview)

--- a/internal/run/manifestbody.go
+++ b/internal/run/manifestbody.go
@@ -153,14 +153,24 @@ var engineVerificationNames = map[string]bool{
 // superseded.
 var reviewCycleNamePattern = regexp.MustCompile(`^review-cycle-[0-9]+$`)
 
+// acceptanceCriterionNamePattern matches the per-criterion names Review
+// writes for the reviewer's judgments (acceptance-criterion-<n>). Those
+// are replace-by-name entries like the singletons above, so a
+// caller-supplied entry of the same name would not sit as a visible
+// duplicate — it would silently stand in for a judgment about an
+// approved criterion until the next review cycle overwrote it, which is
+// the one entry in the record that must never be a caller's assertion.
+var acceptanceCriterionNamePattern = regexp.MustCompile(`^acceptance-criterion-[0-9]+$`)
+
 // rejectEngineOwnedNames fails closed with ErrBadRequest naming the
 // first verification in vs whose name collides with an engine-owned
-// singleton or a review-cycle-N entry, so the audit record's
-// engine-written entries can never be quietly overwritten — or quietly
-// duplicated — by a caller-supplied verification of the same name.
+// singleton, a review-cycle-N entry, or an acceptance-criterion-N
+// judgment, so the audit record's engine-written entries can never be
+// quietly overwritten — or quietly duplicated — by a caller-supplied
+// verification of the same name.
 func rejectEngineOwnedNames(vs []manifest.Verification) error {
 	for _, v := range vs {
-		if engineVerificationNames[v.Name] || reviewCycleNamePattern.MatchString(v.Name) {
+		if engineVerificationNames[v.Name] || reviewCycleNamePattern.MatchString(v.Name) || acceptanceCriterionNamePattern.MatchString(v.Name) {
 			return fmt.Errorf("%w: verification name %q is engine-owned and cannot be supplied by a caller", ErrBadRequest, v.Name)
 		}
 	}

--- a/internal/run/metrics_test.go
+++ b/internal/run/metrics_test.go
@@ -112,7 +112,7 @@ func reviewApproveJSON(usage string) string {
 	if usage != "" {
 		extra = `,"usage":` + usage
 	}
-	return `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"}` + extra + `}`
+	return `{"schema_version":2,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"},` + fixtureJudgments + extra + `}`
 }
 
 // reviewApproveJSONWithExecutorUsage extends reviewApproveJSON's request
@@ -123,7 +123,7 @@ func reviewApproveJSONWithExecutorUsage(usage, executorUsage string) string {
 	if usage != "" {
 		extra = `,"usage":` + usage
 	}
-	return `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"}` + extra + `,"executor_usage":` + executorUsage + `}`
+	return `{"schema_version":2,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"},` + fixtureJudgments + extra + `,"executor_usage":` + executorUsage + `}`
 }
 
 // TestReviewRecordsMetricWhenEnabled pins internal/run/metrics.go's

--- a/internal/run/propen.go
+++ b/internal/run/propen.go
@@ -19,10 +19,10 @@ const PROpenSchemaVersion = 1
 // VerificationInput is one required-test evidence entry the executor
 // supplies (PRD §15: completion requires targeted-test evidence). A
 // missing At is stamped by the engine. Name must not collide with an
-// engine-owned verification (required-ci, merge, abandoned, or
-// review-cycle-<n>) — those are reserved so the engine's own record can
-// never be quietly overwritten or duplicated by a caller-supplied entry
-// (rejectEngineOwnedNames).
+// engine-owned verification (required-ci, merge, abandoned,
+// review-cycle-<n>, or acceptance-criterion-<n>) — those are reserved
+// so the engine's own record can never be quietly overwritten or
+// duplicated by a caller-supplied entry (rejectEngineOwnedNames).
 //
 // There is deliberately no commit-OID field: the commit an entry was
 // gathered at is stamped by the engine from a head it read itself

--- a/internal/run/review.go
+++ b/internal/run/review.go
@@ -3,6 +3,9 @@ package run
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strconv"
+	"strings"
 
 	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/manifest"
@@ -12,13 +15,47 @@ import (
 
 // ReviewSchemaVersion is the review request/result schema this build
 // accepts and emits.
-const ReviewSchemaVersion = 1
+//
+// v2 requires one judgment per acceptance criterion (the Judgments
+// field below). It is a version bump rather than an optional field
+// because a v1 review says nothing about any individual criterion, and
+// accepting one would keep recording approvals that assert nothing —
+// the hole this schema closes. Raising the constant is what makes the
+// version check fire first, so a build-behind adapter is told which
+// version this build supports instead of being handed a confusing
+// complaint about a missing field.
+const ReviewSchemaVersion = 2
 
 // The two review verdicts (PRD §12 step 11).
 const (
 	VerdictApprove        = "approve"
 	VerdictRequestChanges = "request-changes"
 )
+
+// The three judgments a reviewer records for one acceptance criterion.
+// satisfied and unsatisfied are calls about the work, so an unsatisfied
+// criterion routes back to the executor exactly as a request-changes
+// review always has. wrong is a call about the criterion itself, and it
+// is the human's to answer: the engine has no verb that amends a gated
+// acceptance criterion, so returning the issue to the executor would
+// only ask it to re-satisfy text that cannot be satisfied.
+const (
+	JudgmentSatisfied   = "satisfied"
+	JudgmentUnsatisfied = "unsatisfied"
+	JudgmentWrong       = "wrong"
+)
+
+// CriterionJudgment is the reviewer's call on one acceptance criterion,
+// with the reason that call rests on. Criterion is the criterion's
+// 1-based position in the issue's approved acceptance criteria — the
+// same order the audit record lists them in — and the engine counts
+// those from its own state, so a request can neither invent a criterion
+// nor quietly omit one.
+type CriterionJudgment struct {
+	Criterion int    `json:"criterion"`
+	Judgment  string `json:"judgment"`
+	Reason    string `json:"reason"`
+}
 
 // ReviewRequest records one consolidated review cycle for an open PR.
 // Reviewer is the selection that actually performed the review; it must
@@ -31,6 +68,12 @@ type ReviewRequest struct {
 	Verdict         string             `json:"verdict"`
 	Summary         string             `json:"summary"`
 	Reviewer        manifest.Selection `json:"reviewer"`
+	// Judgments carries exactly one judgment, with its reason, for each
+	// acceptance criterion the issue holds (checkJudgments). It is
+	// mandatory: a consolidated summary can approve while saying nothing
+	// about any individual criterion, and the judgments are what make an
+	// approval an assertion about each one.
+	Judgments []CriterionJudgment `json:"judgments"`
 	// Verifications is optional evidence gathered on this review cycle
 	// (for example, tests re-run on a fix commit), using the same
 	// {name, command, result, detail} input shape pr-open accepts. Each
@@ -38,9 +81,9 @@ type ReviewRequest struct {
 	// review-cycle-N entry this verb already writes, so resubmitting the
 	// same name updates that entry rather than duplicating it. A name
 	// colliding with an engine-owned entry (required-ci, merge,
-	// abandoned, or review-cycle-<n>) is rejected — those are never
-	// caller-suppliable, so the engine's own record can never be quietly
-	// overwritten or duplicated.
+	// abandoned, review-cycle-<n>, or acceptance-criterion-<n>) is
+	// rejected — those are never caller-suppliable, so the engine's own
+	// record can never be quietly overwritten or duplicated.
 	Verifications []VerificationInput `json:"verifications,omitempty"`
 	// Usage is adapter-reported model usage for this review cycle
 	// (PRD §21 "where available"); optional and best-effort. This is
@@ -55,25 +98,45 @@ type ReviewRequest struct {
 	ExecutorUsage *metrics.Usage `json:"executor_usage,omitempty"`
 }
 
-// ReviewResult reports the recorded review cycle.
+// ReviewResult reports the recorded review cycle. Phase is the phase
+// the recording left the issue in, and WrongCriteria/BlockedReason are
+// populated only when a criterion was judged wrong: that outcome blocks
+// the issue for the human inside this call, so the result has to say so
+// — there is no second verb call left to report it.
 type ReviewResult struct {
-	SchemaVersion int    `json:"schema_version"`
-	IssueNumber   int    `json:"issue_number"`
-	ReviewCycles  int    `json:"review_cycles"`
-	Verdict       string `json:"verdict"`
+	SchemaVersion int         `json:"schema_version"`
+	IssueNumber   int         `json:"issue_number"`
+	ReviewCycles  int         `json:"review_cycles"`
+	Verdict       string      `json:"verdict"`
+	Phase         state.Phase `json:"phase"`
+	WrongCriteria []int       `json:"wrong_criteria,omitempty"`
+	BlockedReason string      `json:"blocked_reason,omitempty"`
 }
 
 // Review records one consolidated review cycle (PRD §12 step 11). It
 // requires the reporting reviewer to be the issue's routed reviewer
-// (PRD §13: the audit record's reviewer is the one that reviewed), and
-// enforces PRD §14's "review begins only after the PR stops changing" by
-// requiring the reviewed head OID to equal the PR's live head — a stale
-// review is rejected so the reviewer re-reads. It advances the issue to
-// in-review, appends the cycle to the issue and PR audit records
-// alongside any caller-supplied verification evidence (replace-by-name,
-// so a fix-commit re-run reaches the record even though the issue is no
-// longer in phase dispatched), and, on request-changes, sets the status
-// back to in-progress.
+// (PRD §13: the audit record's reviewer is the one that reviewed), one
+// judgment with a stated reason for every acceptance criterion the
+// issue holds (checkJudgments, before any mutation), and — enforcing
+// PRD §14's "review begins only after the PR stops changing" — a
+// reviewed head OID equal to the PR's live head, so a stale review is
+// rejected and the reviewer re-reads.
+//
+// It appends the cycle to the issue and PR audit records alongside the
+// per-criterion judgments and any caller-supplied verification evidence
+// (replace-by-name, so a fix-commit re-run reaches the record even
+// though the issue is no longer in phase dispatched). Where it leaves
+// the issue follows the judgments:
+//
+//   - a criterion judged wrong blocks the issue and flags it for the
+//     human, the same transition escalate's return-to-architect makes,
+//     but taken here so no second verb call stands between the reviewer
+//     saying an approved criterion is false and the human hearing it;
+//   - otherwise a request-changes verdict sets the status back to
+//     in-progress and the issue stays in-review, unchanged;
+//   - an approving verdict (which checkJudgments allows only when every
+//     criterion is satisfied) leaves the issue in-review, ready for the
+//     merge report.
 func Review(ctx context.Context, env Env, reqJSON []byte) (*ReviewResult, error) {
 	var req ReviewRequest
 	if err := decodeRequest(reqJSON, &req); err != nil {
@@ -113,6 +176,18 @@ func Review(ctx context.Context, env Env, reqJSON []byte) (*ReviewResult, error)
 	if req.Reviewer != issue.Decision.Reviewer {
 		return nil, fmt.Errorf("%w: reviewer %s@%s is not the routed reviewer %s@%s; review with the routed selection, or run `orch run escalate` to reroute first", ErrReviewerMismatch, req.Reviewer.Model, req.Reviewer.Effort, issue.Decision.Reviewer.Model, issue.Decision.Reviewer.Effort)
 	}
+	// The criteria the judgments must cover are read from state, never
+	// counted from the request, so a review cannot decide for itself how
+	// many criteria it is answering. checkApprovedWork guards the one
+	// shape that would make that count vacuously zero.
+	if err := checkApprovedWork(issue); err != nil {
+		return nil, err
+	}
+	if err := checkJudgments(req.Judgments, req.Verdict, issue.AcceptanceCriteria); err != nil {
+		return nil, err
+	}
+	slices.SortFunc(req.Judgments, func(a, b CriterionJudgment) int { return a.Criterion - b.Criterion })
+	wrong := wrongCriteria(req.Judgments)
 
 	gh, err := openGitHub(ctx, env)
 	if err != nil {
@@ -132,6 +207,10 @@ func Review(ctx context.Context, env Env, reqJSON []byte) (*ReviewResult, error)
 	issue.ReviewCycles++
 	issue.LastReviewVerdict = req.Verdict
 	issue.Phase = state.PhaseInReview
+	if len(wrong) > 0 {
+		issue.Phase = state.PhaseBlocked
+		issue.BlockedReason = wrongCriteriaReason(wrong, issue.ReviewCycles)
+	}
 	if err := c.save(); err != nil {
 		return nil, err
 	}
@@ -149,6 +228,11 @@ func Review(ctx context.Context, env Env, reqJSON []byte) (*ReviewResult, error)
 	for _, v := range verifications {
 		setVerification(&m, v)
 	}
+	judged := criterionVerifications(req.Judgments, env.nowStamp())
+	stampCommitOID(judged, pr.HeadRefOid)
+	for _, v := range judged {
+		setVerification(&m, v)
+	}
 	m.Verifications = append(m.Verifications, manifest.Verification{
 		Name:      fmt.Sprintf("review-cycle-%d", issue.ReviewCycles),
 		Result:    req.Verdict,
@@ -160,7 +244,12 @@ func Review(ctx context.Context, env Env, reqJSON []byte) (*ReviewResult, error)
 		return nil, wrapAfterMutation(err)
 	}
 
-	if req.Verdict == VerdictRequestChanges {
+	switch {
+	case len(wrong) > 0:
+		if err := gh.SetStatus(ctx, issue.Number, ghops.StatusNeedsHuman); err != nil {
+			return nil, wrapAfterMutation(err)
+		}
+	case req.Verdict == VerdictRequestChanges:
 		if err := gh.SetStatus(ctx, issue.Number, ghops.StatusInProgress); err != nil {
 			return nil, wrapAfterMutation(err)
 		}
@@ -199,5 +288,101 @@ func Review(ctx context.Context, env Env, reqJSON []byte) (*ReviewResult, error)
 		IssueNumber:   issue.Number,
 		ReviewCycles:  issue.ReviewCycles,
 		Verdict:       req.Verdict,
+		Phase:         issue.Phase,
+		WrongCriteria: wrong,
+		BlockedReason: issue.BlockedReason,
 	}, nil
+}
+
+// checkJudgments fails closed unless js carries exactly one judgment,
+// from the closed set and with a stated reason, for each of the issue's
+// acceptance criteria, and unless an approving verdict finds every one
+// of them satisfied. criteria is the issue's own approved list, so the
+// coverage the request must meet is the engine's count, not its own.
+//
+// An approving verdict over a criterion judged anything but satisfied
+// is refused rather than silently re-routed: it is the reviewer
+// contradicting itself, and recording it either way would put the
+// contradiction into the audit record — an approval on the merge path
+// over a criterion the same review says is not met.
+func checkJudgments(js []CriterionJudgment, verdict string, criteria []string) error {
+	seen := make(map[int]bool, len(criteria))
+	for i, j := range js {
+		switch j.Judgment {
+		case JudgmentSatisfied, JudgmentUnsatisfied, JudgmentWrong:
+		default:
+			return fmt.Errorf("%w: judgments[%d] judgment %q is not one of %s, %s, %s", ErrBadRequest, i, j.Judgment, JudgmentSatisfied, JudgmentUnsatisfied, JudgmentWrong)
+		}
+		if j.Reason == "" {
+			return fmt.Errorf("%w: judgments[%d] states no reason; the audit record carries the reviewer's reason for every judgment", ErrBadRequest, i)
+		}
+		if j.Criterion < 1 || j.Criterion > len(criteria) {
+			return fmt.Errorf("%w: judgments[%d] judges criterion %d, but the issue holds %d acceptance criteria, numbered 1 to %d", ErrBadRequest, i, j.Criterion, len(criteria), len(criteria))
+		}
+		if seen[j.Criterion] {
+			return fmt.Errorf("%w: criterion %d is judged more than once; each acceptance criterion takes exactly one judgment", ErrBadRequest, j.Criterion)
+		}
+		seen[j.Criterion] = true
+		if verdict == VerdictApprove && j.Judgment != JudgmentSatisfied {
+			return fmt.Errorf("%w: criterion %d is judged %s, so the verdict cannot be %s; record %s", ErrBadRequest, j.Criterion, j.Judgment, VerdictApprove, VerdictRequestChanges)
+		}
+	}
+	for i := range criteria {
+		if !seen[i+1] {
+			return fmt.Errorf("%w: acceptance criterion %d carries no judgment; a review judges each of the issue's %d acceptance criteria", ErrBadRequest, i+1, len(criteria))
+		}
+	}
+	return nil
+}
+
+// wrongCriteria are the criteria js judges wrong, in the ascending
+// order js is sorted into. It is empty for every review that judges no
+// criterion wrong, which is what the ordinary approve and
+// request-changes paths test.
+func wrongCriteria(js []CriterionJudgment) []int {
+	var out []int
+	for _, j := range js {
+		if j.Judgment == JudgmentWrong {
+			out = append(out, j.Criterion)
+		}
+	}
+	return out
+}
+
+// wrongCriteriaReason is the blocked reason a review that judges a
+// criterion wrong leaves on the issue. It names the criteria and the
+// cycle, and states plainly that the correction belongs at the plan
+// gate: there is no engine verb that amends a gated acceptance
+// criterion, so a reason implying the run can fix one itself would send
+// the human looking for a command that does not exist.
+func wrongCriteriaReason(nums []int, cycle int) string {
+	labels := make([]string, len(nums))
+	for i, n := range nums {
+		labels[i] = strconv.Itoa(n)
+	}
+	return fmt.Sprintf("Acceptance criteria judged wrong on review cycle %d: %s; returning to the human — a gated criterion is corrected at the plan gate, not by the executor, and no verb amends one in place", cycle, strings.Join(labels, ", "))
+}
+
+// criterionVerifications renders the judgments into audit-record
+// entries: one per acceptance criterion, named for its 1-based position
+// in the record's own acceptance-criteria list, carrying the judgment
+// as its result and the reviewer's stated reason as its detail.
+//
+// They are written replace-by-name rather than once per cycle, so the
+// record's answer to "how does this criterion stand" is the current one
+// and the entry count stays bounded by the criteria count however many
+// cycles run. Each cycle's narrative still accumulates in its own
+// review-cycle-<n> entry. The name shape is engine-owned and refused
+// from callers (acceptanceCriterionNamePattern, manifestbody.go).
+func criterionVerifications(js []CriterionJudgment, stamp string) []manifest.Verification {
+	out := make([]manifest.Verification, len(js))
+	for i, j := range js {
+		out[i] = manifest.Verification{
+			Name:   fmt.Sprintf("acceptance-criterion-%d", j.Criterion),
+			Result: j.Judgment,
+			Detail: truncateDetail(j.Reason),
+			At:     stamp,
+		}
+	}
+	return out
 }

--- a/internal/run/verb_unit_test.go
+++ b/internal/run/verb_unit_test.go
@@ -367,7 +367,7 @@ func TestReviewStaleHeadIsPure(t *testing.T) {
 	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
 	before := stateBytes(t, root)
 	script := &execxtest.Script{T: t, Calls: []execxtest.Call{ghAuth(), ghPRViewCall(10, "OPEN", "real-head")}}
-	_, err := Review(context.Background(), ghEnv(root, script), []byte(`{"schema_version":1,"issue_number":1,"reviewed_head_oid":"stale-head","verdict":"approve","summary":"s","reviewer":{"model":"claude-opus-4-8","effort":"high"}}`))
+	_, err := Review(context.Background(), ghEnv(root, script), []byte(`{"schema_version":2,"issue_number":1,"reviewed_head_oid":"stale-head","verdict":"approve","summary":"s","reviewer":{"model":"claude-opus-4-8","effort":"high"},`+fixtureJudgments+`}`))
 	if !errors.Is(err, ErrReviewStale) {
 		t.Fatalf("err = %v, want ErrReviewStale", err)
 	}
@@ -381,7 +381,7 @@ func TestReviewWrongReviewerIsPure(t *testing.T) {
 	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
 	before := stateBytes(t, root)
 	script := &execxtest.Script{T: t} // fails before any gh call
-	_, err := Review(context.Background(), ghEnv(root, script), []byte(`{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head","verdict":"approve","summary":"s","reviewer":{"model":"claude-haiku-4-5","effort":"low"}}`))
+	_, err := Review(context.Background(), ghEnv(root, script), []byte(`{"schema_version":2,"issue_number":1,"reviewed_head_oid":"head","verdict":"approve","summary":"s","reviewer":{"model":"claude-haiku-4-5","effort":"low"},`+fixtureJudgments+`}`))
 	if !errors.Is(err, ErrReviewerMismatch) {
 		t.Fatalf("err = %v, want ErrReviewerMismatch", err)
 	}
@@ -399,7 +399,7 @@ func TestReviewBadVerificationIsBadRequestBeforeMutation(t *testing.T) {
 	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
 	before := stateBytes(t, root)
 	script := &execxtest.Script{T: t}
-	req := `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head","verdict":"approve","summary":"s","reviewer":{"model":"claude-opus-4-8","effort":"high"},"verifications":[{"name":"","result":"pass"}]}`
+	req := `{"schema_version":2,"issue_number":1,"reviewed_head_oid":"head","verdict":"approve","summary":"s","reviewer":{"model":"claude-opus-4-8","effort":"high"},` + fixtureJudgments + `,"verifications":[{"name":"","result":"pass"}]}`
 	_, err := Review(context.Background(), ghEnv(root, script), []byte(req))
 	if !errors.Is(err, ErrBadRequest) {
 		t.Fatalf("err = %v, want ErrBadRequest", err)
@@ -561,7 +561,7 @@ func TestReviewWritesSuppliedVerifications(t *testing.T) {
 		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-1"),
 		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghSetPRBodyCall(10),
 	}}
-	req := `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"},"verifications":[{"name":"go test ./...","result":"pass","detail":"22 packages ok"}]}`
+	req := `{"schema_version":2,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"},` + fixtureJudgments + `,"verifications":[{"name":"go test ./...","result":"pass","detail":"22 packages ok"}]}`
 	res, err := Review(context.Background(), ghEnv(root, script), []byte(req))
 	if err != nil {
 		t.Fatalf("Review: %v", err)
@@ -608,7 +608,7 @@ func TestReviewVerificationReplacesByName(t *testing.T) {
 		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-1"),
 		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghSetPRBodyCall(10),
 	}}
-	req := `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"},"verifications":[{"name":"go test ./...","result":"pass","detail":"all green"}]}`
+	req := `{"schema_version":2,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"},` + fixtureJudgments + `,"verifications":[{"name":"go test ./...","result":"pass","detail":"all green"}]}`
 	if _, err := Review(context.Background(), ghEnv(root, script), []byte(req)); err != nil {
 		t.Fatalf("Review: %v", err)
 	}
@@ -647,7 +647,7 @@ func TestReviewSummaryRoundTripsUnderReviewDetailCap(t *testing.T) {
 	if len(summary) >= reviewDetailCap {
 		t.Fatalf("fixture summary length %d must stay under reviewDetailCap %d", len(summary), reviewDetailCap)
 	}
-	req := fmt.Sprintf(`{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":%q,"reviewer":{"model":"claude-opus-4-8","effort":"high"}}`, summary)
+	req := fmt.Sprintf(`{"schema_version":2,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":%q,"reviewer":{"model":"claude-opus-4-8","effort":"high"},`+fixtureJudgments+`}`, summary)
 	if _, err := Review(context.Background(), ghEnv(root, script), []byte(req)); err != nil {
 		t.Fatalf("Review: %v", err)
 	}
@@ -687,7 +687,7 @@ func TestReviewSuppliedVerificationStillCappedAtVerificationDetailCap(t *testing
 		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghSetPRBodyCall(10),
 	}}
 	long := strings.Repeat("x", verificationDetailCap+500)
-	req := fmt.Sprintf(`{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"},"verifications":[{"name":"go test","result":"pass","detail":%q}]}`, long)
+	req := fmt.Sprintf(`{"schema_version":2,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"},`+fixtureJudgments+`,"verifications":[{"name":"go test","result":"pass","detail":%q}]}`, long)
 	if _, err := Review(context.Background(), ghEnv(root, script), []byte(req)); err != nil {
 		t.Fatalf("Review: %v", err)
 	}
@@ -716,9 +716,11 @@ func TestReviewSuppliedVerificationStillCappedAtVerificationDetailCap(t *testing
 }
 
 // engineOwnedVerificationNames are the names Change 2 reserves: the
-// three singletons the engine's own verbs write by replace-by-name, and
-// one name matching the review-cycle-<n> pattern Review generates.
-var engineOwnedVerificationNames = []string{"required-ci", "merge", "abandoned", "review-cycle-1"}
+// three singletons the engine's own verbs write by replace-by-name, one
+// name matching the review-cycle-<n> pattern Review generates, and one
+// matching the acceptance-criterion-<n> pattern Review writes for the
+// reviewer's per-criterion judgments.
+var engineOwnedVerificationNames = []string{"required-ci", "merge", "abandoned", "review-cycle-1", "acceptance-criterion-1"}
 
 // TestReviewRejectsEngineOwnedVerificationNames proves a caller-supplied
 // verification whose name collides with an engine-owned entry is
@@ -730,7 +732,7 @@ func TestReviewRejectsEngineOwnedVerificationNames(t *testing.T) {
 			root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhasePROpen)})
 			before := stateBytes(t, root)
 			script := &execxtest.Script{T: t}
-			req := fmt.Sprintf(`{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head","verdict":"approve","summary":"s","reviewer":{"model":"claude-opus-4-8","effort":"high"},"verifications":[{"name":%q,"result":"pass"}]}`, name)
+			req := fmt.Sprintf(`{"schema_version":2,"issue_number":1,"reviewed_head_oid":"head","verdict":"approve","summary":"s","reviewer":{"model":"claude-opus-4-8","effort":"high"},`+fixtureJudgments+`,"verifications":[{"name":%q,"result":"pass"}]}`, name)
 			_, err := Review(context.Background(), ghEnv(root, script), []byte(req))
 			if !errors.Is(err, ErrBadRequest) {
 				t.Fatalf("err = %v, want ErrBadRequest", err)
@@ -792,7 +794,7 @@ func TestReviewStampsTheReviewedHead(t *testing.T) {
 		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-2"),
 		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghSetPRBodyCall(10),
 	}}
-	req := `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-2","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"},"verifications":[{"name":"go test ./...","result":"pass"}]}`
+	req := `{"schema_version":2,"issue_number":1,"reviewed_head_oid":"head-oid-2","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"},` + fixtureJudgments + `,"verifications":[{"name":"go test ./...","result":"pass"}]}`
 	if _, err := Review(context.Background(), ghEnv(root, script), []byte(req)); err != nil {
 		t.Fatalf("Review: %v", err)
 	}
@@ -912,7 +914,7 @@ func TestVerificationInputRejectsACallerSuppliedCommitOID(t *testing.T) {
 		"review": {
 			fn:    func(ctx context.Context, e Env, b []byte) error { _, err := Review(ctx, e, b); return err },
 			phase: state.PhaseInReview,
-			req:   `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"h","verdict":"approve","summary":"s","reviewer":{"model":"claude-opus-4-8","effort":"high"},"verifications":[{"name":"go test","result":"pass","commit_oid":"claimed-head"}]}`,
+			req:   `{"schema_version":2,"issue_number":1,"reviewed_head_oid":"h","verdict":"approve","summary":"s","reviewer":{"model":"claude-opus-4-8","effort":"high"},` + fixtureJudgments + `,"verifications":[{"name":"go test","result":"pass","commit_oid":"claimed-head"}]}`,
 		},
 		"pr-open": {
 			fn:    func(ctx context.Context, e Env, b []byte) error { _, err := PROpen(ctx, e, b); return err },
@@ -937,6 +939,260 @@ func TestVerificationInputRejectsACallerSuppliedCommitOID(t *testing.T) {
 				t.Error("state changed on a request claiming its own commit OID")
 			}
 		})
+	}
+}
+
+// --- Per-criterion judgments (issue #154) ---
+
+// twoCriteriaAcceptance is fixtureAcceptance plus a second criterion, so
+// the coverage cases a single-criterion fixture cannot express — a
+// review that answers one criterion and says nothing about the other —
+// are reachable.
+func twoCriteriaAcceptance() []string {
+	return append(fixtureAcceptance(), "The status line names the lock owner.")
+}
+
+// twoCriteriaIssue is fixtureIssue carrying twoCriteriaAcceptance.
+func twoCriteriaIssue(phase state.Phase) state.Issue {
+	iss := fixtureIssue("a", 1, phase)
+	iss.AcceptanceCriteria = twoCriteriaAcceptance()
+	return iss
+}
+
+// twoCriteriaBody is the scripted issue body whose audit record matches
+// twoCriteriaIssue's approved work.
+func twoCriteriaBody(t *testing.T) string {
+	t.Helper()
+	m := baseManifest()
+	m.AcceptanceCriteria = twoCriteriaAcceptance()
+	body, err := manifest.Upsert("**Objective**\n\ndo it\n", m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+// reviewReq builds a review request at this build's schema version for
+// issue 1, carrying verdict and the judgments array fragment.
+func reviewReq(verdict, judgments string) string {
+	return fmt.Sprintf(`{"schema_version":%d,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":%q,"summary":"s","reviewer":{"model":"claude-opus-4-8","effort":"high"},"judgments":%s}`,
+		ReviewSchemaVersion, verdict, judgments)
+}
+
+// TestReviewRequiresOneJudgmentPerAcceptanceCriterion proves review
+// refuses, before any mutation, a request that does not carry exactly
+// one well-formed judgment for each acceptance criterion the issue
+// holds. The criteria are counted from the engine's own state, so a
+// request can neither invent a criterion nor answer fewer than the
+// issue carries. Every case fails with no gh call at all and leaves
+// state byte-identical.
+func TestReviewRequiresOneJudgmentPerAcceptanceCriterion(t *testing.T) {
+	const met = `{"criterion":1,"judgment":"satisfied","reason":"r1"}`
+	cases := map[string]struct{ verdict, judgments, want string }{
+		"no judgments at all": {
+			"approve", `[]`, "acceptance criterion 1 carries no judgment",
+		},
+		"one of two criteria judged": {
+			"approve", `[` + met + `]`, "acceptance criterion 2 carries no judgment",
+		},
+		"one criterion judged twice": {
+			"approve", `[` + met + `,{"criterion":1,"judgment":"satisfied","reason":"r2"}]`, "judged more than once",
+		},
+		"a criterion the issue does not hold": {
+			"approve", `[` + met + `,{"criterion":3,"judgment":"satisfied","reason":"r2"}]`, "the issue holds 2 acceptance criteria",
+		},
+		"a judgment outside the closed set": {
+			"request-changes", `[` + met + `,{"criterion":2,"judgment":"partly","reason":"r2"}]`, "is not one of satisfied",
+		},
+		"a judgment with no stated reason": {
+			"approve", `[` + met + `,{"criterion":2,"judgment":"satisfied","reason":""}]`, "states no reason",
+		},
+		"approve over a criterion judged unsatisfied": {
+			"approve", `[` + met + `,{"criterion":2,"judgment":"unsatisfied","reason":"r2"}]`, "cannot be approve",
+		},
+		"approve over a criterion judged wrong": {
+			"approve", `[` + met + `,{"criterion":2,"judgment":"wrong","reason":"r2"}]`, "cannot be approve",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			root := setupDeliveryRepo(t, "r1", []state.Issue{twoCriteriaIssue(state.PhaseInReview)})
+			before := stateBytes(t, root)
+			script := &execxtest.Script{T: t}
+			_, err := Review(context.Background(), ghEnv(root, script), []byte(reviewReq(tc.verdict, tc.judgments)))
+			if !errors.Is(err, ErrBadRequest) {
+				t.Fatalf("err = %v, want ErrBadRequest", err)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err = %v, want it to name %q", err, tc.want)
+			}
+			script.AssertExhausted() // refused before any gh call
+			if got := stateBytes(t, root); string(got) != string(before) {
+				t.Error("state changed on a review that did not judge every acceptance criterion")
+			}
+		})
+	}
+}
+
+// TestReviewWrongCriterionBlocksForTheHuman proves a review that judges
+// any acceptance criterion wrong leaves the issue blocked and flagged
+// needs-human inside the same call that records it — the transition
+// escalate's return-to-architect makes, reached with no second verb
+// call. The cycle is still recorded (the reviewer's report is not lost
+// to the block), and the result names the wrong criteria and the reason
+// the human is being handed, since nothing later in the run will.
+func TestReviewWrongCriterionBlocksForTheHuman(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{twoCriteriaIssue(state.PhaseInReview)})
+	body := twoCriteriaBody(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-1"),
+		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghSetPRBodyCall(10),
+		ghSetStatusCall(1, ghops.StatusNeedsHuman),
+	}}
+	judgments := `[{"criterion":1,"judgment":"satisfied","reason":"-race is clean"},` +
+		`{"criterion":2,"judgment":"wrong","reason":"there is no lock owner to name; the lock is per-process"}]`
+	res, err := Review(context.Background(), ghEnv(root, script), []byte(reviewReq("request-changes", judgments)))
+	if err != nil {
+		t.Fatalf("Review: %v", err)
+	}
+	script.AssertExhausted()
+
+	if res.Phase != state.PhaseBlocked {
+		t.Errorf("result phase = %s, want %s", res.Phase, state.PhaseBlocked)
+	}
+	if len(res.WrongCriteria) != 1 || res.WrongCriteria[0] != 2 {
+		t.Errorf("result wrong criteria = %v, want [2]", res.WrongCriteria)
+	}
+	if !strings.Contains(res.BlockedReason, "plan gate") {
+		t.Errorf("result blocked reason = %q, want it to name where a wrong criterion is corrected", res.BlockedReason)
+	}
+	wantPhase(t, root, 1, state.PhaseBlocked)
+	iss := loadRun(t, root).Run.Issues[0]
+	if iss.BlockedReason != res.BlockedReason {
+		t.Errorf("persisted blocked reason = %q, want the reported %q", iss.BlockedReason, res.BlockedReason)
+	}
+	if iss.ReviewCycles != 1 || iss.LastReviewVerdict != VerdictRequestChanges {
+		t.Errorf("issue = %+v, want the cycle recorded despite the block", iss)
+	}
+}
+
+// TestReviewUnsatisfiedCriterionReturnsToTheExecutor proves the other
+// half of the split: a criterion judged unsatisfied, with none judged
+// wrong, is ordinary fix-and-push work — the issue stays in-review and
+// the status goes back to in-progress, exactly as a request-changes
+// review has always behaved.
+func TestReviewUnsatisfiedCriterionReturnsToTheExecutor(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{twoCriteriaIssue(state.PhaseInReview)})
+	body := twoCriteriaBody(t)
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-1"),
+		ghIssueViewCall(t, 1, "OPEN", body), ghSetIssueBodyCall(1), ghSetPRBodyCall(10),
+		ghSetStatusCall(1, ghops.StatusInProgress),
+	}}
+	judgments := `[{"criterion":1,"judgment":"satisfied","reason":"-race is clean"},` +
+		`{"criterion":2,"judgment":"unsatisfied","reason":"the status line still omits the owner"}]`
+	res, err := Review(context.Background(), ghEnv(root, script), []byte(reviewReq("request-changes", judgments)))
+	if err != nil {
+		t.Fatalf("Review: %v", err)
+	}
+	script.AssertExhausted()
+	if res.Phase != state.PhaseInReview || len(res.WrongCriteria) != 0 {
+		t.Errorf("result = %+v, want in-review with no wrong criteria", res)
+	}
+	wantPhase(t, root, 1, state.PhaseInReview)
+	if got := loadRun(t, root).Run.Issues[0].BlockedReason; got != "" {
+		t.Errorf("blocked reason = %q, want none: no criterion was judged wrong", got)
+	}
+}
+
+// TestReviewRecordsEachJudgmentAndItsReason proves every criterion's
+// judgment and the reviewer's stated reason for it reach the issue's
+// audit record, named for the criterion's position in the record's own
+// acceptance-criteria list and stamped with the head the engine read.
+// The second cycle proves the entries are replace-by-name: the record
+// holds one entry per criterion carrying the current judgment, not one
+// per criterion per cycle.
+func TestReviewRecordsEachJudgmentAndItsReason(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{twoCriteriaIssue(state.PhaseInReview)})
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-1"),
+		ghIssueViewCall(t, 1, "OPEN", twoCriteriaBody(t)), ghSetIssueBodyCall(1), ghSetPRBodyCall(10),
+		ghSetStatusCall(1, ghops.StatusInProgress),
+	}}
+	judgments := `[{"criterion":2,"judgment":"unsatisfied","reason":"the status line still omits the owner"},` +
+		`{"criterion":1,"judgment":"satisfied","reason":"-race is clean"}]`
+	if _, err := Review(context.Background(), ghEnv(root, script), []byte(reviewReq("request-changes", judgments))); err != nil {
+		t.Fatalf("Review: %v", err)
+	}
+	script.AssertExhausted()
+
+	posted := script.StdinAt(3)
+	for name, want := range map[string][2]string{
+		"acceptance-criterion-1": {"satisfied", "-race is clean"},
+		"acceptance-criterion-2": {"unsatisfied", "the status line still omits the owner"},
+	} {
+		v := findVerification(t, posted, name)
+		if v.Result != want[0] || v.Detail != want[1] {
+			t.Errorf("%s = %+v, want judgment %q with reason %q", name, v, want[0], want[1])
+		}
+		if v.CommitOID != "head-oid-1" {
+			t.Errorf("%s commit = %q, want the PR's live head", name, v.CommitOID)
+		}
+	}
+
+	// Cycle 2 re-judges criterion 2 against the record cycle 1 posted.
+	script2 := &execxtest.Script{T: t, Calls: []execxtest.Call{
+		ghAuth(), ghPRViewCall(10, "OPEN", "head-oid-2"),
+		ghIssueViewCall(t, 1, "OPEN", posted), ghSetIssueBodyCall(1), ghSetPRBodyCall(10),
+	}}
+	req2 := strings.Replace(reviewReq("approve",
+		`[{"criterion":1,"judgment":"satisfied","reason":"-race is clean"},`+
+			`{"criterion":2,"judgment":"satisfied","reason":"the owner is named now"}]`),
+		`"head-oid-1"`, `"head-oid-2"`, 1)
+	if _, err := Review(context.Background(), ghEnv(root, script2), []byte(req2)); err != nil {
+		t.Fatalf("Review cycle 2: %v", err)
+	}
+	script2.AssertExhausted()
+
+	m, err := manifest.Parse(script2.StdinAt(3))
+	if err != nil {
+		t.Fatalf("Parse the posted issue body: %v", err)
+	}
+	count := 0
+	for _, v := range m.Verifications {
+		if v.Name != "acceptance-criterion-2" {
+			continue
+		}
+		count++
+		if v.Result != "satisfied" || v.Detail != "the owner is named now" {
+			t.Errorf("acceptance-criterion-2 = %+v, want cycle 2's judgment and reason", v)
+		}
+	}
+	if count != 1 {
+		t.Errorf("acceptance-criterion-2 appears %d times, want 1 (replace-by-name, not one per cycle)", count)
+	}
+}
+
+// TestReviewRefusesThePreviousSchemaVersion proves an adapter still
+// sending the v1 request — well-formed under v1, and silent about every
+// individual acceptance criterion — is refused naming the version this
+// build supports, rather than being told a field it has never heard of
+// is missing.
+func TestReviewRefusesThePreviousSchemaVersion(t *testing.T) {
+	root := setupDeliveryRepo(t, "r1", []state.Issue{fixtureIssue("a", 1, state.PhaseInReview)})
+	before := stateBytes(t, root)
+	script := &execxtest.Script{T: t}
+	req := `{"schema_version":1,"issue_number":1,"reviewed_head_oid":"head-oid-1","verdict":"approve","summary":"looks good","reviewer":{"model":"claude-opus-4-8","effort":"high"}}`
+	_, err := Review(context.Background(), ghEnv(root, script), []byte(req))
+	if !errors.Is(err, ErrBadRequest) {
+		t.Fatalf("err = %v, want ErrBadRequest", err)
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("this build supports %d", ReviewSchemaVersion)) {
+		t.Errorf("err = %v, want it to name the supported version %d", err, ReviewSchemaVersion)
+	}
+	script.AssertExhausted()
+	if got := stateBytes(t, root); string(got) != string(before) {
+		t.Error("state changed on a review request at the previous schema version")
 	}
 }
 


### PR DESCRIPTION
Delivers issue #154: Require a judgment for every acceptance criterion, and let the engine block on a wrong one

Closes #154

**Plan digest:** `sha256:b295dff5d34e850c8ce0d923a9fbfd0cec12902c1dffd23b86cfb7afcf01c7cc`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** A reviewer can record an approving review today without stating anything about any individual acceptance criterion, and a review that rejects a criterion as wrong reaches the human only if the Architect reads a paragraph and makes a second call by hand. Make the review verb require one judgment per acceptance criterion on the issue, and make a criterion judged wrong block the issue for the human as part of recording that review.

**Acceptance criteria:**
- `orch run review` refuses, before any mutation, a request that does not carry exactly one judgment for each acceptance criterion the issue holds.
- A recorded review that judges every acceptance criterion satisfied, with an approving verdict, leaves the issue ready for the merge report exactly as it is today.
- A recorded review that judges any acceptance criterion wrong leaves the issue blocked and flagged for the human, with no further verb call needed.
- A recorded review that judges a criterion unsatisfied without judging any criterion wrong returns the issue to the executor as a request-changes review does today.
- Each acceptance criterion's judgment and the reviewer's stated reason for it appear in the issue's audit record.
- A review request declaring the previously supported request schema version is refused with a message naming the version this build supports.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `specialist` |
| Executor | `claude-opus-5` — effort `high` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to a specialist with a strong reviewer because the task is unusually difficult.

**Escalations:** _none_

**Verification:**
- **go-test-all** — pass — `go clean -testcache && go test ./...` — Executor reported all packages ok with 0 failures on commit 733a3f2, with the test cache cleared first so nothing was reported from cache. — commit `733a3f2053e72a75d0cac8ea0f8e1d0228f850fb` (2026-08-01T03:06:08Z)
- **gofmt** — pass — `gofmt -l .` — Executor reported no output on commit 733a3f2. — commit `733a3f2053e72a75d0cac8ea0f8e1d0228f850fb` (2026-08-01T03:06:08Z)
- **go-vet** — pass — `go vet ./...` — Executor reported exit 0 with no diagnostics on commit 733a3f2. — commit `733a3f2053e72a75d0cac8ea0f8e1d0228f850fb` (2026-08-01T03:06:08Z)
- **branch-scope: commits and files vs main** — pass — `git log --oneline main..HEAD; git diff --name-only main...HEAD; git diff --shortstat main...HEAD` — Architect re-ran these at the reviewed head: one commit 733a3f2 on top of main ddee1b3, eight files, 503 insertions and 46 deletions, all under internal/run and internal/cli. Unchanged since pr-open; no fix commit has been pushed. — commit `733a3f2053e72a75d0cac8ea0f8e1d0228f850fb` (2026-08-01T03:14:02Z)
- **architect-scope-boundary** — pass — `git diff --name-only main...HEAD -- adapters/` — Architect confirmed no file under adapters/ is touched. Both hosts' Delivery skills and reviewer definitions still document the superseded request shape and the by-hand escalate step; correcting them is issue #155's job, and the request schema version bump is what makes a stale adapter fail closed in the meantime. — commit `733a3f2053e72a75d0cac8ea0f8e1d0228f850fb` (2026-08-01T03:06:08Z)
- **review-go-test-all** — pass — `go clean -testcache && go test ./...` — Reviewer ran all packages uncached on the reviewed head; all ok, 0 failures. — commit `733a3f2053e72a75d0cac8ea0f8e1d0228f850fb` (2026-08-01T03:14:02Z)
- **review-gofmt** — pass — `gofmt -l .` — Reviewer observed no output, exit 0, on the reviewed head. — commit `733a3f2053e72a75d0cac8ea0f8e1d0228f850fb` (2026-08-01T03:14:02Z)
- **review-go-vet** — pass — `go vet ./...` — Reviewer observed exit 0 with no diagnostics on the reviewed head. — commit `733a3f2053e72a75d0cac8ea0f8e1d0228f850fb` (2026-08-01T03:14:02Z)
- **review-ci-checks** — pass — `gh pr checks 158` — Reviewer observed 6 of 6 CI jobs passing on the reviewed head; the three test jobs that were in progress when the PR body snapshot was taken have since passed. — commit `733a3f2053e72a75d0cac8ea0f8e1d0228f850fb` (2026-08-01T03:14:02Z)
- **review-verdict-judgment-matrix** — pass — `trace all four verdict and judgment combinations through internal/run/review.go` — Reviewer confirmed: approve with all satisfied records and stays merge-ready; approve with any unsatisfied or wrong is refused before any mutation; request-changes with any wrong records then blocks for the human; request-changes with unsatisfied and none wrong records then returns to the executor. — commit `733a3f2053e72a75d0cac8ea0f8e1d0228f850fb` (2026-08-01T03:14:02Z)
- **review-judgment-entry-forgery** — pass — `trace rejectEngineOwnedNames against the reserved acceptance-criterion name pattern in both review and pr-open` — Reviewer confirmed neither verb lets a caller seed or overwrite a judgment entry; the reserved pattern is deliberately broader than the names the engine emits, which is the fail-closed direction, and caller names are rejected before the engine writes its own. — commit `733a3f2053e72a75d0cac8ea0f8e1d0228f850fb` (2026-08-01T03:14:02Z)
- **architect-accepted-contract-decision** — pass — `Architect decision recorded at review, not derived from an acceptance criterion` — No acceptance criterion states what an approve verdict submitted alongside a criterion judged unsatisfied or wrong should do. The executor made it a refusal before any mutation and asked the Architect to confirm rather than stand on its own call. The Architect accepted it as resolving an underspecified corner in the fail-closed direction rather than expanding the contract, and flagged it to the reviewer for disagreement; the reviewer independently agreed and identified the resume-path fail-open it closes. Recorded here because the reviewer correctly found it was contract surface living only in a doc comment. — commit `733a3f2053e72a75d0cac8ea0f8e1d0228f850fb` (2026-08-01T03:14:02Z)
- **review-cycle-1** — approve — Approve. All six acceptance criteria met, each with a test that would fail if the logic broke. Criterion 1: the judgment check sits after loadVerb (read-only) and before openGitHub, proven against an empty execxtest.Script that fails on any call, plus a byte-comparison of state before and after; the criteria count is read from engine state, never from the request. Criterion 2: the approve branch makes no SetStatus call exactly as the old code did, and MergeReport's gate is untouched. Criterion 3: the blocked transition is byte-for-byte the one escalateReturnToArchitect makes, the blocked reason is never empty so state validation holds, and the review cycle is still recorded before the block so the report is not lost. Criterion 4: unsatisfied-without-wrong pins in-review plus in-progress plus an empty blocked reason. Criterion 5: each judgment lands as a reserved acceptance-criterion-&lt;n&gt; verification whose commit OID is stamped from the head the engine read itself rather than from the request; the reserved name pattern is enforced in both review and pr-open so neither verb can seed or overwrite a judgment entry, and replace-by-name keeps the entry count bounded by the criteria count across cycles. Criterion 6: the version refusal fires before any missing-field complaint and names the supported version. The reviewer explicitly considered whether any criterion was itself wrong and returned no such finding, noting criterion 6 comes closest to naming a mechanism but that the version check and its message format already existed on main, so nothing had to be invented to satisfy it. On the unrequested design decision the Architect accepted -- refusing an approve verdict submitted alongside a criterion judged unsatisfied or wrong -- the reviewer traced all four verdict/judgment combinations, agreed with the refusal, and found no conflict with criterion 3, which is scoped to a recorded review: the refused combination is never recorded. It also identified a concrete fail-open the refusal closes that the Architect had not: recording approve-plus-wrong would persist an approving last verdict, and resume's rederive can lift a blocked issue back to in-review without clearing that approval, putting an issue whose own review says a criterion is false back on the merge-report path. Six findings, all low or informational, none blocking: (1) orch resume clears a wrong-criterion block and drops its reason, a pre-existing property of escalateReturnToArchitect rather than a regression, bounded because the judgment entries survive and the last verdict stays request-changes so merge-report still refuses; the fix belongs in resume's reconciliation table, not here. (2) The body-cap arithmetic documented at reviewDetailCap is now stale, since permanent judgment reasons add to the base body and rotation drops the oldest details first, which is pr-open's test evidence; the reviewer deliberately declined to add a tighter cap against a hypothesis. (3) The accepted design decision was absent from the audit record -- recorded now as its own verification entry on this cycle. (4) A wrong-criterion block is indistinguishable from an ordinary fix cycle in metrics, unlike block and escalate which carry a class field. (5) request-changes is a slightly off verdict for work that is fine against a criterion that is wrong, noted without asking for a third verdict. (6) The new zero-criteria guard is technically a new refusal path for pre-schema-2 issues reaching review, judged the correct call since dispatch already refuses them and letting them through is the vacuous-count hole the issue exists to close. Scope clean: eight files under internal/run and internal/cli, nothing under adapters/, no go.mod or configuration change. Security strictly narrows what a caller may assert. — commit `733a3f2053e72a75d0cac8ea0f8e1d0228f850fb` (2026-08-01T03:14:03Z)
- **required-ci** — passing — scripts (ubuntu-latest)=pass, test (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass, lint=pass — commit `733a3f2053e72a75d0cac8ea0f8e1d0228f850fb` (2026-08-01T03:14:07Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "A reviewer can record an approving review today without stating anything about any individual acceptance criterion, and a review that rejects a criterion as wrong reaches the human only if the Architect reads a paragraph and makes a second call by hand. Make the review verb require one judgment per acceptance criterion on the issue, and make a criterion judged wrong block the issue for the human as part of recording that review.",
  "acceptance_criteria": [
    "`orch run review` refuses, before any mutation, a request that does not carry exactly one judgment for each acceptance criterion the issue holds.",
    "A recorded review that judges every acceptance criterion satisfied, with an approving verdict, leaves the issue ready for the merge report exactly as it is today.",
    "A recorded review that judges any acceptance criterion wrong leaves the issue blocked and flagged for the human, with no further verb call needed.",
    "A recorded review that judges a criterion unsatisfied without judging any criterion wrong returns the issue to the executor as a request-changes review does today.",
    "Each acceptance criterion's judgment and the reviewer's stated reason for it appear in the issue's audit record.",
    "A review request declaring the previously supported request schema version is refused with a message naming the version this build supports."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "specialist",
  "executor": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "routing_rationale": "Routed to a specialist with a strong reviewer because the task is unusually difficult.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test-all",
      "command": "go clean -testcache \u0026\u0026 go test ./...",
      "result": "pass",
      "detail": "Executor reported all packages ok with 0 failures on commit 733a3f2, with the test cache cleared first so nothing was reported from cache.",
      "commit_oid": "733a3f2053e72a75d0cac8ea0f8e1d0228f850fb",
      "at": "2026-08-01T03:06:08Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Executor reported no output on commit 733a3f2.",
      "commit_oid": "733a3f2053e72a75d0cac8ea0f8e1d0228f850fb",
      "at": "2026-08-01T03:06:08Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Executor reported exit 0 with no diagnostics on commit 733a3f2.",
      "commit_oid": "733a3f2053e72a75d0cac8ea0f8e1d0228f850fb",
      "at": "2026-08-01T03:06:08Z"
    },
    {
      "name": "branch-scope: commits and files vs main",
      "command": "git log --oneline main..HEAD; git diff --name-only main...HEAD; git diff --shortstat main...HEAD",
      "result": "pass",
      "detail": "Architect re-ran these at the reviewed head: one commit 733a3f2 on top of main ddee1b3, eight files, 503 insertions and 46 deletions, all under internal/run and internal/cli. Unchanged since pr-open; no fix commit has been pushed.",
      "commit_oid": "733a3f2053e72a75d0cac8ea0f8e1d0228f850fb",
      "at": "2026-08-01T03:14:02Z"
    },
    {
      "name": "architect-scope-boundary",
      "command": "git diff --name-only main...HEAD -- adapters/",
      "result": "pass",
      "detail": "Architect confirmed no file under adapters/ is touched. Both hosts' Delivery skills and reviewer definitions still document the superseded request shape and the by-hand escalate step; correcting them is issue #155's job, and the request schema version bump is what makes a stale adapter fail closed in the meantime.",
      "commit_oid": "733a3f2053e72a75d0cac8ea0f8e1d0228f850fb",
      "at": "2026-08-01T03:06:08Z"
    },
    {
      "name": "review-go-test-all",
      "command": "go clean -testcache \u0026\u0026 go test ./...",
      "result": "pass",
      "detail": "Reviewer ran all packages uncached on the reviewed head; all ok, 0 failures.",
      "commit_oid": "733a3f2053e72a75d0cac8ea0f8e1d0228f850fb",
      "at": "2026-08-01T03:14:02Z"
    },
    {
      "name": "review-gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Reviewer observed no output, exit 0, on the reviewed head.",
      "commit_oid": "733a3f2053e72a75d0cac8ea0f8e1d0228f850fb",
      "at": "2026-08-01T03:14:02Z"
    },
    {
      "name": "review-go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Reviewer observed exit 0 with no diagnostics on the reviewed head.",
      "commit_oid": "733a3f2053e72a75d0cac8ea0f8e1d0228f850fb",
      "at": "2026-08-01T03:14:02Z"
    },
    {
      "name": "review-ci-checks",
      "command": "gh pr checks 158",
      "result": "pass",
      "detail": "Reviewer observed 6 of 6 CI jobs passing on the reviewed head; the three test jobs that were in progress when the PR body snapshot was taken have since passed.",
      "commit_oid": "733a3f2053e72a75d0cac8ea0f8e1d0228f850fb",
      "at": "2026-08-01T03:14:02Z"
    },
    {
      "name": "review-verdict-judgment-matrix",
      "command": "trace all four verdict and judgment combinations through internal/run/review.go",
      "result": "pass",
      "detail": "Reviewer confirmed: approve with all satisfied records and stays merge-ready; approve with any unsatisfied or wrong is refused before any mutation; request-changes with any wrong records then blocks for the human; request-changes with unsatisfied and none wrong records then returns to the executor.",
      "commit_oid": "733a3f2053e72a75d0cac8ea0f8e1d0228f850fb",
      "at": "2026-08-01T03:14:02Z"
    },
    {
      "name": "review-judgment-entry-forgery",
      "command": "trace rejectEngineOwnedNames against the reserved acceptance-criterion name pattern in both review and pr-open",
      "result": "pass",
      "detail": "Reviewer confirmed neither verb lets a caller seed or overwrite a judgment entry; the reserved pattern is deliberately broader than the names the engine emits, which is the fail-closed direction, and caller names are rejected before the engine writes its own.",
      "commit_oid": "733a3f2053e72a75d0cac8ea0f8e1d0228f850fb",
      "at": "2026-08-01T03:14:02Z"
    },
    {
      "name": "architect-accepted-contract-decision",
      "command": "Architect decision recorded at review, not derived from an acceptance criterion",
      "result": "pass",
      "detail": "No acceptance criterion states what an approve verdict submitted alongside a criterion judged unsatisfied or wrong should do. The executor made it a refusal before any mutation and asked the Architect to confirm rather than stand on its own call. The Architect accepted it as resolving an underspecified corner in the fail-closed direction rather than expanding the contract, and flagged it to the reviewer for disagreement; the reviewer independently agreed and identified the resume-path fail-open it closes. Recorded here because the reviewer correctly found it was contract surface living only in a doc comment.",
      "commit_oid": "733a3f2053e72a75d0cac8ea0f8e1d0228f850fb",
      "at": "2026-08-01T03:14:02Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approve. All six acceptance criteria met, each with a test that would fail if the logic broke. Criterion 1: the judgment check sits after loadVerb (read-only) and before openGitHub, proven against an empty execxtest.Script that fails on any call, plus a byte-comparison of state before and after; the criteria count is read from engine state, never from the request. Criterion 2: the approve branch makes no SetStatus call exactly as the old code did, and MergeReport's gate is untouched. Criterion 3: the blocked transition is byte-for-byte the one escalateReturnToArchitect makes, the blocked reason is never empty so state validation holds, and the review cycle is still recorded before the block so the report is not lost. Criterion 4: unsatisfied-without-wrong pins in-review plus in-progress plus an empty blocked reason. Criterion 5: each judgment lands as a reserved acceptance-criterion-\u003cn\u003e verification whose commit OID is stamped from the head the engine read itself rather than from the request; the reserved name pattern is enforced in both review and pr-open so neither verb can seed or overwrite a judgment entry, and replace-by-name keeps the entry count bounded by the criteria count across cycles. Criterion 6: the version refusal fires before any missing-field complaint and names the supported version. The reviewer explicitly considered whether any criterion was itself wrong and returned no such finding, noting criterion 6 comes closest to naming a mechanism but that the version check and its message format already existed on main, so nothing had to be invented to satisfy it. On the unrequested design decision the Architect accepted -- refusing an approve verdict submitted alongside a criterion judged unsatisfied or wrong -- the reviewer traced all four verdict/judgment combinations, agreed with the refusal, and found no conflict with criterion 3, which is scoped to a recorded review: the refused combination is never recorded. It also identified a concrete fail-open the refusal closes that the Architect had not: recording approve-plus-wrong would persist an approving last verdict, and resume's rederive can lift a blocked issue back to in-review without clearing that approval, putting an issue whose own review says a criterion is false back on the merge-report path. Six findings, all low or informational, none blocking: (1) orch resume clears a wrong-criterion block and drops its reason, a pre-existing property of escalateReturnToArchitect rather than a regression, bounded because the judgment entries survive and the last verdict stays request-changes so merge-report still refuses; the fix belongs in resume's reconciliation table, not here. (2) The body-cap arithmetic documented at reviewDetailCap is now stale, since permanent judgment reasons add to the base body and rotation drops the oldest details first, which is pr-open's test evidence; the reviewer deliberately declined to add a tighter cap against a hypothesis. (3) The accepted design decision was absent from the audit record -- recorded now as its own verification entry on this cycle. (4) A wrong-criterion block is indistinguishable from an ordinary fix cycle in metrics, unlike block and escalate which carry a class field. (5) request-changes is a slightly off verdict for work that is fine against a criterion that is wrong, noted without asking for a third verdict. (6) The new zero-criteria guard is technically a new refusal path for pre-schema-2 issues reaching review, judged the correct call since dispatch already refuses them and letting them through is the vacuous-count hole the issue exists to close. Scope clean: eight files under internal/run and internal/cli, nothing under adapters/, no go.mod or configuration change. Security strictly narrows what a caller may assert.",
      "commit_oid": "733a3f2053e72a75d0cac8ea0f8e1d0228f850fb",
      "at": "2026-08-01T03:14:03Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "scripts (ubuntu-latest)=pass, test (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass, lint=pass",
      "commit_oid": "733a3f2053e72a75d0cac8ea0f8e1d0228f850fb",
      "at": "2026-08-01T03:14:07Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->