### PR TITLE
Correct README.md's release-version references and Status counts for v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/License-MIT-2E7D32?style=flat&logo=opensourceinitiative&logoColor=white" alt="License: MIT"/>
   <img src="https://img.shields.io/badge/Go-1.26%2B-00ADD8?style=flat&logo=go&logoColor=white" alt="Go 1.26+"/>
-  <img src="https://img.shields.io/badge/Release-v0.5.7-24292F?style=flat&logo=github&logoColor=white" alt="Release: v0.5.7"/>
+  <img src="https://img.shields.io/badge/Release-v0.6.0-24292F?style=flat&logo=github&logoColor=white" alt="Release: v0.6.0"/>
   <br/>
   <img src="https://img.shields.io/badge/Platform-Linux%20%C2%B7%20macOS%20%C2%B7%20Windows-607D8B?style=flat" alt="Platform: Linux, macOS, Windows"/>
   <img src="https://img.shields.io/badge/Hosts-Claude%20Code%20%C2%B7%20Codex%20CLI-6E56CF?style=flat" alt="Hosts: Claude Code and Codex CLI"/>
@@ -70,7 +70,7 @@ The full product definition lives in [ORCH-PRD.md](ORCH-PRD.md).
 
 ## Status
 
-Early software. What can be stated as fact: 12 tagged releases (v0.1.0 through v0.5.7) and 75 merged pull requests, 37 of which carry an Orch audit record in their body — every merge from PR #40 through PR #117 except #50 and #103, both of which `orch configure` delivered in its own body format. Since PR #40, this repository has been built through the pipeline described above: a plan gate, an isolated worktree per issue, a review dispatched separately from the work, CI, and a merge that fails closed unless it carries an approval pinned to the commit `merge-report` recorded.
+Early software. What can be stated as fact: 15 tagged releases (v0.1.0 through v0.6.0) and 96 merged pull requests, 55 of which carry an Orch audit record in their body — every merge from PR #40 through PR #167 except #50, #103, #121, #129 and #133, all of which `orch configure` delivered in its own body format. Since PR #40, this repository has been built through the pipeline described above: a plan gate, an isolated worktree per issue, a review dispatched separately from the work, CI, and a merge that fails closed unless it carries an approval pinned to the commit `merge-report` recorded.
 
 All of that evidence comes from one repository: this one.
 
@@ -101,7 +101,7 @@ on this machine. Work in a scratch directory, not in one of my projects.
 
 2. Confirm that `orch` resolves on PATH and that `orch status` prints a
    release version on its first line — a line beginning `orch:` and giving
-   a release tag such as v0.5.7. Run it from anywhere: outside an
+   a release tag such as v0.6.0. Run it from anywhere: outside an
    initialized repository it prints that version line first and then exits
    non-zero saying the repository is not initialized, which is expected
    here. On Windows the installer adds its install directory to my user
@@ -189,7 +189,7 @@ your OS and architecture, verify its SHA-256 against the release's
 `SHA256SUMS` **before** installing, and fail closed on any mismatch.
 
 Linux / macOS — installs to `~/.local/bin` (override with
-`ORCH_INSTALL_DIR`); pin a version with `ORCH_VERSION=v0.5.7`:
+`ORCH_INSTALL_DIR`); pin a version with `ORCH_VERSION=v0.6.0`:
 
 ```sh
 curl -fsSLO https://raw.githubusercontent.com/kninetimmy/orch/main/install.sh
@@ -199,7 +199,7 @@ sh install.sh
 
 Windows (PowerShell) — installs to `%LOCALAPPDATA%\Programs\orch` and
 appends that directory to your user `PATH`; skip the `PATH` change with
-`-NoPathUpdate`, pin a version with `-Version v0.5.7`:
+`-NoPathUpdate`, pin a version with `-Version v0.6.0`:
 
 ```powershell
 iwr https://raw.githubusercontent.com/kninetimmy/orch/main/install.ps1 -OutFile install.ps1
@@ -504,10 +504,50 @@ continue, or `orch abort` to end it.
 <details>
 <summary>Defects already corrected, newest first</summary>
 
-Everything here is merged on `main`. v0.5.7 is the latest tagged
-release; PRs #113, #115, and #117 landed after it, so they ship in the
-next release rather than the current one.
+Everything here is merged on `main` and shipped in v0.6.0, the latest
+tagged release.
 
+- `orch doctor` now checks each configured host's installed Orch
+  adapter and fails when it is absent, disabled, ambiguous or a
+  different version from the one this build ships, naming the installed
+  and the expected version; before, an adapter left behind by a
+  binary-only upgrade kept running while doctor reported the host
+  healthy —
+  [#167](https://github.com/kninetimmy/orch/pull/167)
+- `orch doctor` and Codex plan activation now compare the rendered
+  agent definitions in `.codex/agents/` against the current build and
+  the effective role configuration, and fail closed naming `orch
+  render-agents`; before, definitions rendered from an older
+  configuration went on being dispatched with nothing reporting them
+  stale —
+  [#166](https://github.com/kninetimmy/orch/pull/166)
+- `orch run review` now refuses, before any mutation, a review that
+  does not carry exactly one judgment per acceptance criterion the
+  issue holds, and a criterion judged wrong blocks the issue for you as
+  part of recording that review; before, a review could approve without
+  saying anything about an individual criterion, and a criterion that
+  was itself wrong reached you only if the Architect read the paragraph
+  and made a second call by hand —
+  [#158](https://github.com/kninetimmy/orch/pull/158)
+- Codex usage capture now depends only on the rollout that actually
+  identifies as the dispatched child, so an unrelated neighbour in the
+  sessions tree — a zero-byte file caught mid-creation, one with no
+  session metadata, an unparseable first line, or a shape written by
+  another Codex version — no longer reports usage unavailable for every
+  child in the run; a rollout that does match is still fully validated
+  and two matching rollouts still fail closed —
+  [#148](https://github.com/kninetimmy/orch/pull/148)
+- A verification entry whose text describes the branch as a whole is
+  given its `branch-scope:` name prefix at `pr-open`, where the name is
+  first chosen; before, a prefix added on a later review cycle appended
+  a second entry instead of replacing the original, leaving the stale
+  unprefixed one in the audit record permanently —
+  [#113](https://github.com/kninetimmy/orch/pull/113)
+- `.gitattributes` gained the rule that checks `.gitignore` out with LF
+  on every platform; before, a Windows checkout could get CRLF line
+  endings in that file, which is what feeds the empty-pattern hazard
+  the next entry describes —
+  [#110](https://github.com/kninetimmy/orch/pull/110)
 - Worktree containment no longer fails open on a `.gitignore` whose
   blank line survives as an empty pattern — a CRLF blank line, or a
   whitespace-only line under LF — because `RequireIgnored` now queries


### PR DESCRIPTION
Delivers issue #168: Correct README.md's release-version references and Status counts for v0.6.0

Closes #168

**Plan digest:** `sha256:3120534e3e9b4fec35057e00b1296076323d0cfe4c4f2e9759193ac0eabd481d`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Every claim README.md makes about this repository's own release history is stale. The Release badge, three release-tag examples in the install instructions, and the Fixed section's opening sentence all name v0.5.7, which was superseded by v0.5.8, v0.5.10 and v0.6.0. The Status paragraph's four counts were measured before twenty-one further pull requests merged. Bring all of it to the state at v0.6.0, and extend the Fixed list to cover the defects corrected since it was last written.

**Acceptance criteria:**
- README.md contains no occurrence of the string v0.5.7. The Release badge names v0.6.0 in both its shields.io image URL and its alt text, and every release-tag example in the install instructions - the orch status step of the agent-install prompt, the ORCH_VERSION example, and the -Version example - names v0.6.0.
- The Status section states that this repository has 15 tagged releases spanning v0.1.0 through v0.6.0, and 96 merged pull requests.
- The Status section states that 55 of those merged pull requests carry an Orch audit record in their body, identifies them as every merge from PR #40 through PR #167 except #50, #103, #121, #129 and #133, and keeps its existing explanation that the exceptions are orch configure deliveries carrying their own body format.
- The Fixed section's opening sentence states that everything listed is merged on main and shipped in v0.6.0, the latest tagged release, and no longer claims that any listed pull request is waiting for a future release.
- The Fixed list gains one entry for each of pull requests #167, #166, #158, #148, #113 and #110, placed newest first above the existing #106 entry, and each new entry describes what a user would have observed going wrong before that fix in the same symptom-then-link form the existing entries use.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — 23 packages ok, 3 with no test files, no failures. Reported honestly: no Go test pins README.md, so this command passes on an untouched or a wrong README alike. It is the issue's required test, not evidence the change is correct. — commit `cda274fc6adeac725ad770559b8009473b4084ac` (2026-08-01T17:38:48Z)
- **gofmt** — pass — `gofmt -l .` — No output, exit 0. Same caveat as go-test: the change is markdown only, so gofmt cannot observe it. — commit `cda274fc6adeac725ad770559b8009473b4084ac` (2026-08-01T17:38:48Z)
- **branch-scope: diff** — pass — `git fetch origin main && git diff --stat origin/main...orch/issue-168-correct-readme-md-s-release-version-refe && git rev-list --count origin/main..orch/issue-168-correct-readme-md-s-release-version-refe` — 1 commit (cda274f) ahead of origin/main at d02ee0d. One file changed: README.md, 49 insertions, 9 deletions. Measured against a freshly fetched origin/main, not a local ref. — commit `cda274fc6adeac725ad770559b8009473b4084ac` (2026-08-01T17:38:48Z)
- **criterion-1-v0.5.7-absent** — pass — `git grep -c "v0\\.5\\.7" orch/issue-168-correct-readme-md-s-release-version-refe -- README.md` — No matches (exit 1). The string v0.5.7 does not occur anywhere in README.md on the branch head. — commit `cda274fc6adeac725ad770559b8009473b4084ac` (2026-08-01T17:38:48Z)
- **criteria-2-3-counts-reconfirmed** — pass — `gh release list --limit 100; gh pr list --state merged --limit 300; body scan for the literal <!-- orch:manifest:begin -->` — Executor independently re-derived every number rather than inheriting the Architect's: 15 releases v0.1.0 through v0.6.0 with no v0.5.9; 96 merged pull requests; 55 carrying an audit record, min #40 max #167; the five merged PRs in that range without one are #50, #103, #121, #129, #133, and it pulled all five titles to confirm each is an 'Update orch configuration' delivery before extending the README's existing explanation to cover them. — commit `cda274fc6adeac725ad770559b8009473b4084ac` (2026-08-01T17:38:48Z)
- **prose-word-diff** — pass — `git diff --word-diff --ignore-all-space -- README.md` — Every removal marker covers intended content: the four v0.5.7 strings, the counts 12/75/37/#117, '#50 and' to '#50,', 'both' to 'all', and the deliberately deleted sentence claiming #113/#115/#117 ship in a future release. No unintended word loss. The executor noted the word diff interleaves a few common tokens as alignment noise around the deleted sentence, and confirmed the rendered text reads correctly. — commit `cda274fc6adeac725ad770559b8009473b4084ac` (2026-08-01T17:38:48Z)
- **reviewer-independent-count-rederivation** — pass — `gh release list --limit 200; git ls-remote --tags origin; gh pr list --state merged --limit 500; body scan for the literal <!-- orch:manifest:begin -->; gh api repos/:owner/:repo/git/ref/tags/v0.6.0` — Reviewer re-derived every number from scratch rather than inheriting the executor's. 15 releases v0.1.0 through v0.6.0, no v0.5.9, cross-checked against the remote tag list. 96 merged pull requests. 55 carrying an audit record, min #40 max #167. Exceptions exactly [50, 103, 121, 129, 133]. v0.6.0 tag resolves to d02ee0d, the merge commit of #167 and current origin/main. Only PR #170 is open, so nothing merged between the executor's derivation and the reviewer's. — commit `cda274fc6adeac725ad770559b8009473b4084ac` (2026-08-01T17:47:56Z)
- **reviewer-required-ci-by-oid** — pass — `gh api check-runs for cda274fc6adeac725ad770559b8009473b4084ac` — All six required CI checks report SUCCESS at the head OID, queried through the check-runs API by object id rather than through gh pr checks, so the result is pinned to the reviewed commit and cannot be a concurrent verb's ref. — commit `cda274fc6adeac725ad770559b8009473b4084ac` (2026-08-01T17:47:56Z)
- **acceptance-criterion-1** — satisfied — grep -c "v0\.5\.7" README.md in the review worktree returns 0, exit 1. README.md:8 carries Release-v0.6.0 in the shields.io URL and alt="Release: v0.6.0". The three install examples are at README.md:104 (the orch status step of the agent-install prompt), :192 (ORCH_VERSION=v0.6.0) and :202 (-Version v0.6.0). v0.6.0 is confirmed the real latest tag. — commit `cda274fc6adeac725ad770559b8009473b4084ac` (2026-08-01T17:47:57Z)
- **acceptance-criterion-2** — satisfied — README.md:73 reads '15 tagged releases (v0.1.0 through v0.6.0) and 96 merged pull requests'. Both numbers were re-derived independently: gh release list --limit 200 cross-checked against git ls-remote --tags origin gives 15 with earliest v0.1.0 and latest v0.6.0 and no v0.5.9; gh pr list --state merged --limit 500 gives 96. — commit `cda274fc6adeac725ad770559b8009473b4084ac` (2026-08-01T17:47:57Z)
- **acceptance-criterion-3** — satisfied — README.md:73 continues with 55 carrying an audit record, the #40 through #167 span, and the exception set #50, #103, #121, #129, #133. Scanning all 96 merged bodies for the literal &lt;!-- orch:manifest:begin --&gt; reproduces 55 with min #40 and max #167, and the merged PRs in that range lacking it are exactly those five, no more and no fewer. Each was opened with gh pr view and confirmed to be titled 'Update orch configuration' with the Detection/Configuration body format, so the existing explanation is correctly extended rather than merely generalized. The only prose change is 'both of which' to 'all of which', forced by the count going from two to five. — commit `cda274fc6adeac725ad770559b8009473b4084ac` (2026-08-01T17:47:57Z)
- **acceptance-criterion-4** — satisfied — README.md:507-508 now reads 'Everything here is merged on main and shipped in v0.6.0, the latest tagged release.' The sentence claiming #113, #115 and #117 ship in the next release rather than the current one is gone, visible as a deletion in the diff. The new claim is factually true: gh api on the v0.6.0 tag ref resolves to d02ee0d, which is the merge commit of #167 and is current origin/main, so every merged pull request in the list is shipped. — commit `cda274fc6adeac725ad770559b8009473b4084ac` (2026-08-01T17:47:57Z)
- **acceptance-criterion-5** — satisfied — Six new entries at README.md:510, 517, 524, 532, 540 and 546 for #167, #166, #158, #148, #113 and #110, all above the existing #106 entry at :551. Ordering is strictly newest-first by merge time rather than by number, which matters here: #110 merged 07-28T23:28Z, after #106 at 21:52Z, so its placement is correct. Each entry was read against its own pull request, and the two describing engine behavior were checked against the code as well. #110's entry correctly does not claim that PR fixed the empty-pattern hazard, only that a CRLF .gitignore feeds it, and the 'next entry' it points at is indeed the #106 entry immediately below. All six use the existing symptom-then-link form, 2-space continuation indent, LF endings, and the link on its own line after an em dash. — commit `cda274fc6adeac725ad770559b8009473b4084ac` (2026-08-01T17:47:57Z)
- **review-cycle-1** — approve — Approve. One commit, one file, README.md +49/-9 against origin/main at d02ee0d; no code, config, or adapter touched. Every number in the change was re-derived from scratch with gh rather than inherited from the executor or the Architect, and all of it reproduces exactly: 15 releases v0.1.0 through v0.6.0 with no v0.5.9 (cross-checked against git ls-remote --tags), 96 merged pull requests, 55 carrying the literal &lt;!-- orch:manifest:begin --&gt; spanning #40 to #167, and exactly the five exceptions #50, #103, #121, #129, #133, each confirmed by title and body format to be an orch configure delivery. The v0.6.0 tag resolves to d02ee0d, which is the merge commit of #167 and current origin/main, so the Fixed section's new everything-is-shipped claim is true. All six new Fixed entries were read against their own pull requests and, where the entry describes engine behavior, against the code: doctor.go:122-125 and checkAdapter at :216-295 for #167, doctor.go:129-137 and activate.go:187-193 for #166. Decision 94 respected: the Release badge is still a static shields.io literal with only its version string changed. Required CI is green at the head OID, queried through the check-runs API by OID rather than gh pr checks. Five non-blocking findings, all to the backlog: the #167 entry's closing clause overstates that all four failure cases name both the installed and expected version (the absent case names only the expected one, doctor.go:263); the Known-issues paragraph at README.md:465-472 still says a stale Codex TOML merely keeps running the old model, which #166 changed to an outright activation refusal, a staleness that predates this PR and sits outside its criteria; #115 and #117 lost their only mention when the future-release sentence was deleted; #110's own audit record calls itself repository hygiene rather than a bug fix, so listing it under Defects is a mild category stretch inherited from the criterion; and the Status counts go stale on merge, which is inherent to a hand-maintained snapshot and is why this issue exists. Both required tests pass and neither observes README.md, which the executor disclosed and the reviewer confirms: they are satisfied as required tests but are not evidence for any criterion. — commit `cda274fc6adeac725ad770559b8009473b4084ac` (2026-08-01T17:47:57Z)
- **required-ci** — passing — scripts (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, scripts (windows-latest)=pass — commit `cda274fc6adeac725ad770559b8009473b4084ac` (2026-08-01T17:48:15Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Every claim README.md makes about this repository's own release history is stale. The Release badge, three release-tag examples in the install instructions, and the Fixed section's opening sentence all name v0.5.7, which was superseded by v0.5.8, v0.5.10 and v0.6.0. The Status paragraph's four counts were measured before twenty-one further pull requests merged. Bring all of it to the state at v0.6.0, and extend the Fixed list to cover the defects corrected since it was last written.",
  "acceptance_criteria": [
    "README.md contains no occurrence of the string v0.5.7. The Release badge names v0.6.0 in both its shields.io image URL and its alt text, and every release-tag example in the install instructions - the orch status step of the agent-install prompt, the ORCH_VERSION example, and the -Version example - names v0.6.0.",
    "The Status section states that this repository has 15 tagged releases spanning v0.1.0 through v0.6.0, and 96 merged pull requests.",
    "The Status section states that 55 of those merged pull requests carry an Orch audit record in their body, identifies them as every merge from PR #40 through PR #167 except #50, #103, #121, #129 and #133, and keeps its existing explanation that the exceptions are orch configure deliveries carrying their own body format.",
    "The Fixed section's opening sentence states that everything listed is merged on main and shipped in v0.6.0, the latest tagged release, and no longer claims that any listed pull request is waiting for a future release.",
    "The Fixed list gains one entry for each of pull requests #167, #166, #158, #148, #113 and #110, placed newest first above the existing #106 entry, and each new entry describes what a user would have observed going wrong before that fix in the same symptom-then-link form the existing entries use."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "23 packages ok, 3 with no test files, no failures. Reported honestly: no Go test pins README.md, so this command passes on an untouched or a wrong README alike. It is the issue's required test, not evidence the change is correct.",
      "commit_oid": "cda274fc6adeac725ad770559b8009473b4084ac",
      "at": "2026-08-01T17:38:48Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No output, exit 0. Same caveat as go-test: the change is markdown only, so gofmt cannot observe it.",
      "commit_oid": "cda274fc6adeac725ad770559b8009473b4084ac",
      "at": "2026-08-01T17:38:48Z"
    },
    {
      "name": "branch-scope: diff",
      "command": "git fetch origin main \u0026\u0026 git diff --stat origin/main...orch/issue-168-correct-readme-md-s-release-version-refe \u0026\u0026 git rev-list --count origin/main..orch/issue-168-correct-readme-md-s-release-version-refe",
      "result": "pass",
      "detail": "1 commit (cda274f) ahead of origin/main at d02ee0d. One file changed: README.md, 49 insertions, 9 deletions. Measured against a freshly fetched origin/main, not a local ref.",
      "commit_oid": "cda274fc6adeac725ad770559b8009473b4084ac",
      "at": "2026-08-01T17:38:48Z"
    },
    {
      "name": "criterion-1-v0.5.7-absent",
      "command": "git grep -c \"v0\\\\.5\\\\.7\" orch/issue-168-correct-readme-md-s-release-version-refe -- README.md",
      "result": "pass",
      "detail": "No matches (exit 1). The string v0.5.7 does not occur anywhere in README.md on the branch head.",
      "commit_oid": "cda274fc6adeac725ad770559b8009473b4084ac",
      "at": "2026-08-01T17:38:48Z"
    },
    {
      "name": "criteria-2-3-counts-reconfirmed",
      "command": "gh release list --limit 100; gh pr list --state merged --limit 300; body scan for the literal \u003c!-- orch:manifest:begin --\u003e",
      "result": "pass",
      "detail": "Executor independently re-derived every number rather than inheriting the Architect's: 15 releases v0.1.0 through v0.6.0 with no v0.5.9; 96 merged pull requests; 55 carrying an audit record, min #40 max #167; the five merged PRs in that range without one are #50, #103, #121, #129, #133, and it pulled all five titles to confirm each is an 'Update orch configuration' delivery before extending the README's existing explanation to cover them.",
      "commit_oid": "cda274fc6adeac725ad770559b8009473b4084ac",
      "at": "2026-08-01T17:38:48Z"
    },
    {
      "name": "prose-word-diff",
      "command": "git diff --word-diff --ignore-all-space -- README.md",
      "result": "pass",
      "detail": "Every removal marker covers intended content: the four v0.5.7 strings, the counts 12/75/37/#117, '#50 and' to '#50,', 'both' to 'all', and the deliberately deleted sentence claiming #113/#115/#117 ship in a future release. No unintended word loss. The executor noted the word diff interleaves a few common tokens as alignment noise around the deleted sentence, and confirmed the rendered text reads correctly.",
      "commit_oid": "cda274fc6adeac725ad770559b8009473b4084ac",
      "at": "2026-08-01T17:38:48Z"
    },
    {
      "name": "reviewer-independent-count-rederivation",
      "command": "gh release list --limit 200; git ls-remote --tags origin; gh pr list --state merged --limit 500; body scan for the literal \u003c!-- orch:manifest:begin --\u003e; gh api repos/:owner/:repo/git/ref/tags/v0.6.0",
      "result": "pass",
      "detail": "Reviewer re-derived every number from scratch rather than inheriting the executor's. 15 releases v0.1.0 through v0.6.0, no v0.5.9, cross-checked against the remote tag list. 96 merged pull requests. 55 carrying an audit record, min #40 max #167. Exceptions exactly [50, 103, 121, 129, 133]. v0.6.0 tag resolves to d02ee0d, the merge commit of #167 and current origin/main. Only PR #170 is open, so nothing merged between the executor's derivation and the reviewer's.",
      "commit_oid": "cda274fc6adeac725ad770559b8009473b4084ac",
      "at": "2026-08-01T17:47:56Z"
    },
    {
      "name": "reviewer-required-ci-by-oid",
      "command": "gh api check-runs for cda274fc6adeac725ad770559b8009473b4084ac",
      "result": "pass",
      "detail": "All six required CI checks report SUCCESS at the head OID, queried through the check-runs API by object id rather than through gh pr checks, so the result is pinned to the reviewed commit and cannot be a concurrent verb's ref.",
      "commit_oid": "cda274fc6adeac725ad770559b8009473b4084ac",
      "at": "2026-08-01T17:47:56Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "grep -c \"v0\\.5\\.7\" README.md in the review worktree returns 0, exit 1. README.md:8 carries Release-v0.6.0 in the shields.io URL and alt=\"Release: v0.6.0\". The three install examples are at README.md:104 (the orch status step of the agent-install prompt), :192 (ORCH_VERSION=v0.6.0) and :202 (-Version v0.6.0). v0.6.0 is confirmed the real latest tag.",
      "commit_oid": "cda274fc6adeac725ad770559b8009473b4084ac",
      "at": "2026-08-01T17:47:57Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "README.md:73 reads '15 tagged releases (v0.1.0 through v0.6.0) and 96 merged pull requests'. Both numbers were re-derived independently: gh release list --limit 200 cross-checked against git ls-remote --tags origin gives 15 with earliest v0.1.0 and latest v0.6.0 and no v0.5.9; gh pr list --state merged --limit 500 gives 96.",
      "commit_oid": "cda274fc6adeac725ad770559b8009473b4084ac",
      "at": "2026-08-01T17:47:57Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "README.md:73 continues with 55 carrying an audit record, the #40 through #167 span, and the exception set #50, #103, #121, #129, #133. Scanning all 96 merged bodies for the literal \u003c!-- orch:manifest:begin --\u003e reproduces 55 with min #40 and max #167, and the merged PRs in that range lacking it are exactly those five, no more and no fewer. Each was opened with gh pr view and confirmed to be titled 'Update orch configuration' with the Detection/Configuration body format, so the existing explanation is correctly extended rather than merely generalized. The only prose change is 'both of which' to 'all of which', forced by the count going from two to five.",
      "commit_oid": "cda274fc6adeac725ad770559b8009473b4084ac",
      "at": "2026-08-01T17:47:57Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "README.md:507-508 now reads 'Everything here is merged on main and shipped in v0.6.0, the latest tagged release.' The sentence claiming #113, #115 and #117 ship in the next release rather than the current one is gone, visible as a deletion in the diff. The new claim is factually true: gh api on the v0.6.0 tag ref resolves to d02ee0d, which is the merge commit of #167 and is current origin/main, so every merged pull request in the list is shipped.",
      "commit_oid": "cda274fc6adeac725ad770559b8009473b4084ac",
      "at": "2026-08-01T17:47:57Z"
    },
    {
      "name": "acceptance-criterion-5",
      "result": "satisfied",
      "detail": "Six new entries at README.md:510, 517, 524, 532, 540 and 546 for #167, #166, #158, #148, #113 and #110, all above the existing #106 entry at :551. Ordering is strictly newest-first by merge time rather than by number, which matters here: #110 merged 07-28T23:28Z, after #106 at 21:52Z, so its placement is correct. Each entry was read against its own pull request, and the two describing engine behavior were checked against the code as well. #110's entry correctly does not claim that PR fixed the empty-pattern hazard, only that a CRLF .gitignore feeds it, and the 'next entry' it points at is indeed the #106 entry immediately below. All six use the existing symptom-then-link form, 2-space continuation indent, LF endings, and the link on its own line after an em dash.",
      "commit_oid": "cda274fc6adeac725ad770559b8009473b4084ac",
      "at": "2026-08-01T17:47:57Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approve. One commit, one file, README.md +49/-9 against origin/main at d02ee0d; no code, config, or adapter touched. Every number in the change was re-derived from scratch with gh rather than inherited from the executor or the Architect, and all of it reproduces exactly: 15 releases v0.1.0 through v0.6.0 with no v0.5.9 (cross-checked against git ls-remote --tags), 96 merged pull requests, 55 carrying the literal \u003c!-- orch:manifest:begin --\u003e spanning #40 to #167, and exactly the five exceptions #50, #103, #121, #129, #133, each confirmed by title and body format to be an orch configure delivery. The v0.6.0 tag resolves to d02ee0d, which is the merge commit of #167 and current origin/main, so the Fixed section's new everything-is-shipped claim is true. All six new Fixed entries were read against their own pull requests and, where the entry describes engine behavior, against the code: doctor.go:122-125 and checkAdapter at :216-295 for #167, doctor.go:129-137 and activate.go:187-193 for #166. Decision 94 respected: the Release badge is still a static shields.io literal with only its version string changed. Required CI is green at the head OID, queried through the check-runs API by OID rather than gh pr checks. Five non-blocking findings, all to the backlog: the #167 entry's closing clause overstates that all four failure cases name both the installed and expected version (the absent case names only the expected one, doctor.go:263); the Known-issues paragraph at README.md:465-472 still says a stale Codex TOML merely keeps running the old model, which #166 changed to an outright activation refusal, a staleness that predates this PR and sits outside its criteria; #115 and #117 lost their only mention when the future-release sentence was deleted; #110's own audit record calls itself repository hygiene rather than a bug fix, so listing it under Defects is a mild category stretch inherited from the criterion; and the Status counts go stale on merge, which is inherent to a hand-maintained snapshot and is why this issue exists. Both required tests pass and neither observes README.md, which the executor disclosed and the reviewer confirms: they are satisfied as required tests but are not evidence for any criterion.",
      "commit_oid": "cda274fc6adeac725ad770559b8009473b4084ac",
      "at": "2026-08-01T17:47:57Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "scripts (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "cda274fc6adeac725ad770559b8009473b4084ac",
      "at": "2026-08-01T17:48:15Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->