### PR TITLE
Bring both hosts' reviewer definitions and Delivery skills into agreement with the review verb

### DIFF
--- a/adapters/claude/agents/orch-reviewer-safe.md
+++ b/adapters/claude/agents/orch-reviewer-safe.md
@@ -54,6 +54,15 @@ and state the rejected criterion and reason in the consolidated report
 so the Architect can surface the rejected criterion and reason to the
 human.
 
+A criterion is also wrong when the only evidence available for it is a
+proxy for what it asked. A criterion requiring a check on how an agent
+routes, what it decides, or how it behaves is the standing instance:
+nothing in the repository observes an instruction an agent follows, so
+the only thing that can satisfy such a criterion is a check asserting
+the instruction's prose is still present — which pins the words and
+says nothing about the behavior the criterion asked about. Judge that
+criterion wrong rather than accepting the proxy as evidence for it.
+
 Before you request a change that adds code, establish that the added
 code needs to exist at all. "This case is unhandled" is a finding only
 once you can say what breaks without the handling; absent that, the
@@ -68,8 +77,9 @@ Your `Bash` access is for **read-only** investigation only: `git diff`,
 test/build commands to confirm evidence — never a write, a commit, or
 anything that changes the repository. You have no `Edit` or `Write`
 tool for the same reason: your job is to judge the change, not to fix
-it. If the change needs a fix, that is a `request-changes` verdict
-sent back to the executor, not something you do yourself.
+it. If the change needs a fix the verdict grounds below make blocking,
+that is a `request-changes` verdict sent back to the executor, not
+something you do yourself.
 
 ## Report
 
@@ -79,11 +89,26 @@ you are uncertain about; do not hold one back because it seems minor
 or falls under some bar. Give each finding a severity and a
 confidence.
 
+Judge each acceptance criterion by number, one at a time. For each,
+state the specific observation that satisfies it — the file and line
+you read, the command you ran and what it printed, the test that
+passed. Restating the criterion in other words is not an observation,
+and neither is "the diff implements it". A criterion you cannot point
+at an observation for is not satisfied: say that plainly, or say it is
+wrong in the sense above. The Architect submits one judgment per
+criterion, with your reason attached, so an approval asserts something
+about every criterion instead of one summary standing in for all of
+them.
+
 Decide the verdict after the findings are listed, as a separate
-judgment: `request-changes` applies on exactly two grounds — a finding
-blocks an acceptance criterion, or an acceptance criterion is itself
-wrong in the sense above. A finding that is neither stays in the report
-without by itself forcing another review cycle.
+judgment. `request-changes` is not confined to findings that block an
+acceptance criterion: a required test that fails, a security boundary
+the change weakens, and any defect of comparable severity are each
+grounds on their own, even when no acceptance criterion names the area
+they sit in. An acceptance criterion that is itself wrong in the sense
+above is grounds too. What stays in the report without forcing another
+review cycle is a finding that is none of these — a nit, a preference,
+a low-severity observation.
 
 Produce **one consolidated report** per review cycle — do not report
 findings piecemeal across several messages. State a clear verdict

--- a/adapters/claude/agents/orch-reviewer.md
+++ b/adapters/claude/agents/orch-reviewer.md
@@ -46,6 +46,15 @@ and state the rejected criterion and reason in the consolidated report
 so the Architect can surface the rejected criterion and reason to the
 human.
 
+A criterion is also wrong when the only evidence available for it is a
+proxy for what it asked. A criterion requiring a check on how an agent
+routes, what it decides, or how it behaves is the standing instance:
+nothing in the repository observes an instruction an agent follows, so
+the only thing that can satisfy such a criterion is a check asserting
+the instruction's prose is still present — which pins the words and
+says nothing about the behavior the criterion asked about. Judge that
+criterion wrong rather than accepting the proxy as evidence for it.
+
 Before you request a change that adds code, establish that the added
 code needs to exist at all. "This case is unhandled" is a finding only
 once you can say what breaks without the handling; absent that, the
@@ -60,8 +69,9 @@ Your `Bash` access is for **read-only** investigation only: `git diff`,
 test/build commands to confirm evidence — never a write, a commit, or
 anything that changes the repository. You have no `Edit` or `Write`
 tool for the same reason: your job is to judge the change, not to fix
-it. If the change needs a fix, that is a `request-changes` verdict
-sent back to the executor, not something you do yourself.
+it. If the change needs a fix the verdict grounds below make blocking,
+that is a `request-changes` verdict sent back to the executor, not
+something you do yourself.
 
 ## Report
 
@@ -71,11 +81,26 @@ you are uncertain about; do not hold one back because it seems minor
 or falls under some bar. Give each finding a severity and a
 confidence.
 
+Judge each acceptance criterion by number, one at a time. For each,
+state the specific observation that satisfies it — the file and line
+you read, the command you ran and what it printed, the test that
+passed. Restating the criterion in other words is not an observation,
+and neither is "the diff implements it". A criterion you cannot point
+at an observation for is not satisfied: say that plainly, or say it is
+wrong in the sense above. The Architect submits one judgment per
+criterion, with your reason attached, so an approval asserts something
+about every criterion instead of one summary standing in for all of
+them.
+
 Decide the verdict after the findings are listed, as a separate
-judgment: `request-changes` applies on exactly two grounds — a finding
-blocks an acceptance criterion, or an acceptance criterion is itself
-wrong in the sense above. A finding that is neither stays in the report
-without by itself forcing another review cycle.
+judgment. `request-changes` is not confined to findings that block an
+acceptance criterion: a required test that fails, a security boundary
+the change weakens, and any defect of comparable severity are each
+grounds on their own, even when no acceptance criterion names the area
+they sit in. An acceptance criterion that is itself wrong in the sense
+above is grounds too. What stays in the report without forcing another
+review cycle is a finding that is none of these — a nit, a preference,
+a low-severity observation.
 
 Produce **one consolidated report** per review cycle — do not report
 findings piecemeal across several messages. State a clear verdict

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -313,31 +313,31 @@ func TestAgentFrontmatter(t *testing.T) {
 	}
 }
 
-// reviewerCoverageInstruction and reviewerBlockingVerdictInstruction
-// are the two prose anchors the reviewer agents' "## Report" section
-// must carry: the finding stage is about coverage, not a severity
-// filter, and the approve/request-changes verdict is a separate
-// judgment turning on a closed pair of grounds. The verdict anchor
-// enumerates both grounds rather than only the blocking one (its
-// original issue #117 form): a wrong-criterion finding does not block
-// an acceptance criterion — it rejects one — so an exclusive blocking
-// rule would foreclose the very verdict the "When a criterion is
-// itself wrong" section grants, and a reviewer reading the file in
-// order would take the later rule and approve. Neither anchor includes
-// the backtick-quoted `request-changes` token itself, so a formatting
-// change around that token doesn't make this check brittle.
+// reviewerCoverageInstruction and reviewerVerdictGroundsInstruction are
+// the two prose anchors the reviewer agents' "## Report" section must
+// carry: the finding stage is about coverage, not a severity filter,
+// and the approve/request-changes verdict is a separate judgment whose
+// grounds are not closed over the acceptance criteria. The verdict
+// anchor names a failing required test and a weakened security boundary
+// explicitly, because both earlier forms — "applies only when a finding
+// blocks an acceptance criterion" (issue #117) and "applies on exactly
+// two grounds" (PR #147) — left a severe defect touching no criterion
+// reportable but non-blocking, so a reviewer that found one filed it and
+// approved. Neither anchor includes the backtick-quoted
+// `request-changes` token itself, so a formatting change around that
+// token doesn't make this check brittle.
 const reviewerCoverageInstruction = "this stage is about coverage, not filtering"
-const reviewerBlockingVerdictInstruction = "applies on exactly two grounds — a finding blocks an acceptance criterion, or an acceptance criterion is itself wrong"
+const reviewerVerdictGroundsInstruction = "is not confined to findings that block an acceptance criterion: a required test that fails, a security boundary the change weakens, and any defect of comparable severity are each grounds on their own, even when no acceptance criterion names the area they sit in"
 
-// TestReviewerReportsCoverageAndBlockingVerdict checks the two reviewer
+// TestReviewerReportsCoverageAndVerdictGrounds checks the two reviewer
 // agent files directly by stem, not via agentRoster: agentRoster is a
 // name-keyed map iterated by TestAgentFrontmatter, so a file it doesn't
 // list would go unchecked there, and a body-content assertion has
 // nothing to do with the tools/model fields that map exists for. This
-// mechanically guards the coverage-not-filtering and blocking-only-verdict
+// mechanically guards the coverage-not-filtering and verdict-grounds
 // instructions instead of leaving them as prose a future reader must
 // re-verify by hand.
-func TestReviewerReportsCoverageAndBlockingVerdict(t *testing.T) {
+func TestReviewerReportsCoverageAndVerdictGrounds(t *testing.T) {
 	for _, stem := range []string{"orch-reviewer", "orch-reviewer-safe"} {
 		t.Run(stem, func(t *testing.T) {
 			path := filepath.Join("agents", stem+".md")
@@ -349,8 +349,8 @@ func TestReviewerReportsCoverageAndBlockingVerdict(t *testing.T) {
 			if !strings.Contains(content, reviewerCoverageInstruction) {
 				t.Errorf("%s: missing coverage instruction %q", path, reviewerCoverageInstruction)
 			}
-			if !strings.Contains(content, reviewerBlockingVerdictInstruction) {
-				t.Errorf("%s: missing blocking-only verdict instruction %q", path, reviewerBlockingVerdictInstruction)
+			if !strings.Contains(content, adaptertest.NormalizeWhitespace(reviewerVerdictGroundsInstruction)) {
+				t.Errorf("%s: missing verdict-grounds instruction %q", path, reviewerVerdictGroundsInstruction)
 			}
 		})
 	}
@@ -391,24 +391,46 @@ func TestDeliverySkillHasBranchScopeVerificationGuidance(t *testing.T) {
 	adaptertest.CheckBranchScopeVerificationGuidance(t, deliverySkillPath)
 }
 
-// These statements keep a wrong acceptance criterion reachable and route
-// it to the human rather than through the ordinary executor fix cycle.
-// Each phrase is pinned without its surrounding punctuation or em dashes,
-// so a prose reflow stays possible while deleting the statement fails.
+// These statements keep a wrong acceptance criterion reachable, keep the
+// plan gate from writing one no evidence can settle, and route a rejected
+// criterion to the human inside the review call rather than through a
+// second verb or the ordinary executor fix cycle. Each phrase is pinned
+// without its surrounding punctuation or em dashes, so a prose reflow
+// stays possible while deleting the statement fails.
+//
+// A pin catches deletion or rewording of the words, and nothing more: no
+// check here can observe whether a reviewer or Architect actually obeys
+// the statement it pins.
 const observableOutcomeCriterionGuidance = "An acceptance criterion describes an observable outcome, and never names a function, a control-flow step, or a validity notion the change is expected to introduce"
+const unproducibleEvidenceCriterionGuidance = "A criterion requiring evidence the repository cannot produce is not a valid criterion"
 const reviewerWrongCriterionGuidance = "You may return `request-changes` on the ground that an acceptance criterion is itself wrong"
 const reviewerAddedCodeNecessityGuidance = "Before you request a change that adds code, establish that the added code needs to exist at all"
 const reviewerWrongCriterionHumanGuidance = "Mark it `wrong acceptance criterion` and state the rejected criterion and reason in the consolidated report so the Architect can surface the rejected criterion and reason to the human"
-const wrongCriterionEscalationGuidance = "A `request-changes` report with a `wrong acceptance criterion` is not an executor fix cycle"
-const wrongCriterionEscalationTrigger = "call `orch run escalate` with `trigger` `architectural-ambiguity`"
+const reviewerProxyEvidenceGuidance = "A criterion is also wrong when the only evidence available for it is a proxy for what it asked. A criterion requiring a check on how an agent routes, what it decides, or how it behaves is the standing instance"
+const reviewerPerCriterionObservationGuidance = "Judge each acceptance criterion by number, one at a time. For each, state the specific observation that satisfies it"
+const reviewJudgmentsGuidance = "`judgments` is required and carries exactly one entry per acceptance criterion the issue holds"
+const reviewApproveRequiresAllSatisfied = "A `verdict` of `approve` is accepted only when every criterion is judged `satisfied`"
+const wrongCriterionInReviewCallGuidance = "A criterion judged `wrong` is the needs-human outcome, and this one `orch run review` call makes it"
+const wrongCriterionNoSecondVerbGuidance = "do not call `orch run escalate` for it and do not resume the executor"
 const wrongCriterionHumanGuidance = "surface the rejected criterion and reason to the human"
 const codeFindingFixCycleGuidance = "A `request-changes` based on a code finding resumes the same executor in the **same worktree** on the same branch: it fixes and pushes, then a **fresh** reviewer is spawned"
 
+// removedWrongCriterionEscalationGuidance is the instruction the v2
+// review verb made false: it told the Architect to record the review and
+// then call `orch run escalate` by hand, when `orch run review` now
+// blocks the issue and flags it needs-human inside the same call. It is
+// asserted absent, not present, so restoring the by-hand escalation step
+// fails this test.
+const removedWrongCriterionEscalationGuidance = "A `request-changes` report with a `wrong acceptance criterion` is not an executor fix cycle"
+
 // TestDeliverySkillAndReviewersHaveWrongCriterionGuidance checks the
-// Delivery escalation/fix-cycle split and both reviewer definitions. Like
-// TestReviewerReportsCoverageAndBlockingVerdict above, the reviewer files
+// Delivery per-criterion judgment contract, the wrong-criterion/fix-cycle
+// split, and both reviewer definitions. Like
+// TestReviewerReportsCoverageAndVerdictGrounds above, the reviewer files
 // are addressed by stem rather than through agentRoster, whose job is the
-// tools/model frontmatter. Comparison ignores hard wraps.
+// tools/model frontmatter. Comparison ignores hard wraps. It fails when a
+// pinned statement is deleted or reworded; it cannot tell whether any
+// agent that reads the statement follows it.
 func TestDeliverySkillAndReviewersHaveWrongCriterionGuidance(t *testing.T) {
 	data, err := os.ReadFile(deliverySkillPath)
 	if err != nil {
@@ -417,14 +439,20 @@ func TestDeliverySkillAndReviewersHaveWrongCriterionGuidance(t *testing.T) {
 	skill := adaptertest.NormalizeWhitespace(string(data))
 	for _, phrase := range []string{
 		observableOutcomeCriterionGuidance,
-		wrongCriterionEscalationGuidance,
-		wrongCriterionEscalationTrigger,
+		unproducibleEvidenceCriterionGuidance,
+		reviewJudgmentsGuidance,
+		reviewApproveRequiresAllSatisfied,
+		wrongCriterionInReviewCallGuidance,
+		wrongCriterionNoSecondVerbGuidance,
 		wrongCriterionHumanGuidance,
 		codeFindingFixCycleGuidance,
 	} {
 		if !strings.Contains(skill, adaptertest.NormalizeWhitespace(phrase)) {
 			t.Errorf("%s does not contain wrong-criterion guidance %q", deliverySkillPath, phrase)
 		}
+	}
+	if strings.Contains(skill, adaptertest.NormalizeWhitespace(removedWrongCriterionEscalationGuidance)) {
+		t.Errorf("%s still instructs a by-hand escalation after a wrong-criterion review: %q", deliverySkillPath, removedWrongCriterionEscalationGuidance)
 	}
 	for _, stem := range []string{"orch-reviewer", "orch-reviewer-safe"} {
 		t.Run(stem, func(t *testing.T) {
@@ -434,7 +462,13 @@ func TestDeliverySkillAndReviewersHaveWrongCriterionGuidance(t *testing.T) {
 				t.Fatalf("read %s: %v", path, err)
 			}
 			content := adaptertest.NormalizeWhitespace(string(data))
-			for _, phrase := range []string{reviewerWrongCriterionGuidance, reviewerAddedCodeNecessityGuidance, reviewerWrongCriterionHumanGuidance} {
+			for _, phrase := range []string{
+				reviewerWrongCriterionGuidance,
+				reviewerAddedCodeNecessityGuidance,
+				reviewerWrongCriterionHumanGuidance,
+				reviewerProxyEvidenceGuidance,
+				reviewerPerCriterionObservationGuidance,
+			} {
 				if !strings.Contains(content, adaptertest.NormalizeWhitespace(phrase)) {
 					t.Errorf("%s: missing reviewer guidance %q", path, phrase)
 				}

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -91,6 +91,17 @@ later review then grades how completely that invention was built rather
 than whether it needed to exist at all — state what must be true once
 the issue is done, and leave the mechanism to the executor.
 
+A criterion requiring evidence the repository cannot produce is not a
+valid criterion. When nothing in the repository can observe what the
+criterion asks about — how an agent routes, what it decides, whether it
+follows an instruction it was given — the only thing that could satisfy
+it is a check on a proxy, such as a test asserting the instruction's
+prose is still present, which pins the words and says nothing about the
+behavior. Ask what evidence would settle the criterion before you write
+it: if the honest answer is a proxy, write the criterion against
+something the repository can actually produce evidence for, or leave it
+out of the plan.
+
 Plan text must never reference machine-local or gitignored paths such
 as `.memhub/`, `.orchestrator/state.json`, or
 `.orchestrator/config.local.toml` — an executor sees only the committed
@@ -314,9 +325,10 @@ in flight at once. For each issue:
    already left, so you must track whichever value is current yourself:
 
    ```json
-   {"schema_version": 1, "issue_number": N, "reviewed_head_oid": "...",
+   {"schema_version": 2, "issue_number": N, "reviewed_head_oid": "...",
     "verdict": "approve|request-changes", "summary": "...",
     "reviewer": {"model": "...", "effort": "..."},
+    "judgments": [{"criterion": 1, "judgment": "satisfied|unsatisfied|wrong", "reason": "..."}],
     "verifications": [{"name": "...", "command": "...", "result": "...", "detail": "..."}],
     "usage": {"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0,
                "cache_creation_tokens": 0, "total_tokens": 0, "duration_ms": 0},
@@ -324,25 +336,40 @@ in flight at once. For each issue:
                "cache_creation_tokens": 0, "total_tokens": 0, "duration_ms": 0}}
    ```
 
+   `judgments` is required and carries exactly one entry per acceptance
+   criterion the issue holds: `criterion` is the criterion's 1-based
+   position in the issue's approved acceptance criteria, `judgment` is
+   one of `satisfied`, `unsatisfied`, `wrong`, and `reason` is the
+   reviewer's own reason for that call, which the audit record keeps as
+   an engine-owned `acceptance-criterion-<n>` verification you never
+   supply yourself. The engine counts the criteria from its own state,
+   so the request cannot decide how many it is answering — a missing,
+   duplicated, or out-of-range criterion is refused before any mutation.
+   A `verdict` of `approve` is accepted only when every criterion is
+   judged `satisfied`; record `request-changes` otherwise. Transcribe
+   the reviewer's per-criterion calls, never your own reading of its
+   summary.
+
    `usage` is optional (PRD §21), same rule as PR-open: it is the
    reviewer's own cost — only report what the reviewer subagent's
    Task result actually carries, including `total_tokens` when that
    is what it reports instead of the input/output/cache split.
-    A `request-changes` report with a `wrong acceptance criterion` is not
-    an executor fix cycle. Record the review with `orch run review`, then,
-    before asking the executor to change anything, call `orch run escalate`
-    with `trigger` `architectural-ambiguity` and a `detail` that names the
-    rejected criterion and its reason. A `return-to-architect` result is
-    the needs-human outcome: surface the rejected criterion and reason to
-    the human and do not resume the executor. A `request-changes` based on
-    a code finding resumes the same executor in the **same worktree** on
-    the same branch: it fixes and pushes, then a **fresh** reviewer is
-    spawned (step 4) and `orch run review` is called again. Because this is
-    the only verb call on that cycle, `executor_usage` (same optional shape
-    as `usage`) carries the executor's fix-and-push cost for the cycle just
-    finished — report only what its Task result actually gives you, never an
-    estimate, and omit it when there was no fix cycle (the first review
-    after pr-open).
+   A criterion judged `wrong` is the needs-human outcome, and this one
+   `orch run review` call makes it: the engine blocks the issue and
+   flags it needs-human itself, and the result says so in `phase`,
+   `wrong_criteria`, and `blocked_reason`. There is no second verb call
+   to make — do not call `orch run escalate` for it and do not resume
+   the executor. Instead surface the rejected criterion and reason to
+   the human, together with the returned `blocked_reason`, and stop
+   working the issue. A `request-changes` based on
+   a code finding resumes the same executor in the **same worktree** on
+   the same branch: it fixes and pushes, then a **fresh** reviewer is
+   spawned (step 4) and `orch run review` is called again. Because this is
+   the only verb call on that cycle, `executor_usage` (same optional shape
+   as `usage`) carries the executor's fix-and-push cost for the cycle just
+   finished — report only what its Task result actually gives you, never an
+   estimate, and omit it when there was no fix cycle (the first review
+   after pr-open).
    `orch run pr-open` is not reachable a second time, so `verifications`
    is optional and takes pr-open's input shape — use it to carry
    evidence re-run on the fix commit (e.g. tests re-run before

--- a/adapters/codex/agents/orch-reviewer-safe.toml
+++ b/adapters/codex/agents/orch-reviewer-safe.toml
@@ -60,6 +60,15 @@ and state the rejected criterion and reason in the consolidated report
 so the Architect can surface the rejected criterion and reason to the
 human.
 
+A criterion is also wrong when the only evidence available for it is a
+proxy for what it asked. A criterion requiring a check on how an agent
+routes, what it decides, or how it behaves is the standing instance:
+nothing in the repository observes an instruction an agent follows, so
+the only thing that can satisfy such a criterion is a check asserting
+the instruction's prose is still present — which pins the words and
+says nothing about the behavior the criterion asked about. Judge that
+criterion wrong rather than accepting the proxy as evidence for it.
+
 Before you request a change that adds code, establish that the added
 code needs to exist at all. "This case is unhandled" is a finding only
 once you can say what breaks without the handling; absent that, the
@@ -72,10 +81,32 @@ issue that asked for it.
 Investigate read-only: `git diff`, `git log`, `gh pr view`, `gh pr
 diff`, and running the project's existing test/build commands to
 confirm evidence — never a write, a commit, or anything that changes
-the repository. If the change needs a fix, that is a `request-changes`
-verdict sent back to the executor, not something you do yourself.
+the repository. If the change needs a fix the verdict grounds below
+make blocking, that is a `request-changes` verdict sent back to the
+executor, not something you do yourself.
 
 ## Report
+
+Judge each acceptance criterion by number, one at a time. For each,
+state the specific observation that satisfies it — the file and line
+you read, the command you ran and what it printed, the test that
+passed. Restating the criterion in other words is not an observation,
+and neither is "the diff implements it". A criterion you cannot point
+at an observation for is not satisfied: say that plainly, or say it is
+wrong in the sense above. The Architect submits one judgment per
+criterion, with your reason attached, so an approval asserts something
+about every criterion instead of one summary standing in for all of
+them.
+
+Decide the verdict after the findings are listed, as a separate
+judgment. `request-changes` is not confined to findings that block an
+acceptance criterion: a required test that fails, a security boundary
+the change weakens, and any defect of comparable severity are each
+grounds on their own, even when no acceptance criterion names the area
+they sit in. An acceptance criterion that is itself wrong in the sense
+above is grounds too. What stays in the report without forcing another
+review cycle is a finding that is none of these — a nit, a preference,
+a low-severity observation.
 
 Produce one consolidated report per review cycle — do not report
 findings piecemeal across several messages. State a clear verdict

--- a/adapters/codex/agents/orch-reviewer.toml
+++ b/adapters/codex/agents/orch-reviewer.toml
@@ -52,6 +52,15 @@ and state the rejected criterion and reason in the consolidated report
 so the Architect can surface the rejected criterion and reason to the
 human.
 
+A criterion is also wrong when the only evidence available for it is a
+proxy for what it asked. A criterion requiring a check on how an agent
+routes, what it decides, or how it behaves is the standing instance:
+nothing in the repository observes an instruction an agent follows, so
+the only thing that can satisfy such a criterion is a check asserting
+the instruction's prose is still present — which pins the words and
+says nothing about the behavior the criterion asked about. Judge that
+criterion wrong rather than accepting the proxy as evidence for it.
+
 Before you request a change that adds code, establish that the added
 code needs to exist at all. "This case is unhandled" is a finding only
 once you can say what breaks without the handling; absent that, the
@@ -64,10 +73,32 @@ issue that asked for it.
 Investigate read-only: `git diff`, `git log`, `gh pr view`, `gh pr
 diff`, and running the project's existing test/build commands to
 confirm evidence — never a write, a commit, or anything that changes
-the repository. If the change needs a fix, that is a `request-changes`
-verdict sent back to the executor, not something you do yourself.
+the repository. If the change needs a fix the verdict grounds below
+make blocking, that is a `request-changes` verdict sent back to the
+executor, not something you do yourself.
 
 ## Report
+
+Judge each acceptance criterion by number, one at a time. For each,
+state the specific observation that satisfies it — the file and line
+you read, the command you ran and what it printed, the test that
+passed. Restating the criterion in other words is not an observation,
+and neither is "the diff implements it". A criterion you cannot point
+at an observation for is not satisfied: say that plainly, or say it is
+wrong in the sense above. The Architect submits one judgment per
+criterion, with your reason attached, so an approval asserts something
+about every criterion instead of one summary standing in for all of
+them.
+
+Decide the verdict after the findings are listed, as a separate
+judgment. `request-changes` is not confined to findings that block an
+acceptance criterion: a required test that fails, a security boundary
+the change weakens, and any defect of comparable severity are each
+grounds on their own, even when no acceptance criterion names the area
+they sit in. An acceptance criterion that is itself wrong in the sense
+above is grounds too. What stays in the report without forcing another
+review cycle is a finding that is none of these — a nit, a preference,
+a low-severity observation.
 
 Produce one consolidated report per review cycle — do not report
 findings piecemeal across several messages. State a clear verdict

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -283,24 +283,55 @@ func TestDeliverySkillHasBranchScopeVerificationGuidance(t *testing.T) {
 	adaptertest.CheckBranchScopeVerificationGuidance(t, deliverySkillPath)
 }
 
-// These statements keep a wrong acceptance criterion reachable and route
-// it to the human rather than through the ordinary executor fix cycle.
-// Each phrase is pinned without its surrounding punctuation or em dashes,
-// so a prose reflow stays possible while deleting the statement fails.
+// These statements keep a wrong acceptance criterion reachable, keep the
+// plan gate from writing one no evidence can settle, and route a rejected
+// criterion to the human inside the review call rather than through a
+// second verb or the ordinary executor fix cycle. Each phrase is pinned
+// without its surrounding punctuation or em dashes, so a prose reflow
+// stays possible while deleting the statement fails.
+//
+// reviewerVerdictGroundsInstruction is the widened request-changes bar:
+// both earlier forms — "applies only when a finding blocks an acceptance
+// criterion" (issue #117) and "applies on exactly two grounds" (PR #147)
+// — left a severe defect touching no criterion reportable but
+// non-blocking, so a reviewer that found one filed it and approved. The
+// pin names a failing required test and a weakened security boundary
+// explicitly, since those are the two the enumeration used to exclude.
+//
+// A pin catches deletion or rewording of the words, and nothing more: no
+// check here can observe whether a reviewer or Architect actually obeys
+// the statement it pins.
 const observableOutcomeCriterionGuidance = "An acceptance criterion describes an observable outcome, and never names a function, a control-flow step, or a validity notion the change is expected to introduce"
+const unproducibleEvidenceCriterionGuidance = "A criterion requiring evidence the repository cannot produce is not a valid criterion"
 const reviewerWrongCriterionGuidance = "You may return `request-changes` on the ground that an acceptance criterion is itself wrong"
 const reviewerAddedCodeNecessityGuidance = "Before you request a change that adds code, establish that the added code needs to exist at all"
 const reviewerWrongCriterionHumanGuidance = "Mark it `wrong acceptance criterion` and state the rejected criterion and reason in the consolidated report so the Architect can surface the rejected criterion and reason to the human"
-const wrongCriterionEscalationGuidance = "A `request-changes` report with a `wrong acceptance criterion` is not an executor fix cycle"
-const wrongCriterionEscalationTrigger = "call `orch run escalate` with `trigger` `architectural-ambiguity`"
+const reviewerProxyEvidenceGuidance = "A criterion is also wrong when the only evidence available for it is a proxy for what it asked. A criterion requiring a check on how an agent routes, what it decides, or how it behaves is the standing instance"
+const reviewerPerCriterionObservationGuidance = "Judge each acceptance criterion by number, one at a time. For each, state the specific observation that satisfies it"
+const reviewerVerdictGroundsInstruction = "is not confined to findings that block an acceptance criterion: a required test that fails, a security boundary the change weakens, and any defect of comparable severity are each grounds on their own, even when no acceptance criterion names the area they sit in"
+const reviewJudgmentsGuidance = "`judgments` is required and carries exactly one entry per acceptance criterion the issue holds"
+const reviewApproveRequiresAllSatisfied = "A `verdict` of `approve` is accepted only when every criterion is judged `satisfied`"
+const wrongCriterionInReviewCallGuidance = "A criterion judged `wrong` is the needs-human outcome, and this one `orch run review` call makes it"
+const wrongCriterionNoSecondVerbGuidance = "do not call `orch run escalate` for it and do not resume the executor"
 const wrongCriterionHumanGuidance = "surface the rejected criterion and reason to the human"
 const codeFindingFixCycleGuidance = "A `request-changes` based on a code finding resumes the same executor with `followup_task` in the **same worktree** on the same branch: it fixes and pushes, then a **fresh** reviewer is dispatched"
 
+// removedWrongCriterionEscalationGuidance is the instruction the v2
+// review verb made false: it told the Architect to record the review and
+// then call `orch run escalate` by hand, when `orch run review` now
+// blocks the issue and flags it needs-human inside the same call. It is
+// asserted absent, not present, so restoring the by-hand escalation step
+// fails this test.
+const removedWrongCriterionEscalationGuidance = "A `request-changes` report with a `wrong acceptance criterion` is not an executor fix cycle"
+
 // TestDeliverySkillAndReviewersHaveWrongCriterionGuidance checks the
-// Delivery escalation/fix-cycle split and both reviewer definitions. The
-// agent files are decoded as TOML rather than scanned raw, so a statement
-// only counts when it is inside developer_instructions — the field the
-// agent actually receives. Comparison ignores hard wraps.
+// Delivery per-criterion judgment contract, the wrong-criterion/fix-cycle
+// split, and both reviewer definitions. The agent files are decoded as
+// TOML rather than scanned raw, so a statement only counts when it is
+// inside developer_instructions — the field the agent actually receives.
+// Comparison ignores hard wraps. It fails when a pinned statement is
+// deleted or reworded; it cannot tell whether any agent that reads the
+// statement follows it.
 func TestDeliverySkillAndReviewersHaveWrongCriterionGuidance(t *testing.T) {
 	data, err := os.ReadFile(deliverySkillPath)
 	if err != nil {
@@ -309,14 +340,20 @@ func TestDeliverySkillAndReviewersHaveWrongCriterionGuidance(t *testing.T) {
 	skill := adaptertest.NormalizeWhitespace(string(data))
 	for _, phrase := range []string{
 		observableOutcomeCriterionGuidance,
-		wrongCriterionEscalationGuidance,
-		wrongCriterionEscalationTrigger,
+		unproducibleEvidenceCriterionGuidance,
+		reviewJudgmentsGuidance,
+		reviewApproveRequiresAllSatisfied,
+		wrongCriterionInReviewCallGuidance,
+		wrongCriterionNoSecondVerbGuidance,
 		wrongCriterionHumanGuidance,
 		codeFindingFixCycleGuidance,
 	} {
 		if !strings.Contains(skill, adaptertest.NormalizeWhitespace(phrase)) {
 			t.Errorf("%s does not contain wrong-criterion guidance %q", deliverySkillPath, phrase)
 		}
+	}
+	if strings.Contains(skill, adaptertest.NormalizeWhitespace(removedWrongCriterionEscalationGuidance)) {
+		t.Errorf("%s still instructs a by-hand escalation after a wrong-criterion review: %q", deliverySkillPath, removedWrongCriterionEscalationGuidance)
 	}
 	for _, stem := range []string{"orch-reviewer", "orch-reviewer-safe"} {
 		t.Run(stem, func(t *testing.T) {
@@ -326,7 +363,14 @@ func TestDeliverySkillAndReviewersHaveWrongCriterionGuidance(t *testing.T) {
 				t.Fatalf("decode %s: %v", path, err)
 			}
 			content := adaptertest.NormalizeWhitespace(a.DeveloperInstructions)
-			for _, phrase := range []string{reviewerWrongCriterionGuidance, reviewerAddedCodeNecessityGuidance, reviewerWrongCriterionHumanGuidance} {
+			for _, phrase := range []string{
+				reviewerWrongCriterionGuidance,
+				reviewerAddedCodeNecessityGuidance,
+				reviewerWrongCriterionHumanGuidance,
+				reviewerProxyEvidenceGuidance,
+				reviewerPerCriterionObservationGuidance,
+				reviewerVerdictGroundsInstruction,
+			} {
 				if !strings.Contains(content, adaptertest.NormalizeWhitespace(phrase)) {
 					t.Errorf("%s: missing reviewer guidance %q", path, phrase)
 				}

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -91,6 +91,17 @@ later review then grades how completely that invention was built rather
 than whether it needed to exist at all — state what must be true once
 the issue is done, and leave the mechanism to the executor.
 
+A criterion requiring evidence the repository cannot produce is not a
+valid criterion. When nothing in the repository can observe what the
+criterion asks about — how an agent routes, what it decides, whether it
+follows an instruction it was given — the only thing that could satisfy
+it is a check on a proxy, such as a test asserting the instruction's
+prose is still present, which pins the words and says nothing about the
+behavior. Ask what evidence would settle the criterion before you write
+it: if the honest answer is a proxy, write the criterion against
+something the repository can actually produce evidence for, or leave it
+out of the plan.
+
 Plan text must never reference machine-local or gitignored paths such
 as `.memhub/`, `.orchestrator/state.json`, or
 `.orchestrator/config.local.toml` — an executor sees only the committed
@@ -328,22 +339,38 @@ When capture returns no total, omit the corresponding optional field.
    already left, so you must track whichever value is current yourself:
 
    ```json
-   {"schema_version": 1, "issue_number": N, "reviewed_head_oid": "...",
+   {"schema_version": 2, "issue_number": N, "reviewed_head_oid": "...",
     "verdict": "approve|request-changes", "summary": "...",
     "reviewer": {"model": "...", "effort": "..."},
+    "judgments": [{"criterion": 1, "judgment": "satisfied|unsatisfied|wrong", "reason": "..."}],
     "verifications": [{"name": "...", "command": "...", "result": "...", "detail": "..."}]}
    ```
+
+   `judgments` is required and carries exactly one entry per acceptance
+   criterion the issue holds: `criterion` is the criterion's 1-based
+   position in the issue's approved acceptance criteria, `judgment` is
+   one of `satisfied`, `unsatisfied`, `wrong`, and `reason` is the
+   reviewer's own reason for that call, which the audit record keeps as
+   an engine-owned `acceptance-criterion-<n>` verification you never
+   supply yourself. The engine counts the criteria from its own state,
+   so the request cannot decide how many it is answering — a missing,
+   duplicated, or out-of-range criterion is refused before any mutation.
+   A `verdict` of `approve` is accepted only when every criterion is
+   judged `satisfied`; record `request-changes` otherwise. Transcribe
+   the reviewer's per-criterion calls, never your own reading of its
+   summary.
 
      `usage` is optional (PRD §21), same rule as PR-open: every reviewer
      is fresh, so add only its full exact `{"total_tokens": N}` when
      available.
-    A `request-changes` report with a `wrong acceptance criterion` is not
-    an executor fix cycle. Record the review with `orch run review`, then,
-    before asking the executor to change anything, call `orch run escalate`
-    with `trigger` `architectural-ambiguity` and a `detail` that names the
-    rejected criterion and its reason. A `return-to-architect` result is
-    the needs-human outcome: surface the rejected criterion and reason to
-    the human and do not resume the executor. A `request-changes` based on
+   A criterion judged `wrong` is the needs-human outcome, and this one
+   `orch run review` call makes it: the engine blocks the issue and
+   flags it needs-human itself, and the result says so in `phase`,
+   `wrong_criteria`, and `blocked_reason`. There is no second verb call
+   to make — do not call `orch run escalate` for it and do not resume
+   the executor. Instead surface the rejected criterion and reason to
+   the human, together with the returned `blocked_reason`, and stop
+   working the issue. A `request-changes` based on
     a code finding resumes the same executor with `followup_task` in the
     **same worktree** on the same branch: it fixes and pushes, then a
     **fresh** reviewer is dispatched (step 4) and `orch run review` is


### PR DESCRIPTION
Delivers issue #155: Bring both hosts' reviewer definitions and Delivery skills into agreement with the review verb

Closes #155

**Plan digest:** `sha256:b295dff5d34e850c8ce0d923a9fbfd0cec12902c1dffd23b86cfb7afcf01c7cc`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Both hosts' reviewer definitions and Delivery skills describe a contract the engine no longer implements. They tell the Architect to escalate a wrong-criterion review by hand, they enumerate the grounds for request-changes as a closed pair that leaves a severe defect touching no acceptance criterion reportable but not blocking, and neither the reviewer definitions nor the plan-construction guidance says anything about a criterion no available evidence can satisfy. Correct all of them, and pin each statement so deleting it fails a test.

**Acceptance criteria:**
- Both hosts' Delivery skills describe the per-criterion judgment the review verb requires, and no longer instruct the Architect to make a separate escalation call after a review that rejects an acceptance criterion.
- Every reviewer agent definition instructs the reviewer to state, for each acceptance criterion, the specific observation that satisfies it.
- Every reviewer agent definition states that a criterion is wrong when the only evidence available for it is a proxy for what it asked, and names a criterion requiring a check on how an agent routes, decides, or behaves as an instance.
- Every reviewer agent definition's grounds for request-changes admit a defect that blocks no acceptance criterion, naming at least a failing required test and a weakened security boundary.
- Both hosts' plan-construction guidance states that a criterion requiring evidence the repository cannot produce is not a valid criterion.
- A runnable check fails when any statement the five criteria above require is deleted from the file that carries it.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **go-test-all** — pass — `go test ./...` — Executor reported the full module suite green on commit e795f75, including both adapters' extended guidance tests. — commit `e795f750dfb613d93c2924af779823f90cf2f6a3` (2026-08-01T03:29:20Z)
- **gofmt** — pass — `gofmt -l .` — Executor reported empty output on commit e795f75. — commit `e795f750dfb613d93c2924af779823f90cf2f6a3` (2026-08-01T03:29:20Z)
- **go-vet** — pass — `go vet ./...` — Executor reported no diagnostics on commit e795f75. — commit `e795f750dfb613d93c2924af779823f90cf2f6a3` (2026-08-01T03:29:20Z)
- **pin-mutation-check** — pass — `delete a pinned statement, run go test ./adapters/..., restore it` — Executor deleted two pinned statements on the pre-commit tree and confirmed each produced a naming failure: the unproducible-evidence rule from the Claude Delivery skill, and the per-criterion observation instruction from the Codex reviewer definition. Both restored afterward. This is direct evidence for criterion 6 rather than an assertion that the test exists. — commit `e795f750dfb613d93c2924af779823f90cf2f6a3` (2026-08-01T03:29:20Z)
- **branch-scope: commits and files vs origin/main** — pass — `git log --oneline origin/main..HEAD; git diff --name-only origin/main...HEAD; git diff --shortstat origin/main...HEAD; git diff --name-only origin/main...HEAD -- ':!adapters/'` — Architect re-ran these at the reviewed head against origin/main, which already carries the merged issue #154 engine change: one commit e795f75, eight files, 328 insertions and 84 deletions, every file under adapters/, nothing outside. Reviewer independently reproduced the same figures. Unchanged since pr-open; no fix commit has been pushed. — commit `e795f750dfb613d93c2924af779823f90cf2f6a3` (2026-08-01T03:39:25Z)
- **review-go-test-all** — pass — `go test ./...` — Reviewer ran the full module suite on the reviewed head; all packages ok. Also ran go test -count=1 ./adapters/... ./internal/run/... uncached, all ok. — commit `e795f750dfb613d93c2924af779823f90cf2f6a3` (2026-08-01T03:39:25Z)
- **review-gofmt** — pass — `gofmt -l .` — Reviewer observed empty output on the reviewed head. — commit `e795f750dfb613d93c2924af779823f90cf2f6a3` (2026-08-01T03:39:25Z)
- **review-go-vet** — pass — `go vet ./...` — Reviewer observed a clean run on the reviewed head. — commit `e795f750dfb613d93c2924af779823f90cf2f6a3` (2026-08-01T03:39:25Z)
- **review-ci-checks** — pass — `gh pr checks 159` — Reviewer observed all six checks green on the reviewed head; the two jobs still in progress when the PR body snapshot was taken have since passed. — commit `e795f750dfb613d93c2924af779823f90cf2f6a3` (2026-08-01T03:39:25Z)
- **review-contract-truth-check** — pass — `compare both hosts' documented review contract against internal/run/review.go on origin/main` — Reviewer confirmed every documented element matches the merged engine: schema version, judgments field name and shape, the closed judgment set, the pre-mutation ordering of the judgment check, approve accepted only on all-satisfied, the reserved verification name, and the wrong-judgment block-and-flag inside one call. The retired by-hand escalate instruction is false under this engine and is absent. — commit `e795f750dfb613d93c2924af779823f90cf2f6a3` (2026-08-01T03:39:25Z)
- **review-pin-mutation-sweep** — pass — `22 mutations (18 paragraph deletions, 2 sentence deletions, 2 re-insertions) against an exported copy of the head tree, each followed by go test ./adapters/...` — Reviewer ran its own mutation sweep rather than inheriting the executor's two-case check. Every mutation produced a naming failure, including the two re-insertions of the retired escalate instruction, which proves the absence assertion is real and not merely additions being pinned. — commit `e795f750dfb613d93c2924af779823f90cf2f6a3` (2026-08-01T03:39:25Z)
- **review-four-definition-parity** — pass — `whitespace-normalized comparison of the criterion 2, 3, and 4 paragraphs across all four reviewer definitions` — Reviewer confirmed all four definitions carry each paragraph and that the Codex copies are identical to the Claude ones, with no drift introduced while the same text was written twice. — commit `e795f750dfb613d93c2924af779823f90cf2f6a3` (2026-08-01T03:39:25Z)
- **review-cycle-1** — approve — Approve. All six acceptance criteria satisfied, and the reviewer checked the thing that actually matters for a prose change: whether the documented contract is true of the merged engine, not merely present. It traced every documented element against internal/run/review.go on origin/main and found them matching -- schema version 2 in both the constant and the sample JSON, the judgments field name and shape, the closed satisfied/unsatisfied/wrong set, the judgment check running before any save or GitHub write, an approving verdict accepted only when every judgment is satisfied, the reserved acceptance-criterion-&lt;n&gt; verification name, and a wrong judgment producing blocked plus needs-human inside the one call. It confirmed the retired by-hand escalate instruction is genuinely false under this engine and is gone, and that the generic Escalation section survives for its other uses without contradicting the review path. Criterion 1's two halves were both mutation-tested: deleting the new sentences fails, and re-inserting the retired escalate sentence fails an absence assertion. Criteria 2, 3, and 4 were verified in all four reviewer definitions rather than a sample, with a whitespace-normalized comparison confirming the Codex copies are byte-identical to the Claude ones and did not drift while being written twice; the two Codex definitions previously stated no verdict grounds at all and gained the paragraph rather than having one edited. Criterion 5's sentence sits in the plan-construction section directly after the observable-outcome paragraph. For criterion 6 the reviewer ran 22 mutations of its own -- 18 paragraph deletions, 2 sentence deletions, 2 re-insertions -- and every one produced a naming failure; it also confirmed the test comments claim only what a pin can do, quoting the new disclaimer that no check here can observe whether a reviewer or Architect actually obeys the statement it pins. It considered whether criterion 6 is itself the proxy that criteria 3 and 5 forbid and concluded it is not: criteria 1 through 5 ask what a file states and criterion 6 asks whether a check fails on deletion, both directly producible by this repository. Seven findings, all low or informational, none blocking. The one the reviewer would most want closed is that the reviewer definitions' phrase naming a check on how an agent routes as the standing wrong-criterion instance reads categorically, while this repository's own routing in internal/routing is deterministic engine code and directly testable -- so a reviewer applying it literally could judge a producible engine-routing criterion wrong and block an issue for the human. The skills' version of the same rule is properly conditional. The suggested close is qualifying the phrase to an LLM agent. Also found: the new Codex verdict paragraph contains a sentence imported verbatim from Claude that refers back to a findings paragraph the Codex definitions do not carry, a pre-existing host asymmetry; the How you look narrowing was judged in scope rather than unrequested, because the ledger records it as the residual explicitly paired with the widened bar and leaving it would have left the file contradicting the paragraph criterion 4 required; the omitted acceptance-criterion-&lt;n&gt; entry in the engine-owned name lists fails the necessity test and was correctly not requested, since a caller supplying it is refused before any mutation at both verbs and the new judgments paragraph already calls the name engine-owned. The reviewer corrected one imprecision in the executor's reasoning: the sentence pinned in internal/adaptertest/adaptertest.go is step 3's prefix-collision phrase, not step 5's, though the conclusion stands because step 5 refers back to pr-open's names and a coherent edit would still reach the pinned shared phrase. Remaining informational items: the engine's non-empty reason requirement is undocumented in the skills, one Claude test comment lacks the cannot-observe-obedience disclaimer its Codex counterpart carries, and one Codex paragraph sits at 3-space indent where its neighbours use 4. All seven go to the backlog per the non-blocking default; none sits inside text a blocking fix touches, because there is no blocking fix. — commit `e795f750dfb613d93c2924af779823f90cf2f6a3` (2026-08-01T03:39:26Z)
- **required-ci** — passing — scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (windows-latest)=pass — commit `e795f750dfb613d93c2924af779823f90cf2f6a3` (2026-08-01T03:39:30Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Both hosts' reviewer definitions and Delivery skills describe a contract the engine no longer implements. They tell the Architect to escalate a wrong-criterion review by hand, they enumerate the grounds for request-changes as a closed pair that leaves a severe defect touching no acceptance criterion reportable but not blocking, and neither the reviewer definitions nor the plan-construction guidance says anything about a criterion no available evidence can satisfy. Correct all of them, and pin each statement so deleting it fails a test.",
  "acceptance_criteria": [
    "Both hosts' Delivery skills describe the per-criterion judgment the review verb requires, and no longer instruct the Architect to make a separate escalation call after a review that rejects an acceptance criterion.",
    "Every reviewer agent definition instructs the reviewer to state, for each acceptance criterion, the specific observation that satisfies it.",
    "Every reviewer agent definition states that a criterion is wrong when the only evidence available for it is a proxy for what it asked, and names a criterion requiring a check on how an agent routes, decides, or behaves as an instance.",
    "Every reviewer agent definition's grounds for request-changes admit a defect that blocks no acceptance criterion, naming at least a failing required test and a weakened security boundary.",
    "Both hosts' plan-construction guidance states that a criterion requiring evidence the repository cannot produce is not a valid criterion.",
    "A runnable check fails when any statement the five criteria above require is deleted from the file that carries it."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Executor reported the full module suite green on commit e795f75, including both adapters' extended guidance tests.",
      "commit_oid": "e795f750dfb613d93c2924af779823f90cf2f6a3",
      "at": "2026-08-01T03:29:20Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Executor reported empty output on commit e795f75.",
      "commit_oid": "e795f750dfb613d93c2924af779823f90cf2f6a3",
      "at": "2026-08-01T03:29:20Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Executor reported no diagnostics on commit e795f75.",
      "commit_oid": "e795f750dfb613d93c2924af779823f90cf2f6a3",
      "at": "2026-08-01T03:29:20Z"
    },
    {
      "name": "pin-mutation-check",
      "command": "delete a pinned statement, run go test ./adapters/..., restore it",
      "result": "pass",
      "detail": "Executor deleted two pinned statements on the pre-commit tree and confirmed each produced a naming failure: the unproducible-evidence rule from the Claude Delivery skill, and the per-criterion observation instruction from the Codex reviewer definition. Both restored afterward. This is direct evidence for criterion 6 rather than an assertion that the test exists.",
      "commit_oid": "e795f750dfb613d93c2924af779823f90cf2f6a3",
      "at": "2026-08-01T03:29:20Z"
    },
    {
      "name": "branch-scope: commits and files vs origin/main",
      "command": "git log --oneline origin/main..HEAD; git diff --name-only origin/main...HEAD; git diff --shortstat origin/main...HEAD; git diff --name-only origin/main...HEAD -- ':!adapters/'",
      "result": "pass",
      "detail": "Architect re-ran these at the reviewed head against origin/main, which already carries the merged issue #154 engine change: one commit e795f75, eight files, 328 insertions and 84 deletions, every file under adapters/, nothing outside. Reviewer independently reproduced the same figures. Unchanged since pr-open; no fix commit has been pushed.",
      "commit_oid": "e795f750dfb613d93c2924af779823f90cf2f6a3",
      "at": "2026-08-01T03:39:25Z"
    },
    {
      "name": "review-go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Reviewer ran the full module suite on the reviewed head; all packages ok. Also ran go test -count=1 ./adapters/... ./internal/run/... uncached, all ok.",
      "commit_oid": "e795f750dfb613d93c2924af779823f90cf2f6a3",
      "at": "2026-08-01T03:39:25Z"
    },
    {
      "name": "review-gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Reviewer observed empty output on the reviewed head.",
      "commit_oid": "e795f750dfb613d93c2924af779823f90cf2f6a3",
      "at": "2026-08-01T03:39:25Z"
    },
    {
      "name": "review-go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Reviewer observed a clean run on the reviewed head.",
      "commit_oid": "e795f750dfb613d93c2924af779823f90cf2f6a3",
      "at": "2026-08-01T03:39:25Z"
    },
    {
      "name": "review-ci-checks",
      "command": "gh pr checks 159",
      "result": "pass",
      "detail": "Reviewer observed all six checks green on the reviewed head; the two jobs still in progress when the PR body snapshot was taken have since passed.",
      "commit_oid": "e795f750dfb613d93c2924af779823f90cf2f6a3",
      "at": "2026-08-01T03:39:25Z"
    },
    {
      "name": "review-contract-truth-check",
      "command": "compare both hosts' documented review contract against internal/run/review.go on origin/main",
      "result": "pass",
      "detail": "Reviewer confirmed every documented element matches the merged engine: schema version, judgments field name and shape, the closed judgment set, the pre-mutation ordering of the judgment check, approve accepted only on all-satisfied, the reserved verification name, and the wrong-judgment block-and-flag inside one call. The retired by-hand escalate instruction is false under this engine and is absent.",
      "commit_oid": "e795f750dfb613d93c2924af779823f90cf2f6a3",
      "at": "2026-08-01T03:39:25Z"
    },
    {
      "name": "review-pin-mutation-sweep",
      "command": "22 mutations (18 paragraph deletions, 2 sentence deletions, 2 re-insertions) against an exported copy of the head tree, each followed by go test ./adapters/...",
      "result": "pass",
      "detail": "Reviewer ran its own mutation sweep rather than inheriting the executor's two-case check. Every mutation produced a naming failure, including the two re-insertions of the retired escalate instruction, which proves the absence assertion is real and not merely additions being pinned.",
      "commit_oid": "e795f750dfb613d93c2924af779823f90cf2f6a3",
      "at": "2026-08-01T03:39:25Z"
    },
    {
      "name": "review-four-definition-parity",
      "command": "whitespace-normalized comparison of the criterion 2, 3, and 4 paragraphs across all four reviewer definitions",
      "result": "pass",
      "detail": "Reviewer confirmed all four definitions carry each paragraph and that the Codex copies are identical to the Claude ones, with no drift introduced while the same text was written twice.",
      "commit_oid": "e795f750dfb613d93c2924af779823f90cf2f6a3",
      "at": "2026-08-01T03:39:25Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approve. All six acceptance criteria satisfied, and the reviewer checked the thing that actually matters for a prose change: whether the documented contract is true of the merged engine, not merely present. It traced every documented element against internal/run/review.go on origin/main and found them matching -- schema version 2 in both the constant and the sample JSON, the judgments field name and shape, the closed satisfied/unsatisfied/wrong set, the judgment check running before any save or GitHub write, an approving verdict accepted only when every judgment is satisfied, the reserved acceptance-criterion-\u003cn\u003e verification name, and a wrong judgment producing blocked plus needs-human inside the one call. It confirmed the retired by-hand escalate instruction is genuinely false under this engine and is gone, and that the generic Escalation section survives for its other uses without contradicting the review path. Criterion 1's two halves were both mutation-tested: deleting the new sentences fails, and re-inserting the retired escalate sentence fails an absence assertion. Criteria 2, 3, and 4 were verified in all four reviewer definitions rather than a sample, with a whitespace-normalized comparison confirming the Codex copies are byte-identical to the Claude ones and did not drift while being written twice; the two Codex definitions previously stated no verdict grounds at all and gained the paragraph rather than having one edited. Criterion 5's sentence sits in the plan-construction section directly after the observable-outcome paragraph. For criterion 6 the reviewer ran 22 mutations of its own -- 18 paragraph deletions, 2 sentence deletions, 2 re-insertions -- and every one produced a naming failure; it also confirmed the test comments claim only what a pin can do, quoting the new disclaimer that no check here can observe whether a reviewer or Architect actually obeys the statement it pins. It considered whether criterion 6 is itself the proxy that criteria 3 and 5 forbid and concluded it is not: criteria 1 through 5 ask what a file states and criterion 6 asks whether a check fails on deletion, both directly producible by this repository. Seven findings, all low or informational, none blocking. The one the reviewer would most want closed is that the reviewer definitions' phrase naming a check on how an agent routes as the standing wrong-criterion instance reads categorically, while this repository's own routing in internal/routing is deterministic engine code and directly testable -- so a reviewer applying it literally could judge a producible engine-routing criterion wrong and block an issue for the human. The skills' version of the same rule is properly conditional. The suggested close is qualifying the phrase to an LLM agent. Also found: the new Codex verdict paragraph contains a sentence imported verbatim from Claude that refers back to a findings paragraph the Codex definitions do not carry, a pre-existing host asymmetry; the How you look narrowing was judged in scope rather than unrequested, because the ledger records it as the residual explicitly paired with the widened bar and leaving it would have left the file contradicting the paragraph criterion 4 required; the omitted acceptance-criterion-\u003cn\u003e entry in the engine-owned name lists fails the necessity test and was correctly not requested, since a caller supplying it is refused before any mutation at both verbs and the new judgments paragraph already calls the name engine-owned. The reviewer corrected one imprecision in the executor's reasoning: the sentence pinned in internal/adaptertest/adaptertest.go is step 3's prefix-collision phrase, not step 5's, though the conclusion stands because step 5 refers back to pr-open's names and a coherent edit would still reach the pinned shared phrase. Remaining informational items: the engine's non-empty reason requirement is undocumented in the skills, one Claude test comment lacks the cannot-observe-obedience disclaimer its Codex counterpart carries, and one Codex paragraph sits at 3-space indent where its neighbours use 4. All seven go to the backlog per the non-blocking default; none sits inside text a blocking fix touches, because there is no blocking fix.",
      "commit_oid": "e795f750dfb613d93c2924af779823f90cf2f6a3",
      "at": "2026-08-01T03:39:26Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (windows-latest)=pass",
      "commit_oid": "e795f750dfb613d93c2924af779823f90cf2f6a3",
      "at": "2026-08-01T03:39:30Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->