### PR TITLE
Close README.md's description gaps: codexusage, review-worktree, two host-tooling limitations, and the tagline pronoun

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Orch
 
-*Your coding agent doesn't choose its own model, and it puts mechanical bounds on what it may write.*
+*Your coding agent doesn't choose its own model, and Orch puts mechanical bounds on what it may write.*
 
 <p align="center">
   <img src="https://img.shields.io/badge/License-MIT-2E7D32?style=flat&logo=opensourceinitiative&logoColor=white" alt="License: MIT"/>
@@ -442,6 +442,36 @@ expected one, and no Orch block at session start. Workaround: install
 the binary before the plugin, approve the trust prompt, and run `orch
 doctor`; a missing session-start block is the visible tell.
 
+**`claude plugin install` on a host that already has the adapter
+changes nothing and leaves the old version running.** Claude Code
+treats an install of a plugin it already carries as satisfied: `claude
+plugin install orch-claude@orch` exits 0 reporting `Plugin
+"orch-claude@orch" is already installed`, even when `claude plugin
+marketplace update orch` has just fetched a newer adapter into the
+plugin cache. Installing and upgrading are two different commands, and
+only `claude plugin update orch-claude@orch` replaces the active
+version (it says `Restart to apply changes` when it does). Symptom:
+following the agent install prompt's step 3 on a machine that already
+has Orch reports success while the previous adapter goes on running.
+Workaround: on an existing install use the upgrade commands above, not
+the first-install ones; `orch doctor` names the installed and the
+expected adapter version when they diverge.
+
+**`orch doctor` fails on a machine that lacks a configured host's
+command-line tool.** Doctor checks every host the committed
+configuration names, and fails when that host's CLI is missing from
+`PATH`, when its plugin listing cannot be read, or when its adapter is
+absent, ambiguous, disabled or a different version from the one this
+build ships. Host enablement is a committed-only key — the Settings
+table above marks `hosts.claude` / `hosts.codex` as `no (committed)` —
+so machine-local configuration cannot switch a host off for one
+machine. Symptom: a repository configured for both hosts reports a
+failing doctor on every machine that has only one of them installed.
+Workaround: enable only the hosts every machine working on the
+repository will have, or install the missing CLI on that machine.
+There is no override for this, by design: the check exists so an
+adapter that is absent or out of date is reported rather than trusted.
+
 **Codex `workspace-write` sandbox mode on Windows fails every agent
 write where the sandbox helper infrastructure is absent.** Observed
 live: every `apply_patch` fails with `orchestrator_helper_launch_failed`
@@ -677,7 +707,9 @@ pull request), and one branch and isolated worktree per issue under
 Each issue then walks a closed lifecycle driven by plumbing verbs:
 `dispatch` (dependencies must be merged; the branch is fast-forwarded
 onto the default branch) → `pr-open` (clean, strictly-ahead,
-orphan-PR guarded) → `review` (the routed reviewer, verified against
+orphan-PR guarded) → `review-worktree` (a disposable detached
+worktree of the pull request head, so the review does not run in the
+primary checkout) → `review` (the routed reviewer, verified against
 the live PR head) → `ci` (reads required checks as one of four honest
 states — `passing`, `failing`, `pending`, or the explicit `no-checks`,
 which is never conflated with passing) → `merge-report` (pins the
@@ -735,6 +767,7 @@ its own.
 | `internal/manifest/` | The issue/PR audit record — lossless render/parse over a managed body region |
 | `internal/memhub/` | Read-only client for the external memhub CLI: health probe and fixed-canary recall check |
 | `internal/metrics/` | Local, opt-in per-run JSON metrics recorder (schema-versioned, never transmitted) |
+| `internal/codexusage/` | Reader that recovers exact Codex subagent token totals from persisted child rollout files |
 | `internal/routing/` | Pure role routing and the escalation ladder |
 | `internal/guard/` | Mechanical pre-write enforcement behind host PreToolUse hooks |
 | `internal/run/` | The Delivery run engine: plan gate, activation, per-issue lifecycle, resume |


### PR DESCRIPTION
Delivers issue #169: Close README.md's description gaps: codexusage, review-worktree, two host-tooling limitations, and the tagline pronoun

Closes #169

**Plan digest:** `sha256:3120534e3e9b4fec35057e00b1296076323d0cfe4c4f2e9759193ac0eabd481d`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Three things the README describes are now incomplete, and one sentence reads backwards. The package-layout table has no row for internal/codexusage, which has existed since the Codex subagent token-capture work. The Delivery pipeline's lifecycle walk goes straight from pr-open to review and never names review-worktree, the verb that keeps a reviewer out of the primary checkout. Known issues records neither of the two host-tooling failures found since the section was last written. And the tagline's second clause reads as the agent bounding itself, which inverts the pitch.

**Acceptance criteria:**
- The package-layout table lists internal/codexusage with a purpose describing it as the reader that recovers exact Codex subagent token totals from persisted rollout files, in the same one-line register the table's other rows use.
- The Delivery pipeline section's lifecycle walk names review-worktree in its correct position between pr-open and review, and states what it does: it gives the reviewer a disposable detached worktree of the pull request head so the review does not run in the primary checkout.
- The Known issues section gains an entry stating that orch doctor fails when the committed configuration names a host whose command-line tool is not installed on that machine, that machine-local configuration cannot switch a host off because host enablement is a committed-only key, and what a user on such a machine can actually do.
- The Known issues section gains an entry stating that running the plugin install command against a host that already has the adapter installed reports it as already installed and leaves the previous version active, and that the separate plugin update command is what actually upgrades it.
- The tagline directly under the README's title names Orch, rather than a pronoun, as the thing that bounds what the agent may write, so the sentence cannot be read as the agent bounding itself.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — All 24 packages ok, no failures. Reported honestly: no Go test pins README.md, so this passes on an untouched or a wrong README alike. It is the issue's required test, not evidence the change is correct. — commit `8e8b54edc09a8694e04e3d8b21c8490af3dd97e1` (2026-08-01T17:55:11Z)
- **gofmt** — pass — `gofmt -l .` — Empty listing, exit 0. Vacuous here: no Go file changed. — commit `8e8b54edc09a8694e04e3d8b21c8490af3dd97e1` (2026-08-01T17:55:11Z)
- **branch-scope: diff** — pass — `git fetch origin main && git diff --stat origin/main...orch/issue-169-close-readme-md-s-description-gaps-codex && git rev-list --count origin/main..orch/issue-169-close-readme-md-s-description-gaps-codex` — 1 commit (8e8b54e) ahead of origin/main at 94896fd, which is the squash of PR #170 from wave 1. One file changed: README.md, 35 insertions, 2 deletions. Measured against a freshly fetched origin/main, not a local ref. — commit `8e8b54edc09a8694e04e3d8b21c8490af3dd97e1` (2026-08-01T17:55:11Z)
- **prose-word-diff** — pass — `git diff --word-diff --ignore-all-space -- README.md` — The single removal marker in the entire diff is [-it-] in the tagline, replaced by {+Orch+}, which is criterion 5's intended change. The reflowed lifecycle-walk paragraph produced only addition markers, so no word was dropped in the one paragraph this change reflows. — commit `8e8b54edc09a8694e04e3d8b21c8490af3dd97e1` (2026-08-01T17:55:11Z)
- **criterion-3-source-check** — pass — `read internal/cli/doctor.go runDoctor per-host branches and checkAdapter; read the README Settings table row for hosts.claude / hosts.codex` — Executor confirmed against source rather than inheriting the Architect's brief: runDoctor probes every host the committed configuration names, checkAdapter hard-fails on a missing executable, and the README's own Settings table already marks hosts.* as committed-only, so the new entry's claim that machine-local configuration cannot switch a host off is consistent with what the README already states elsewhere. — commit `8e8b54edc09a8694e04e3d8b21c8490af3dd97e1` (2026-08-01T17:55:11Z)
- **brief-correction-head-oid-width** — pass — `read internal/run/reviewworktree.go headOIDPattern` — The executor contradicted the Architect's dispatch brief and was right. The brief said orch run review-worktree takes a full 40-hex object id; headOIDPattern is ^[0-9a-fA-F]{40}$|^[0-9a-fA-F]{64}$, accepting a full SHA-1 or a full SHA-256 id and rejecting abbreviations and symbolic names in both cases. Not load-bearing for any criterion here, since the README text this change adds says nothing about the field's width, but recorded so the error does not propagate. This matches memhub task 88 item 2, which documents the same two-width pattern and notes it is not hash-algorithm-aware. — commit `8e8b54edc09a8694e04e3d8b21c8490af3dd97e1` (2026-08-01T17:55:11Z)
- **reviewer-source-crosscheck** — pass — `read internal/codexusage/capture.go, internal/cli/codexusage.go, internal/cli/run.go, internal/run/lifecycle.go, internal/run/run.go, internal/run/reviewworktree.go, internal/cli/doctor.go, internal/config/overlay.go, internal/cli/cli.go` — Every factual claim the new README text makes about doctor, the config overlay, review-worktree and codexusage was checked against the implementation at this head, with file and line cited for each. No claim was accepted from the prose or from the dispatch brief. — commit `8e8b54edc09a8694e04e3d8b21c8490af3dd97e1` (2026-08-01T18:02:30Z)
- **reviewer-independent-word-diff** — pass — `git diff --word-diff=plain --word-diff-regex='[^[:space:]]+'` — Run independently of the executor's. Exactly one removal marker in the entire diff: [-it-] replaced by {+Orch+} in the tagline. The reflowed lifecycle-walk paragraph at README.md:708-712 produced addition markers only. No word was lost. — commit `8e8b54edc09a8694e04e3d8b21c8490af3dd97e1` (2026-08-01T18:02:30Z)
- **reviewer-required-ci-and-mergeability** — pass — `gh checks and gh pr view for 8e8b54edc09a8694e04e3d8b21c8490af3dd97e1` — All six required CI checks SUCCESS at the reviewed head OID, and mergeStateStatus is CLEAN. — commit `8e8b54edc09a8694e04e3d8b21c8490af3dd97e1` (2026-08-01T18:02:30Z)
- **acceptance-criterion-1** — satisfied — README.md:768 adds the row 'internal/codexusage/ | Reader that recovers exact Codex subagent token totals from persisted child rollout files'. Checked against internal/codexusage/capture.go:1-2, whose package doc says it recovers exact completed Codex child-rollout totals, and against TotalTokens at :27-70, which returns (int64, bool) and answers false on every ambiguity: two matching rollouts, a malformed identified rollout, or a missing terminal token_count and task_complete pair. The row does not overstate, because it promises exactness, which is the design, and never promises a value. The input description is right: internal/cli/codexusage.go:64-73 reads $CODEX_HOME/sessions or ~/.codex/sessions, and :14-21 confirms these are Codex subagent child rollouts keyed by parent thread plus spawn task identity. Length and register match the metrics and routing rows it sits between. — commit `8e8b54edc09a8694e04e3d8b21c8490af3dd97e1` (2026-08-01T18:02:31Z)
- **acceptance-criterion-2** — satisfied — README.md:708-712. The verb exists and is dispatched at internal/cli/run.go:25, which maps review-worktree to run.ReviewWorktree. Its position between pr-open and review is correct in all three places that order the lifecycle: the usage string at internal/cli/run.go:15, internal/run/lifecycle.go:6, and internal/run/run.go:15-16. Disposable and detached are both real: internal/run/reviewworktree.go:126-133 removes any prior checkout for the issue via RemoveDetachedWorktree, tolerating ErrUnknownWorktree, then calls AddDetachedWorktree at the requested head. The clause 'so the review does not run in the primary checkout' restates the verb's own doc comment at :57-60. No property is claimed that the verb lacks. — commit `8e8b54edc09a8694e04e3d8b21c8490af3dd97e1` (2026-08-01T18:02:31Z)
- **acceptance-criterion-3** — satisfied — README.md:462-474. It hard-fails rather than warns: internal/cli/doctor.go:120-127 runs checkAdapter for every host the config names, checkAdapter:225-227 returns an error when LookPath on the host executable fails, check sets failed at :53-57, and runDoctor:202-204 returns 'one or more checks failed'. That is materially different from the deliberately soft note paths at :84, :99 and :179 in the same function, so 'fails' is the correct word. Host enablement really is committed-only: internal/config/overlay.go:38-55's leafClasses contains no hosts.&lt;host&gt; leaf at all, only hosts.&lt;host&gt;.roles.&lt;role&gt;.model and .effort as preference keys; a bare [hosts.x] table header in the local file is skipped at :124-127, and mergeOverride at :147 applies only named preference keys, so no local file can remove a host. The README's own Settings table row at :329 already says the same thing, so the cross-reference is verbatim accurate. Nothing is invented: the entry offers only enabling fewer hosts or installing the missing CLI, and doctor is registered as noArgs at internal/cli/cli.go:71 and takes no flags at all. — commit `8e8b54edc09a8694e04e3d8b21c8490af3dd97e1` (2026-08-01T18:02:31Z)
- **acceptance-criterion-4** — satisfied — README.md:445-460, and it stays inside its evidence. The reviewer pulled memhub fact 78 claude-plugin-install-no-ops-on-upgrade directly rather than trusting the brief, and found it carries both the cache-versus-installed_plugins.json observation and the literal string 'Restart to apply changes', so the entry's parenthetical is quoted evidence rather than inference. The exit-0 already-installed claim matches the Architect's independent re-run. Nothing generalizes to Codex: both the headline and every command in the body are claude commands, and the README's Codex install and upgrade verbs are different commands entirely (codex plugin add at :220 versus codex plugin marketplace upgrade at :244), so nothing reads across. Cross-references resolve: the agent-install prompt's step 3 is at :112-119 and the upgrade block is at :236-244, which already opens 'Do not repeat the first-install commands above', so the new entry explains that instruction rather than contradicting it. The entry's doctor claim is true at doctor.go:294-295. — commit `8e8b54edc09a8694e04e3d8b21c8490af3dd97e1` (2026-08-01T18:02:31Z)
- **acceptance-criterion-5** — satisfied — README.md:3 now reads 'and Orch puts mechanical bounds on what it may write.' The reading in which the agent bounds itself is gone. A residual note, non-blocking: 'it' in 'what it may write' remains formally attachable to Orch, but that reading is semantically implausible and the defect the criterion names is fixed. — commit `8e8b54edc09a8694e04e3d8b21c8490af3dd97e1` (2026-08-01T18:02:31Z)
- **review-cycle-1** — approve — Approve. One commit, one file, README.md +35/-2 against base 94896fd, the squash of PR #170 from wave 1 of this run. Every criterion here asserts something about how this repository actually behaves, and the reviewer checked each claim against the implementation rather than against the prose: internal/codexusage/capture.go and its TotalTokens signature for the new package-layout row; internal/cli/run.go:25, internal/run/lifecycle.go, internal/run/run.go and internal/run/reviewworktree.go:126-133 for the review-worktree clause, confirming the verb exists, sits between pr-open and review in all three places that order the lifecycle, and really does remove-then-add a detached worktree; internal/cli/doctor.go:120-127 and checkAdapter for the doctor entry, confirming a configured host with a missing CLI hard-fails rather than warns, materially unlike the deliberately soft paths at :84, :99 and :179 in the same function; and internal/config/overlay.go:38-55, where leafClasses contains no hosts.&lt;host&gt; leaf at all, so no machine-local file can switch a host off. The doctor entry invents no escape hatch: doctor is registered as noArgs and takes no flags, and the workaround names only enabling fewer hosts or installing the missing CLI. The plugin-install entry stays inside its evidence: the reviewer pulled memhub fact 78 itself and found the parenthetical is quoted from it rather than inferred, and confirmed the entry generalizes nothing to Codex, whose install and upgrade verbs are different commands. Cross-references resolve, and the new entry explains the existing 'Do not repeat the first-install commands above' instruction rather than contradicting it. An independent whitespace-insensitive word diff over the whole file produced exactly one removal marker, [-it-] replaced by {+Orch+} in the tagline, so the reflowed lifecycle paragraph dropped nothing. All six required CI checks are SUCCESS at the head OID with mergeStateStatus CLEAN. Four non-blocking findings to the backlog: the doctor entry's failure list reads as exhaustive but omits two cases checkAdapter also hard-fails on (an empty version string at doctor.go:291-293, and installed:false on Codex at :285-287); the new entry's headline says 'host' where this README uses 'host' strictly for Claude Code and Codex CLI and 'machine' is meant, phrasing inherited from the criterion rather than executor drift; the reworded tagline leaves 'it' formally attachable to Orch, a semantically implausible reading noted only for completeness; and README.md:73's counts were invalidated by PR #170's own merge, which is inherent to a hand-maintained snapshot and outside this issue. Both required tests pass and neither observes README.md, which the executor disclosed and the reviewer confirms. — commit `8e8b54edc09a8694e04e3d8b21c8490af3dd97e1` (2026-08-01T18:02:31Z)
- **required-ci** — passing — scripts (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass — commit `8e8b54edc09a8694e04e3d8b21c8490af3dd97e1` (2026-08-01T18:02:35Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Three things the README describes are now incomplete, and one sentence reads backwards. The package-layout table has no row for internal/codexusage, which has existed since the Codex subagent token-capture work. The Delivery pipeline's lifecycle walk goes straight from pr-open to review and never names review-worktree, the verb that keeps a reviewer out of the primary checkout. Known issues records neither of the two host-tooling failures found since the section was last written. And the tagline's second clause reads as the agent bounding itself, which inverts the pitch.",
  "acceptance_criteria": [
    "The package-layout table lists internal/codexusage with a purpose describing it as the reader that recovers exact Codex subagent token totals from persisted rollout files, in the same one-line register the table's other rows use.",
    "The Delivery pipeline section's lifecycle walk names review-worktree in its correct position between pr-open and review, and states what it does: it gives the reviewer a disposable detached worktree of the pull request head so the review does not run in the primary checkout.",
    "The Known issues section gains an entry stating that orch doctor fails when the committed configuration names a host whose command-line tool is not installed on that machine, that machine-local configuration cannot switch a host off because host enablement is a committed-only key, and what a user on such a machine can actually do.",
    "The Known issues section gains an entry stating that running the plugin install command against a host that already has the adapter installed reports it as already installed and leaves the previous version active, and that the separate plugin update command is what actually upgrades it.",
    "The tagline directly under the README's title names Orch, rather than a pronoun, as the thing that bounds what the agent may write, so the sentence cannot be read as the agent bounding itself."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All 24 packages ok, no failures. Reported honestly: no Go test pins README.md, so this passes on an untouched or a wrong README alike. It is the issue's required test, not evidence the change is correct.",
      "commit_oid": "8e8b54edc09a8694e04e3d8b21c8490af3dd97e1",
      "at": "2026-08-01T17:55:11Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Empty listing, exit 0. Vacuous here: no Go file changed.",
      "commit_oid": "8e8b54edc09a8694e04e3d8b21c8490af3dd97e1",
      "at": "2026-08-01T17:55:11Z"
    },
    {
      "name": "branch-scope: diff",
      "command": "git fetch origin main \u0026\u0026 git diff --stat origin/main...orch/issue-169-close-readme-md-s-description-gaps-codex \u0026\u0026 git rev-list --count origin/main..orch/issue-169-close-readme-md-s-description-gaps-codex",
      "result": "pass",
      "detail": "1 commit (8e8b54e) ahead of origin/main at 94896fd, which is the squash of PR #170 from wave 1. One file changed: README.md, 35 insertions, 2 deletions. Measured against a freshly fetched origin/main, not a local ref.",
      "commit_oid": "8e8b54edc09a8694e04e3d8b21c8490af3dd97e1",
      "at": "2026-08-01T17:55:11Z"
    },
    {
      "name": "prose-word-diff",
      "command": "git diff --word-diff --ignore-all-space -- README.md",
      "result": "pass",
      "detail": "The single removal marker in the entire diff is [-it-] in the tagline, replaced by {+Orch+}, which is criterion 5's intended change. The reflowed lifecycle-walk paragraph produced only addition markers, so no word was dropped in the one paragraph this change reflows.",
      "commit_oid": "8e8b54edc09a8694e04e3d8b21c8490af3dd97e1",
      "at": "2026-08-01T17:55:11Z"
    },
    {
      "name": "criterion-3-source-check",
      "command": "read internal/cli/doctor.go runDoctor per-host branches and checkAdapter; read the README Settings table row for hosts.claude / hosts.codex",
      "result": "pass",
      "detail": "Executor confirmed against source rather than inheriting the Architect's brief: runDoctor probes every host the committed configuration names, checkAdapter hard-fails on a missing executable, and the README's own Settings table already marks hosts.* as committed-only, so the new entry's claim that machine-local configuration cannot switch a host off is consistent with what the README already states elsewhere.",
      "commit_oid": "8e8b54edc09a8694e04e3d8b21c8490af3dd97e1",
      "at": "2026-08-01T17:55:11Z"
    },
    {
      "name": "brief-correction-head-oid-width",
      "command": "read internal/run/reviewworktree.go headOIDPattern",
      "result": "pass",
      "detail": "The executor contradicted the Architect's dispatch brief and was right. The brief said orch run review-worktree takes a full 40-hex object id; headOIDPattern is ^[0-9a-fA-F]{40}$|^[0-9a-fA-F]{64}$, accepting a full SHA-1 or a full SHA-256 id and rejecting abbreviations and symbolic names in both cases. Not load-bearing for any criterion here, since the README text this change adds says nothing about the field's width, but recorded so the error does not propagate. This matches memhub task 88 item 2, which documents the same two-width pattern and notes it is not hash-algorithm-aware.",
      "commit_oid": "8e8b54edc09a8694e04e3d8b21c8490af3dd97e1",
      "at": "2026-08-01T17:55:11Z"
    },
    {
      "name": "reviewer-source-crosscheck",
      "command": "read internal/codexusage/capture.go, internal/cli/codexusage.go, internal/cli/run.go, internal/run/lifecycle.go, internal/run/run.go, internal/run/reviewworktree.go, internal/cli/doctor.go, internal/config/overlay.go, internal/cli/cli.go",
      "result": "pass",
      "detail": "Every factual claim the new README text makes about doctor, the config overlay, review-worktree and codexusage was checked against the implementation at this head, with file and line cited for each. No claim was accepted from the prose or from the dispatch brief.",
      "commit_oid": "8e8b54edc09a8694e04e3d8b21c8490af3dd97e1",
      "at": "2026-08-01T18:02:30Z"
    },
    {
      "name": "reviewer-independent-word-diff",
      "command": "git diff --word-diff=plain --word-diff-regex='[^[:space:]]+'",
      "result": "pass",
      "detail": "Run independently of the executor's. Exactly one removal marker in the entire diff: [-it-] replaced by {+Orch+} in the tagline. The reflowed lifecycle-walk paragraph at README.md:708-712 produced addition markers only. No word was lost.",
      "commit_oid": "8e8b54edc09a8694e04e3d8b21c8490af3dd97e1",
      "at": "2026-08-01T18:02:30Z"
    },
    {
      "name": "reviewer-required-ci-and-mergeability",
      "command": "gh checks and gh pr view for 8e8b54edc09a8694e04e3d8b21c8490af3dd97e1",
      "result": "pass",
      "detail": "All six required CI checks SUCCESS at the reviewed head OID, and mergeStateStatus is CLEAN.",
      "commit_oid": "8e8b54edc09a8694e04e3d8b21c8490af3dd97e1",
      "at": "2026-08-01T18:02:30Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "README.md:768 adds the row 'internal/codexusage/ | Reader that recovers exact Codex subagent token totals from persisted child rollout files'. Checked against internal/codexusage/capture.go:1-2, whose package doc says it recovers exact completed Codex child-rollout totals, and against TotalTokens at :27-70, which returns (int64, bool) and answers false on every ambiguity: two matching rollouts, a malformed identified rollout, or a missing terminal token_count and task_complete pair. The row does not overstate, because it promises exactness, which is the design, and never promises a value. The input description is right: internal/cli/codexusage.go:64-73 reads $CODEX_HOME/sessions or ~/.codex/sessions, and :14-21 confirms these are Codex subagent child rollouts keyed by parent thread plus spawn task identity. Length and register match the metrics and routing rows it sits between.",
      "commit_oid": "8e8b54edc09a8694e04e3d8b21c8490af3dd97e1",
      "at": "2026-08-01T18:02:31Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "README.md:708-712. The verb exists and is dispatched at internal/cli/run.go:25, which maps review-worktree to run.ReviewWorktree. Its position between pr-open and review is correct in all three places that order the lifecycle: the usage string at internal/cli/run.go:15, internal/run/lifecycle.go:6, and internal/run/run.go:15-16. Disposable and detached are both real: internal/run/reviewworktree.go:126-133 removes any prior checkout for the issue via RemoveDetachedWorktree, tolerating ErrUnknownWorktree, then calls AddDetachedWorktree at the requested head. The clause 'so the review does not run in the primary checkout' restates the verb's own doc comment at :57-60. No property is claimed that the verb lacks.",
      "commit_oid": "8e8b54edc09a8694e04e3d8b21c8490af3dd97e1",
      "at": "2026-08-01T18:02:31Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "README.md:462-474. It hard-fails rather than warns: internal/cli/doctor.go:120-127 runs checkAdapter for every host the config names, checkAdapter:225-227 returns an error when LookPath on the host executable fails, check sets failed at :53-57, and runDoctor:202-204 returns 'one or more checks failed'. That is materially different from the deliberately soft note paths at :84, :99 and :179 in the same function, so 'fails' is the correct word. Host enablement really is committed-only: internal/config/overlay.go:38-55's leafClasses contains no hosts.\u003chost\u003e leaf at all, only hosts.\u003chost\u003e.roles.\u003crole\u003e.model and .effort as preference keys; a bare [hosts.x] table header in the local file is skipped at :124-127, and mergeOverride at :147 applies only named preference keys, so no local file can remove a host. The README's own Settings table row at :329 already says the same thing, so the cross-reference is verbatim accurate. Nothing is invented: the entry offers only enabling fewer hosts or installing the missing CLI, and doctor is registered as noArgs at internal/cli/cli.go:71 and takes no flags at all.",
      "commit_oid": "8e8b54edc09a8694e04e3d8b21c8490af3dd97e1",
      "at": "2026-08-01T18:02:31Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "README.md:445-460, and it stays inside its evidence. The reviewer pulled memhub fact 78 claude-plugin-install-no-ops-on-upgrade directly rather than trusting the brief, and found it carries both the cache-versus-installed_plugins.json observation and the literal string 'Restart to apply changes', so the entry's parenthetical is quoted evidence rather than inference. The exit-0 already-installed claim matches the Architect's independent re-run. Nothing generalizes to Codex: both the headline and every command in the body are claude commands, and the README's Codex install and upgrade verbs are different commands entirely (codex plugin add at :220 versus codex plugin marketplace upgrade at :244), so nothing reads across. Cross-references resolve: the agent-install prompt's step 3 is at :112-119 and the upgrade block is at :236-244, which already opens 'Do not repeat the first-install commands above', so the new entry explains that instruction rather than contradicting it. The entry's doctor claim is true at doctor.go:294-295.",
      "commit_oid": "8e8b54edc09a8694e04e3d8b21c8490af3dd97e1",
      "at": "2026-08-01T18:02:31Z"
    },
    {
      "name": "acceptance-criterion-5",
      "result": "satisfied",
      "detail": "README.md:3 now reads 'and Orch puts mechanical bounds on what it may write.' The reading in which the agent bounds itself is gone. A residual note, non-blocking: 'it' in 'what it may write' remains formally attachable to Orch, but that reading is semantically implausible and the defect the criterion names is fixed.",
      "commit_oid": "8e8b54edc09a8694e04e3d8b21c8490af3dd97e1",
      "at": "2026-08-01T18:02:31Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approve. One commit, one file, README.md +35/-2 against base 94896fd, the squash of PR #170 from wave 1 of this run. Every criterion here asserts something about how this repository actually behaves, and the reviewer checked each claim against the implementation rather than against the prose: internal/codexusage/capture.go and its TotalTokens signature for the new package-layout row; internal/cli/run.go:25, internal/run/lifecycle.go, internal/run/run.go and internal/run/reviewworktree.go:126-133 for the review-worktree clause, confirming the verb exists, sits between pr-open and review in all three places that order the lifecycle, and really does remove-then-add a detached worktree; internal/cli/doctor.go:120-127 and checkAdapter for the doctor entry, confirming a configured host with a missing CLI hard-fails rather than warns, materially unlike the deliberately soft paths at :84, :99 and :179 in the same function; and internal/config/overlay.go:38-55, where leafClasses contains no hosts.\u003chost\u003e leaf at all, so no machine-local file can switch a host off. The doctor entry invents no escape hatch: doctor is registered as noArgs and takes no flags, and the workaround names only enabling fewer hosts or installing the missing CLI. The plugin-install entry stays inside its evidence: the reviewer pulled memhub fact 78 itself and found the parenthetical is quoted from it rather than inferred, and confirmed the entry generalizes nothing to Codex, whose install and upgrade verbs are different commands. Cross-references resolve, and the new entry explains the existing 'Do not repeat the first-install commands above' instruction rather than contradicting it. An independent whitespace-insensitive word diff over the whole file produced exactly one removal marker, [-it-] replaced by {+Orch+} in the tagline, so the reflowed lifecycle paragraph dropped nothing. All six required CI checks are SUCCESS at the head OID with mergeStateStatus CLEAN. Four non-blocking findings to the backlog: the doctor entry's failure list reads as exhaustive but omits two cases checkAdapter also hard-fails on (an empty version string at doctor.go:291-293, and installed:false on Codex at :285-287); the new entry's headline says 'host' where this README uses 'host' strictly for Claude Code and Codex CLI and 'machine' is meant, phrasing inherited from the criterion rather than executor drift; the reworded tagline leaves 'it' formally attachable to Orch, a semantically implausible reading noted only for completeness; and README.md:73's counts were invalidated by PR #170's own merge, which is inherent to a hand-maintained snapshot and outside this issue. Both required tests pass and neither observes README.md, which the executor disclosed and the reviewer confirms.",
      "commit_oid": "8e8b54edc09a8694e04e3d8b21c8490af3dd97e1",
      "at": "2026-08-01T18:02:31Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "scripts (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "8e8b54edc09a8694e04e3d8b21c8490af3dd97e1",
      "at": "2026-08-01T18:02:35Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->