### PR TITLE
Correct README accuracy gaps found by the PR #170 and #171 reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,13 +578,12 @@ tagged release.
   and two matching rollouts still fail closed —
   [#148](https://github.com/kninetimmy/orch/pull/148)
 - Claude Code's two reviewer agents now report every finding they make,
-  low-severity and uncertain ones included, and decide the verdict
-  afterwards: `request-changes` turns only on a finding that blocks an
-  acceptance criterion, so a non-blocking nit is recorded in the report
-  without by itself costing another review cycle; before, neither
-  agent said whether a minor or uncertain finding belonged in the
-  report at all, or what separated an `approve` from a
-  `request-changes` —
+  low-severity and uncertain ones included, each carrying a severity
+  and a confidence, and decide the verdict afterwards as a separate
+  judgment, so a nit stays in the report without by itself costing
+  another review cycle; before, neither agent said whether a minor or
+  uncertain finding belonged in the report at all, nor that the verdict
+  was a judgment made after the findings were listed —
   [#117](https://github.com/kninetimmy/orch/pull/117)
 - A verification entry whose text describes the branch as a whole is
   given its `branch-scope:` name prefix at `pr-open`, where the name is

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The full product definition lives in [ORCH-PRD.md](ORCH-PRD.md).
 
 ## Status
 
-Early software. What can be stated as fact: 15 tagged releases (v0.1.0 through v0.6.0) and 96 merged pull requests, 55 of which carry an Orch audit record in their body — every merge from PR #40 through PR #167 except #50, #103, #121, #129 and #133, all of which `orch configure` delivered in its own body format. Since PR #40, this repository has been built through the pipeline described above: a plan gate, an isolated worktree per issue, a review dispatched separately from the work, CI, and a merge that fails closed unless it carries an approval pinned to the commit `merge-report` recorded.
+Early software. What can be stated as fact: 15 tagged releases, v0.1.0 through v0.6.0, and every pull request merged since PR #40 carries an Orch audit record in its body — apart from the configuration deliveries, which `orch configure` writes in its own body format. Since PR #40, this repository has been built through the pipeline described above: a plan gate, an isolated worktree per issue, a review dispatched separately from the work, CI, and a merge that fails closed unless it carries an approval pinned to the commit `merge-report` recorded.
 
 All of that evidence comes from one repository: this one.
 
@@ -461,8 +461,10 @@ expected adapter version when they diverge.
 command-line tool.** Doctor checks every host the committed
 configuration names, and fails when that host's CLI is missing from
 `PATH`, when its plugin listing cannot be read, or when its adapter is
-absent, ambiguous, disabled or a different version from the one this
-build ships. Host enablement is a committed-only key — the Settings
+anything other than one enabled entry at the version this build ships
+— absent, listed more than once, disabled, reporting no version at
+all, reporting a different version, or, on Codex, marked not
+installed. Host enablement is a committed-only key — the Settings
 table above marks `hosts.claude` / `hosts.codex` as `no (committed)` —
 so machine-local configuration cannot switch a host off for one
 machine. Symptom: a repository configured for both hosts reports a
@@ -491,12 +493,18 @@ either host.** Neither host can override a model per spawn, so the
 routed selection has to match an installed agent definition. On Codex
 that means the five agent TOMLs are a separate install step the
 marketplace install does not perform — you copy them or run `orch
-render-agents` — and after you change `hosts.codex.roles`, dispatched
-agents keep running the model pinned in the installed TOMLs until you
-re-render. On Claude Code the failure is louder: if the routed model
-matches no installed agent's frontmatter, the spawn stops and the
-Architect tells you, rather than silently running a different model.
-Either way, changing a role's model — which the Settings section above
+render-agents` — and after you change `hosts.codex.roles`, the
+installed TOMLs still pin the old model until you re-render. That much
+the binary now catches: `orch doctor` and Codex plan activation both
+compare the rendered definitions against the effective configuration
+and fail closed naming `orch render-agents`, so activation refuses
+rather than dispatching agents pinned to a stale model. On Claude Code
+nothing in the binary checks this. The Architect's skill instructs it
+to compare the routed model against the installed agent's frontmatter
+and, on a mismatch, to stop and tell you rather than spawn a different
+model — so that stop rests on the Architect following an instruction,
+not on a check the engine performs. Either way, changing a role's
+model — which the Settings section above
 recommends as ordinary tuning — is not finished until the installed
 agent definitions carry it too.
 
@@ -539,10 +547,12 @@ tagged release.
 
 - `orch doctor` now checks each configured host's installed Orch
   adapter and fails when it is absent, disabled, ambiguous or a
-  different version from the one this build ships, naming the installed
-  and the expected version; before, an adapter left behind by a
-  binary-only upgrade kept running while doctor reported the host
-  healthy —
+  different version from the one this build ships, naming the expected
+  version and, whenever there is an installed one to name, the
+  installed version too — an absent adapter has no installed version,
+  so that failure reports the expected version alone; before, an
+  adapter left behind by a binary-only upgrade kept running while
+  doctor reported the host healthy —
   [#167](https://github.com/kninetimmy/orch/pull/167)
 - `orch doctor` and Codex plan activation now compare the rendered
   agent definitions in `.codex/agents/` against the current build and
@@ -567,6 +577,15 @@ tagged release.
   child in the run; a rollout that does match is still fully validated
   and two matching rollouts still fail closed —
   [#148](https://github.com/kninetimmy/orch/pull/148)
+- Claude Code's two reviewer agents now report every finding they make,
+  low-severity and uncertain ones included, and decide the verdict
+  afterwards: `request-changes` turns only on a finding that blocks an
+  acceptance criterion, so a non-blocking nit is recorded in the report
+  without by itself costing another review cycle; before, neither
+  agent said whether a minor or uncertain finding belonged in the
+  report at all, or what separated an `approve` from a
+  `request-changes` —
+  [#117](https://github.com/kninetimmy/orch/pull/117)
 - A verification entry whose text describes the branch as a whole is
   given its `branch-scope:` name prefix at `pr-open`, where the name is
   first chosen; before, a prefix added on a later review cycle appended


### PR DESCRIPTION
Delivers issue #172: Correct README accuracy gaps found by the PR #170 and #171 reviews

Closes #172

**Plan digest:** `sha256:733c1a79ad4eee11c77d5cb7f58652fa72804beba64cfc79e42eb576453b1d7b`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Bring README.md's Fixed, Known-issues and Status sections back in line with what the code at this commit actually does. Five separate findings from the two reviews in the v0.6.0 README refresh, plus a Known-issues paragraph both reviewers confirmed stale but left untouched as out of scope. The Status paragraph's hand-maintained totals are reworded so they stop needing a correction after every merge, rather than being reset to numbers that go stale again immediately.

**Acceptance criteria:**
- The Fixed section entry for PR #167 no longer states without qualification that the diagnostic names the installed and the expected adapter version. When no matching adapter is installed at all, checkAdapter in internal/cli/doctor.go reports only the expected version, because there is no installed version to name; the entry is accurate about that case.
- The Known-issues entry about orch doctor failing on a machine that lacks a configured host's command-line tool either covers every case checkAdapter in internal/cli/doctor.go hard-fails on, or is worded so that its list of cases does not read as exhaustive. Two cases the entry currently omits are an installed adapter whose reported version is the empty string, and, on Codex only, an adapter the plugin listing marks as not installed.
- The Known-issues paragraph beginning 'A model override does not reach a dispatched agent by itself, on either host.' describes what Codex activation does at this commit. Since the change in PR #166, activation refuses outright and names orch render-agents rather than dispatching agents that go on running a model pinned by an out-of-date rendered definition. The paragraph's claim that Claude Code is the louder of the two failures is corrected or removed, and the Claude half accurately states that its stop comes from an instruction the Architect follows rather than from a check the engine performs.
- The Fixed section carries an entry for PR #117, whose merged title is 'Reviewer reports every finding; only blocking findings drive request-changes' - a change in behavior a user of Orch would notice. PR #115, whose merged title is 'Add /.codex/ to .gitignore', is added only if it clears that same bar; leaving it out is an acceptable outcome for this criterion.
- The Status paragraph carries no total that the next merge into the default branch falsifies. The count of merged pull requests and the count of those carrying an audit record are either removed or replaced with a claim that stays true as later pull requests merge, and any exception it names is described by kind rather than by a fixed number of exceptions. Every claim the reworded paragraph does make is true at this branch's head commit.
- The set of files this pull request changes is exactly README.md.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — Re-run by the cycle-2 reviewer against a Go tree byte-identical to the branch head, established by confirming git diff from 926c238 to 21dd09d is README-only. Every package reports ok. — commit `21dd09def16cc5b7448deb6707791896e4db5dbb` (2026-08-01T19:54:09Z)
- **gofmt** — pass — `gofmt -l .` — Re-run by the cycle-2 reviewer at the same tree. Printed nothing. — commit `21dd09def16cc5b7448deb6707791896e4db5dbb` (2026-08-01T19:54:09Z)
- **branch-scope: changed files and commit count** — pass — `git diff --stat 926c238 21dd09d && git show 21dd09d --stat && gh pr view 175 --json files` — Re-stamped at the cycle-2 head 21dd09d, superseding the stale entry that recorded 1 commit at b32a55c. The branch is now 2 commits, b32a55c and 21dd09d, and the changed-file set across both is exactly README.md, at 31 insertions and 13 deletions. The second commit alone touches only README.md. This is acceptance criterion 6. — commit `21dd09def16cc5b7448deb6707791896e4db5dbb` (2026-08-01T19:54:09Z)
- **branch-scope: word-diff check for silently dropped prose** — pass — `git diff --word-diff=plain --ignore-all-space 926c238 21dd09d` — Re-stamped at the cycle-2 head across both commits. Every removal marker is paired with its replacement inside the four intended sites plus the new PR #117 entry; nothing was removed outside them. The Fixed section's newest-first ordering is preserved at 167, 166, 158, 148, 117, 113, 110, and nothing rides along in the diff. — commit `21dd09def16cc5b7448deb6707791896e4db5dbb` (2026-08-01T19:54:09Z)
- **criterion-1 doctor absent-case evidence** — pass — `read internal/cli/doctor.go checkAdapter` — Line 264 emits only the expected version for the no-match case; lines 289 and 295 name both installed and expected; lines 275 and 277 name installed versions only when at least one match reported a non-empty version. The Fixed entry for #167 now states that an absent adapter reports the expected version alone. — commit `b32a55ce8f97bc46eaf1953be941d03298840b19` (2026-08-01T19:29:29Z)
- **criterion-2 omitted doctor failure cases** — pass — `read internal/cli/doctor.go checkAdapter` — The Known-issues list now closes on anything other than one enabled entry at this build's version, and enumerates absent, listed more than once, disabled, reporting no version at all (lines 291-293), reporting a different version, and, on Codex only, marked not installed (lines 285-287, gated on spec.host == codex). — commit `b32a55ce8f97bc46eaf1953be941d03298840b19` (2026-08-01T19:29:29Z)
- **criterion-3 codex activation and claude stop** — pass — `read internal/run/activate.go and adapters/claude/skills/orch-delivery/SKILL.md` — internal/run/activate.go:186-198 and internal/cli/doctor.go:129-143 both fail closed naming orch render-agents, both Codex-gated. The claim that Claude is the louder failure was removed; the Claude half now states that nothing in the binary checks this and the stop rests on the Architect following SKILL.md:227-229. — commit `b32a55ce8f97bc46eaf1953be941d03298840b19` (2026-08-01T19:29:29Z)
- **criterion-4 pr-117-included pr-115-excluded** — pass — `gh pr view 117 && gh pr view 115` — PR #117 confirmed merged and added to Fixed; the before-clause was written against its actual diff, which showed the prior reviewer files were silent on whether a minor or uncertain finding belonged in the report. PR #115 was deliberately left out: its diff is one line adding /.codex/ to this repository's own .gitignore, which is contributor hygiene rather than a behavior change an Orch user would notice. — commit `b32a55ce8f97bc46eaf1953be941d03298840b19` (2026-08-01T19:29:29Z)
- **criterion-5 status paragraph derivation** — pass — `gh pr list --state merged filtered for bodies lacking orch:manifest:begin && git tag --list` — The merged-PR total and the audit-record total were removed, and the enumerated PR range was replaced with a claim naming the exception by kind rather than by count. The filter returned exactly the five configuration deliveries, all titled Update orch configuration. The retained claim of 15 tagged releases v0.1.0 through v0.6.0 matches git tag --list and is not falsified by a merge. No badge, script or generated block was added. — commit `b32a55ce8f97bc46eaf1953be941d03298840b19` (2026-08-01T19:29:29Z)
- **reviewer-pr117-claim-against-shipped-reviewer-definitions** — fail — `read the Report section of adapters/claude/agents/orch-reviewer.md and orch-reviewer-safe.md at head, then git tag --contains 5ab6ce1` — This is the blocking finding. The new Fixed entry says request-changes turns only on a finding that blocks an acceptance criterion. Both shipped reviewer definitions say the opposite at this head: request-changes is not confined to findings that block an acceptance criterion, and a failing required test, a weakened security boundary, or any defect of comparable severity are each grounds on their own, as is an acceptance criterion that is itself wrong. PR #159 at 5ab6ce1 made that change and git tag --contains 5ab6ce1 returns v0.6.0, the release the Fixed preamble names, so the claim is false at head rather than a historical note. — commit `b32a55ce8f97bc46eaf1953be941d03298840b19` (2026-08-01T19:40:19Z)
- **reviewer-status-paragraph-independent-derivation** — pass — `gh pr list --state merged --limit 300 --json number,title,body filtered to number >= 40 with bodies lacking the manifest begin marker, plus git tag --list` — Re-derived without inheriting the executor's filter result. Exactly 50, 103, 121, 129 and 133 lack an audit record, all titled Update orch configuration. 62 merged pull requests at or above 40; highest merged 171; 40 itself carries a record. git tag --list gives 15 tags v0.1.0 through v0.6.0. The reworded Status paragraph's claims are true at this head. — commit `b32a55ce8f97bc46eaf1953be941d03298840b19` (2026-08-01T19:40:19Z)
- **reviewer-no-stale-totals-and-no-dropped-prose** — pass — `grep the file for the removed totals, and git diff --word-diff=plain --ignore-all-space` — No stale 96 or 55 remains anywhere in the file. Every word-diff removal marker is paired with its replacement inside the four intended sites, so no prose was silently dropped. The Fixed section's newest-first ordering is preserved at 148 then 117 then 113, and no badge, script, workflow or generated block was added. — commit `b32a55ce8f97bc46eaf1953be941d03298840b19` (2026-08-01T19:40:19Z)
- **acceptance-criterion-1** — satisfied — The entry now says doctor names the expected version and, whenever there is an installed one to name, the installed version too, and that an absent adapter has no installed version so that failure reports the expected version alone. Checked against every failure return in checkAdapter: line 264 absent emits the expected version only; line 277 ambiguous with no non-empty version reported is expected only; line 275 ambiguous with versions names both; lines 281-283 build the version detail as expected and upgrade it to installed plus expected only when the reported version is non-empty; line 295 mismatch names both. The qualified wording is true for each of the four cases the entry lists, including the empty-version sub-case. — commit `21dd09def16cc5b7448deb6707791896e4db5dbb` (2026-08-01T19:54:10Z)
- **acceptance-criterion-2** — satisfied — The entry now names absent, listed more than once, disabled, reporting no version at all, reporting a different version, and on Codex marked not installed. The two cases the criterion identified as omitted are both present and both map to code: empty version to doctor.go lines 291-292, and Codex not-installed to lines 285-286 gated on the codex host. The remaining hard-fails are covered by the entry's existing phrasing: line 226 by CLI is missing from PATH, and lines 240-248 by plugin listing cannot be read. The only uncovered return is the embedded-manifest version read, which cannot fire in a built binary. Finding F5 records an imprecision in the generalizing clause that does not affect this judgment. — commit `21dd09def16cc5b7448deb6707791896e4db5dbb` (2026-08-01T19:54:10Z)
- **acceptance-criterion-3** — satisfied — Codex half verified at internal/run/activate.go lines 186-197, which returns ErrAgentsStale naming orch render-agents in the primary checkout, and internal/cli/doctor.go lines 129-142 making the same agents.Stale call. internal/agents/agents.go lines 174-200 shows Stale byte-comparing the repository's .codex/agents TOMLs against Render output substituted from hosts.codex.roles, so the README's description of comparing rendered definitions against the effective configuration and failing closed is exact rather than an overclaim. The louder-failure clause is gone, confirmed in the word-diff removal markers. Claude half: grepping origin/main's internal and cmd trees for installed_plugins or frontmatter returned nothing, so no engine check exists, while the stop is prose in the Claude adapter's orch-delivery skill at lines 227-229. The README's statement that the stop rests on the Architect following an instruction rather than on a check the engine performs is accurate. — commit `21dd09def16cc5b7448deb6707791896e4db5dbb` (2026-08-01T19:54:10Z)
- **acceptance-criterion-4** — satisfied — This is the criterion that blocked in cycle 1. Each of the entry's three surviving claims was checked sentence by sentence against the Report section of both Claude reviewer definitions at origin/main: report every finding including low-severity and uncertain ones each carrying a severity and a confidence, matching List every finding your review turns up, Report low-severity findings and anything you are uncertain about, and Give each finding a severity and a confidence; decide the verdict afterwards as a separate judgment, matching Decide the verdict after the findings are listed, as a separate judgment; and a nit stays in the report without by itself costing another review cycle, matching What stays in the report without forcing another review cycle is a finding that is none of these, a nit, a preference, a low-severity observation. All three are present in both files. No trace of the blocking-only clause PR #159 inverted remains. Attribution verified with gh pr diff 117: that diff added the coverage and severity paragraph, the separate-judgment sentence, and a non-blocking finding stays in the report clause, so the narrowed nit claim is a true subset of what #117 introduced rather than a claim borrowed from a later pull request. The before half checks out at 9165b92, where the Report section said only to produce one consolidated report and state a clear verdict with reasoning, and a grep for severity, minor, uncertain or coverage over both pre-#117 files returns no hit. git tag --contains on #117's merge returns v0.5.8, v0.5.10 and v0.6.0, so the Fixed preamble's shipped in v0.6.0 holds. PR #115 remains correctly excluded as gitignore hygiene invisible to a user of Orch. — commit `21dd09def16cc5b7448deb6707791896e4db5dbb` (2026-08-01T19:54:10Z)
- **acceptance-criterion-5** — satisfied — Re-derived independently against live GitHub after PRs #176 and #177 merged, which is the test the rewording had to survive. Both hand-maintained totals are gone and the exception is named by kind with no count. Results: 100 merged pull requests total, 64 merged at or after PR #40's merge time with none numbered below 40, and exactly 50, 103, 121, 129 and 133 lacking the manifest begin marker, all five titled Update orch configuration. PRs #176 and #177 both carry audit records. No orch configure generated pull request since #40 carries a manifest, so the carve-out is exactly by kind, and #133's body is the Detection and Configuration format confirming its own body format. Tags via git ls-remote give 15, v0.1.0 through v0.6.0 with v0.5.9 skipped, which a count-plus-range claim does not assert, and which a merge cannot falsify. Every claim the paragraph makes is true at this head and still true at current main. — commit `21dd09def16cc5b7448deb6707791896e4db5dbb` (2026-08-01T19:54:10Z)
- **acceptance-criterion-6** — satisfied — git diff --stat from 926c238 to 21dd09d gives README.md alone, one file changed, 31 insertions and 13 deletions. Both commits touch only README.md; git show 21dd09d --stat gives README.md alone. — commit `21dd09def16cc5b7448deb6707791896e4db5dbb` (2026-08-01T19:54:10Z)
- **review-cycle-1** — request-changes — Five of six criteria hold, each confirmed against source rather than against the diff. The blocker is a new false claim introduced by the fix for criterion 4. The Fixed entry added for PR #117 tells a reader that request-changes turns only on a finding that blocks an acceptance criterion, but PR #159 at commit 5ab6ce1 reversed that rule in both adapters/claude/agents/orch-reviewer.md and orch-reviewer-safe.md before v0.6.0 shipped; git tag --contains 5ab6ce1 gives v0.6.0, which is the release the Fixed preamble names. Those files now say outright that request-changes is not confined to findings that block an acceptance criterion, and that a failing required test, a security boundary the change weakens, or any defect of comparable severity are each grounds on their own. The entry is written in the present tense, so this is a live false claim rather than a historical note. A pull request whose whole purpose is removing README claims the code does not support should not land carrying a new one. The rest of that entry is sound and the fix is one clause, not a rewrite. Three further findings are reported for coverage and do not require a cycle on their own. F2: the PR #167 Fixed entry's failure list omits the two cases PR #167 itself added, so the README now describes the same function at two different levels of completeness in adjacent sections; pre-existing, and this pull request edited the entry without touching that list. F3: the Known-issues generalizing clause closes on anything other than one enabled entry at the version this build ships, but a Codex entry that is enabled, unique and at the exact expected version still hard-fails when installed is false, because that check is ordered before the enabled check; the enumeration that follows names the case explicitly, so no reader is misled. F4: one line left at 42 characters mid-paragraph by the reflow, where surrounding lines run 63 to 71. — commit `b32a55ce8f97bc46eaf1953be941d03298840b19` (2026-08-01T19:40:21Z)
- **reviewer-pr117-entry-attribution** — pass — `gh pr diff 117, read the Report section of both Claude reviewer definitions at origin/main, and read both files at 9165b92` — Closes the cycle-1 blocker and checks the specific risk that a narrowed claim could be true but no longer describe what PR #117 changed. All three claims are present verbatim in both shipped definitions at current main, and gh pr diff 117 shows #117 is what introduced each of them, so the narrowed nit claim is a true subset of #117's own addition rather than a later PR's. The before half matches the pre-#117 files, where the Report section said only to state a clear verdict with reasoning and no mention of severity, minor, uncertain or coverage appears. — commit `21dd09def16cc5b7448deb6707791896e4db5dbb` (2026-08-01T19:54:09Z)
- **reviewer-entry-scoping-against-codex-definitions** — pass — `read the Report section of adapters/codex/agents/orch-reviewer.toml at origin/main` — Confirms the entry's scoping to Claude Code's two reviewer agents is exact rather than incidentally narrow. The Codex reviewer TOMLs carry the verdict paragraph introduced by PR #159 but not the every-finding and severity-and-confidence paragraph, whose Report section begins at Judge each acceptance criterion. — commit `21dd09def16cc5b7448deb6707791896e4db5dbb` (2026-08-01T19:54:09Z)
- **reviewer-backlogged-findings-left-untouched** — pass — `inspect the cycle-2 diff hunk against the three findings routed to the backlog in cycle 1` — Confirms the fix cycle did not quietly widen its own scope. The PR #167 entry's failure list is still the shorter four-case form, the Known-issues generalizing clause is unchanged, and the short line at README.md:507 is untouched. The cycle-2 diff removes exactly the inverted clause and nothing else. — commit `21dd09def16cc5b7448deb6707791896e4db5dbb` (2026-08-01T19:54:09Z)
- **reviewer-cross-file-consistency-after-siblings-merged** — pass — `read README.md lines 410-420 against the merged ORCH-PRD.md section 15 and both merged adapter READMEs` — Checked because this branch was cut before PRs #176 and #177 merged and was never rebased. README.md lines 410-420 already say the orch-scout whitelist closes its write surface because it carries no Bash, while orch-reviewer and orch-reviewer-safe both carry Bash so their read-only discipline rests on instructions. That agrees with the new ORCH-PRD.md section 15 qualification and with both adapter READMEs. No contradiction anywhere in the README's new text. — commit `21dd09def16cc5b7448deb6707791896e4db5dbb` (2026-08-01T19:54:09Z)
- **review-cycle-2** — approve — Cycle 2, reviewed by a fresh reviewer against origin/main at 6cbbdd2, with PRs #176 and #177 already merged, rather than against the branch's base. All six criteria satisfied on the reviewer's own reading of the tree. The cycle-1 blocker is properly closed: the PR #117 entry now asserts only claims present verbatim in both shipped reviewer definitions at current main, correctly attributed to what gh pr diff 117 actually changed, with a before half matching the pre-#117 files at 9165b92. The reviewer also confirmed the entry's scoping to Claude Code's two reviewer agents is exact at head, because the Codex reviewer TOMLs carry the verdict paragraph from PR #159 but not the every-finding and severity-and-confidence paragraph. Criterion 5 was re-derived live after the two intervening merges: 100 merged pull requests, 64 at or after PR #40, and exactly 50, 103, 121, 129 and 133 lacking an audit record, all titled Update orch configuration; the reworded paragraph stayed true across both merges, which is the property the rewording existed to guarantee. Eight findings reported, none blocking. F1 is the record-completeness gap that every verification was still pinned to the cycle-1 commit b32a55c; that is corrected by the re-stamped entries submitted with this review. F2: the entry's so connector links two individually true claims by a loose causal step. F3: the reviewer agrees PR #159 was correctly left out of this change's scope but judges that it does clear the standing bar on its own and deserves a follow-up entry, since the Fixed section is currently silent on what does drive request-changes at head. F4, F5 and F6 are the three findings deliberately backlogged in cycle 1, and the reviewer confirmed all three were left untouched rather than quietly folded in. F7: the retained count of 15 tagged releases is still hand-maintained and will need a bump at the next release, though a merge cannot falsify it. F8: a grammar nit in the Status sentence. — commit `21dd09def16cc5b7448deb6707791896e4db5dbb` (2026-08-01T19:54:10Z)
- **required-ci** — passing — scripts (ubuntu-latest)=pass, lint=pass, test (windows-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass — commit `21dd09def16cc5b7448deb6707791896e4db5dbb` (2026-08-01T19:54:14Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Bring README.md's Fixed, Known-issues and Status sections back in line with what the code at this commit actually does. Five separate findings from the two reviews in the v0.6.0 README refresh, plus a Known-issues paragraph both reviewers confirmed stale but left untouched as out of scope. The Status paragraph's hand-maintained totals are reworded so they stop needing a correction after every merge, rather than being reset to numbers that go stale again immediately.",
  "acceptance_criteria": [
    "The Fixed section entry for PR #167 no longer states without qualification that the diagnostic names the installed and the expected adapter version. When no matching adapter is installed at all, checkAdapter in internal/cli/doctor.go reports only the expected version, because there is no installed version to name; the entry is accurate about that case.",
    "The Known-issues entry about orch doctor failing on a machine that lacks a configured host's command-line tool either covers every case checkAdapter in internal/cli/doctor.go hard-fails on, or is worded so that its list of cases does not read as exhaustive. Two cases the entry currently omits are an installed adapter whose reported version is the empty string, and, on Codex only, an adapter the plugin listing marks as not installed.",
    "The Known-issues paragraph beginning 'A model override does not reach a dispatched agent by itself, on either host.' describes what Codex activation does at this commit. Since the change in PR #166, activation refuses outright and names orch render-agents rather than dispatching agents that go on running a model pinned by an out-of-date rendered definition. The paragraph's claim that Claude Code is the louder of the two failures is corrected or removed, and the Claude half accurately states that its stop comes from an instruction the Architect follows rather than from a check the engine performs.",
    "The Fixed section carries an entry for PR #117, whose merged title is 'Reviewer reports every finding; only blocking findings drive request-changes' - a change in behavior a user of Orch would notice. PR #115, whose merged title is 'Add /.codex/ to .gitignore', is added only if it clears that same bar; leaving it out is an acceptable outcome for this criterion.",
    "The Status paragraph carries no total that the next merge into the default branch falsifies. The count of merged pull requests and the count of those carrying an audit record are either removed or replaced with a claim that stays true as later pull requests merge, and any exception it names is described by kind rather than by a fixed number of exceptions. Every claim the reworded paragraph does make is true at this branch's head commit.",
    "The set of files this pull request changes is exactly README.md."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Re-run by the cycle-2 reviewer against a Go tree byte-identical to the branch head, established by confirming git diff from 926c238 to 21dd09d is README-only. Every package reports ok.",
      "commit_oid": "21dd09def16cc5b7448deb6707791896e4db5dbb",
      "at": "2026-08-01T19:54:09Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Re-run by the cycle-2 reviewer at the same tree. Printed nothing.",
      "commit_oid": "21dd09def16cc5b7448deb6707791896e4db5dbb",
      "at": "2026-08-01T19:54:09Z"
    },
    {
      "name": "branch-scope: changed files and commit count",
      "command": "git diff --stat 926c238 21dd09d \u0026\u0026 git show 21dd09d --stat \u0026\u0026 gh pr view 175 --json files",
      "result": "pass",
      "detail": "Re-stamped at the cycle-2 head 21dd09d, superseding the stale entry that recorded 1 commit at b32a55c. The branch is now 2 commits, b32a55c and 21dd09d, and the changed-file set across both is exactly README.md, at 31 insertions and 13 deletions. The second commit alone touches only README.md. This is acceptance criterion 6.",
      "commit_oid": "21dd09def16cc5b7448deb6707791896e4db5dbb",
      "at": "2026-08-01T19:54:09Z"
    },
    {
      "name": "branch-scope: word-diff check for silently dropped prose",
      "command": "git diff --word-diff=plain --ignore-all-space 926c238 21dd09d",
      "result": "pass",
      "detail": "Re-stamped at the cycle-2 head across both commits. Every removal marker is paired with its replacement inside the four intended sites plus the new PR #117 entry; nothing was removed outside them. The Fixed section's newest-first ordering is preserved at 167, 166, 158, 148, 117, 113, 110, and nothing rides along in the diff.",
      "commit_oid": "21dd09def16cc5b7448deb6707791896e4db5dbb",
      "at": "2026-08-01T19:54:09Z"
    },
    {
      "name": "criterion-1 doctor absent-case evidence",
      "command": "read internal/cli/doctor.go checkAdapter",
      "result": "pass",
      "detail": "Line 264 emits only the expected version for the no-match case; lines 289 and 295 name both installed and expected; lines 275 and 277 name installed versions only when at least one match reported a non-empty version. The Fixed entry for #167 now states that an absent adapter reports the expected version alone.",
      "commit_oid": "b32a55ce8f97bc46eaf1953be941d03298840b19",
      "at": "2026-08-01T19:29:29Z"
    },
    {
      "name": "criterion-2 omitted doctor failure cases",
      "command": "read internal/cli/doctor.go checkAdapter",
      "result": "pass",
      "detail": "The Known-issues list now closes on anything other than one enabled entry at this build's version, and enumerates absent, listed more than once, disabled, reporting no version at all (lines 291-293), reporting a different version, and, on Codex only, marked not installed (lines 285-287, gated on spec.host == codex).",
      "commit_oid": "b32a55ce8f97bc46eaf1953be941d03298840b19",
      "at": "2026-08-01T19:29:29Z"
    },
    {
      "name": "criterion-3 codex activation and claude stop",
      "command": "read internal/run/activate.go and adapters/claude/skills/orch-delivery/SKILL.md",
      "result": "pass",
      "detail": "internal/run/activate.go:186-198 and internal/cli/doctor.go:129-143 both fail closed naming orch render-agents, both Codex-gated. The claim that Claude is the louder failure was removed; the Claude half now states that nothing in the binary checks this and the stop rests on the Architect following SKILL.md:227-229.",
      "commit_oid": "b32a55ce8f97bc46eaf1953be941d03298840b19",
      "at": "2026-08-01T19:29:29Z"
    },
    {
      "name": "criterion-4 pr-117-included pr-115-excluded",
      "command": "gh pr view 117 \u0026\u0026 gh pr view 115",
      "result": "pass",
      "detail": "PR #117 confirmed merged and added to Fixed; the before-clause was written against its actual diff, which showed the prior reviewer files were silent on whether a minor or uncertain finding belonged in the report. PR #115 was deliberately left out: its diff is one line adding /.codex/ to this repository's own .gitignore, which is contributor hygiene rather than a behavior change an Orch user would notice.",
      "commit_oid": "b32a55ce8f97bc46eaf1953be941d03298840b19",
      "at": "2026-08-01T19:29:29Z"
    },
    {
      "name": "criterion-5 status paragraph derivation",
      "command": "gh pr list --state merged filtered for bodies lacking orch:manifest:begin \u0026\u0026 git tag --list",
      "result": "pass",
      "detail": "The merged-PR total and the audit-record total were removed, and the enumerated PR range was replaced with a claim naming the exception by kind rather than by count. The filter returned exactly the five configuration deliveries, all titled Update orch configuration. The retained claim of 15 tagged releases v0.1.0 through v0.6.0 matches git tag --list and is not falsified by a merge. No badge, script or generated block was added.",
      "commit_oid": "b32a55ce8f97bc46eaf1953be941d03298840b19",
      "at": "2026-08-01T19:29:29Z"
    },
    {
      "name": "reviewer-pr117-claim-against-shipped-reviewer-definitions",
      "command": "read the Report section of adapters/claude/agents/orch-reviewer.md and orch-reviewer-safe.md at head, then git tag --contains 5ab6ce1",
      "result": "fail",
      "detail": "This is the blocking finding. The new Fixed entry says request-changes turns only on a finding that blocks an acceptance criterion. Both shipped reviewer definitions say the opposite at this head: request-changes is not confined to findings that block an acceptance criterion, and a failing required test, a weakened security boundary, or any defect of comparable severity are each grounds on their own, as is an acceptance criterion that is itself wrong. PR #159 at 5ab6ce1 made that change and git tag --contains 5ab6ce1 returns v0.6.0, the release the Fixed preamble names, so the claim is false at head rather than a historical note.",
      "commit_oid": "b32a55ce8f97bc46eaf1953be941d03298840b19",
      "at": "2026-08-01T19:40:19Z"
    },
    {
      "name": "reviewer-status-paragraph-independent-derivation",
      "command": "gh pr list --state merged --limit 300 --json number,title,body filtered to number \u003e= 40 with bodies lacking the manifest begin marker, plus git tag --list",
      "result": "pass",
      "detail": "Re-derived without inheriting the executor's filter result. Exactly 50, 103, 121, 129 and 133 lack an audit record, all titled Update orch configuration. 62 merged pull requests at or above 40; highest merged 171; 40 itself carries a record. git tag --list gives 15 tags v0.1.0 through v0.6.0. The reworded Status paragraph's claims are true at this head.",
      "commit_oid": "b32a55ce8f97bc46eaf1953be941d03298840b19",
      "at": "2026-08-01T19:40:19Z"
    },
    {
      "name": "reviewer-no-stale-totals-and-no-dropped-prose",
      "command": "grep the file for the removed totals, and git diff --word-diff=plain --ignore-all-space",
      "result": "pass",
      "detail": "No stale 96 or 55 remains anywhere in the file. Every word-diff removal marker is paired with its replacement inside the four intended sites, so no prose was silently dropped. The Fixed section's newest-first ordering is preserved at 148 then 117 then 113, and no badge, script, workflow or generated block was added.",
      "commit_oid": "b32a55ce8f97bc46eaf1953be941d03298840b19",
      "at": "2026-08-01T19:40:19Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "The entry now says doctor names the expected version and, whenever there is an installed one to name, the installed version too, and that an absent adapter has no installed version so that failure reports the expected version alone. Checked against every failure return in checkAdapter: line 264 absent emits the expected version only; line 277 ambiguous with no non-empty version reported is expected only; line 275 ambiguous with versions names both; lines 281-283 build the version detail as expected and upgrade it to installed plus expected only when the reported version is non-empty; line 295 mismatch names both. The qualified wording is true for each of the four cases the entry lists, including the empty-version sub-case.",
      "commit_oid": "21dd09def16cc5b7448deb6707791896e4db5dbb",
      "at": "2026-08-01T19:54:10Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "The entry now names absent, listed more than once, disabled, reporting no version at all, reporting a different version, and on Codex marked not installed. The two cases the criterion identified as omitted are both present and both map to code: empty version to doctor.go lines 291-292, and Codex not-installed to lines 285-286 gated on the codex host. The remaining hard-fails are covered by the entry's existing phrasing: line 226 by CLI is missing from PATH, and lines 240-248 by plugin listing cannot be read. The only uncovered return is the embedded-manifest version read, which cannot fire in a built binary. Finding F5 records an imprecision in the generalizing clause that does not affect this judgment.",
      "commit_oid": "21dd09def16cc5b7448deb6707791896e4db5dbb",
      "at": "2026-08-01T19:54:10Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "Codex half verified at internal/run/activate.go lines 186-197, which returns ErrAgentsStale naming orch render-agents in the primary checkout, and internal/cli/doctor.go lines 129-142 making the same agents.Stale call. internal/agents/agents.go lines 174-200 shows Stale byte-comparing the repository's .codex/agents TOMLs against Render output substituted from hosts.codex.roles, so the README's description of comparing rendered definitions against the effective configuration and failing closed is exact rather than an overclaim. The louder-failure clause is gone, confirmed in the word-diff removal markers. Claude half: grepping origin/main's internal and cmd trees for installed_plugins or frontmatter returned nothing, so no engine check exists, while the stop is prose in the Claude adapter's orch-delivery skill at lines 227-229. The README's statement that the stop rests on the Architect following an instruction rather than on a check the engine performs is accurate.",
      "commit_oid": "21dd09def16cc5b7448deb6707791896e4db5dbb",
      "at": "2026-08-01T19:54:10Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "This is the criterion that blocked in cycle 1. Each of the entry's three surviving claims was checked sentence by sentence against the Report section of both Claude reviewer definitions at origin/main: report every finding including low-severity and uncertain ones each carrying a severity and a confidence, matching List every finding your review turns up, Report low-severity findings and anything you are uncertain about, and Give each finding a severity and a confidence; decide the verdict afterwards as a separate judgment, matching Decide the verdict after the findings are listed, as a separate judgment; and a nit stays in the report without by itself costing another review cycle, matching What stays in the report without forcing another review cycle is a finding that is none of these, a nit, a preference, a low-severity observation. All three are present in both files. No trace of the blocking-only clause PR #159 inverted remains. Attribution verified with gh pr diff 117: that diff added the coverage and severity paragraph, the separate-judgment sentence, and a non-blocking finding stays in the report clause, so the narrowed nit claim is a true subset of what #117 introduced rather than a claim borrowed from a later pull request. The before half checks out at 9165b92, where the Report section said only to produce one consolidated report and state a clear verdict with reasoning, and a grep for severity, minor, uncertain or coverage over both pre-#117 files returns no hit. git tag --contains on #117's merge returns v0.5.8, v0.5.10 and v0.6.0, so the Fixed preamble's shipped in v0.6.0 holds. PR #115 remains correctly excluded as gitignore hygiene invisible to a user of Orch.",
      "commit_oid": "21dd09def16cc5b7448deb6707791896e4db5dbb",
      "at": "2026-08-01T19:54:10Z"
    },
    {
      "name": "acceptance-criterion-5",
      "result": "satisfied",
      "detail": "Re-derived independently against live GitHub after PRs #176 and #177 merged, which is the test the rewording had to survive. Both hand-maintained totals are gone and the exception is named by kind with no count. Results: 100 merged pull requests total, 64 merged at or after PR #40's merge time with none numbered below 40, and exactly 50, 103, 121, 129 and 133 lacking the manifest begin marker, all five titled Update orch configuration. PRs #176 and #177 both carry audit records. No orch configure generated pull request since #40 carries a manifest, so the carve-out is exactly by kind, and #133's body is the Detection and Configuration format confirming its own body format. Tags via git ls-remote give 15, v0.1.0 through v0.6.0 with v0.5.9 skipped, which a count-plus-range claim does not assert, and which a merge cannot falsify. Every claim the paragraph makes is true at this head and still true at current main.",
      "commit_oid": "21dd09def16cc5b7448deb6707791896e4db5dbb",
      "at": "2026-08-01T19:54:10Z"
    },
    {
      "name": "acceptance-criterion-6",
      "result": "satisfied",
      "detail": "git diff --stat from 926c238 to 21dd09d gives README.md alone, one file changed, 31 insertions and 13 deletions. Both commits touch only README.md; git show 21dd09d --stat gives README.md alone.",
      "commit_oid": "21dd09def16cc5b7448deb6707791896e4db5dbb",
      "at": "2026-08-01T19:54:10Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "Five of six criteria hold, each confirmed against source rather than against the diff. The blocker is a new false claim introduced by the fix for criterion 4. The Fixed entry added for PR #117 tells a reader that request-changes turns only on a finding that blocks an acceptance criterion, but PR #159 at commit 5ab6ce1 reversed that rule in both adapters/claude/agents/orch-reviewer.md and orch-reviewer-safe.md before v0.6.0 shipped; git tag --contains 5ab6ce1 gives v0.6.0, which is the release the Fixed preamble names. Those files now say outright that request-changes is not confined to findings that block an acceptance criterion, and that a failing required test, a security boundary the change weakens, or any defect of comparable severity are each grounds on their own. The entry is written in the present tense, so this is a live false claim rather than a historical note. A pull request whose whole purpose is removing README claims the code does not support should not land carrying a new one. The rest of that entry is sound and the fix is one clause, not a rewrite. Three further findings are reported for coverage and do not require a cycle on their own. F2: the PR #167 Fixed entry's failure list omits the two cases PR #167 itself added, so the README now describes the same function at two different levels of completeness in adjacent sections; pre-existing, and this pull request edited the entry without touching that list. F3: the Known-issues generalizing clause closes on anything other than one enabled entry at the version this build ships, but a Codex entry that is enabled, unique and at the exact expected version still hard-fails when installed is false, because that check is ordered before the enabled check; the enumeration that follows names the case explicitly, so no reader is misled. F4: one line left at 42 characters mid-paragraph by the reflow, where surrounding lines run 63 to 71.",
      "commit_oid": "b32a55ce8f97bc46eaf1953be941d03298840b19",
      "at": "2026-08-01T19:40:21Z"
    },
    {
      "name": "reviewer-pr117-entry-attribution",
      "command": "gh pr diff 117, read the Report section of both Claude reviewer definitions at origin/main, and read both files at 9165b92",
      "result": "pass",
      "detail": "Closes the cycle-1 blocker and checks the specific risk that a narrowed claim could be true but no longer describe what PR #117 changed. All three claims are present verbatim in both shipped definitions at current main, and gh pr diff 117 shows #117 is what introduced each of them, so the narrowed nit claim is a true subset of #117's own addition rather than a later PR's. The before half matches the pre-#117 files, where the Report section said only to state a clear verdict with reasoning and no mention of severity, minor, uncertain or coverage appears.",
      "commit_oid": "21dd09def16cc5b7448deb6707791896e4db5dbb",
      "at": "2026-08-01T19:54:09Z"
    },
    {
      "name": "reviewer-entry-scoping-against-codex-definitions",
      "command": "read the Report section of adapters/codex/agents/orch-reviewer.toml at origin/main",
      "result": "pass",
      "detail": "Confirms the entry's scoping to Claude Code's two reviewer agents is exact rather than incidentally narrow. The Codex reviewer TOMLs carry the verdict paragraph introduced by PR #159 but not the every-finding and severity-and-confidence paragraph, whose Report section begins at Judge each acceptance criterion.",
      "commit_oid": "21dd09def16cc5b7448deb6707791896e4db5dbb",
      "at": "2026-08-01T19:54:09Z"
    },
    {
      "name": "reviewer-backlogged-findings-left-untouched",
      "command": "inspect the cycle-2 diff hunk against the three findings routed to the backlog in cycle 1",
      "result": "pass",
      "detail": "Confirms the fix cycle did not quietly widen its own scope. The PR #167 entry's failure list is still the shorter four-case form, the Known-issues generalizing clause is unchanged, and the short line at README.md:507 is untouched. The cycle-2 diff removes exactly the inverted clause and nothing else.",
      "commit_oid": "21dd09def16cc5b7448deb6707791896e4db5dbb",
      "at": "2026-08-01T19:54:09Z"
    },
    {
      "name": "reviewer-cross-file-consistency-after-siblings-merged",
      "command": "read README.md lines 410-420 against the merged ORCH-PRD.md section 15 and both merged adapter READMEs",
      "result": "pass",
      "detail": "Checked because this branch was cut before PRs #176 and #177 merged and was never rebased. README.md lines 410-420 already say the orch-scout whitelist closes its write surface because it carries no Bash, while orch-reviewer and orch-reviewer-safe both carry Bash so their read-only discipline rests on instructions. That agrees with the new ORCH-PRD.md section 15 qualification and with both adapter READMEs. No contradiction anywhere in the README's new text.",
      "commit_oid": "21dd09def16cc5b7448deb6707791896e4db5dbb",
      "at": "2026-08-01T19:54:09Z"
    },
    {
      "name": "review-cycle-2",
      "result": "approve",
      "detail": "Cycle 2, reviewed by a fresh reviewer against origin/main at 6cbbdd2, with PRs #176 and #177 already merged, rather than against the branch's base. All six criteria satisfied on the reviewer's own reading of the tree. The cycle-1 blocker is properly closed: the PR #117 entry now asserts only claims present verbatim in both shipped reviewer definitions at current main, correctly attributed to what gh pr diff 117 actually changed, with a before half matching the pre-#117 files at 9165b92. The reviewer also confirmed the entry's scoping to Claude Code's two reviewer agents is exact at head, because the Codex reviewer TOMLs carry the verdict paragraph from PR #159 but not the every-finding and severity-and-confidence paragraph. Criterion 5 was re-derived live after the two intervening merges: 100 merged pull requests, 64 at or after PR #40, and exactly 50, 103, 121, 129 and 133 lacking an audit record, all titled Update orch configuration; the reworded paragraph stayed true across both merges, which is the property the rewording existed to guarantee. Eight findings reported, none blocking. F1 is the record-completeness gap that every verification was still pinned to the cycle-1 commit b32a55c; that is corrected by the re-stamped entries submitted with this review. F2: the entry's so connector links two individually true claims by a loose causal step. F3: the reviewer agrees PR #159 was correctly left out of this change's scope but judges that it does clear the standing bar on its own and deserves a follow-up entry, since the Fixed section is currently silent on what does drive request-changes at head. F4, F5 and F6 are the three findings deliberately backlogged in cycle 1, and the reviewer confirmed all three were left untouched rather than quietly folded in. F7: the retained count of 15 tagged releases is still hand-maintained and will need a bump at the next release, though a merge cannot falsify it. F8: a grammar nit in the Status sentence.",
      "commit_oid": "21dd09def16cc5b7448deb6707791896e4db5dbb",
      "at": "2026-08-01T19:54:10Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "scripts (ubuntu-latest)=pass, lint=pass, test (windows-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass",
      "commit_oid": "21dd09def16cc5b7448deb6707791896e4db5dbb",
      "at": "2026-08-01T19:54:14Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->