### PR TITLE
Qualify ORCH-PRD.md section 15's read-only-role claim and fix the guard comment citing it

### DIFF
--- a/ORCH-PRD.md
+++ b/ORCH-PRD.md
@@ -351,7 +351,9 @@ Orch fails closed.
 - The active branch must not be `main`.
 - Completion requires a commit, pushed branch, PR, targeted-test evidence, and explicit CI state.
 - Read-only roles are held read-only by per-agent tool whitelists on Claude Code and by agent
-  instructions on Codex, not by the guard.
+  instructions on Codex, not by the guard. The Claude whitelist accounts fully only for the Scout,
+  which is granted no shell tool; the Reviewer and its safe review downgrade are granted one, so
+  their read-only discipline rests on instructions there too.
 - Neither closes the shell-write gap: the pre-write hook covers only the file-write tools, so a
   shell-mediated write falls to the host's own approval prompts.
 - No agent may merge.

--- a/internal/guard/guard.go
+++ b/internal/guard/guard.go
@@ -119,7 +119,9 @@ func evaluate(req Request, f facts) Verdict {
 			return deny(f.path, "run stopped: "+f.stopped)
 		}
 		// Row 10: an asserted role outside {implementer, specialist} is
-		// mechanically read-only (§15). No assertion falls through.
+		// mechanically read-only. This narrows only when an adapter passes
+		// --role; neither shipped adapter does, so read-only roles are held
+		// read-only outside the guard (PRD §15). No assertion falls through.
 		if req.Role != "" && req.Role != manifest.RoleImplementer && req.Role != manifest.RoleSpecialist {
 			return deny(f.path, fmt.Sprintf("role %s is mechanically read-only", req.Role))
 		}


### PR DESCRIPTION
Delivers issue #173: Qualify ORCH-PRD.md section 15's read-only-role claim and fix the guard comment citing it

Closes #173

**Plan digest:** `sha256:733c1a79ad4eee11c77d5cb7f58652fa72804beba64cfc79e42eb576453b1d7b`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** ORCH-PRD.md section 15 is the last place in the tree carrying the unqualified claim that per-agent tool whitelists hold read-only roles read-only on Claude Code. Both adapter READMEs were corrected in PR #90; the PRD was explicitly out of that issue's scope. An inline comment in internal/guard/guard.go cites that section for a claim the section no longer supports, which is the same dangling-citation problem PR #90 removed from the package doc twelve lines above it. Both sites are corrected together because the comment's accuracy depends on what the section ends up saying.

**Acceptance criteria:**
- The ORCH-PRD.md section 15 bullet describing how read-only roles are held read-only is accurate for Claude Code at this commit. Of the three Claude agent definitions that role is meant to cover, only orch-scout is fully accounted for by its tool whitelist; orch-reviewer and orch-reviewer-safe each carry Bash, so their read-only discipline rests on their instructions rather than on the whitelist.
- The inline comment in internal/guard/guard.go on the decision-table row that denies a write when an asserted role is outside implementer and specialist no longer cites a PRD section as the authority for a claim that section does not make.
- The change to internal/guard/guard.go alters comments only: no Go statement, declaration, or literal in that file differs from its state at this branch's base commit.
- go build ./..., go vet ./..., go test ./... and gofmt -l . all succeed at this branch's head, with gofmt -l . listing no files.
- The set of files this pull request changes is exactly ORCH-PRD.md and internal/guard/guard.go.

**Required tests:**
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **go-build** — pass — `go build ./...` — No output. — commit `e6f7f7c583b83378562af977df420bad8efaf4fb` (2026-08-01T19:29:35Z)
- **go-vet** — pass — `go vet ./...` — No output. — commit `e6f7f7c583b83378562af977df420bad8efaf4fb` (2026-08-01T19:29:35Z)
- **go-test** — pass — `go test -count=1 ./...` — Corrected count. Re-run by the reviewer at the reviewed head: exit 0, no non-ok lines, 23 packages ok and 3 reporting no test files. This supersedes the pr-open entry, which said 22 packages ok and four with no test files; the pass result was correct and only the counts were wrong. — commit `e6f7f7c583b83378562af977df420bad8efaf4fb` (2026-08-01T19:40:16Z)
- **gofmt** — pass — `gofmt -l .` — Listed nothing. — commit `e6f7f7c583b83378562af977df420bad8efaf4fb` (2026-08-01T19:29:35Z)
- **branch-scope: guard.go change is comment-only** — pass — `go/scanner token-stream comparison of git show origin/main:internal/guard/guard.go against head, plus git diff -U0 origin/main...HEAD -- internal/guard/guard.go filtered to changed lines not matching a comment prefix` — Primary method: a throwaway scanner scanned both revisions with go/scanner in mode 0 so comments are skipped rather than emitted, then compared the full token streams. Result: identical, 549 Go tokens of the same kind and literal in the same order; 298 tokens shifted line or column because the comment grew by two lines. Corroborating method: the filtered diff printed nothing, so every changed line is a comment line. The single hunk at @@ -119,7 +119,9 @@ replaces a two-line comment with a four-line one; the surrounding statements are context lines. This is acceptance criterion 3. — commit `e6f7f7c583b83378562af977df420bad8efaf4fb` (2026-08-01T19:29:35Z)
- **branch-scope: changed files and commit count** — pass — `git fetch origin main && git diff --name-only origin/main...HEAD && git rev-list --count origin/main..HEAD && git status --porcelain` — Changed files are exactly ORCH-PRD.md and internal/guard/guard.go. Commit count against origin/main is 1 (e6f7f7c). git status --porcelain is empty; the token-comparison scratch files were written outside the repository. The three README files owned by the two parallel sibling issues were not opened for writing. This is acceptance criterion 5. — commit `e6f7f7c583b83378562af977df420bad8efaf4fb` (2026-08-01T19:29:35Z)
- **branch-scope: word-diff check for silently dropped prose** — pass — `git diff --word-diff --ignore-all-space origin/main...HEAD -- ORCH-PRD.md` — Three insertion markers and zero removal markers: the change to ORCH-PRD.md is purely additive, so the pre-existing wrapped lines 353-354 kept every word. New lines wrap at 93, 98, 96 and 61 characters, matching the section's existing width. — commit `e6f7f7c583b83378562af977df420bad8efaf4fb` (2026-08-01T19:29:35Z)
- **criterion-1 agent whitelist evidence** — pass — `read the tools frontmatter of adapters/claude/agents/orch-scout.md, orch-reviewer.md and orch-reviewer-safe.md` — orch-scout carries Read, Grep, Glob, WebFetch, WebSearch and no shell tool. orch-reviewer and orch-reviewer-safe both carry Read, Grep, Glob, Bash. The section 15 bullet was extended in place rather than replaced or split, because the following bullet opens with the word Neither, which binds to the two mechanisms this bullet names; inserting a bullet between them would leave that reference dangling. The added clauses stay at PRD role vocabulary (Scout, Reviewer, safe review downgrade) and say shell rather than naming agent files, matching the document's existing usage at lines 27, 106 and 355. — commit `e6f7f7c583b83378562af977df420bad8efaf4fb` (2026-08-01T19:29:35Z)
- **criterion-2 guard comment citation** — pass — `read internal/guard/guard.go Row 10 comment and the package doc` — The Row 10 comment no longer cites section 15 as the authority for mechanical read-only-ness. It now points at what section 15 actually says, that read-only roles are held read-only outside the guard, and records that no shipped adapter passes --role so the row is unreached in practice. Row behavior is untouched. The package doc comment at lines 9-13 was deliberately left alone because its section 15 citation covers the containment, branch and phase rules, which section 15 does state. — commit `e6f7f7c583b83378562af977df420bad8efaf4fb` (2026-08-01T19:29:35Z)
- **reviewer-independent-comment-only-check** — pass — `diff of both revisions with trailing whitespace stripped and whole-line comments removed, plus a raw-string-literal safety check and git diff -U0` — Independent of the executor's go/scanner token comparison. Stripping whole-line comments from both revisions leaves no difference. The method's soundness was established by confirming the file holds exactly one backtick, on line 4 inside the package doc comment, so no raw string literal exists that could contain a comment-shaped line. git diff -U0 shows one hunk at @@ -122 +122,3 @@ with every changed line matching a comment prefix. — commit `e6f7f7c583b83378562af977df420bad8efaf4fb` (2026-08-01T19:40:16Z)
- **reviewer-citation-not-bent-check** — pass — `git diff --word-diff origin/main...HEAD -- ORCH-PRD.md and inspection of the cited clause` — Checks that the citation was not made to match by weakening the cited section rather than correcting the citing comment. The section 15 clause the comment now cites, not by the guard at line 354, is byte-identical to origin/main, and the word-diff on ORCH-PRD.md is purely additive with zero removal markers. — commit `e6f7f7c583b83378562af977df420bad8efaf4fb` (2026-08-01T19:40:16Z)
- **reviewer-no-adapter-passes-role-flag** — pass — `grep for orch guard across JSON files tree-wide, and read both adapters' hooks.json` — Confirms the comment's new factual claim. Both adapters invoke a bare orch guard command with no --role, and the tree-wide grep returns only those two hook invocations. Noted as informational finding F4: internal/cli/guard.go exposes --role to any caller and internal/cli/guard_test.go exercises it, so the comment's phrase only when an adapter passes --role is true of shipping callers but narrower than the flag's reach. — commit `e6f7f7c583b83378562af977df420bad8efaf4fb` (2026-08-01T19:40:16Z)
- **acceptance-criterion-1** — satisfied — The bullet at ORCH-PRD.md lines 353-356 now says the Claude whitelist accounts fully only for the Scout, which is granted no shell tool, and that the Reviewer and its safe review downgrade are granted one so their read-only discipline rests on instructions there too. The reviewer verified the frontmatter directly rather than inheriting it: orch-scout is Read, Grep, Glob, WebFetch, WebSearch; orch-reviewer and orch-reviewer-safe are both Read, Grep, Glob, Bash. So no shell tool and granted one are both true, and the Scout's list contains no write tool either, so accounts fully holds. Overcorrection test performed by reading the whole section rather than the diff: lines 349-350 still state that the guard enforces containment and that writes must remain inside the registered worktree, so the section does not imply the Reviewer is mechanically unconstrained. The executor's structural reasoning also checks out: line 357 opens with Neither closes the shell-write gap, whose antecedent is the two mechanisms named at the head of line 353, so a bullet inserted between them would have stranded it. The new clauses do not duplicate line 357, which is about the pre-write hook's tool coverage rather than the whitelist's contents, and safe review downgrade is genuine PRD vocabulary appearing at lines 240 and 251. — commit `e6f7f7c583b83378562af977df420bad8efaf4fb` (2026-08-01T19:40:17Z)
- **acceptance-criterion-2** — satisfied — The old text cited section 15 for exactly the claim section 15 denies. The new comment attaches its citation to read-only roles are held read-only outside the guard, which section 15 states verbatim as not by the guard. The reviewer checked the specific trap and confirmed section 15 was not bent to fit the comment: the cited clause at line 354 is pre-existing and untouched, the word-diff on ORCH-PRD.md is purely additive, and the hunk shows line 354's original text preserved intact with new sentences appended, so the citation is supported by text that predates this pull request. The comment's factual claim is independently true: both adapters' hooks.json run a bare orch guard command with no --role, and a tree-wide grep for orch guard across JSON files returns only those two hook invocations. — commit `e6f7f7c583b83378562af977df420bad8efaf4fb` (2026-08-01T19:40:17Z)
- **acceptance-criterion-3** — satisfied — The reviewer did not inherit the executor's token-count claim and ran an independent check: diffing both revisions of the file with trailing whitespace stripped and whole-line comments removed produced no difference. That method is sound only if no comment-shaped line could sit inside a raw string, which the reviewer established by confirming the file contains exactly one backtick, on line 4 inside the package doc comment, so there are no raw string literals at all. git diff -U0 confirms a single hunk at @@ -122 +122,3 @@ with all four changed lines matching a comment prefix. — commit `e6f7f7c583b83378562af977df420bad8efaf4fb` (2026-08-01T19:40:17Z)
- **acceptance-criterion-4** — satisfied — Run by the reviewer in the issue-173 worktree at the reviewed head: go build ./... no output exit 0; go vet ./... no output exit 0; gofmt -l . printed nothing exit 0; go test -count=1 ./... exit 0 with no non-ok lines, 23 packages ok and 3 reporting no test files. All six CI checks are green at head. — commit `e6f7f7c583b83378562af977df420bad8efaf4fb` (2026-08-01T19:40:17Z)
- **acceptance-criterion-5** — satisfied — git diff --name-only against origin/main gives exactly ORCH-PRD.md and internal/guard/guard.go, git rev-list --count gives 1, and the pull request's own file list matches at ORCH-PRD.md plus 3 minus 1 and internal/guard/guard.go plus 3 minus 1. The three README files owned by the sibling issues are untouched. — commit `e6f7f7c583b83378562af977df420bad8efaf4fb` (2026-08-01T19:40:17Z)
- **review-cycle-1** — approve — The substantive criterion is met with real evidence, and the trap this issue set up was avoided: the citation was fixed by correcting the comment, not by weakening the cited section. PRD section 15's not by the guard clause is byte-identical to origin/main, and the comment now cites it rather than contradicting it. All four required commands pass at head under the reviewer's own execution, all six CI checks are green, and the file set is exactly the two named. Five findings reported for coverage, none blocking. F1: the new PRD clause says read-only discipline rests on instructions there too, dropping the shell-mediated scoping the adapter README carries, which understates the residual mechanical coverage since reviewers still carry no Edit, Write, MultiEdit or NotebookEdit; it is an understatement of protection rather than the dangerous direction and matches prose already shipped elsewhere in the repository. F2: the new clause that the Scout is granted no shell tool sits immediately above the next bullet's blanket Neither closes the shell-write gap, a prose tension inherited rather than created by this edit. F3: the go-test verification detail miscounts, saying 22 packages ok and four with no test files where the reviewer's own run at the same commit gives 23 ok and 3 with no test files; the pass result itself is correct, and a corrected entry is submitted with this review. F4: the comment's phrase only when an adapter passes --role is narrower than the flag's reach, since internal/cli/guard.go exposes --role to any caller. F5: one comment line runs 72 characters against the file's 61 to 70 norm, which nothing enforces. — commit `e6f7f7c583b83378562af977df420bad8efaf4fb` (2026-08-01T19:40:17Z)
- **required-ci** — passing — test (macos-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `e6f7f7c583b83378562af977df420bad8efaf4fb` (2026-08-01T19:40:26Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "ORCH-PRD.md section 15 is the last place in the tree carrying the unqualified claim that per-agent tool whitelists hold read-only roles read-only on Claude Code. Both adapter READMEs were corrected in PR #90; the PRD was explicitly out of that issue's scope. An inline comment in internal/guard/guard.go cites that section for a claim the section no longer supports, which is the same dangling-citation problem PR #90 removed from the package doc twelve lines above it. Both sites are corrected together because the comment's accuracy depends on what the section ends up saying.",
  "acceptance_criteria": [
    "The ORCH-PRD.md section 15 bullet describing how read-only roles are held read-only is accurate for Claude Code at this commit. Of the three Claude agent definitions that role is meant to cover, only orch-scout is fully accounted for by its tool whitelist; orch-reviewer and orch-reviewer-safe each carry Bash, so their read-only discipline rests on their instructions rather than on the whitelist.",
    "The inline comment in internal/guard/guard.go on the decision-table row that denies a write when an asserted role is outside implementer and specialist no longer cites a PRD section as the authority for a claim that section does not make.",
    "The change to internal/guard/guard.go alters comments only: no Go statement, declaration, or literal in that file differs from its state at this branch's base commit.",
    "go build ./..., go vet ./..., go test ./... and gofmt -l . all succeed at this branch's head, with gofmt -l . listing no files.",
    "The set of files this pull request changes is exactly ORCH-PRD.md and internal/guard/guard.go."
  ],
  "required_tests": [
    "go build ./...",
    "go vet ./...",
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "No output.",
      "commit_oid": "e6f7f7c583b83378562af977df420bad8efaf4fb",
      "at": "2026-08-01T19:29:35Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "No output.",
      "commit_oid": "e6f7f7c583b83378562af977df420bad8efaf4fb",
      "at": "2026-08-01T19:29:35Z"
    },
    {
      "name": "go-test",
      "command": "go test -count=1 ./...",
      "result": "pass",
      "detail": "Corrected count. Re-run by the reviewer at the reviewed head: exit 0, no non-ok lines, 23 packages ok and 3 reporting no test files. This supersedes the pr-open entry, which said 22 packages ok and four with no test files; the pass result was correct and only the counts were wrong.",
      "commit_oid": "e6f7f7c583b83378562af977df420bad8efaf4fb",
      "at": "2026-08-01T19:40:16Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Listed nothing.",
      "commit_oid": "e6f7f7c583b83378562af977df420bad8efaf4fb",
      "at": "2026-08-01T19:29:35Z"
    },
    {
      "name": "branch-scope: guard.go change is comment-only",
      "command": "go/scanner token-stream comparison of git show origin/main:internal/guard/guard.go against head, plus git diff -U0 origin/main...HEAD -- internal/guard/guard.go filtered to changed lines not matching a comment prefix",
      "result": "pass",
      "detail": "Primary method: a throwaway scanner scanned both revisions with go/scanner in mode 0 so comments are skipped rather than emitted, then compared the full token streams. Result: identical, 549 Go tokens of the same kind and literal in the same order; 298 tokens shifted line or column because the comment grew by two lines. Corroborating method: the filtered diff printed nothing, so every changed line is a comment line. The single hunk at @@ -119,7 +119,9 @@ replaces a two-line comment with a four-line one; the surrounding statements are context lines. This is acceptance criterion 3.",
      "commit_oid": "e6f7f7c583b83378562af977df420bad8efaf4fb",
      "at": "2026-08-01T19:29:35Z"
    },
    {
      "name": "branch-scope: changed files and commit count",
      "command": "git fetch origin main \u0026\u0026 git diff --name-only origin/main...HEAD \u0026\u0026 git rev-list --count origin/main..HEAD \u0026\u0026 git status --porcelain",
      "result": "pass",
      "detail": "Changed files are exactly ORCH-PRD.md and internal/guard/guard.go. Commit count against origin/main is 1 (e6f7f7c). git status --porcelain is empty; the token-comparison scratch files were written outside the repository. The three README files owned by the two parallel sibling issues were not opened for writing. This is acceptance criterion 5.",
      "commit_oid": "e6f7f7c583b83378562af977df420bad8efaf4fb",
      "at": "2026-08-01T19:29:35Z"
    },
    {
      "name": "branch-scope: word-diff check for silently dropped prose",
      "command": "git diff --word-diff --ignore-all-space origin/main...HEAD -- ORCH-PRD.md",
      "result": "pass",
      "detail": "Three insertion markers and zero removal markers: the change to ORCH-PRD.md is purely additive, so the pre-existing wrapped lines 353-354 kept every word. New lines wrap at 93, 98, 96 and 61 characters, matching the section's existing width.",
      "commit_oid": "e6f7f7c583b83378562af977df420bad8efaf4fb",
      "at": "2026-08-01T19:29:35Z"
    },
    {
      "name": "criterion-1 agent whitelist evidence",
      "command": "read the tools frontmatter of adapters/claude/agents/orch-scout.md, orch-reviewer.md and orch-reviewer-safe.md",
      "result": "pass",
      "detail": "orch-scout carries Read, Grep, Glob, WebFetch, WebSearch and no shell tool. orch-reviewer and orch-reviewer-safe both carry Read, Grep, Glob, Bash. The section 15 bullet was extended in place rather than replaced or split, because the following bullet opens with the word Neither, which binds to the two mechanisms this bullet names; inserting a bullet between them would leave that reference dangling. The added clauses stay at PRD role vocabulary (Scout, Reviewer, safe review downgrade) and say shell rather than naming agent files, matching the document's existing usage at lines 27, 106 and 355.",
      "commit_oid": "e6f7f7c583b83378562af977df420bad8efaf4fb",
      "at": "2026-08-01T19:29:35Z"
    },
    {
      "name": "criterion-2 guard comment citation",
      "command": "read internal/guard/guard.go Row 10 comment and the package doc",
      "result": "pass",
      "detail": "The Row 10 comment no longer cites section 15 as the authority for mechanical read-only-ness. It now points at what section 15 actually says, that read-only roles are held read-only outside the guard, and records that no shipped adapter passes --role so the row is unreached in practice. Row behavior is untouched. The package doc comment at lines 9-13 was deliberately left alone because its section 15 citation covers the containment, branch and phase rules, which section 15 does state.",
      "commit_oid": "e6f7f7c583b83378562af977df420bad8efaf4fb",
      "at": "2026-08-01T19:29:35Z"
    },
    {
      "name": "reviewer-independent-comment-only-check",
      "command": "diff of both revisions with trailing whitespace stripped and whole-line comments removed, plus a raw-string-literal safety check and git diff -U0",
      "result": "pass",
      "detail": "Independent of the executor's go/scanner token comparison. Stripping whole-line comments from both revisions leaves no difference. The method's soundness was established by confirming the file holds exactly one backtick, on line 4 inside the package doc comment, so no raw string literal exists that could contain a comment-shaped line. git diff -U0 shows one hunk at @@ -122 +122,3 @@ with every changed line matching a comment prefix.",
      "commit_oid": "e6f7f7c583b83378562af977df420bad8efaf4fb",
      "at": "2026-08-01T19:40:16Z"
    },
    {
      "name": "reviewer-citation-not-bent-check",
      "command": "git diff --word-diff origin/main...HEAD -- ORCH-PRD.md and inspection of the cited clause",
      "result": "pass",
      "detail": "Checks that the citation was not made to match by weakening the cited section rather than correcting the citing comment. The section 15 clause the comment now cites, not by the guard at line 354, is byte-identical to origin/main, and the word-diff on ORCH-PRD.md is purely additive with zero removal markers.",
      "commit_oid": "e6f7f7c583b83378562af977df420bad8efaf4fb",
      "at": "2026-08-01T19:40:16Z"
    },
    {
      "name": "reviewer-no-adapter-passes-role-flag",
      "command": "grep for orch guard across JSON files tree-wide, and read both adapters' hooks.json",
      "result": "pass",
      "detail": "Confirms the comment's new factual claim. Both adapters invoke a bare orch guard command with no --role, and the tree-wide grep returns only those two hook invocations. Noted as informational finding F4: internal/cli/guard.go exposes --role to any caller and internal/cli/guard_test.go exercises it, so the comment's phrase only when an adapter passes --role is true of shipping callers but narrower than the flag's reach.",
      "commit_oid": "e6f7f7c583b83378562af977df420bad8efaf4fb",
      "at": "2026-08-01T19:40:16Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "The bullet at ORCH-PRD.md lines 353-356 now says the Claude whitelist accounts fully only for the Scout, which is granted no shell tool, and that the Reviewer and its safe review downgrade are granted one so their read-only discipline rests on instructions there too. The reviewer verified the frontmatter directly rather than inheriting it: orch-scout is Read, Grep, Glob, WebFetch, WebSearch; orch-reviewer and orch-reviewer-safe are both Read, Grep, Glob, Bash. So no shell tool and granted one are both true, and the Scout's list contains no write tool either, so accounts fully holds. Overcorrection test performed by reading the whole section rather than the diff: lines 349-350 still state that the guard enforces containment and that writes must remain inside the registered worktree, so the section does not imply the Reviewer is mechanically unconstrained. The executor's structural reasoning also checks out: line 357 opens with Neither closes the shell-write gap, whose antecedent is the two mechanisms named at the head of line 353, so a bullet inserted between them would have stranded it. The new clauses do not duplicate line 357, which is about the pre-write hook's tool coverage rather than the whitelist's contents, and safe review downgrade is genuine PRD vocabulary appearing at lines 240 and 251.",
      "commit_oid": "e6f7f7c583b83378562af977df420bad8efaf4fb",
      "at": "2026-08-01T19:40:17Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "The old text cited section 15 for exactly the claim section 15 denies. The new comment attaches its citation to read-only roles are held read-only outside the guard, which section 15 states verbatim as not by the guard. The reviewer checked the specific trap and confirmed section 15 was not bent to fit the comment: the cited clause at line 354 is pre-existing and untouched, the word-diff on ORCH-PRD.md is purely additive, and the hunk shows line 354's original text preserved intact with new sentences appended, so the citation is supported by text that predates this pull request. The comment's factual claim is independently true: both adapters' hooks.json run a bare orch guard command with no --role, and a tree-wide grep for orch guard across JSON files returns only those two hook invocations.",
      "commit_oid": "e6f7f7c583b83378562af977df420bad8efaf4fb",
      "at": "2026-08-01T19:40:17Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "The reviewer did not inherit the executor's token-count claim and ran an independent check: diffing both revisions of the file with trailing whitespace stripped and whole-line comments removed produced no difference. That method is sound only if no comment-shaped line could sit inside a raw string, which the reviewer established by confirming the file contains exactly one backtick, on line 4 inside the package doc comment, so there are no raw string literals at all. git diff -U0 confirms a single hunk at @@ -122 +122,3 @@ with all four changed lines matching a comment prefix.",
      "commit_oid": "e6f7f7c583b83378562af977df420bad8efaf4fb",
      "at": "2026-08-01T19:40:17Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "Run by the reviewer in the issue-173 worktree at the reviewed head: go build ./... no output exit 0; go vet ./... no output exit 0; gofmt -l . printed nothing exit 0; go test -count=1 ./... exit 0 with no non-ok lines, 23 packages ok and 3 reporting no test files. All six CI checks are green at head.",
      "commit_oid": "e6f7f7c583b83378562af977df420bad8efaf4fb",
      "at": "2026-08-01T19:40:17Z"
    },
    {
      "name": "acceptance-criterion-5",
      "result": "satisfied",
      "detail": "git diff --name-only against origin/main gives exactly ORCH-PRD.md and internal/guard/guard.go, git rev-list --count gives 1, and the pull request's own file list matches at ORCH-PRD.md plus 3 minus 1 and internal/guard/guard.go plus 3 minus 1. The three README files owned by the sibling issues are untouched.",
      "commit_oid": "e6f7f7c583b83378562af977df420bad8efaf4fb",
      "at": "2026-08-01T19:40:17Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "The substantive criterion is met with real evidence, and the trap this issue set up was avoided: the citation was fixed by correcting the comment, not by weakening the cited section. PRD section 15's not by the guard clause is byte-identical to origin/main, and the comment now cites it rather than contradicting it. All four required commands pass at head under the reviewer's own execution, all six CI checks are green, and the file set is exactly the two named. Five findings reported for coverage, none blocking. F1: the new PRD clause says read-only discipline rests on instructions there too, dropping the shell-mediated scoping the adapter README carries, which understates the residual mechanical coverage since reviewers still carry no Edit, Write, MultiEdit or NotebookEdit; it is an understatement of protection rather than the dangerous direction and matches prose already shipped elsewhere in the repository. F2: the new clause that the Scout is granted no shell tool sits immediately above the next bullet's blanket Neither closes the shell-write gap, a prose tension inherited rather than created by this edit. F3: the go-test verification detail miscounts, saying 22 packages ok and four with no test files where the reviewer's own run at the same commit gives 23 ok and 3 with no test files; the pass result itself is correct, and a corrected entry is submitted with this review. F4: the comment's phrase only when an adapter passes --role is narrower than the flag's reach, since internal/cli/guard.go exposes --role to any caller. F5: one comment line runs 72 characters against the file's 61 to 70 norm, which nothing enforces.",
      "commit_oid": "e6f7f7c583b83378562af977df420bad8efaf4fb",
      "at": "2026-08-01T19:40:17Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (macos-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "e6f7f7c583b83378562af977df420bad8efaf4fb",
      "at": "2026-08-01T19:40:26Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->