### PR TITLE
Bump the adapter version to 0.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "kninetimmy" },
   "metadata": {
     "description": "Host adapters for the Orch development orchestrator",
-    "version": "0.5.10"
+    "version": "0.6.0"
   },
   "plugins": [
     {

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Claude Code host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.10",
+  "version": "0.6.0",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -78,8 +78,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.10" {
-		t.Errorf("version = %q, want 0.5.10", m.Version)
+	if m.Version != "0.6.0" {
+		t.Errorf("version = %q, want 0.6.0", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Codex CLI host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.5.10",
+  "version": "0.6.0",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -79,8 +79,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.5.10" {
-		t.Errorf("version = %q, want 0.5.10", m.Version)
+	if m.Version != "0.6.0" {
+		t.Errorf("version = %q, want 0.6.0", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")


### PR DESCRIPTION
Delivers issue #156: Bump the adapter version to 0.6.0

Closes #156

**Plan digest:** `sha256:b295dff5d34e850c8ce0d923a9fbfd0cec12902c1dffd23b86cfb7afcf01c7cc`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Neither host reinstalls a changed adapter while its published version is unchanged, so the corrected reviewer definitions and Delivery skills stay in the repository and never reach a running session. Publish the changed adapters under a new version. The minor bump rather than a patch reflects that the review verb's request contract changed in a way an older adapter cannot satisfy.

**Acceptance criteria:**
- The marketplace manifest and both host plugin manifests declare the version 0.6.0.
- Each host adapter's tests assert that version, and pass.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `medium` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **go-test-all** — pass — `go test ./...` — Executor reported all packages ok on commit af5ba30, including both adapter packages whose manifest test now asserts 0.6.0. — commit `af5ba308b7c463cea5738a0733b9156b819c3239` (2026-08-01T03:44:38Z)
- **gofmt** — pass — `gofmt -l .` — Executor reported empty output on commit af5ba30. — commit `af5ba308b7c463cea5738a0733b9156b819c3239` (2026-08-01T03:44:38Z)
- **go-vet** — pass — `go vet ./...` — Executor reported exit 0 with no diagnostics on commit af5ba30. — commit `af5ba308b7c463cea5738a0733b9156b819c3239` (2026-08-01T03:44:38Z)
- **occurrence-audit** — pass — `search the worktree for 0.5.10, then for 0\.5\.\d+, then for 0.6.0, adapterVersion, and AdapterVersion` — Executor found exactly seven 0.5.10 occurrences across five files and changed all of them. The wider search surfaced v0.5.7 in README.md on five lines, correctly identified as the Orch release tag rather than the adapter version and left untouched, matching precedent ddee1b3. No other code path carries the adapter version. — commit `af5ba308b7c463cea5738a0733b9156b819c3239` (2026-08-01T03:44:38Z)
- **architect-residual-version-check** — pass — `git grep -c '0\.5\.10' <branch>` — Architect confirmed directly that no 0.5.10 string survives anywhere on the branch. — commit `af5ba308b7c463cea5738a0733b9156b819c3239` (2026-08-01T03:44:38Z)
- **usage-figure-discrepancy** — partial — `compare the executor's self-reported token figure against the harness-reported Task result usage` — The executor stated 46,376 tokens in its report while the harness Task result carries 25,232. The usage field on this request reports the harness figure, since that is what the Task result actually carries. Recorded rather than silently resolved, because PRD section 21 requires reported usage to be what the result gives and never an estimate. — commit `af5ba308b7c463cea5738a0733b9156b819c3239` (2026-08-01T03:44:38Z)
- **branch-scope: commits and files vs origin/main** — pass — `git fetch origin main; git log --oneline origin/main..HEAD; git diff --name-only origin/main...HEAD; git diff --shortstat origin/main...HEAD` — Architect and reviewer independently reproduced the same figures against a freshly fetched origin/main: one commit af5ba30, five files, seven insertions and seven deletions, the same file set as precedent ddee1b3. Unchanged since pr-open; no fix commit has been pushed. — commit `af5ba308b7c463cea5738a0733b9156b819c3239` (2026-08-01T03:48:30Z)
- **review-go-test-all** — pass — `go test ./...` — Reviewer ran all packages on the reviewed head worktree at af5ba30; all ok, exit 0. — commit `af5ba308b7c463cea5738a0733b9156b819c3239` (2026-08-01T03:48:30Z)
- **review-gofmt** — pass — `gofmt -l .` — Reviewer observed empty output on the reviewed head. — commit `af5ba308b7c463cea5738a0733b9156b819c3239` (2026-08-01T03:48:30Z)
- **review-go-vet** — pass — `go vet ./...` — Reviewer observed exit 0 with no diagnostics on the reviewed head. — commit `af5ba308b7c463cea5738a0733b9156b819c3239` (2026-08-01T03:48:30Z)
- **review-ci-checks** — pass — `gh pr checks 160` — Reviewer observed all six checks passing on the reviewed head; the windows test job pending mid-review completed pass. — commit `af5ba308b7c463cea5738a0733b9156b819c3239` (2026-08-01T03:48:30Z)
- **review-version-completeness** — pass — `git grep '0\.5\.10'; git grep -E '0\.5\.[0-9]+'; search for adapterVersion, AdapterVersion, adapter_version` — Reviewer independently confirmed zero surviving 0.5.10 hits, that the six remaining 0.5.x references in README.md are all the Orch release tag rather than the adapter version, and that no other symbol anywhere carries the adapter version. — commit `af5ba308b7c463cea5738a0733b9156b819c3239` (2026-08-01T03:48:30Z)
- **review-adapter-test-assertion** — pass — `go test -count=1 -v -run TestPluginManifestStrict ./adapters/claude ./adapters/codex` — Reviewer confirmed both host adapters pin the literal 0.6.0 in both the assertion and its failure message, and ran both uncached. — commit `af5ba308b7c463cea5738a0733b9156b819c3239` (2026-08-01T03:48:30Z)
- **review-cycle-1** — approve — Approve. Both acceptance criteria met directly. The three manifests declare 0.6.0, and both host adapters' manifest tests pin the literal string with their error messages updated too, so no stale want-0.5.10 message survives; the reviewer ran both uncached and they pass. It verified the executor's completeness claims rather than accepting them: no 0.5.10 string survives anywhere at the reviewed head, 0.6.0 appears in exactly the seven expected places across the five expected files, and the wider version search returns only README.md's release-tag references on six lines, each unambiguously the Orch release tag rather than the adapter version, correctly left alone in line with precedent ddee1b3. It also confirmed no other spelling of the adapter version exists anywhere -- no adapterVersion, AdapterVersion, or adapter_version symbol, and the other version symbols in the tree belong to unrelated schemas -- and that no Go code, install script, or adapter README pins the adapter version, since installation is the host CLIs' job through the marketplace, which is the objective's premise. Scope is one commit against a freshly fetched origin/main, five files, seven insertions and seven deletions, the same file set as precedent ddee1b3, nothing beyond version strings and the tests asserting them. Two findings, both informational and neither blocking. The marketplace manifest's version is pinned only transitively: no test asserts the literal on marketplace.json itself, but the root marketplace test asserts each plugin's version equals the marketplace metadata version while the two adapter tests pin the literal, so the value cannot silently drift. That is the existing design, unchanged by this PR, and criterion 2 asks only for the host adapters' tests; the reviewer applied the necessity test and declined to request a direct assertion. On the recorded usage-figure discrepancy the reviewer explicitly agreed with the handling and raised no separate finding. It judged both acceptance criteria correct as written, naming outcomes rather than mechanisms, with nothing invented to satisfy the wording. — commit `af5ba308b7c463cea5738a0733b9156b819c3239` (2026-08-01T03:48:31Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, scripts (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (windows-latest)=pass — commit `af5ba308b7c463cea5738a0733b9156b819c3239` (2026-08-01T03:48:35Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Neither host reinstalls a changed adapter while its published version is unchanged, so the corrected reviewer definitions and Delivery skills stay in the repository and never reach a running session. Publish the changed adapters under a new version. The minor bump rather than a patch reflects that the review verb's request contract changed in a way an older adapter cannot satisfy.",
  "acceptance_criteria": [
    "The marketplace manifest and both host plugin manifests declare the version 0.6.0.",
    "Each host adapter's tests assert that version, and pass."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Executor reported all packages ok on commit af5ba30, including both adapter packages whose manifest test now asserts 0.6.0.",
      "commit_oid": "af5ba308b7c463cea5738a0733b9156b819c3239",
      "at": "2026-08-01T03:44:38Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Executor reported empty output on commit af5ba30.",
      "commit_oid": "af5ba308b7c463cea5738a0733b9156b819c3239",
      "at": "2026-08-01T03:44:38Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Executor reported exit 0 with no diagnostics on commit af5ba30.",
      "commit_oid": "af5ba308b7c463cea5738a0733b9156b819c3239",
      "at": "2026-08-01T03:44:38Z"
    },
    {
      "name": "occurrence-audit",
      "command": "search the worktree for 0.5.10, then for 0\\.5\\.\\d+, then for 0.6.0, adapterVersion, and AdapterVersion",
      "result": "pass",
      "detail": "Executor found exactly seven 0.5.10 occurrences across five files and changed all of them. The wider search surfaced v0.5.7 in README.md on five lines, correctly identified as the Orch release tag rather than the adapter version and left untouched, matching precedent ddee1b3. No other code path carries the adapter version.",
      "commit_oid": "af5ba308b7c463cea5738a0733b9156b819c3239",
      "at": "2026-08-01T03:44:38Z"
    },
    {
      "name": "architect-residual-version-check",
      "command": "git grep -c '0\\.5\\.10' \u003cbranch\u003e",
      "result": "pass",
      "detail": "Architect confirmed directly that no 0.5.10 string survives anywhere on the branch.",
      "commit_oid": "af5ba308b7c463cea5738a0733b9156b819c3239",
      "at": "2026-08-01T03:44:38Z"
    },
    {
      "name": "usage-figure-discrepancy",
      "command": "compare the executor's self-reported token figure against the harness-reported Task result usage",
      "result": "partial",
      "detail": "The executor stated 46,376 tokens in its report while the harness Task result carries 25,232. The usage field on this request reports the harness figure, since that is what the Task result actually carries. Recorded rather than silently resolved, because PRD section 21 requires reported usage to be what the result gives and never an estimate.",
      "commit_oid": "af5ba308b7c463cea5738a0733b9156b819c3239",
      "at": "2026-08-01T03:44:38Z"
    },
    {
      "name": "branch-scope: commits and files vs origin/main",
      "command": "git fetch origin main; git log --oneline origin/main..HEAD; git diff --name-only origin/main...HEAD; git diff --shortstat origin/main...HEAD",
      "result": "pass",
      "detail": "Architect and reviewer independently reproduced the same figures against a freshly fetched origin/main: one commit af5ba30, five files, seven insertions and seven deletions, the same file set as precedent ddee1b3. Unchanged since pr-open; no fix commit has been pushed.",
      "commit_oid": "af5ba308b7c463cea5738a0733b9156b819c3239",
      "at": "2026-08-01T03:48:30Z"
    },
    {
      "name": "review-go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Reviewer ran all packages on the reviewed head worktree at af5ba30; all ok, exit 0.",
      "commit_oid": "af5ba308b7c463cea5738a0733b9156b819c3239",
      "at": "2026-08-01T03:48:30Z"
    },
    {
      "name": "review-gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Reviewer observed empty output on the reviewed head.",
      "commit_oid": "af5ba308b7c463cea5738a0733b9156b819c3239",
      "at": "2026-08-01T03:48:30Z"
    },
    {
      "name": "review-go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Reviewer observed exit 0 with no diagnostics on the reviewed head.",
      "commit_oid": "af5ba308b7c463cea5738a0733b9156b819c3239",
      "at": "2026-08-01T03:48:30Z"
    },
    {
      "name": "review-ci-checks",
      "command": "gh pr checks 160",
      "result": "pass",
      "detail": "Reviewer observed all six checks passing on the reviewed head; the windows test job pending mid-review completed pass.",
      "commit_oid": "af5ba308b7c463cea5738a0733b9156b819c3239",
      "at": "2026-08-01T03:48:30Z"
    },
    {
      "name": "review-version-completeness",
      "command": "git grep '0\\.5\\.10'; git grep -E '0\\.5\\.[0-9]+'; search for adapterVersion, AdapterVersion, adapter_version",
      "result": "pass",
      "detail": "Reviewer independently confirmed zero surviving 0.5.10 hits, that the six remaining 0.5.x references in README.md are all the Orch release tag rather than the adapter version, and that no other symbol anywhere carries the adapter version.",
      "commit_oid": "af5ba308b7c463cea5738a0733b9156b819c3239",
      "at": "2026-08-01T03:48:30Z"
    },
    {
      "name": "review-adapter-test-assertion",
      "command": "go test -count=1 -v -run TestPluginManifestStrict ./adapters/claude ./adapters/codex",
      "result": "pass",
      "detail": "Reviewer confirmed both host adapters pin the literal 0.6.0 in both the assertion and its failure message, and ran both uncached.",
      "commit_oid": "af5ba308b7c463cea5738a0733b9156b819c3239",
      "at": "2026-08-01T03:48:30Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approve. Both acceptance criteria met directly. The three manifests declare 0.6.0, and both host adapters' manifest tests pin the literal string with their error messages updated too, so no stale want-0.5.10 message survives; the reviewer ran both uncached and they pass. It verified the executor's completeness claims rather than accepting them: no 0.5.10 string survives anywhere at the reviewed head, 0.6.0 appears in exactly the seven expected places across the five expected files, and the wider version search returns only README.md's release-tag references on six lines, each unambiguously the Orch release tag rather than the adapter version, correctly left alone in line with precedent ddee1b3. It also confirmed no other spelling of the adapter version exists anywhere -- no adapterVersion, AdapterVersion, or adapter_version symbol, and the other version symbols in the tree belong to unrelated schemas -- and that no Go code, install script, or adapter README pins the adapter version, since installation is the host CLIs' job through the marketplace, which is the objective's premise. Scope is one commit against a freshly fetched origin/main, five files, seven insertions and seven deletions, the same file set as precedent ddee1b3, nothing beyond version strings and the tests asserting them. Two findings, both informational and neither blocking. The marketplace manifest's version is pinned only transitively: no test asserts the literal on marketplace.json itself, but the root marketplace test asserts each plugin's version equals the marketplace metadata version while the two adapter tests pin the literal, so the value cannot silently drift. That is the existing design, unchanged by this PR, and criterion 2 asks only for the host adapters' tests; the reviewer applied the necessity test and declined to request a direct assertion. On the recorded usage-figure discrepancy the reviewer explicitly agreed with the handling and raised no separate finding. It judged both acceptance criteria correct as written, naming outcomes rather than mechanisms, with nothing invented to satisfy the wording.",
      "commit_oid": "af5ba308b7c463cea5738a0733b9156b819c3239",
      "at": "2026-08-01T03:48:31Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, scripts (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (windows-latest)=pass",
      "commit_oid": "af5ba308b7c463cea5738a0733b9156b819c3239",
      "at": "2026-08-01T03:48:35Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->