### PR TITLE
Report stale installed Orch adapters for configured hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,21 @@ hook trust approval, the five agent TOMLs copied into `.codex/agents/`
 (or rendered there with `orch render-agents`), and the two
 `request_user_input` stanzas in `~/.codex/config.toml`.
 
+**Plugin upgrade (existing installs).** Do not repeat the first-install
+commands above. Upgrade the configured host's marketplace and adapter:
+
+```sh
+# Claude Code
+claude plugin marketplace update orch
+claude plugin update orch-claude@orch
+
+# Codex CLI
+codex plugin marketplace upgrade orch
+```
+
+Restart Claude Code or Codex CLI after upgrading its adapter so the new
+hooks and skills are loaded.
+
 **Manual download.** Take the static binary for your OS and
 architecture from
 [GitHub Releases](https://github.com/kninetimmy/orch/releases)

--- a/adapters/claude/README.md
+++ b/adapters/claude/README.md
@@ -104,6 +104,18 @@ gap before it can matter. `orch doctor` is the health check for the
 locally installed environment (Git, GitHub, memhub, and configuration);
 run it after installing the binary and again after `orch init`.
 
+## Upgrade
+
+The marketplace-add and plugin-install commands above are for a first
+installation. Upgrade an existing adapter with both of these commands:
+
+```sh
+claude plugin marketplace update orch
+claude plugin update orch-claude@orch
+```
+
+Restart Claude Code after the upgrade so it loads the updated adapter.
+
 ## Known limitations
 
 These are accepted for this PR and the adapter as a whole, not open

--- a/adapters/claude/doc.go
+++ b/adapters/claude/doc.go
@@ -2,6 +2,13 @@
 // so its validation tests (plugin_test.go) build and run under the
 // module's ordinary `go test ./...`. The Claude Code plugin itself is
 // non-Go: the manifest, hooks, skills, commands, and agents under this
-// directory are read directly by Claude Code, never compiled. This file
-// carries no runtime code.
+// directory are read directly by Claude Code, never compiled.
 package claude
+
+import _ "embed"
+
+// PluginManifestJSON is the shipped plugin manifest and therefore the
+// canonical adapter version for this build.
+//
+//go:embed .claude-plugin/plugin.json
+var PluginManifestJSON string

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -127,6 +127,17 @@ decision, not an oversight).
 6. Run `orch doctor` to confirm the environment (Git, GitHub, memhub,
    configuration) is healthy.
 
+## Upgrade
+
+The marketplace-add and plugin-add commands above are for a first
+installation. Upgrade an existing adapter with:
+
+```sh
+codex plugin marketplace upgrade orch
+```
+
+Restart Codex CLI after the upgrade so it loads the updated adapter.
+
 ## Known limitations
 
 These are accepted for this PR and the adapter as a whole, not open

--- a/adapters/codex/embed.go
+++ b/adapters/codex/embed.go
@@ -2,6 +2,12 @@ package codex
 
 import "embed"
 
+// PluginManifestJSON is the shipped plugin manifest and therefore the
+// canonical adapter version for this build.
+//
+//go:embed .codex-plugin/plugin.json
+var PluginManifestJSON string
+
 // AgentTOMLs embeds the five shipped Codex agent definitions under
 // agents/ verbatim (LF-only, byte-identical to what this plugin ships,
 // since go:embed reads the file at build time). internal/agents reads

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -30,8 +30,8 @@ type Env struct {
 	Stdin io.Reader
 	// LookPath resolves an executable name; defaults to exec.LookPath.
 	LookPath func(string) (string, error)
-	// Runner executes external commands (git, gh); defaults to
-	// execx.Local resolving through LookPath.
+	// Runner executes external commands; defaults to execx.Local
+	// resolving through LookPath.
 	Runner execx.Runner
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -75,16 +75,24 @@ func testEnv(t *testing.T) (Env, *bytes.Buffer, *bytes.Buffer) {
 	return env, &stdout, &stderr
 }
 
-// fakeRunner answers the doctor probes: `git rev-parse
-// --show-toplevel` with a fixed top level, `gh auth status` and
-// `gh repo view` with scripted exits (zero values report healthy).
+// fakeRunner answers the doctor probes: git and gh with scripted exits,
+// plus each host's plugin listing (zero values report healthy).
 type fakeRunner struct {
-	toplevel  string
-	gitExit   int
-	gitStderr string
-	authExit  int
-	repoExit  int
-	repoJSON  string
+	toplevel           string
+	gitExit            int
+	gitStderr          string
+	authExit           int
+	repoExit           int
+	repoJSON           string
+	beforeRun          func(execx.Cmd)
+	claudePluginJSON   string
+	claudePluginExit   int
+	claudePluginStderr string
+	claudePluginErr    error
+	codexPluginJSON    string
+	codexPluginExit    int
+	codexPluginStderr  string
+	codexPluginErr     error
 	// checkIgnoreExit scripts `git check-ignore`: 0 ignored, 1 not
 	// ignored, anything else an error (the guard ignore probe).
 	checkIgnoreExit int
@@ -105,6 +113,9 @@ type fakeRunner struct {
 }
 
 func (f fakeRunner) Run(_ context.Context, c execx.Cmd) (execx.Result, error) {
+	if f.beforeRun != nil {
+		f.beforeRun(c)
+	}
 	switch c.Name {
 	case "git":
 		if len(c.Args) > 0 && c.Args[0] == "check-ignore" {
@@ -137,6 +148,36 @@ func (f fakeRunner) Run(_ context.Context, c execx.Cmd) (execx.Result, error) {
 			}
 			return execx.Result{Stdout: tag + "\n"}, nil
 		}
+	case "claude", "codex":
+		if len(c.Args) != 3 || c.Args[0] != "plugin" || c.Args[1] != "list" || c.Args[2] != "--json" {
+			return execx.Result{}, fmt.Errorf("fakeRunner: unexpected command %s %v", c.Name, c.Args)
+		}
+		var stdout, stderr string
+		var exit int
+		var err error
+		var spec adapterSpec
+		if c.Name == "claude" {
+			stdout, stderr, exit, err = f.claudePluginJSON, f.claudePluginStderr, f.claudePluginExit, f.claudePluginErr
+			spec = claudeAdapter
+		} else {
+			stdout, stderr, exit, err = f.codexPluginJSON, f.codexPluginStderr, f.codexPluginExit, f.codexPluginErr
+			spec = codexAdapter
+		}
+		if err != nil {
+			return execx.Result{}, err
+		}
+		if stdout == "" {
+			version, versionErr := adapterVersion(spec.manifestJSON)
+			if versionErr != nil {
+				return execx.Result{}, versionErr
+			}
+			if c.Name == "claude" {
+				stdout = fmt.Sprintf(`[{"id":"orch-claude@orch","version":%q,"enabled":true}]`, version)
+			} else {
+				stdout = fmt.Sprintf(`{"installed":[{"pluginId":"orch@orch","version":%q,"installed":true,"enabled":true}]}`, version)
+			}
+		}
+		return execx.Result{Stdout: stdout, Stderr: stderr, ExitCode: exit}, nil
 	case "memhub":
 		switch c.Args[0] {
 		case "status":

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -2,19 +2,48 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"strings"
 
+	"github.com/kninetimmy/orch/adapters/claude"
+	"github.com/kninetimmy/orch/adapters/codex"
 	"github.com/kninetimmy/orch/internal/agents"
 	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/execx"
 	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/gitops"
 	"github.com/kninetimmy/orch/internal/lockfile"
 	"github.com/kninetimmy/orch/internal/memhub"
 	"github.com/kninetimmy/orch/internal/metrics"
 	"github.com/kninetimmy/orch/internal/state"
+)
+
+type adapterSpec struct {
+	host         string
+	executable   string
+	pluginID     string
+	manifestJSON string
+	repair       string
+}
+
+var (
+	claudeAdapter = adapterSpec{
+		host:         "claude",
+		executable:   "claude",
+		pluginID:     "orch-claude@orch",
+		manifestJSON: claude.PluginManifestJSON,
+		repair:       "run `claude plugin marketplace update orch`, then `claude plugin update orch-claude@orch`, then restart Claude Code",
+	}
+	codexAdapter = adapterSpec{
+		host:         "codex",
+		executable:   "codex",
+		pluginID:     "orch@orch",
+		manifestJSON: codex.PluginManifestJSON,
+		repair:       "run `codex plugin marketplace upgrade orch`, then restart Codex CLI",
+	}
 )
 
 func runDoctor(env Env) error {
@@ -85,6 +114,15 @@ func runDoctor(env Env) error {
 			fmt.Fprintf(env.Stdout, "note  %s applied; overrides: %s\n", config.LocalOverridePath, strings.Join(cfg.Overrides, ", "))
 		} else {
 			fmt.Fprintf(env.Stdout, "note  %s present; no overrides set\n", config.LocalOverridePath)
+		}
+	}
+
+	if cfgErr == nil {
+		if cfg.Hosts.Claude != nil {
+			check("claude adapter", checkAdapter(env, claudeAdapter))
+		}
+		if cfg.Hosts.Codex != nil {
+			check("codex adapter", checkAdapter(env, codexAdapter))
 		}
 	}
 
@@ -165,4 +203,133 @@ func runDoctor(env Env) error {
 		return errors.New("one or more checks failed")
 	}
 	return nil
+}
+
+type adapterPlugin struct {
+	ID        string `json:"id"`
+	PluginID  string `json:"pluginId"`
+	Version   string `json:"version"`
+	Installed bool   `json:"installed"`
+	Enabled   bool   `json:"enabled"`
+}
+
+func checkAdapter(env Env, spec adapterSpec) error {
+	fail := func(detail string) error {
+		return fmt.Errorf("%s; %s", detail, spec.repair)
+	}
+
+	expected, err := adapterVersion(spec.manifestJSON)
+	if err != nil {
+		return fail(fmt.Sprintf("read shipped %s adapter version: %v", spec.host, err))
+	}
+	if _, err := env.LookPath(spec.executable); err != nil {
+		return fail(fmt.Sprintf("%s not found on PATH (expected adapter version %q); install it or adjust PATH: %v", spec.executable, expected, err))
+	}
+
+	res, err := env.Runner.Run(context.Background(), execx.Cmd{
+		Name: spec.executable,
+		Args: []string{"plugin", "list", "--json"},
+		Dir:  env.RepoRoot,
+	})
+	command := spec.executable + " plugin list --json"
+	if err != nil {
+		return fail(fmt.Sprintf("run `%s`: %v", command, err))
+	}
+	if res.ExitCode != 0 {
+		detail := strings.TrimSpace(res.Stderr)
+		if detail == "" {
+			detail = "no error output"
+		}
+		return fail(fmt.Sprintf("`%s` exited %d: %s", command, res.ExitCode, detail))
+	}
+
+	plugins, err := decodeAdapterPlugins(spec.host, []byte(res.Stdout))
+	if err != nil {
+		return fail(fmt.Sprintf("malformed `%s` output: %v", command, err))
+	}
+
+	var matches []adapterPlugin
+	for _, plugin := range plugins {
+		id := plugin.ID
+		if spec.host == "codex" {
+			id = plugin.PluginID
+		}
+		if id == spec.pluginID {
+			matches = append(matches, plugin)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return fail(fmt.Sprintf("%s is absent (expected version %q)", spec.pluginID, expected))
+	case 1:
+		// Continue below.
+	default:
+		var versions []string
+		for _, plugin := range matches {
+			if plugin.Version != "" {
+				versions = append(versions, plugin.Version)
+			}
+		}
+		if len(versions) > 0 {
+			return fail(fmt.Sprintf("%s appears %d times (installed versions %q, expected %q); exactly one is required", spec.pluginID, len(matches), versions, expected))
+		}
+		return fail(fmt.Sprintf("%s appears %d times; exactly one at version %q is required", spec.pluginID, len(matches), expected))
+	}
+
+	plugin := matches[0]
+	versionDetail := fmt.Sprintf("expected %q", expected)
+	if plugin.Version != "" {
+		versionDetail = fmt.Sprintf("installed %q, expected %q", plugin.Version, expected)
+	}
+	if spec.host == "codex" && !plugin.Installed {
+		return fail(fmt.Sprintf("%s is marked not installed (%s)", spec.pluginID, versionDetail))
+	}
+	if !plugin.Enabled {
+		return fail(fmt.Sprintf("%s is disabled (%s)", spec.pluginID, versionDetail))
+	}
+	if plugin.Version == "" {
+		return fail(fmt.Sprintf("%s has no version (expected %q)", spec.pluginID, expected))
+	}
+	if plugin.Version != expected {
+		return fail(fmt.Sprintf("%s version mismatch: installed %q, expected %q", spec.pluginID, plugin.Version, expected))
+	}
+	return nil
+}
+
+func adapterVersion(manifestJSON string) (string, error) {
+	var manifest struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal([]byte(manifestJSON), &manifest); err != nil {
+		return "", err
+	}
+	if manifest.Version == "" {
+		return "", errors.New("manifest has no version")
+	}
+	return manifest.Version, nil
+}
+
+func decodeAdapterPlugins(host string, data []byte) ([]adapterPlugin, error) {
+	if host == "claude" {
+		var plugins []adapterPlugin
+		if err := json.Unmarshal(data, &plugins); err != nil {
+			return nil, err
+		}
+		if plugins == nil {
+			return nil, errors.New("expected a top-level array")
+		}
+		return plugins, nil
+	}
+
+	var listing struct {
+		Installed []adapterPlugin `json:"installed"`
+	}
+	if err := json.Unmarshal(data, &listing); err != nil {
+		return nil, err
+	}
+	if listing.Installed == nil {
+		return nil, errors.New(`expected an object with an "installed" array`)
+	}
+	return listing.Installed, nil
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -9,6 +11,7 @@ import (
 	"time"
 
 	"github.com/kninetimmy/orch/internal/agents"
+	"github.com/kninetimmy/orch/internal/execx"
 	"github.com/kninetimmy/orch/internal/lockfile"
 	"github.com/kninetimmy/orch/internal/state"
 )
@@ -122,6 +125,294 @@ func TestDoctorMissingConfig(t *testing.T) {
 	if !strings.Contains(stdout.String(), "FAIL  configuration") {
 		t.Errorf("stdout missing configuration failure:\n%s", stdout.String())
 	}
+}
+
+func TestDoctorConfiguredAdaptersPassCurrentListings(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     string
+		executable string
+	}{
+		{"claude", validTOML, "claude"},
+		{"codex", validCodexTOML, "codex"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env, stdout, _ := testEnv(t)
+			writeConfig(t, env.RepoRoot, tc.config)
+			if tc.executable == "codex" {
+				if code := Run([]string{"render-agents"}, env); code != ExitOK {
+					t.Fatalf("render-agents exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+				}
+				stdout.Reset()
+			}
+
+			probed := false
+			env.Runner = fakeRunner{
+				toplevel: env.RepoRoot,
+				beforeRun: func(cmd execx.Cmd) {
+					if cmd.Name != tc.executable {
+						return
+					}
+					probed = true
+					if cmd.Dir != env.RepoRoot {
+						t.Errorf("%s plugin list dir = %q, want %q", tc.executable, cmd.Dir, env.RepoRoot)
+					}
+				},
+			}
+			if code := Run([]string{"doctor"}, env); code != ExitOK {
+				t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+			}
+			if !probed {
+				t.Fatalf("%s plugin listing was not probed", tc.executable)
+			}
+			if !strings.Contains(stdout.String(), "ok    "+tc.name+" adapter") {
+				t.Errorf("stdout missing passing adapter check:\n%s", stdout.String())
+			}
+		})
+	}
+}
+
+func TestDoctorAdapterFailures(t *testing.T) {
+	claudeVersion := mustAdapterVersion(t, claudeAdapter)
+	codexVersion := mustAdapterVersion(t, codexAdapter)
+	tests := []struct {
+		name        string
+		config      string
+		spec        adapterSpec
+		missingCLI  bool
+		configure   func(*fakeRunner)
+		wantDetails []string
+	}{
+		{
+			name:       "missing host CLI",
+			config:     validTOML,
+			spec:       claudeAdapter,
+			missingCLI: true,
+			wantDetails: []string{
+				"claude not found on PATH",
+				fmt.Sprintf(`expected adapter version %q`, claudeVersion),
+			},
+		},
+		{
+			name:   "listing command fails",
+			config: validCodexTOML,
+			spec:   codexAdapter,
+			configure: func(r *fakeRunner) {
+				r.codexPluginExit = 1
+				r.codexPluginStderr = "registry unavailable"
+			},
+			wantDetails: []string{"`codex plugin list --json` exited 1", "registry unavailable"},
+		},
+		{
+			name:   "listing cannot start",
+			config: validTOML,
+			spec:   claudeAdapter,
+			configure: func(r *fakeRunner) {
+				r.claudePluginErr = errors.New("spawn failed")
+			},
+			wantDetails: []string{"run `claude plugin list --json`", "spawn failed"},
+		},
+		{
+			name:   "claude malformed JSON",
+			config: validTOML,
+			spec:   claudeAdapter,
+			configure: func(r *fakeRunner) {
+				r.claudePluginJSON = "{"
+			},
+			wantDetails: []string{"malformed `claude plugin list --json` output"},
+		},
+		{
+			name:   "codex malformed shape",
+			config: validCodexTOML,
+			spec:   codexAdapter,
+			configure: func(r *fakeRunner) {
+				r.codexPluginJSON = "[]"
+			},
+			wantDetails: []string{"malformed `codex plugin list --json` output"},
+		},
+		{
+			name:   "adapter absent",
+			config: validTOML,
+			spec:   claudeAdapter,
+			configure: func(r *fakeRunner) {
+				r.claudePluginJSON = fmt.Sprintf(`[{"id":"orch@orch","version":%q,"enabled":true}]`, claudeVersion)
+			},
+			wantDetails: []string{"orch-claude@orch is absent", fmt.Sprintf(`expected version %q`, claudeVersion)},
+		},
+		{
+			name:   "adapter ambiguous",
+			config: validCodexTOML,
+			spec:   codexAdapter,
+			configure: func(r *fakeRunner) {
+				r.codexPluginJSON = fmt.Sprintf(
+					`{"installed":[{"pluginId":"orch@orch","version":"0.5.0","installed":true,"enabled":true},{"pluginId":"orch@orch","version":%q,"installed":true,"enabled":true}]}`,
+					codexVersion,
+				)
+			},
+			wantDetails: []string{"orch@orch appears 2 times", "installed versions", "0.5.0", codexVersion, "exactly one is required"},
+		},
+		{
+			name:   "adapter marked not installed",
+			config: validCodexTOML,
+			spec:   codexAdapter,
+			configure: func(r *fakeRunner) {
+				r.codexPluginJSON = fmt.Sprintf(
+					`{"installed":[{"pluginId":"orch@orch","version":%q,"installed":false,"enabled":true}]}`,
+					codexVersion,
+				)
+			},
+			wantDetails: []string{"orch@orch is marked not installed", fmt.Sprintf(`installed %q, expected %q`, codexVersion, codexVersion)},
+		},
+		{
+			name:   "adapter disabled",
+			config: validTOML,
+			spec:   claudeAdapter,
+			configure: func(r *fakeRunner) {
+				r.claudePluginJSON = fmt.Sprintf(
+					`[{"id":"orch-claude@orch","version":%q,"enabled":false}]`,
+					claudeVersion,
+				)
+			},
+			wantDetails: []string{"orch-claude@orch is disabled", fmt.Sprintf(`installed %q, expected %q`, claudeVersion, claudeVersion)},
+		},
+		{
+			name:   "adapter version missing",
+			config: validTOML,
+			spec:   claudeAdapter,
+			configure: func(r *fakeRunner) {
+				r.claudePluginJSON = `[{"id":"orch-claude@orch","enabled":true}]`
+			},
+			wantDetails: []string{"orch-claude@orch has no version", fmt.Sprintf(`expected %q`, claudeVersion)},
+		},
+		{
+			name:   "adapter version mismatch",
+			config: validCodexTOML,
+			spec:   codexAdapter,
+			configure: func(r *fakeRunner) {
+				r.codexPluginJSON = `{"installed":[{"pluginId":"orch@orch","version":"0.5.0","installed":true,"enabled":true}]}`
+			},
+			wantDetails: []string{"orch@orch version mismatch", fmt.Sprintf(`installed "0.5.0", expected %q`, codexVersion)},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env, stdout, _ := testEnv(t)
+			writeConfig(t, env.RepoRoot, tc.config)
+			if tc.spec.host == "codex" {
+				if code := Run([]string{"render-agents"}, env); code != ExitOK {
+					t.Fatalf("render-agents exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+				}
+				stdout.Reset()
+			}
+
+			runner := fakeRunner{toplevel: env.RepoRoot}
+			if tc.configure != nil {
+				tc.configure(&runner)
+			}
+			if tc.missingCLI {
+				runner.beforeRun = func(cmd execx.Cmd) {
+					if cmd.Name == tc.spec.executable {
+						t.Fatalf("%s listing ran though the CLI was absent", tc.spec.executable)
+					}
+				}
+				lookPath := env.LookPath
+				env.LookPath = func(name string) (string, error) {
+					if name == tc.spec.executable {
+						return "", errNotFound
+					}
+					return lookPath(name)
+				}
+			}
+			env.Runner = runner
+
+			if code := Run([]string{"doctor"}, env); code != ExitError {
+				t.Fatalf("exit = %d, want %d\n%s", code, ExitError, stdout.String())
+			}
+			out := stdout.String()
+			if !strings.Contains(out, "FAIL  "+tc.spec.host+" adapter") {
+				t.Errorf("stdout missing host adapter failure:\n%s", out)
+			}
+			for _, want := range tc.wantDetails {
+				if !strings.Contains(out, want) {
+					t.Errorf("stdout missing %q:\n%s", want, out)
+				}
+			}
+			if !strings.Contains(out, tc.spec.repair) {
+				t.Errorf("stdout missing executable update and restart remediation %q:\n%s", tc.spec.repair, out)
+			}
+		})
+	}
+}
+
+func TestDoctorUnconfiguredHostIsNotProbed(t *testing.T) {
+	tests := []struct {
+		name         string
+		config       string
+		unconfigured string
+	}{
+		{"claude only", validTOML, "codex"},
+		{"codex only", validCodexTOML, "claude"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env, stdout, _ := testEnv(t)
+			writeConfig(t, env.RepoRoot, tc.config)
+			if tc.unconfigured == "claude" {
+				if code := Run([]string{"render-agents"}, env); code != ExitOK {
+					t.Fatalf("render-agents exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+				}
+				stdout.Reset()
+			}
+
+			lookPath := env.LookPath
+			env.LookPath = func(name string) (string, error) {
+				if name == tc.unconfigured {
+					t.Fatalf("LookPath probed unconfigured host %s", name)
+				}
+				return lookPath(name)
+			}
+			env.Runner = fakeRunner{
+				toplevel: env.RepoRoot,
+				beforeRun: func(cmd execx.Cmd) {
+					if cmd.Name == tc.unconfigured {
+						t.Fatalf("plugin listing probed unconfigured host %s", cmd.Name)
+					}
+				},
+			}
+			if code := Run([]string{"doctor"}, env); code != ExitOK {
+				t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+			}
+		})
+	}
+}
+
+func TestDoctorAdapterVersionIsIndependentOfBinaryRelease(t *testing.T) {
+	old := Version
+	Version = "v9.9.9"
+	t.Cleanup(func() { Version = old })
+
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	env.Runner = fakeRunner{toplevel: env.RepoRoot, releaseTag: Version}
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (binary-only release must not stale the unchanged adapter)\n%s", code, ExitOK, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "ok    claude adapter") {
+		t.Errorf("stdout missing passing adapter check:\n%s", stdout.String())
+	}
+}
+
+func mustAdapterVersion(t *testing.T, spec adapterSpec) string {
+	t.Helper()
+	version, err := adapterVersion(spec.manifestJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return version
 }
 
 func TestDoctorMemhubModeOffNeverProbes(t *testing.T) {

--- a/internal/execx/execx.go
+++ b/internal/execx/execx.go
@@ -1,5 +1,5 @@
 // Package execx defines the injectable external-command runner the
-// orchestration core uses for git and gh (PRD §5, §12). Commands are
+// orchestration core uses for git, gh, and host CLIs. Commands are
 // always argument vectors — never shell strings — so external input
 // can never be shell-interpreted. A non-zero exit is data in Result,
 // not an error: callers that need exit codes as information (PRD §16


### PR DESCRIPTION
Delivers issue #165: Report stale installed Orch adapters for configured hosts

Closes #165

**Plan digest:** `sha256:f734d4f0b7fc5b815314909a89ced8143e71553bb1f51ee6869daa9dd12d43fc`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Make doctor verify that each configured host is running the installed and enabled Orch adapter version shipped with the current build, with precise repair guidance and upgrade documentation.

**Acceptance criteria:**
- For each configured host, `orch doctor` consumes that host CLI's JSON plugin listing and passes its adapter check only when exactly one target Orch adapter is installed, enabled, and has the version shipped for that adapter in the current build; an unconfigured host is not probed.
- A missing host CLI, failed listing command, malformed listing, absent or ambiguous target adapter, disabled adapter, or version mismatch makes doctor exit non-zero with a host-specific diagnostic; when a version is available the diagnostic reports installed and expected values, and every failure names executable update and restart remediation.
- Adapter freshness is independent of the Orch binary release version and the latest GitHub release, so a binary-only release does not report an unchanged adapter as stale.
- Installation documentation distinguishes first installation from upgrade: Claude upgrades use marketplace update followed by plugin update, Codex upgrades use marketplace upgrade, and both hosts are told to restart after an adapter upgrade.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `specialist` |
| Executor | `gpt-5.6-sol` — effort `max` |
| Reviewer | `gpt-5.6-sol` — effort `xhigh` |
| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to a specialist with a strong reviewer because risk domains (security).

**Escalations:** _none_

**Verification:**
- **required-tests** — pass — `go test ./...` — All packages passed on final post-wording rerun. — commit `cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee` (2026-08-01T14:15:36Z)
- **required-vet** — pass — `go vet ./...` — No findings. — commit `cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee` (2026-08-01T14:15:36Z)
- **required-format** — pass — `gofmt -l .` — No files listed. — commit `cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee` (2026-08-01T14:15:36Z)
- **focused-adapter-doctor** — pass — `go test ./internal/cli ./internal/execx ./adapters/claude ./adapters/codex` — Host JSON parsing, failure matrix, configured-host probing, and version independence passed. — commit `cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee` (2026-08-01T14:15:36Z)
- **diff-audit** — pass — `git diff --check origin/main...HEAD` — No whitespace errors; worktree clean and remote matches HEAD. — commit `cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee` (2026-08-01T14:15:36Z)
- **reviewer-required-tests** — pass — `go test ./...` — All packages passed in isolated review worktree. — commit `cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee` (2026-08-01T14:28:02Z)
- **reviewer-required-vet** — pass — `go vet ./...` — No output. — commit `cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee` (2026-08-01T14:28:02Z)
- **reviewer-required-format** — pass — `gofmt -l .` — No files listed. — commit `cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee` (2026-08-01T14:28:02Z)
- **reviewer-focused-adapter-doctor** — pass — `focused adapter-doctor suite` — Configured/unconfigured hosts, eleven failure cases, and release independence passed. — commit `cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee` (2026-08-01T14:28:02Z)
- **reviewer-live-adapters** — pass — `claude plugin list --json; codex plugin list --json` — Confirmed production shapes, exact target IDs, enabled state, and version 0.6.0. — commit `cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee` (2026-08-01T14:28:02Z)
- **reviewer-live-ci** — pass — `gh pr checks 167` — All six checks passed: Windows/macOS/Linux tests, lint, and both script jobs. — commit `cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee` (2026-08-01T14:28:02Z)
- **reviewer-diff-audit** — pass — `git diff --check origin/main...HEAD` — One scoped commit, ten relevant files, clean worktree, no new dependency. — commit `cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee` (2026-08-01T14:28:02Z)
- **acceptance-criterion-1** — satisfied — Configured hosts alone are probed; exact host JSON shapes and target IDs are parsed; exactly one installed, enabled adapter at the embedded manifest version is required. — commit `cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee` (2026-08-01T14:28:03Z)
- **acceptance-criterion-2** — satisfied — Missing CLI, command/decode, absent/ambiguous, installed/enabled, and mismatch failures are host-specific, nonzero, and append executable update plus restart guidance with installed/expected versions where available. — commit `cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee` (2026-08-01T14:28:03Z)
- **acceptance-criterion-3** — satisfied — Expected adapter versions come only from embedded plugin manifests; the binary/latest-release check remains separate and the independence test passes with binary v9.9.9. — commit `cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee` (2026-08-01T14:28:03Z)
- **acceptance-criterion-4** — satisfied — Root and host READMEs distinguish first installation from Claude marketplace+plugin update and Codex marketplace upgrade, with restart instructions. — commit `cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee` (2026-08-01T14:28:03Z)
- **review-cycle-1** — approve — All four acceptance criteria are satisfied. Required checks and six live CI jobs pass; no findings. — commit `cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee` (2026-08-01T14:28:03Z)
- **required-ci** — passing — test (windows-latest)=pass, lint=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass — commit `cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee` (2026-08-01T14:29:20Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Make doctor verify that each configured host is running the installed and enabled Orch adapter version shipped with the current build, with precise repair guidance and upgrade documentation.",
  "acceptance_criteria": [
    "For each configured host, `orch doctor` consumes that host CLI's JSON plugin listing and passes its adapter check only when exactly one target Orch adapter is installed, enabled, and has the version shipped for that adapter in the current build; an unconfigured host is not probed.",
    "A missing host CLI, failed listing command, malformed listing, absent or ambiguous target adapter, disabled adapter, or version mismatch makes doctor exit non-zero with a host-specific diagnostic; when a version is available the diagnostic reports installed and expected values, and every failure names executable update and restart remediation.",
    "Adapter freshness is independent of the Orch binary release version and the latest GitHub release, so a binary-only release does not report an unchanged adapter as stale.",
    "Installation documentation distinguishes first installation from upgrade: Claude upgrades use marketplace update followed by plugin update, Codex upgrades use marketplace upgrade, and both hosts are told to restart after an adapter upgrade."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "specialist",
  "executor": {
    "model": "gpt-5.6-sol",
    "effort": "max"
  },
  "routing_rationale": "Routed to a specialist with a strong reviewer because risk domains (security).",
  "reviewer": {
    "model": "gpt-5.6-sol",
    "effort": "xhigh"
  },
  "effort_delivery": "parameter",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "required-tests",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All packages passed on final post-wording rerun.",
      "commit_oid": "cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee",
      "at": "2026-08-01T14:15:36Z"
    },
    {
      "name": "required-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "No findings.",
      "commit_oid": "cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee",
      "at": "2026-08-01T14:15:36Z"
    },
    {
      "name": "required-format",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No files listed.",
      "commit_oid": "cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee",
      "at": "2026-08-01T14:15:36Z"
    },
    {
      "name": "focused-adapter-doctor",
      "command": "go test ./internal/cli ./internal/execx ./adapters/claude ./adapters/codex",
      "result": "pass",
      "detail": "Host JSON parsing, failure matrix, configured-host probing, and version independence passed.",
      "commit_oid": "cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee",
      "at": "2026-08-01T14:15:36Z"
    },
    {
      "name": "diff-audit",
      "command": "git diff --check origin/main...HEAD",
      "result": "pass",
      "detail": "No whitespace errors; worktree clean and remote matches HEAD.",
      "commit_oid": "cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee",
      "at": "2026-08-01T14:15:36Z"
    },
    {
      "name": "reviewer-required-tests",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All packages passed in isolated review worktree.",
      "commit_oid": "cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee",
      "at": "2026-08-01T14:28:02Z"
    },
    {
      "name": "reviewer-required-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "No output.",
      "commit_oid": "cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee",
      "at": "2026-08-01T14:28:02Z"
    },
    {
      "name": "reviewer-required-format",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No files listed.",
      "commit_oid": "cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee",
      "at": "2026-08-01T14:28:02Z"
    },
    {
      "name": "reviewer-focused-adapter-doctor",
      "command": "focused adapter-doctor suite",
      "result": "pass",
      "detail": "Configured/unconfigured hosts, eleven failure cases, and release independence passed.",
      "commit_oid": "cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee",
      "at": "2026-08-01T14:28:02Z"
    },
    {
      "name": "reviewer-live-adapters",
      "command": "claude plugin list --json; codex plugin list --json",
      "result": "pass",
      "detail": "Confirmed production shapes, exact target IDs, enabled state, and version 0.6.0.",
      "commit_oid": "cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee",
      "at": "2026-08-01T14:28:02Z"
    },
    {
      "name": "reviewer-live-ci",
      "command": "gh pr checks 167",
      "result": "pass",
      "detail": "All six checks passed: Windows/macOS/Linux tests, lint, and both script jobs.",
      "commit_oid": "cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee",
      "at": "2026-08-01T14:28:02Z"
    },
    {
      "name": "reviewer-diff-audit",
      "command": "git diff --check origin/main...HEAD",
      "result": "pass",
      "detail": "One scoped commit, ten relevant files, clean worktree, no new dependency.",
      "commit_oid": "cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee",
      "at": "2026-08-01T14:28:02Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "Configured hosts alone are probed; exact host JSON shapes and target IDs are parsed; exactly one installed, enabled adapter at the embedded manifest version is required.",
      "commit_oid": "cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee",
      "at": "2026-08-01T14:28:03Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "Missing CLI, command/decode, absent/ambiguous, installed/enabled, and mismatch failures are host-specific, nonzero, and append executable update plus restart guidance with installed/expected versions where available.",
      "commit_oid": "cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee",
      "at": "2026-08-01T14:28:03Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "Expected adapter versions come only from embedded plugin manifests; the binary/latest-release check remains separate and the independence test passes with binary v9.9.9.",
      "commit_oid": "cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee",
      "at": "2026-08-01T14:28:03Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "Root and host READMEs distinguish first installation from Claude marketplace+plugin update and Codex marketplace upgrade, with restart instructions.",
      "commit_oid": "cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee",
      "at": "2026-08-01T14:28:03Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "All four acceptance criteria are satisfied. Required checks and six live CI jobs pass; no findings.",
      "commit_oid": "cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee",
      "at": "2026-08-01T14:28:03Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, lint=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "cef5de794325e764cb2f2ffba1c2bc2cb5cd4bee",
      "at": "2026-08-01T14:29:20Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->