### PR TITLE
Detect stale rendered Codex agent definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ coverage.html
 .orchestrator/metrics/
 
 # Generated orch render-agents output (root-anchored: avoid matching testdata fixtures)
-/.codex/
+.codex/agents/

--- a/README.md
+++ b/README.md
@@ -124,8 +124,7 @@ on this machine. Work in a scratch directory, not in one of my projects.
       into a temporary directory outside my projects:
         git clone --depth 1 https://github.com/kninetimmy/orch.git <tmp>/orch
    b. Copy these five files from <tmp>/orch/adapters/codex/agents/ into
-      .codex/agents/ — use ~/.codex/agents/ for a user-global install, or
-      a specific repository's own .codex/agents/:
+      that repository's own .codex/agents/:
         orch-scout.toml
         orch-implementer.toml
         orch-specialist.toml

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -100,7 +100,7 @@ decision, not an oversight).
    `orch hook codex session-start` silently do not run — the same
    fail-open class as a missing binary, not a denial or an error.
 4. Copy the five agent TOMLs under `agents/` into the project's
-   `.codex/agents/` (or `~/.codex/agents/` for a user-global install).
+   `.codex/agents/`.
    Codex plugins cannot bundle agent definitions, so this copy is a
    separate manual step every install of this adapter needs, not
    something the plugin installs for you — the marketplace install in

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -11,8 +11,10 @@
 package agents
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -165,6 +167,35 @@ func Write(repoRoot string, files []File) error {
 		}
 	}
 	return nil
+}
+
+// Stale reports every file Write would produce that is absent,
+// unreadable, or byte-different from Render's current output. Paths
+// are repo-relative and slash-form; read errors are joined after every
+// expected file has been checked so callers can name all bad files.
+func Stale(repoRoot string, h *config.Host) ([]string, error) {
+	files, err := Render(h)
+	if err != nil {
+		return nil, err
+	}
+
+	dir := filepath.Join(repoRoot, filepath.FromSlash(Dir))
+	var stale []string
+	var readErrs []error
+	for _, f := range files {
+		rel := Dir + "/" + f.Name + ".toml"
+		got, err := os.ReadFile(filepath.Join(dir, f.Name+".toml"))
+		switch {
+		case errors.Is(err, fs.ErrNotExist):
+			stale = append(stale, rel)
+		case err != nil:
+			stale = append(stale, rel)
+			readErrs = append(readErrs, fmt.Errorf("read %s: %w", rel, err))
+		case !bytes.Equal(got, f.Content):
+			stale = append(stale, rel)
+		}
+	}
+	return stale, errors.Join(readErrs...)
 }
 
 func writeAtomic(path, dir string, data []byte) error {

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -1,4 +1,6 @@
-package agents
+// Package agents_test is external because adaptertest imports
+// internal/run, which imports internal/agents for activation preflight.
+package agents_test
 
 import (
 	"os"
@@ -10,6 +12,7 @@ import (
 
 	"github.com/kninetimmy/orch/adapters/codex"
 	"github.com/kninetimmy/orch/internal/adaptertest"
+	"github.com/kninetimmy/orch/internal/agents"
 	"github.com/kninetimmy/orch/internal/config"
 )
 
@@ -39,7 +42,7 @@ func defaultCodexHost() *config.Host {
 // Render itself uses, since that embed is the single canonical
 // source — see adapters/codex/embed.go).
 func TestRenderDefaultProfileByteIdenticalToShipped(t *testing.T) {
-	files, err := Render(defaultCodexHost())
+	files, err := agents.Render(defaultCodexHost())
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -60,7 +63,7 @@ func TestRenderDefaultProfileByteIdenticalToShipped(t *testing.T) {
 // TestRenderOrderAndNames pins the exact five file stems Render
 // produces, in order.
 func TestRenderOrderAndNames(t *testing.T) {
-	files, err := Render(defaultCodexHost())
+	files, err := agents.Render(defaultCodexHost())
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -99,7 +102,7 @@ func TestRenderOverrideSubstitution(t *testing.T) {
 		Reviewer:        config.RoleProfile{Model: "gpt-9000-ultra", Effort: "medium"},
 		ReviewDowngrade: config.RoleProfile{Model: "gpt-9000", Effort: "high"},
 	}}
-	files, err := Render(h)
+	files, err := agents.Render(h)
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -155,8 +158,8 @@ func TestRenderOverrideSubstitution(t *testing.T) {
 }
 
 func TestRenderNilHostFailsClosed(t *testing.T) {
-	if _, err := Render(nil); err == nil {
-		t.Error("Render(nil) succeeded, want an error")
+	if _, err := agents.Render(nil); err == nil {
+		t.Error("agents.Render(nil) succeeded, want an error")
 	}
 }
 
@@ -164,7 +167,7 @@ func TestRenderNilHostFailsClosed(t *testing.T) {
 // package documents: a rendered file must never introduce a carriage
 // return the shipped source did not already contain.
 func TestRenderNoTrailingCR(t *testing.T) {
-	files, err := Render(defaultCodexHost())
+	files, err := agents.Render(defaultCodexHost())
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -177,15 +180,15 @@ func TestRenderNoTrailingCR(t *testing.T) {
 
 func TestWriteCreatesDirectoryAndFiles(t *testing.T) {
 	root := t.TempDir()
-	files, err := Render(defaultCodexHost())
+	files, err := agents.Render(defaultCodexHost())
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
-	if err := Write(root, files); err != nil {
+	if err := agents.Write(root, files); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 
-	dir := filepath.Join(root, filepath.FromSlash(Dir))
+	dir := filepath.Join(root, filepath.FromSlash(agents.Dir))
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatalf("ReadDir: %v", err)
@@ -215,7 +218,7 @@ func TestWriteCreatesDirectoryAndFiles(t *testing.T) {
 // content rather than leaving it or appending to it.
 func TestWriteOverwritesExisting(t *testing.T) {
 	root := t.TempDir()
-	dir := filepath.Join(root, filepath.FromSlash(Dir))
+	dir := filepath.Join(root, filepath.FromSlash(agents.Dir))
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -224,11 +227,11 @@ func TestWriteOverwritesExisting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	files, err := Render(defaultCodexHost())
+	files, err := agents.Render(defaultCodexHost())
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
-	if err := Write(root, files); err != nil {
+	if err := agents.Write(root, files); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 
@@ -238,5 +241,67 @@ func TestWriteOverwritesExisting(t *testing.T) {
 	}
 	if strings.Contains(string(got), "stale content") {
 		t.Error("stale content survived Write")
+	}
+}
+
+func TestStaleReportsEveryBadFile(t *testing.T) {
+	root := t.TempDir()
+	h := defaultCodexHost()
+	files, err := agents.Render(h)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if err := agents.Write(root, files); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	dir := filepath.Join(root, filepath.FromSlash(agents.Dir))
+	if err := os.Remove(filepath.Join(dir, "orch-scout.toml")); err != nil {
+		t.Fatal(err)
+	}
+	unreadable := filepath.Join(dir, "orch-implementer.toml")
+	if err := os.Remove(unreadable); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(unreadable, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "orch-reviewer.toml"), []byte("stale\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stale, err := agents.Stale(root, h)
+	want := []string{
+		agents.Dir + "/orch-scout.toml",
+		agents.Dir + "/orch-implementer.toml",
+		agents.Dir + "/orch-reviewer.toml",
+	}
+	if strings.Join(stale, ",") != strings.Join(want, ",") {
+		t.Errorf("Stale = %v, want %v", stale, want)
+	}
+	if err == nil || !strings.Contains(err.Error(), agents.Dir+"/orch-implementer.toml") {
+		t.Errorf("err = %v, want unreadable file named", err)
+	}
+}
+
+func TestStaleTracksEffectiveConfiguration(t *testing.T) {
+	root := t.TempDir()
+	files, err := agents.Render(defaultCodexHost())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if err := agents.Write(root, files); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	h := defaultCodexHost()
+	h.Roles.Reviewer = config.RoleProfile{Model: "gpt-9000-ultra", Effort: "low"}
+	stale, err := agents.Stale(root, h)
+	if err != nil {
+		t.Fatalf("Stale: %v", err)
+	}
+	want := agents.Dir + "/orch-reviewer.toml"
+	if len(stale) != 1 || stale[0] != want {
+		t.Errorf("Stale = %v, want [%s]", stale, want)
 	}
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/kninetimmy/orch/internal/agents"
 	"github.com/kninetimmy/orch/internal/config"
 	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/gitops"
@@ -84,6 +85,22 @@ func runDoctor(env Env) error {
 			fmt.Fprintf(env.Stdout, "note  %s applied; overrides: %s\n", config.LocalOverridePath, strings.Join(cfg.Overrides, ", "))
 		} else {
 			fmt.Fprintf(env.Stdout, "note  %s present; no overrides set\n", config.LocalOverridePath)
+		}
+	}
+
+	if cfgErr == nil && cfg.Hosts.Codex != nil {
+		stale, staleErr := agents.Stale(env.RepoRoot, cfg.Hosts.Codex)
+		switch {
+		case len(stale) > 0:
+			detail := strings.Join(stale, ", ")
+			if staleErr != nil {
+				detail += fmt.Sprintf(" (%v)", staleErr)
+			}
+			check("codex agent files", fmt.Errorf("absent, unreadable, or out of date: %s; run `orch render-agents` to regenerate them", detail))
+		case staleErr != nil:
+			check("codex agent files", staleErr)
+		default:
+			check("codex agent files", nil)
 		}
 	}
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kninetimmy/orch/internal/agents"
 	"github.com/kninetimmy/orch/internal/lockfile"
 	"github.com/kninetimmy/orch/internal/state"
 )
@@ -453,5 +454,83 @@ func TestDoctorPolicyViolatingLocalOverrideFails(t *testing.T) {
 	}
 	if !strings.Contains(out, "schema_version") {
 		t.Errorf("stdout missing policy-violation detail:\n%s", out)
+	}
+}
+
+func TestDoctorNoCodexHostSkipsAgentCheck(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	if strings.Contains(stdout.String(), "codex agent files") {
+		t.Errorf("stdout carries a Codex-only check:\n%s", stdout.String())
+	}
+}
+
+func TestDoctorBothHostsCodexAgentsAbsentFails(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validBothHostsTOML)
+	if code := Run([]string{"doctor"}, env); code != ExitError {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitError, stdout.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "FAIL  codex agent files") {
+		t.Errorf("stdout missing the agent-file failure:\n%s", out)
+	}
+	for _, name := range renderedAgentFiles {
+		if !strings.Contains(out, agents.Dir+"/"+name+".toml") {
+			t.Errorf("stdout does not name %s:\n%s", name, out)
+		}
+	}
+	if !strings.Contains(out, "orch render-agents") {
+		t.Errorf("stdout does not name the repair:\n%s", out)
+	}
+}
+
+func TestDoctorCodexAgentsCurrentThenAllBadStates(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validCodexTOML)
+	if code := Run([]string{"render-agents"}, env); code != ExitOK {
+		t.Fatalf("render-agents exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	stdout.Reset()
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("doctor exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "ok    codex agent files") {
+		t.Errorf("stdout missing the passing agent-file check:\n%s", stdout.String())
+	}
+
+	dir := filepath.Join(env.RepoRoot, filepath.FromSlash(agents.Dir))
+	if err := os.Remove(filepath.Join(dir, "orch-scout.toml")); err != nil {
+		t.Fatal(err)
+	}
+	unreadable := filepath.Join(dir, "orch-implementer.toml")
+	if err := os.Remove(unreadable); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(unreadable, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "orch-reviewer.toml"), []byte("stale\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout.Reset()
+	if code := Run([]string{"doctor"}, env); code != ExitError {
+		t.Fatalf("doctor exit = %d, want %d\n%s", code, ExitError, stdout.String())
+	}
+	out := stdout.String()
+	for _, name := range []string{"orch-scout.toml", "orch-implementer.toml", "orch-reviewer.toml"} {
+		if !strings.Contains(out, agents.Dir+"/"+name) {
+			t.Errorf("stdout does not name %s:\n%s", name, out)
+		}
+	}
+	if strings.Contains(out, agents.Dir+"/orch-specialist.toml") {
+		t.Errorf("stdout names a current file:\n%s", out)
+	}
+	if !strings.Contains(out, "orch render-agents") {
+		t.Errorf("stdout does not name the repair:\n%s", out)
 	}
 }

--- a/internal/cli/renderagents_test.go
+++ b/internal/cli/renderagents_test.go
@@ -48,6 +48,8 @@ model  = "gpt-5.6-sol"
 effort = "high"
 `
 
+var validBothHostsTOML = validTOML + validCodexTOML[strings.Index(validCodexTOML, "[hosts.codex"):]
+
 // validCodexOverrideTOML enables only the codex host with model/effort
 // values that diverge from the PRD §10 defaults.
 const validCodexOverrideTOML = `

--- a/internal/interview/configure_test.go
+++ b/internal/interview/configure_test.go
@@ -81,11 +81,11 @@ func writeInstalledBlock(t *testing.T, root, name string) {
 }
 
 // writeNoMissingGitignore writes root/.gitignore with every line
-// gitignoreLines wants already present (baseGitignoreLines plus the
-// always-proposed metricsGitignoreLine), so gitignoreLines proposes
-// nothing missing — the third precondition (alongside unchanged config
-// bytes and unchanged instruction files) for the no-change blocker to
-// ever fire.
+// gitignoreLines wants already present (baseGitignoreLines includes the
+// rendered-agent destination, plus the always-proposed metrics line),
+// so gitignoreLines proposes nothing missing — the third precondition
+// (alongside unchanged config bytes and unchanged instruction files)
+// for the no-change blocker to ever fire.
 func writeNoMissingGitignore(t *testing.T, root string) {
 	t.Helper()
 	lines := append(append([]string{}, baseGitignoreLines...), metricsGitignoreLine)
@@ -285,6 +285,9 @@ func TestGoldenTranscriptConfigureEnableCodexFromClaudeOnly(t *testing.T) {
 	}
 	if change.Diff == "" {
 		t.Error("AGENTS.md Diff is empty, want an install diff")
+	}
+	if !strings.Contains(strings.Join(doc.Complete.Summary.GitignoreLines, "\n"), ".codex/agents/") {
+		t.Errorf("GitignoreLines = %v, want rendered-agent destination", doc.Complete.Summary.GitignoreLines)
 	}
 }
 

--- a/internal/interview/summary.go
+++ b/internal/interview/summary.go
@@ -46,13 +46,14 @@ func InstructionFile(host string) string {
 // initialized repository needs, mirroring (as literal strings —
 // Detect's execProber-duplication precedent, so this pre-init-safe
 // package need not import internal/run/state/lockfile) the values of
-// run.WorktreeContainer+"/", config.LocalOverridePath, state.Path, and
-// lockfile.Path.
+// run.WorktreeContainer+"/", config.LocalOverridePath, state.Path,
+// lockfile.Path, and agents.Dir+"/".
 var baseGitignoreLines = []string{
 	".orchestrator/worktrees/",
 	".orchestrator/config.local.toml",
 	".orchestrator/state.json",
 	".orchestrator/delivery.lock",
+	".codex/agents/",
 }
 
 // metricsGitignoreLine is the local, gitignored metrics storage

--- a/internal/interview/summary_test.go
+++ b/internal/interview/summary_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kninetimmy/orch/internal/agents"
 	"github.com/kninetimmy/orch/internal/config"
 	"github.com/kninetimmy/orch/internal/instructions"
 	"github.com/kninetimmy/orch/internal/lockfile"
@@ -26,6 +27,7 @@ func TestBaseGitignoreLinesMatchSourceConstants(t *testing.T) {
 		config.LocalOverridePath,
 		state.Path,
 		lockfile.Path,
+		agents.Dir + "/",
 	}
 	if len(baseGitignoreLines) != len(want) {
 		t.Fatalf("baseGitignoreLines = %v, want %v", baseGitignoreLines, want)
@@ -92,6 +94,7 @@ func TestBuildSummaryFreshRepo(t *testing.T) {
 		".orchestrator/config.local.toml",
 		".orchestrator/state.json",
 		".orchestrator/delivery.lock",
+		".codex/agents/",
 		metricsGitignoreLine,
 	}
 	if len(summary.GitignoreLines) != len(want) {
@@ -245,7 +248,7 @@ func TestBuildSummaryFiltersExistingGitignoreLines(t *testing.T) {
 		t.Fatalf("materialize: %v", err)
 	}
 	root := t.TempDir()
-	existing := ".orchestrator/worktrees/\nnode_modules/\n.orchestrator/state.json\n"
+	existing := ".orchestrator/worktrees/\nnode_modules/\n.orchestrator/state.json\n.codex/agents/\n"
 	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(existing), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/interview/testdata/transcript/step_15.json
+++ b/internal/interview/testdata/transcript/step_15.json
@@ -41,6 +41,7 @@
       ".orchestrator/config.local.toml",
       ".orchestrator/state.json",
       ".orchestrator/delivery.lock",
+      ".codex/agents/",
       ".orchestrator/metrics/"
     ]
   }

--- a/internal/interview/testdata/transcript/step_16.json
+++ b/internal/interview/testdata/transcript/step_16.json
@@ -24,6 +24,7 @@
         ".orchestrator/config.local.toml",
         ".orchestrator/state.json",
         ".orchestrator/delivery.lock",
+        ".codex/agents/",
         ".orchestrator/metrics/"
       ]
     },

--- a/internal/interview/testdata/transcript_configure/disable_codex/step_03.json
+++ b/internal/interview/testdata/transcript_configure/disable_codex/step_03.json
@@ -41,6 +41,7 @@
       ".orchestrator/config.local.toml",
       ".orchestrator/state.json",
       ".orchestrator/delivery.lock",
+      ".codex/agents/",
       ".orchestrator/metrics/"
     ],
     "config_diff": "@@ -3,7 +3,7 @@\n # a Delivery PR.\n \n schema_version  = 1\n-config_revision = \"sha256:6240dc99e81e\"\n+config_revision = \"sha256:1a09dc2e9cd2\"\n \n [concurrency]\n max_subagents = 3\n@@ -40,27 +40,3 @@\n [hosts.claude.roles.review_downgrade]\n model  = \"claude-sonnet-5\"\n effort = \"high\"\n-\n-[hosts.codex.roles.architect]\n-model  = \"gpt-5.6-sol\"\n-effort = \"high\"\n-\n-[hosts.codex.roles.scout]\n-model  = \"gpt-5.6-terra\"\n-effort = \"low\"\n-\n-[hosts.codex.roles.implementer]\n-model  = \"gpt-5.6-terra\"\n-effort = \"high\"\n-\n-[hosts.codex.roles.specialist]\n-model  = \"gpt-5.6-sol\"\n-effort = \"medium\"\n-\n-[hosts.codex.roles.reviewer]\n-model  = \"gpt-5.6-sol\"\n-effort = \"medium\"\n-\n-[hosts.codex.roles.review_downgrade]\n-model  = \"gpt-5.6-terra\"\n-effort = \"high\"\n"

--- a/internal/interview/testdata/transcript_configure/disable_codex/step_04.json
+++ b/internal/interview/testdata/transcript_configure/disable_codex/step_04.json
@@ -24,6 +24,7 @@
         ".orchestrator/config.local.toml",
         ".orchestrator/state.json",
         ".orchestrator/delivery.lock",
+        ".codex/agents/",
         ".orchestrator/metrics/"
       ],
       "config_diff": "@@ -3,7 +3,7 @@\n # a Delivery PR.\n \n schema_version  = 1\n-config_revision = \"sha256:6240dc99e81e\"\n+config_revision = \"sha256:1a09dc2e9cd2\"\n \n [concurrency]\n max_subagents = 3\n@@ -40,27 +40,3 @@\n [hosts.claude.roles.review_downgrade]\n model  = \"claude-sonnet-5\"\n effort = \"high\"\n-\n-[hosts.codex.roles.architect]\n-model  = \"gpt-5.6-sol\"\n-effort = \"high\"\n-\n-[hosts.codex.roles.scout]\n-model  = \"gpt-5.6-terra\"\n-effort = \"low\"\n-\n-[hosts.codex.roles.implementer]\n-model  = \"gpt-5.6-terra\"\n-effort = \"high\"\n-\n-[hosts.codex.roles.specialist]\n-model  = \"gpt-5.6-sol\"\n-effort = \"medium\"\n-\n-[hosts.codex.roles.reviewer]\n-model  = \"gpt-5.6-sol\"\n-effort = \"medium\"\n-\n-[hosts.codex.roles.review_downgrade]\n-model  = \"gpt-5.6-terra\"\n-effort = \"high\"\n"

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_09.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_09.json
@@ -41,6 +41,7 @@
       ".orchestrator/config.local.toml",
       ".orchestrator/state.json",
       ".orchestrator/delivery.lock",
+      ".codex/agents/",
       ".orchestrator/metrics/"
     ],
     "config_diff": "@@ -3,7 +3,7 @@\n # a Delivery PR.\n \n schema_version  = 1\n-config_revision = \"sha256:1a09dc2e9cd2\"\n+config_revision = \"sha256:900470e47516\"\n \n [concurrency]\n max_subagents = 3\n@@ -40,3 +40,27 @@\n [hosts.claude.roles.review_downgrade]\n model  = \"claude-sonnet-5\"\n effort = \"high\"\n+\n+[hosts.codex.roles.architect]\n+model  = \"gpt-5.6-sol\"\n+effort = \"xhigh\"\n+\n+[hosts.codex.roles.scout]\n+model  = \"gpt-5.6-luna\"\n+effort = \"max\"\n+\n+[hosts.codex.roles.implementer]\n+model  = \"gpt-5.6-terra\"\n+effort = \"max\"\n+\n+[hosts.codex.roles.specialist]\n+model  = \"gpt-5.6-sol\"\n+effort = \"max\"\n+\n+[hosts.codex.roles.reviewer]\n+model  = \"gpt-5.6-sol\"\n+effort = \"xhigh\"\n+\n+[hosts.codex.roles.review_downgrade]\n+model  = \"gpt-5.6-sol\"\n+effort = \"high\"\n"

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_10.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_10.json
@@ -24,6 +24,7 @@
         ".orchestrator/config.local.toml",
         ".orchestrator/state.json",
         ".orchestrator/delivery.lock",
+        ".codex/agents/",
         ".orchestrator/metrics/"
       ],
       "config_diff": "@@ -3,7 +3,7 @@\n # a Delivery PR.\n \n schema_version  = 1\n-config_revision = \"sha256:1a09dc2e9cd2\"\n+config_revision = \"sha256:900470e47516\"\n \n [concurrency]\n max_subagents = 3\n@@ -40,3 +40,27 @@\n [hosts.claude.roles.review_downgrade]\n model  = \"claude-sonnet-5\"\n effort = \"high\"\n+\n+[hosts.codex.roles.architect]\n+model  = \"gpt-5.6-sol\"\n+effort = \"xhigh\"\n+\n+[hosts.codex.roles.scout]\n+model  = \"gpt-5.6-luna\"\n+effort = \"max\"\n+\n+[hosts.codex.roles.implementer]\n+model  = \"gpt-5.6-terra\"\n+effort = \"max\"\n+\n+[hosts.codex.roles.specialist]\n+model  = \"gpt-5.6-sol\"\n+effort = \"max\"\n+\n+[hosts.codex.roles.reviewer]\n+model  = \"gpt-5.6-sol\"\n+effort = \"xhigh\"\n+\n+[hosts.codex.roles.review_downgrade]\n+model  = \"gpt-5.6-sol\"\n+effort = \"high\"\n"

--- a/internal/interview/testdata/transcript_configure/merge_and_model/step_09.json
+++ b/internal/interview/testdata/transcript_configure/merge_and_model/step_09.json
@@ -39,6 +39,7 @@
       ".orchestrator/config.local.toml",
       ".orchestrator/state.json",
       ".orchestrator/delivery.lock",
+      ".codex/agents/",
       ".orchestrator/metrics/"
     ],
     "config_diff": "@@ -3,13 +3,13 @@\n # a Delivery PR.\n \n schema_version  = 1\n-config_revision = \"sha256:6240dc99e81e\"\n+config_revision = \"sha256:9040056536a9\"\n \n [concurrency]\n max_subagents = 3\n \n [merge]\n-strategy = \"squash\"\n+strategy = \"rebase\"\n \n [memhub]\n mode = \"off\"\n@@ -22,7 +22,7 @@\n effort = \"xhigh\"\n \n [hosts.claude.roles.scout]\n-model  = \"claude-sonnet-5\"\n+model  = \"claude-opus-4-8\"\n effort = \"low\"\n \n [hosts.claude.roles.implementer]\n"

--- a/internal/interview/testdata/transcript_configure/merge_and_model/step_10.json
+++ b/internal/interview/testdata/transcript_configure/merge_and_model/step_10.json
@@ -22,6 +22,7 @@
         ".orchestrator/config.local.toml",
         ".orchestrator/state.json",
         ".orchestrator/delivery.lock",
+        ".codex/agents/",
         ".orchestrator/metrics/"
       ],
       "config_diff": "@@ -3,13 +3,13 @@\n # a Delivery PR.\n \n schema_version  = 1\n-config_revision = \"sha256:6240dc99e81e\"\n+config_revision = \"sha256:9040056536a9\"\n \n [concurrency]\n max_subagents = 3\n \n [merge]\n-strategy = \"squash\"\n+strategy = \"rebase\"\n \n [memhub]\n mode = \"off\"\n@@ -22,7 +22,7 @@\n effort = \"xhigh\"\n \n [hosts.claude.roles.scout]\n-model  = \"claude-sonnet-5\"\n+model  = \"claude-opus-4-8\"\n effort = \"low\"\n \n [hosts.claude.roles.implementer]\n"

--- a/internal/run/activate.go
+++ b/internal/run/activate.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kninetimmy/orch/internal/agents"
 	"github.com/kninetimmy/orch/internal/config"
 	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/gitops"
@@ -114,7 +115,8 @@ func wrapAfterEnter(err error) error {
 //
 //   - Phase 1 (pure validation): decode/validate the plan and its
 //     approval, derive routing and labels for every issue.
-//   - Phase 2 (read-only preflights): Assist+no-lock, clean primary
+//   - Phase 2 (read-only preflights): Assist+no-lock, current rendered
+//     agent files for a Codex plan, clean primary
 //     checkout, authenticated GitHub remote, primary on the default
 //     branch (F4), every plan-declared area label existing in the
 //     repository (area labels are repository-defined per PRD §13, so
@@ -180,6 +182,19 @@ func Activate(ctx context.Context, env Env, reqJSON []byte) (*ActivationResult, 
 	// Phase 2: read-only preflights.
 	if err := requireAssistNoLock(env.RepoRoot); err != nil {
 		return nil, err
+	}
+	if plan.Host == "codex" {
+		stale, staleErr := agents.Stale(env.RepoRoot, cfg.Hosts.Codex)
+		if len(stale) > 0 {
+			detail := strings.Join(stale, ", ")
+			if staleErr != nil {
+				detail += fmt.Sprintf(" (%v)", staleErr)
+			}
+			return nil, fmt.Errorf("%w: %s; run `orch render-agents` in the primary checkout, then resubmit", ErrAgentsStale, detail)
+		}
+		if staleErr != nil {
+			return nil, staleErr
+		}
 	}
 	git, err := gitops.Open(ctx, env.Runner, env.RepoRoot)
 	if err != nil {

--- a/internal/run/activate_test.go
+++ b/internal/run/activate_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kninetimmy/orch/internal/agents"
+	"github.com/kninetimmy/orch/internal/config"
 	"github.com/kninetimmy/orch/internal/execx"
 	"github.com/kninetimmy/orch/internal/execx/execxtest"
 	"github.com/kninetimmy/orch/internal/ghops"
@@ -654,5 +656,169 @@ func TestActivateBranchExistsMidRun(t *testing.T) {
 	}
 	if st.Run.Issues[1].Phase != state.PhaseIssueCreated {
 		t.Errorf("issue b phase = %s, want issue-created (worktree add failed)", st.Run.Issues[1].Phase)
+	}
+}
+
+const testConfigTOMLBothHosts = testConfigTOML + `
+[hosts.codex.roles.architect]
+model  = "gpt-5.6-sol"
+effort = "xhigh"
+
+[hosts.codex.roles.scout]
+model  = "gpt-5.6-luna"
+effort = "max"
+
+[hosts.codex.roles.implementer]
+model  = "gpt-5.6-terra"
+effort = "max"
+
+[hosts.codex.roles.specialist]
+model  = "gpt-5.6-sol"
+effort = "max"
+
+[hosts.codex.roles.reviewer]
+model  = "gpt-5.6-sol"
+effort = "xhigh"
+
+[hosts.codex.roles.review_downgrade]
+model  = "gpt-5.6-sol"
+effort = "high"
+`
+
+func codexPlanJSON() string {
+	return `{
+  "schema_version": 1,
+  "host": "codex",
+  "title": "Codex plan",
+  "issues": [
+    {
+      "id": "a",
+      "title": "Issue A",
+      "objective": "Do A",
+      "acceptance_criteria": ["A works"],
+      "type": "feature",
+      "facts": {"read_only": false},
+      "wave": 1,
+      "required_tests": ["go test ./..."],
+      "usage_class": "light"
+    }
+  ]
+}`
+}
+
+func newBothHostActivateRepo(t *testing.T) string {
+	t.Helper()
+	return newActivateRepoWithConfigAndIgnore(t, testConfigTOMLBothHosts, fullGitignore+".codex/agents/\n")
+}
+
+func renderAgentFiles(t *testing.T, root string) {
+	t.Helper()
+	cfg, err := config.Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files, err := agents.Render(cfg.Hosts.Codex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := agents.Write(root, files); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertNoActivationArtifacts(t *testing.T, root string) {
+	t.Helper()
+	assertNoDeliveryState(t, root)
+	if branches := strings.TrimSpace(rawGit(t, root, "branch", "--list", "orch/*")); branches != "" {
+		t.Errorf("activation branch exists: %s", branches)
+	}
+	if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(WorktreeContainer))); !os.IsNotExist(err) {
+		t.Errorf("worktree container exists after refusal: %v", err)
+	}
+}
+
+func TestActivateCodexAbsentAgentsLeavesNothing(t *testing.T) {
+	root := newBothHostActivateRepo(t)
+	script := &execxtest.Script{T: t}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	_, err := Activate(context.Background(), env, activationJSON(t, codexPlanJSON()))
+	if !errors.Is(err, ErrAgentsStale) {
+		t.Fatalf("err = %v, want ErrAgentsStale", err)
+	}
+	for _, name := range []string{"orch-scout", "orch-implementer", "orch-specialist", "orch-reviewer", "orch-reviewer-safe"} {
+		if !strings.Contains(err.Error(), agents.Dir+"/"+name+".toml") {
+			t.Errorf("err does not name %s: %v", name, err)
+		}
+	}
+	if !strings.Contains(err.Error(), "orch render-agents") {
+		t.Errorf("err does not name the repair: %v", err)
+	}
+	script.AssertExhausted()
+	assertNoActivationArtifacts(t, root)
+}
+
+func TestActivateCodexEditedAgentRefused(t *testing.T) {
+	root := newBothHostActivateRepo(t)
+	renderAgentFiles(t, root)
+	edited := filepath.Join(root, filepath.FromSlash(agents.Dir), "orch-scout.toml")
+	if err := os.WriteFile(edited, []byte("stale\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	script := &execxtest.Script{T: t}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	_, err := Activate(context.Background(), env, activationJSON(t, codexPlanJSON()))
+	if !errors.Is(err, ErrAgentsStale) {
+		t.Fatalf("err = %v, want ErrAgentsStale", err)
+	}
+	if !strings.Contains(err.Error(), agents.Dir+"/orch-scout.toml") {
+		t.Errorf("err does not name edited file: %v", err)
+	}
+	if strings.Contains(err.Error(), agents.Dir+"/orch-reviewer.toml") {
+		t.Errorf("err names current file: %v", err)
+	}
+	if !strings.Contains(err.Error(), "orch render-agents") {
+		t.Errorf("err does not name the repair: %v", err)
+	}
+	script.AssertExhausted()
+	assertNoActivationArtifacts(t, root)
+}
+
+func TestActivateCodexCurrentAgentsProceeds(t *testing.T) {
+	root := newBothHostActivateRepo(t)
+	renderAgentFiles(t, root)
+	calls := append(fullTaxonomyScript(),
+		ghIssueCreateCall("Issue A", []string{"ready", "feature", "implementer", "standard"}, 1),
+	)
+	script := &execxtest.Script{T: t, Calls: calls}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	result, err := Activate(context.Background(), env, activationJSON(t, codexPlanJSON()))
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	script.AssertExhausted()
+	if len(result.Issues) != 1 || result.Issues[0].Number != 1 {
+		t.Errorf("Issues = %+v, want one issue #1", result.Issues)
+	}
+}
+
+func TestActivateClaudeIgnoresAbsentCodexAgentsWithBothHosts(t *testing.T) {
+	root := newBothHostActivateRepo(t)
+	calls := append(fullTaxonomyScript(),
+		ghIssueCreateCall("Issue A", []string{"ready", "feature", "implementer", "standard"}, 1),
+	)
+	script := &execxtest.Script{T: t, Calls: calls}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+	claudePlan := strings.Replace(codexPlanJSON(), `"host": "codex"`, `"host": "claude"`, 1)
+
+	result, err := Activate(context.Background(), env, activationJSON(t, claudePlan))
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	script.AssertExhausted()
+	if len(result.Issues) != 1 || result.Issues[0].Number != 1 {
+		t.Errorf("Issues = %+v, want one issue #1", result.Issues)
 	}
 }

--- a/internal/run/errors.go
+++ b/internal/run/errors.go
@@ -24,6 +24,10 @@ var (
 	// repository-defined (PRD §13), so activation never creates them —
 	// it fails closed before any mutation instead.
 	ErrAreaLabelMissing = errors.New("plan-declared area labels do not exist in the repository")
+	// ErrAgentsStale reports that a Codex activation found the
+	// project-local agent definitions absent, unreadable, or different
+	// from the current build and effective role configuration.
+	ErrAgentsStale = errors.New("rendered codex agent files are absent or out of date")
 	// ErrMemhubRequired reports that config.Memhub.Mode is "required"
 	// and the memhub probe failed or could not run (PRD §20: fail
 	// closed rather than proceed without memory).


### PR DESCRIPTION
Delivers issue #161: Detect stale rendered Codex agent definitions

Closes #161

**Plan digest:** `sha256:c27eb8a08da3d0d83720925568232c9e3b261ed220e00ec444cf19ab21aeac22`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Make stale or absent project-local Codex agent definitions visible in doctor and a fail-closed Codex activation precondition, while ensuring the documented repair does not dirty the repository.

**Acceptance criteria:**
- For an effective configuration enabling Codex, `orch doctor` fails and identifies every expected rendered agent definition that is absent, unreadable, or byte-different from the current build and effective role configuration, names `orch render-agents` as the repair, and passes when every expected definition is current.
- A Codex-host plan cannot activate while an expected rendered agent definition is absent or out of date: the refusal names `orch render-agents`, leaves no Delivery state, GitHub issue, branch, or worktree, and does not alter Claude-host activation.
- `orch init` and `orch configure` summaries propose the rendered-agent destination's ignore entry when it is absent and do not duplicate it when it is already present, so running the named repair cannot make the repository dirty.
- The supported installation documentation describes only the project-local rendered-agent layout and no longer offers a user-global agent layout.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `specialist` |
| Executor | `gpt-5.6-sol` — effort `max` |
| Reviewer | `gpt-5.6-sol` — effort `xhigh` |
| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to a specialist with a strong reviewer because risk domains (data-integrity).

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — All packages passed, including doctor, activation, agent, and interview tests. — commit `8741925a8b8fbdf8d16f4d74375267e503fa058a` (2026-08-01T05:08:44Z)
- **go-vet** — pass — `go vet ./...` — Exit 0 with no output. — commit `8741925a8b8fbdf8d16f4d74375267e503fa058a` (2026-08-01T05:08:44Z)
- **gofmt** — pass — `gofmt -l .` — No files listed. — commit `8741925a8b8fbdf8d16f4d74375267e503fa058a` (2026-08-01T05:08:44Z)
- **diff-check** — pass — `git diff --check 55a349070ad6a4073c0959ae23923ea8e2264c51..8741925a8b8fbdf8d16f4d74375267e503fa058a` — No whitespace errors. — commit `8741925a8b8fbdf8d16f4d74375267e503fa058a` (2026-08-01T05:08:44Z)
- **reviewer-ci** — pass — `gh pr checks 163 --repo kninetimmy/orch --json name,state,bucket,workflow,link` — Six of six checks passed: lint; Ubuntu, Windows, and macOS tests; Ubuntu and Windows scripts. — commit `8741925a8b8fbdf8d16f4d74375267e503fa058a` (2026-08-01T05:08:44Z)
- **acceptance-criterion-1** — satisfied — The shared comparison renders from the effective Codex configuration, checks every expected file for absence, unreadability, or byte difference, and doctor lists stale paths with render-agents remediation; focused and full tests pass. — commit `8741925a8b8fbdf8d16f4d74375267e503fa058a` (2026-08-01T05:08:45Z)
- **acceptance-criterion-2** — satisfied — Codex activation checks freshness before GitHub preparation or Delivery entry, refusal tests prove no state, issue, branch, or worktree is created, and the both-host Claude control remains unaffected. — commit `8741925a8b8fbdf8d16f4d74375267e503fa058a` (2026-08-01T05:08:45Z)
- **acceptance-criterion-3** — wrong — Requiring init/configure summaries to propose the ignore entry is testable and implemented, but it is only a proxy for the promised clean-repository outcome: before that proposal lands, render-agents creates untracked files and configure can then reject the dirty checkout, so the criterion cannot be satisfied as written. — commit `8741925a8b8fbdf8d16f4d74375267e503fa058a` (2026-08-01T05:08:45Z)
- **acceptance-criterion-4** — satisfied — The root and Codex adapter installation documentation now describe only the repository-local rendered-agent layout, and repository-wide search found no remaining user-global layout instruction. — commit `8741925a8b8fbdf8d16f4d74375267e503fa058a` (2026-08-01T05:08:45Z)
- **review-cycle-1** — request-changes — Criteria 1, 2, and 4 are satisfied and all required checks plus six CI jobs pass. Criterion 3 is wrong: a future init/configure summary proposal is only a proxy and does not ensure that running render-agents cannot dirty an already-initialized repository before the ignore entry lands. Non-blocking: the .gitignore comment calls the pattern root-anchored although the pattern has no leading slash. — commit `8741925a8b8fbdf8d16f4d74375267e503fa058a` (2026-08-01T05:08:45Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Make stale or absent project-local Codex agent definitions visible in doctor and a fail-closed Codex activation precondition, while ensuring the documented repair does not dirty the repository.",
  "acceptance_criteria": [
    "For an effective configuration enabling Codex, `orch doctor` fails and identifies every expected rendered agent definition that is absent, unreadable, or byte-different from the current build and effective role configuration, names `orch render-agents` as the repair, and passes when every expected definition is current.",
    "A Codex-host plan cannot activate while an expected rendered agent definition is absent or out of date: the refusal names `orch render-agents`, leaves no Delivery state, GitHub issue, branch, or worktree, and does not alter Claude-host activation.",
    "`orch init` and `orch configure` summaries propose the rendered-agent destination's ignore entry when it is absent and do not duplicate it when it is already present, so running the named repair cannot make the repository dirty.",
    "The supported installation documentation describes only the project-local rendered-agent layout and no longer offers a user-global agent layout."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "specialist",
  "executor": {
    "model": "gpt-5.6-sol",
    "effort": "max"
  },
  "routing_rationale": "Routed to a specialist with a strong reviewer because risk domains (data-integrity).",
  "reviewer": {
    "model": "gpt-5.6-sol",
    "effort": "xhigh"
  },
  "effort_delivery": "parameter",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All packages passed, including doctor, activation, agent, and interview tests.",
      "commit_oid": "8741925a8b8fbdf8d16f4d74375267e503fa058a",
      "at": "2026-08-01T05:08:44Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Exit 0 with no output.",
      "commit_oid": "8741925a8b8fbdf8d16f4d74375267e503fa058a",
      "at": "2026-08-01T05:08:44Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No files listed.",
      "commit_oid": "8741925a8b8fbdf8d16f4d74375267e503fa058a",
      "at": "2026-08-01T05:08:44Z"
    },
    {
      "name": "diff-check",
      "command": "git diff --check 55a349070ad6a4073c0959ae23923ea8e2264c51..8741925a8b8fbdf8d16f4d74375267e503fa058a",
      "result": "pass",
      "detail": "No whitespace errors.",
      "commit_oid": "8741925a8b8fbdf8d16f4d74375267e503fa058a",
      "at": "2026-08-01T05:08:44Z"
    },
    {
      "name": "reviewer-ci",
      "command": "gh pr checks 163 --repo kninetimmy/orch --json name,state,bucket,workflow,link",
      "result": "pass",
      "detail": "Six of six checks passed: lint; Ubuntu, Windows, and macOS tests; Ubuntu and Windows scripts.",
      "commit_oid": "8741925a8b8fbdf8d16f4d74375267e503fa058a",
      "at": "2026-08-01T05:08:44Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "The shared comparison renders from the effective Codex configuration, checks every expected file for absence, unreadability, or byte difference, and doctor lists stale paths with render-agents remediation; focused and full tests pass.",
      "commit_oid": "8741925a8b8fbdf8d16f4d74375267e503fa058a",
      "at": "2026-08-01T05:08:45Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "Codex activation checks freshness before GitHub preparation or Delivery entry, refusal tests prove no state, issue, branch, or worktree is created, and the both-host Claude control remains unaffected.",
      "commit_oid": "8741925a8b8fbdf8d16f4d74375267e503fa058a",
      "at": "2026-08-01T05:08:45Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "wrong",
      "detail": "Requiring init/configure summaries to propose the ignore entry is testable and implemented, but it is only a proxy for the promised clean-repository outcome: before that proposal lands, render-agents creates untracked files and configure can then reject the dirty checkout, so the criterion cannot be satisfied as written.",
      "commit_oid": "8741925a8b8fbdf8d16f4d74375267e503fa058a",
      "at": "2026-08-01T05:08:45Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "The root and Codex adapter installation documentation now describe only the repository-local rendered-agent layout, and repository-wide search found no remaining user-global layout instruction.",
      "commit_oid": "8741925a8b8fbdf8d16f4d74375267e503fa058a",
      "at": "2026-08-01T05:08:45Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "Criteria 1, 2, and 4 are satisfied and all required checks plus six CI jobs pass. Criterion 3 is wrong: a future init/configure summary proposal is only a proxy and does not ensure that running render-agents cannot dirty an already-initialized repository before the ignore entry lands. Non-blocking: the .gitignore comment calls the pattern root-anchored although the pattern has no leading slash.",
      "commit_oid": "8741925a8b8fbdf8d16f4d74375267e503fa058a",
      "at": "2026-08-01T05:08:45Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->