### PR TITLE
Close two imprecise tool-whitelist claims in both adapter READMEs

### DIFF
--- a/adapters/claude/README.md
+++ b/adapters/claude/README.md
@@ -59,17 +59,19 @@ never re-derives a decision the engine already made.
   `agents/orch-specialist.md`, `agents/orch-reviewer.md`,
   `agents/orch-reviewer-safe.md` — the five role subagents the Architect
   spawns during Delivery, each with its own model and tool whitelist
-  (scout, reviewer, and reviewer-safe carry no write tool; no agent
-  carries `Task` or any `mcp__` tool). `orch-reviewer-safe` is the §10
-  safe-review downgrade encoding: Claude Code's Task tool `model` parameter
-  only takes coarse tier aliases (`sonnet`/`opus`/`haiku`/`fable`), so a
-  per-spawn override cannot express a routed selection. A separate
-  installed agent is shipped instead because only an installed definition
-  carries its own system prompt — the safe-downgrade framing and
-  instructions — and a distinct name the frontmatter-match rule can
-  verify; the effort difference from the full reviewer rides the
-  spawn-time prompt cue, per the Known limitations bullet below, not a
-  frontmatter field.
+  (scout, reviewer, and reviewer-safe carry none of the four guarded
+  write tools, but only scout is read-only by whitelist alone: both
+  reviewers carry `Bash`, which can write unguarded — see Known
+  limitations below; no agent carries `Task` or any `mcp__` tool).
+  `orch-reviewer-safe` is the §10 safe-review downgrade encoding:
+  Claude Code's Task tool `model` parameter only takes coarse tier
+  aliases (`sonnet`/`opus`/`haiku`/`fable`), so a per-spawn override
+  cannot express a routed selection. A separate installed agent is
+  shipped instead because only an installed definition carries its own
+  system prompt — the safe-downgrade framing and instructions — and a
+  distinct name the frontmatter-match rule can verify; the effort
+  difference from the full reviewer rides the spawn-time prompt cue,
+  per the Known limitations bullet below, not a frontmatter field.
 
 ## Install order
 
@@ -150,9 +152,11 @@ bugs:
   enforcement instead comes from each subagent's own tool whitelist in its
   agent definition (PR 2), not from guard's role-narrowing flag — but
   the whitelist accounts fully only for `orch-scout`, which carries no
-  `Bash`. `orch-reviewer` and `orch-reviewer-safe` both carry `Bash`,
-  so their whitelist excludes only the four guarded write tools; their
-  read-only discipline for anything Bash-mediated rests on their own
+  `Bash`. `orch-reviewer` and `orch-reviewer-safe` are whitelisted for
+  `Read`, `Grep`, `Glob` and `Bash` — every guarded write tool is
+  excluded, along with `Task`, every `mcp__` tool, `WebFetch` and
+  `WebSearch`, but `Bash` is left and `Bash` can write. Their read-only
+  discipline for anything Bash-mediated rests on their own
   instructions, same as the Bash-mediated write gap above.
 
 ## Host version

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -167,9 +167,10 @@ bugs:
   `developer_instructions` and rests there. The Claude adapter leaves
   `--role` unused for the same reason. Its tool whitelist backs
   `orch-scout`'s read-only-ness fully — `orch-scout` carries no `Bash`
-  — but `orch-reviewer` and `orch-reviewer-safe` both carry `Bash`,
-  so their whitelist excludes only the four guarded write tools there
-  too; their read-only discipline for anything Bash-mediated rests on
+  — but `orch-reviewer` and `orch-reviewer-safe` both carry `Bash`, so
+  their whitelist leaves that same Bash-mediated write path open there
+  too, for all that it excludes every guarded write tool; their
+  read-only discipline for anything Bash-mediated rests on
   instructions, same as this host's.
 - **A missing `orch` binary fails open, not closed.** As described
   under Install order: a hook command that cannot be found exits


### PR DESCRIPTION
Delivers issue #174: Close two imprecise tool-whitelist claims in both adapter READMEs

Closes #174

**Plan digest:** `sha256:733c1a79ad4eee11c77d5cb7f58652fa72804beba64cfc79e42eb576453b1d7b`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Two precision gaps the PR #90 reviewer found and no criterion of that issue named. Neither is false on its own terms, but both invite a reader to conclude that the per-agent tool whitelists make every read-only role unable to write - the exact inference PR #90 removed from the other sites in these same files.

**Acceptance criteria:**
- In adapters/claude/README.md, the bullet listing the five role subagents no longer lets a reader who stops there conclude that the tool whitelist makes orch-scout, orch-reviewer and orch-reviewer-safe all unable to write. The qualification is present where the claim is made rather than only in the known-limitations section far below it.
- Neither adapters/claude/README.md nor adapters/codex/README.md states that the reviewer agents' whitelist excludes only the four guarded write tools. Each README's statement is accurate about what those whitelists exclude, which is more than the four write tools alone.
- go test ./... succeeds at this branch's head, so no prose literal these adapters' plugin tests pin has been broken.
- The set of files this pull request changes is exactly adapters/claude/README.md and adapters/codex/README.md.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — All packages ok. adapters/claude, adapters/codex and internal/agents all pass, so no prose literal pinned by either adapter's plugin_test.go was broken. This is acceptance criterion 3. — commit `6ad9701ff7c40ce155b994082af06d844d62754c` (2026-08-01T19:29:41Z)
- **gofmt** — pass — `gofmt -l .` — Empty output. — commit `6ad9701ff7c40ce155b994082af06d844d62754c` (2026-08-01T19:29:41Z)
- **branch-scope: changed files and commit count** — pass — `git fetch origin main && git diff --name-only origin/main...HEAD && git rev-list --count origin/main..HEAD` — Changed files are exactly adapters/claude/README.md and adapters/codex/README.md. Commit count against origin/main is 1 (6ad9701). This is acceptance criterion 4. — commit `6ad9701ff7c40ce155b994082af06d844d62754c` (2026-08-01T19:29:41Z)
- **branch-scope: word-diff check for silently dropped prose** — pass — `git diff --word-diff --ignore-all-space` — Load-bearing here because prose was reflowed. Every removal marker falls inside a sentence deliberately rewritten: no, tool;, both carry Bash, so their whitelist excludes only the four, tools; their, only the four, tools there, too. The one pure reflow, rewrapping the tail of the orch-reviewer-safe paragraph after an insertion shortened a line, produced zero removal markers on re-run, which is the signal that it dropped nothing. — commit `6ad9701ff7c40ce155b994082af06d844d62754c` (2026-08-01T19:29:41Z)
- **criterion-1 and 2 whitelist evidence** — pass — `read the tools frontmatter of all five adapters/claude/agents definitions` — orch-scout carries Read, Grep, Glob, WebFetch, WebSearch. orch-reviewer and orch-reviewer-safe are identical at Read, Grep, Glob, Bash. orch-implementer and orch-specialist carry Read, Grep, Glob, Edit, Write, NotebookEdit, Bash. Two consequences settled the wording. The reviewers' whitelist excludes every guarded write tool, not only some, so excludes every guarded write tool replaced excludes only the four. And MultiEdit appears in no whitelist at all, including the implementer's, so the four-tool set is the hook matcher's set rather than a whitelist field; the Claude README's known-limitations text now names the whitelist contents literally and says what it leaves open, which avoids that mismatch. — commit `6ad9701ff7c40ce155b994082af06d844d62754c` (2026-08-01T19:29:41Z)
- **criterion-2 codex contrast preserved** — pass — `read adapters/codex/README.md lines 155-173 before editing` — The paragraph's contrast, that Codex agent definitions carry no whitelist at all so the Claude whitelist is the foil, is intact, and the sentence still lands on same as this host's. — commit `6ad9701ff7c40ce155b994082af06d844d62754c` (2026-08-01T19:29:41Z)
- **reviewer-independent-frontmatter-and-matcher** — pass — `read tools frontmatter of all five adapters/claude/agents definitions and the matcher in adapters/claude/hooks/hooks.json` — Reviewer confirmed every executor claim independently. scout is Read, Grep, Glob, WebFetch, WebSearch. reviewer and reviewer-safe are both Read, Grep, Glob, Bash. implementer and specialist are both Read, Grep, Glob, Edit, Write, NotebookEdit, Bash. The hooks.json matcher is Write, Edit, MultiEdit, NotebookEdit. This confirms the executor's observation that MultiEdit appears in no whitelist at all. — commit `6ad9701ff7c40ce155b994082af06d844d62754c` (2026-08-01T19:38:06Z)
- **reviewer-no-go-file-reads-either-readme** — pass — `grep for readme references across internal/adaptertest and the adapters' Go files, and read the embed directives` — No Go file reads either adapter README, and the embeds in adapters/codex/embed.go and adapters/claude/doc.go cover plugin.json and agents TOMLs only. This establishes why no pinned prose literal could break, rather than inferring it from a passing suite. — commit `6ad9701ff7c40ce155b994082af06d844d62754c` (2026-08-01T19:38:06Z)
- **reviewer-overcorrection-check** — pass — `read the new prose in both READMEs against what the guard actually enforces` — Checked explicitly for prose implying the reviewers are unconstrained. The phrases Bash, which can write unguarded and Bash is left and Bash can write are both scoped to the guard and whitelist mechanism and are literally correct: Bash is not in the PreToolUse matcher, so a Bash write on Claude never reaches orch guard claude at all. Both sites route the reader to Known limitations, where the host's own permission prompts are named as the backstop. No claim of less protection than exists. — commit `6ad9701ff7c40ce155b994082af06d844d62754c` (2026-08-01T19:38:06Z)
- **acceptance-criterion-1** — satisfied — The five-subagent bullet now reads that scout, reviewer and reviewer-safe carry none of the four guarded write tools, but only scout is read-only by whitelist alone, because both reviewers carry Bash which can write unguarded, with a pointer to Known limitations. Read as a reader who stops there, the qualification is not merely nearer the claim but inside the same parenthetical and the same sentence, joined by but, so the wrong inference is cut off before the sentence ends. The claim that only scout is read-only by whitelist alone is itself accurate against the frontmatter: scout's list carries no write tool and no Bash, the reviewers' carries Bash. — commit `6ad9701ff7c40ce155b994082af06d844d62754c` (2026-08-01T19:38:07Z)
- **acceptance-criterion-2** — satisfied — Both halves hold. Grepping the head for four returns only the hook matcher at claude line 22, an unrelated four-option at claude line 43, claude lines 62 and 127, a four-tool matcher at codex line 32 and an unrelated codex line 53; no surviving only the four whitelist claim in either file. The Claude side now names the whitelist exhaustively as Read, Grep, Glob and Bash and states that every guarded write tool is excluded along with Task, every mcp__ tool, WebFetch and WebSearch, but that Bash is left and Bash can write, which is accurate against the frontmatter and lets the reader derive the full exclusion set rather than trust a sample. The Codex side, read across the full paragraph from line 155, keeps its foil that Codex definitions carry no whitelist at all, and its there too now attaches to the write path rather than to the exclusion count, which is a strict improvement on the ambiguous original. — commit `6ad9701ff7c40ce155b994082af06d844d62754c` (2026-08-01T19:38:07Z)
- **acceptance-criterion-3** — satisfied — go test ./... exits 0 at the head content with every package ok, including adapters/claude at 0.616s, adapters/codex at 0.526s and internal/agents at 0.552s, and no FAIL lines. CI's test jobs on all three operating systems are green at head OID 6ad9701. Separately confirmed why nothing could break: no Go file reads either README, and the embeds in adapters/codex/embed.go and adapters/claude/doc.go cover plugin.json and agents TOMLs only. — commit `6ad9701ff7c40ce155b994082af06d844d62754c` (2026-08-01T19:38:07Z)
- **acceptance-criterion-4** — satisfied — git diff --name-only against origin/main and gh pr view both report exactly adapters/claude/README.md at plus 18 minus 14 and adapters/codex/README.md at plus 4 minus 3, with a commit count of 1. git show --check reports no whitespace errors and both files are LF UTF-8. — commit `6ad9701ff7c40ce155b994082af06d844d62754c` (2026-08-01T19:38:07Z)
- **review-cycle-1** — approve — Docs-only, exactly in scope, one atomic commit. Both precision gaps are closed at the point of claim rather than only nearer to it, the replacement wording checks out line by line against the shipped agent frontmatter and the hook matcher, nothing was silently dropped in the reflow, and the change avoids the opposite failure of claiming less protection than exists. Required tests and all six CI checks pass at the reviewed head. Reviewed against a git archive extract of the exact head OID, with the repository left untouched. Three non-blocking findings are reported for the backlog rather than folded into a fix cycle: the README labels the same four-tool set as guarded write tools at line 62 and file-editing tools at line 127, with the members named only at line 22; the Codex sentence uses the archaic idiom for all that and does not restate the fuller exclusion set the Claude side now enumerates; and the MultiEdit residual the executor flagged is real and correctly left alone, since MultiEdit sits in the hook matcher but in no shipped whitelist, so that arm of the matcher can only fire for the main non-subagent session. — commit `6ad9701ff7c40ce155b994082af06d844d62754c` (2026-08-01T19:38:07Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `6ad9701ff7c40ce155b994082af06d844d62754c` (2026-08-01T19:38:12Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Two precision gaps the PR #90 reviewer found and no criterion of that issue named. Neither is false on its own terms, but both invite a reader to conclude that the per-agent tool whitelists make every read-only role unable to write - the exact inference PR #90 removed from the other sites in these same files.",
  "acceptance_criteria": [
    "In adapters/claude/README.md, the bullet listing the five role subagents no longer lets a reader who stops there conclude that the tool whitelist makes orch-scout, orch-reviewer and orch-reviewer-safe all unable to write. The qualification is present where the claim is made rather than only in the known-limitations section far below it.",
    "Neither adapters/claude/README.md nor adapters/codex/README.md states that the reviewer agents' whitelist excludes only the four guarded write tools. Each README's statement is accurate about what those whitelists exclude, which is more than the four write tools alone.",
    "go test ./... succeeds at this branch's head, so no prose literal these adapters' plugin tests pin has been broken.",
    "The set of files this pull request changes is exactly adapters/claude/README.md and adapters/codex/README.md."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All packages ok. adapters/claude, adapters/codex and internal/agents all pass, so no prose literal pinned by either adapter's plugin_test.go was broken. This is acceptance criterion 3.",
      "commit_oid": "6ad9701ff7c40ce155b994082af06d844d62754c",
      "at": "2026-08-01T19:29:41Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Empty output.",
      "commit_oid": "6ad9701ff7c40ce155b994082af06d844d62754c",
      "at": "2026-08-01T19:29:41Z"
    },
    {
      "name": "branch-scope: changed files and commit count",
      "command": "git fetch origin main \u0026\u0026 git diff --name-only origin/main...HEAD \u0026\u0026 git rev-list --count origin/main..HEAD",
      "result": "pass",
      "detail": "Changed files are exactly adapters/claude/README.md and adapters/codex/README.md. Commit count against origin/main is 1 (6ad9701). This is acceptance criterion 4.",
      "commit_oid": "6ad9701ff7c40ce155b994082af06d844d62754c",
      "at": "2026-08-01T19:29:41Z"
    },
    {
      "name": "branch-scope: word-diff check for silently dropped prose",
      "command": "git diff --word-diff --ignore-all-space",
      "result": "pass",
      "detail": "Load-bearing here because prose was reflowed. Every removal marker falls inside a sentence deliberately rewritten: no, tool;, both carry Bash, so their whitelist excludes only the four, tools; their, only the four, tools there, too. The one pure reflow, rewrapping the tail of the orch-reviewer-safe paragraph after an insertion shortened a line, produced zero removal markers on re-run, which is the signal that it dropped nothing.",
      "commit_oid": "6ad9701ff7c40ce155b994082af06d844d62754c",
      "at": "2026-08-01T19:29:41Z"
    },
    {
      "name": "criterion-1 and 2 whitelist evidence",
      "command": "read the tools frontmatter of all five adapters/claude/agents definitions",
      "result": "pass",
      "detail": "orch-scout carries Read, Grep, Glob, WebFetch, WebSearch. orch-reviewer and orch-reviewer-safe are identical at Read, Grep, Glob, Bash. orch-implementer and orch-specialist carry Read, Grep, Glob, Edit, Write, NotebookEdit, Bash. Two consequences settled the wording. The reviewers' whitelist excludes every guarded write tool, not only some, so excludes every guarded write tool replaced excludes only the four. And MultiEdit appears in no whitelist at all, including the implementer's, so the four-tool set is the hook matcher's set rather than a whitelist field; the Claude README's known-limitations text now names the whitelist contents literally and says what it leaves open, which avoids that mismatch.",
      "commit_oid": "6ad9701ff7c40ce155b994082af06d844d62754c",
      "at": "2026-08-01T19:29:41Z"
    },
    {
      "name": "criterion-2 codex contrast preserved",
      "command": "read adapters/codex/README.md lines 155-173 before editing",
      "result": "pass",
      "detail": "The paragraph's contrast, that Codex agent definitions carry no whitelist at all so the Claude whitelist is the foil, is intact, and the sentence still lands on same as this host's.",
      "commit_oid": "6ad9701ff7c40ce155b994082af06d844d62754c",
      "at": "2026-08-01T19:29:41Z"
    },
    {
      "name": "reviewer-independent-frontmatter-and-matcher",
      "command": "read tools frontmatter of all five adapters/claude/agents definitions and the matcher in adapters/claude/hooks/hooks.json",
      "result": "pass",
      "detail": "Reviewer confirmed every executor claim independently. scout is Read, Grep, Glob, WebFetch, WebSearch. reviewer and reviewer-safe are both Read, Grep, Glob, Bash. implementer and specialist are both Read, Grep, Glob, Edit, Write, NotebookEdit, Bash. The hooks.json matcher is Write, Edit, MultiEdit, NotebookEdit. This confirms the executor's observation that MultiEdit appears in no whitelist at all.",
      "commit_oid": "6ad9701ff7c40ce155b994082af06d844d62754c",
      "at": "2026-08-01T19:38:06Z"
    },
    {
      "name": "reviewer-no-go-file-reads-either-readme",
      "command": "grep for readme references across internal/adaptertest and the adapters' Go files, and read the embed directives",
      "result": "pass",
      "detail": "No Go file reads either adapter README, and the embeds in adapters/codex/embed.go and adapters/claude/doc.go cover plugin.json and agents TOMLs only. This establishes why no pinned prose literal could break, rather than inferring it from a passing suite.",
      "commit_oid": "6ad9701ff7c40ce155b994082af06d844d62754c",
      "at": "2026-08-01T19:38:06Z"
    },
    {
      "name": "reviewer-overcorrection-check",
      "command": "read the new prose in both READMEs against what the guard actually enforces",
      "result": "pass",
      "detail": "Checked explicitly for prose implying the reviewers are unconstrained. The phrases Bash, which can write unguarded and Bash is left and Bash can write are both scoped to the guard and whitelist mechanism and are literally correct: Bash is not in the PreToolUse matcher, so a Bash write on Claude never reaches orch guard claude at all. Both sites route the reader to Known limitations, where the host's own permission prompts are named as the backstop. No claim of less protection than exists.",
      "commit_oid": "6ad9701ff7c40ce155b994082af06d844d62754c",
      "at": "2026-08-01T19:38:06Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "The five-subagent bullet now reads that scout, reviewer and reviewer-safe carry none of the four guarded write tools, but only scout is read-only by whitelist alone, because both reviewers carry Bash which can write unguarded, with a pointer to Known limitations. Read as a reader who stops there, the qualification is not merely nearer the claim but inside the same parenthetical and the same sentence, joined by but, so the wrong inference is cut off before the sentence ends. The claim that only scout is read-only by whitelist alone is itself accurate against the frontmatter: scout's list carries no write tool and no Bash, the reviewers' carries Bash.",
      "commit_oid": "6ad9701ff7c40ce155b994082af06d844d62754c",
      "at": "2026-08-01T19:38:07Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "Both halves hold. Grepping the head for four returns only the hook matcher at claude line 22, an unrelated four-option at claude line 43, claude lines 62 and 127, a four-tool matcher at codex line 32 and an unrelated codex line 53; no surviving only the four whitelist claim in either file. The Claude side now names the whitelist exhaustively as Read, Grep, Glob and Bash and states that every guarded write tool is excluded along with Task, every mcp__ tool, WebFetch and WebSearch, but that Bash is left and Bash can write, which is accurate against the frontmatter and lets the reader derive the full exclusion set rather than trust a sample. The Codex side, read across the full paragraph from line 155, keeps its foil that Codex definitions carry no whitelist at all, and its there too now attaches to the write path rather than to the exclusion count, which is a strict improvement on the ambiguous original.",
      "commit_oid": "6ad9701ff7c40ce155b994082af06d844d62754c",
      "at": "2026-08-01T19:38:07Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "go test ./... exits 0 at the head content with every package ok, including adapters/claude at 0.616s, adapters/codex at 0.526s and internal/agents at 0.552s, and no FAIL lines. CI's test jobs on all three operating systems are green at head OID 6ad9701. Separately confirmed why nothing could break: no Go file reads either README, and the embeds in adapters/codex/embed.go and adapters/claude/doc.go cover plugin.json and agents TOMLs only.",
      "commit_oid": "6ad9701ff7c40ce155b994082af06d844d62754c",
      "at": "2026-08-01T19:38:07Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "git diff --name-only against origin/main and gh pr view both report exactly adapters/claude/README.md at plus 18 minus 14 and adapters/codex/README.md at plus 4 minus 3, with a commit count of 1. git show --check reports no whitespace errors and both files are LF UTF-8.",
      "commit_oid": "6ad9701ff7c40ce155b994082af06d844d62754c",
      "at": "2026-08-01T19:38:07Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Docs-only, exactly in scope, one atomic commit. Both precision gaps are closed at the point of claim rather than only nearer to it, the replacement wording checks out line by line against the shipped agent frontmatter and the hook matcher, nothing was silently dropped in the reflow, and the change avoids the opposite failure of claiming less protection than exists. Required tests and all six CI checks pass at the reviewed head. Reviewed against a git archive extract of the exact head OID, with the repository left untouched. Three non-blocking findings are reported for the backlog rather than folded into a fix cycle: the README labels the same four-tool set as guarded write tools at line 62 and file-editing tools at line 127, with the members named only at line 22; the Codex sentence uses the archaic idiom for all that and does not restate the fuller exclusion set the Claude side now enumerates; and the MultiEdit residual the executor flagged is real and correctly left alone, since MultiEdit sits in the hook matcher but in no shipped whitelist, so that arm of the matcher can only fire for the main non-subagent session.",
      "commit_oid": "6ad9701ff7c40ce155b994082af06d844d62754c",
      "at": "2026-08-01T19:38:07Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "6ad9701ff7c40ce155b994082af06d844d62754c",
      "at": "2026-08-01T19:38:12Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->