### PR TITLE
Correct README.md's Fixed and Known-issues sections against doctor and the shipped reviewer definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,10 +568,11 @@ tagged release.
   acceptance criterion: a required test that fails, a security boundary
   the change weakens, and any defect of comparable severity are each
   grounds on their own, even when no acceptance criterion names the
-  area they sit in; before, Claude Code's two reviewers were given
-  exactly two grounds — a finding blocking a criterion, or a criterion
-  itself wrong — and Codex's two were given no grounds at all, so on
-  neither host did a required test failing outside every criterion's
+  area they sit in; before, Claude Code's two reviewers closed the set
+  at exactly two grounds — a finding blocking a criterion, or a
+  criterion itself wrong — while Codex's two named the wrong-criterion
+  ground without ever saying what else could drive request-changes, so
+  on neither host did a required test failing outside every criterion's
   wording have to block the review —
   [#159](https://github.com/kninetimmy/orch/pull/159)
 - `orch run review` now refuses, before any mutation, a review that

--- a/README.md
+++ b/README.md
@@ -461,18 +461,18 @@ expected adapter version when they diverge.
 command-line tool.** Doctor checks every host the committed
 configuration names, and fails when that host's CLI is missing from
 `PATH`, when its plugin listing cannot be read, or when its adapter is
-anything other than one enabled entry at the version this build ships
-— absent, listed more than once, disabled, reporting no version at
-all, reporting a different version, or, on Codex, marked not
-installed. Host enablement is a committed-only key — the Settings
-table above marks `hosts.claude` / `hosts.codex` as `no (committed)` —
-so machine-local configuration cannot switch a host off for one
-machine. Symptom: a repository configured for both hosts reports a
-failing doctor on every machine that has only one of them installed.
-Workaround: enable only the hosts every machine working on the
-repository will have, or install the missing CLI on that machine.
-There is no override for this, by design: the check exists so an
-adapter that is absent or out of date is reported rather than trusted.
+in any of six states — absent, listed more than once, disabled,
+reporting no version at all, reporting a different version, or, on
+Codex, marked not installed. Host enablement is a committed-only key
+— the Settings table above marks `hosts.claude` / `hosts.codex` as
+`no (committed)` — so machine-local configuration cannot switch a
+host off for one machine. Symptom: a repository configured for both
+hosts reports a failing doctor on every machine that has only one of
+them installed. Workaround: enable only the hosts every machine
+working on the repository will have, or install the missing CLI on
+that machine. There is no override for this, by design: the check
+exists so an adapter that is absent or out of date is reported rather
+than trusted.
 
 **Codex `workspace-write` sandbox mode on Windows fails every agent
 write where the sandbox helper infrastructure is absent.** Observed
@@ -504,9 +504,9 @@ to compare the routed model against the installed agent's frontmatter
 and, on a mismatch, to stop and tell you rather than spawn a different
 model — so that stop rests on the Architect following an instruction,
 not on a check the engine performs. Either way, changing a role's
-model — which the Settings section above
-recommends as ordinary tuning — is not finished until the installed
-agent definitions carry it too.
+model — which the Settings section above recommends as ordinary
+tuning — is not finished until the installed agent definitions carry
+it too.
 
 **A Codex CLI upgrade that adds a new `apply_patch` directive causes
 denials until `orch` catches up.** The guard's envelope parser treats
@@ -546,13 +546,14 @@ Everything here is merged on `main` and shipped in v0.6.0, the latest
 tagged release.
 
 - `orch doctor` now checks each configured host's installed Orch
-  adapter and fails when it is absent, disabled, ambiguous or a
-  different version from the one this build ships, naming the expected
+  adapter and fails when it is absent, listed more than once, disabled,
+  reporting no version at all, at a different version from the one this
+  build ships, or, on Codex, marked not installed, naming the expected
   version and, whenever there is an installed one to name, the
-  installed version too — an absent adapter has no installed version,
-  so that failure reports the expected version alone; before, an
-  adapter left behind by a binary-only upgrade kept running while
-  doctor reported the host healthy —
+  installed version too — an adapter that is absent or reports no
+  version has none to name, so those failures report the expected
+  version alone; before, an adapter left behind by a binary-only
+  upgrade kept running while doctor reported the host healthy —
   [#167](https://github.com/kninetimmy/orch/pull/167)
 - `orch doctor` and Codex plan activation now compare the rendered
   agent definitions in `.codex/agents/` against the current build and
@@ -561,6 +562,18 @@ tagged release.
   configuration went on being dispatched with nothing reporting them
   stale —
   [#166](https://github.com/kninetimmy/orch/pull/166)
+- Every reviewer agent definition — the standard and the read-only
+  reviewer, on Claude Code and on Codex alike — now states that a
+  `request-changes` verdict is not confined to findings that block an
+  acceptance criterion: a required test that fails, a security boundary
+  the change weakens, and any defect of comparable severity are each
+  grounds on their own, even when no acceptance criterion names the
+  area they sit in; before, Claude Code's two reviewers were given
+  exactly two grounds — a finding blocking a criterion, or a criterion
+  itself wrong — and Codex's two were given no grounds at all, so a
+  required test failing outside every criterion's wording could be
+  written up as a report finding and approved in the same review —
+  [#159](https://github.com/kninetimmy/orch/pull/159)
 - `orch run review` now refuses, before any mutation, a review that
   does not carry exactly one judgment per acceptance criterion the
   issue holds, and a criterion judged wrong blocks the issue for you as

--- a/README.md
+++ b/README.md
@@ -562,17 +562,17 @@ tagged release.
   configuration went on being dispatched with nothing reporting them
   stale —
   [#166](https://github.com/kninetimmy/orch/pull/166)
-- Every reviewer agent definition — the standard and the read-only
-  reviewer, on Claude Code and on Codex alike — now states that a
+- Every reviewer agent definition on both hosts — the standard
+  reviewer and the safe review downgrade alike — now states that a
   `request-changes` verdict is not confined to findings that block an
   acceptance criterion: a required test that fails, a security boundary
   the change weakens, and any defect of comparable severity are each
   grounds on their own, even when no acceptance criterion names the
   area they sit in; before, Claude Code's two reviewers were given
   exactly two grounds — a finding blocking a criterion, or a criterion
-  itself wrong — and Codex's two were given no grounds at all, so a
-  required test failing outside every criterion's wording could be
-  written up as a report finding and approved in the same review —
+  itself wrong — and Codex's two were given no grounds at all, so on
+  neither host did a required test failing outside every criterion's
+  wording have to block the review —
   [#159](https://github.com/kninetimmy/orch/pull/159)
 - `orch run review` now refuses, before any mutation, a review that
   does not carry exactly one judgment per acceptance criterion the


### PR DESCRIPTION
Delivers issue #178: Correct README.md's Fixed and Known-issues sections against doctor and the shipped reviewer definitions

Closes #178

**Plan digest:** `sha256:d98d11a0764d1f121185a2eaa3652430fef471f5c3026609799e95222ea431aa`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** README.md currently makes three claims that its own code and shipped adapter files do not support, and carries one short line from an earlier reflow. The Fixed section says nothing about what drives a reviewer's request-changes verdict, though PR #159 widened that bar and shipped the widened sentence in all four reviewer definitions on both hosts. The Fixed entry for PR #167 lists four adapter failure cases where internal/cli/doctor.go reports six. The Known-issues entry introducing those same failures closes on a condition narrower than the list that immediately follows it. Bring all three in line with the tree, and reflow the short line.

**Acceptance criteria:**
- README.md's Fixed section carries an entry crediting PR #159 that states a reviewer's request-changes verdict is not limited to findings blocking an acceptance criterion, and names the reviewer definitions on both hosts as where that widened bar shipped.
- The Fixed section's entry for PR #167 names every failure case checkAdapter in internal/cli/doctor.go reports, including an adapter that reports no version at all and a Codex adapter marked not installed.
- The Known-issues sentence that introduces doctor's adapter failures no longer describes that failure set in terms an enabled, unique, expected-version Codex entry marked not installed would fall outside of.
- In README.md's Known-issues entry about changing a role's model, no line other than the paragraph's last is shorter than 60 characters.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test -count=1 ./...` — Re-run uncached at the fixed tree after two count errors reached this record earlier in the run: 23 packages report ok and 3 have no test files (cmd/orch, internal/adaptertest, internal/execx/execxtest), 26 total, exit 0, with no cached line anywhere. adapters/claude and adapters/codex both pass, which is where the grounds sentence is pinned. The cycle-3 reviewer independently established the result carries to head by confirming no Go test reads the repository's own README - every README reference in the suite writes a synthetic fixture into a temp repo, and marketplace_test.go:59 is a comment. — commit `54c9a69af85e055527736656d98bc0d65003c18f` (2026-08-01T21:32:03Z)
- **gofmt** — pass — `gofmt -l .` — Re-run by the cycle-2 reviewer at the head OID: empty output, exit 0. — commit `73aa322cdebc07ea61455007f8005325d63e7e4b` (2026-08-01T21:19:34Z)
- **reflow-word-diff** — pass — `git diff --word-diff --ignore-all-space -- README.md` — Run because this commit reflows two paragraphs. Removal markers appear only in the two intentionally reworded spans (the Known-issues summary clause and the PR #167 Fixed entry). Both reflowed paragraphs -- the Known-issues doctor paragraph tail and the model-override paragraph -- produce no removal markers at all, confirming no word was dropped in the rewrap. — commit `d82b6f3510da2362555ae591d9d1e217390c36c7` (2026-08-01T20:48:37Z)
- **criterion-4-line-lengths** — pass — `Python len over README.md read as utf-8, lines 491-509` — Corrected range, superseding the pr-open entry that recorded 63-71. The measured character range is 62-70, with the paragraph's last line at 7. The pr-open figure was two high on every line containing an em dash because awk's length counts BYTES in this environment and an em dash is 3 bytes in UTF-8; an earlier explanation blaming a line terminator was also wrong, since the file is plain UTF-8 with no CRLF. Criterion 4's result is unaffected either way, and the diff between cycle 1 and head does not touch this paragraph, so the corrected measurement describes the same text the original entry described. — commit `54c9a69af85e055527736656d98bc0d65003c18f` (2026-08-01T21:32:03Z)
- **branch-scope: readme-only-single-commit** — pass — `git diff --stat 6be2a2b...54c9a69; git log 6be2a2b..54c9a69; gh pr view 181 --json additions,deletions,changedFiles,baseRefOid` — Re-stamped at the cycle-3 head OID 54c9a69 with live figures, superseding the cycle-2 stamp: README.md alone, 35 insertions, 21 deletions, ONE file, and THREE commits ahead of the merge base - d82b6f3, 73aa322 and 54c9a69. gh pr view independently reports additions 35, deletions 21, changedFiles 1, baseRefOid 6be2a2b. Verified against the live PR base rather than a local main ref, which matters because two sibling issues from this wave merged while this PR was open and moved origin/main to 577a1c9. Those merges touched ORCH-PRD.md, both adapter READMEs and internal/guard/guard.go, never the root README, so there is no conflict and the PR reports MERGEABLE. — commit `54c9a69af85e055527736656d98bc0d65003c18f` (2026-08-01T21:32:03Z)
- **acceptance-criterion-1** — satisfied — README.md:565-577 at head is a Fixed-section bullet ending in the #159 link, and it states the widened bar verbatim as shipped. git grep -l of 'grounds on their own' at the merge base returns exactly six paths - the four reviewer definitions plus the pins at adapters/claude/plugin_test.go:330 and adapters/codex/plugin_test.go:311 - so the sentence really is on all four. The naming element is met by 'Every reviewer agent definition on both hosts - the standard reviewer and the safe review downgrade alike', and git diff 5ab6ce1^ 5ab6ce1 -- adapters/ confirms #159 added that paragraph to all four files. — commit `54c9a69af85e055527736656d98bc0d65003c18f` (2026-08-01T21:32:04Z)
- **acceptance-criterion-2** — satisfied — README.md:549-551 names absent, listed more than once, disabled, reporting no version at all, at a different version, and on Codex marked not installed. checkAdapter at internal/cli/doctor.go:216 has exactly those six adapter-state branches once the plugin listing decodes. Both cases the criterion names explicitly are present. Judged against the criterion's own clarifier and the objective's 'reports six' rather than the literal 'every failure case' reading, which is the routed-to-backlog item. — commit `54c9a69af85e055527736656d98bc0d65003c18f` (2026-08-01T21:32:04Z)
- **acceptance-criterion-3** — satisfied — README.md:463-466 now reads 'in any of six states' followed by the six-item list, and the prior closing condition 'anything other than one enabled entry at the version this build ships' is gone from the diff. A unique, enabled, expected-version Codex entry with Installed:false hits the codex-not-installed branch, which runs before the enabled and version checks, and it is now explicitly inside the described set rather than outside it. — commit `54c9a69af85e055527736656d98bc0d65003c18f` (2026-08-01T21:32:04Z)
- **acceptance-criterion-4** — satisfied — Measured as characters over decoded UTF-8 using Python len on the file read as utf-8, deliberately not awk or bytes, because an em dash is 3 bytes and awk's length counts bytes in this environment. The paragraph is README.md:491-509 with lengths 66, 66, 69, 63, 65, 62, 70, 68, 68, 66, 70, 69, 69, 70, 69, 65, 63, 68, and a last line of 7. The minimum excluding the last line is 62 at line 496, which clears 60. — commit `54c9a69af85e055527736656d98bc0d65003c18f` (2026-08-01T21:32:04Z)
- **review-cycle-1** — request-changes — Criteria 2, 3 and 4 satisfied, re-derived independently against internal/cli/doctor.go and measured line lengths; scope is one file; both required tests and all six CI checks pass. Blocked on criterion 1: the new PR #159 Fixed entry names the four definitions as 'the standard and the read-only reviewer', and no read-only reviewer exists in the tree. orch-reviewer-safe is the review-downgrade profile (internal/agents/agents.go:49 maps review_downgrade to orch-reviewer-safe; its own heading reads 'Orch Reviewer (Safe Downgrade)'), and both reviewers are equally read-only and only by instruction, since both Claude frontmatters carry the identical 'tools: Read, Grep, Glob, Bash'. The clause both invents a distinction and, by contrast, implies the standard reviewer is not read-only, contradicting README.md:415-419 in the same file. That is a fresh unsupported claim about the shipped adapter files inside a PR whose purpose is deleting unsupported claims about the shipped adapter files, and the second time in three PRs a newly added Fixed entry has carried one. The rest of the entry was verified correct against the four shipped definitions and against git show 5ab6ce1^, so the fix is confined to how the entry names the two definitions per host. Non-blocking findings, filed rather than folded in: the closing consequence clause is inference-from-silence for Codex, whose definitions at 5ab6ce1^ had no grounds paragraph and no report-every-finding paragraph (low, medium confidence); 'in any of six states' is a countable claim stated immediately before the list that already shows it (low, high); criterion 2's literal wording is broader than the entry covers, since checkAdapter also fails on an unreadable manifest, a missing executable, a runner error, a nonzero exit and malformed output (low, high); the criterion-4 line-length verification recorded 63-71 where measured characters are 62-70, an apparent line-terminator miscount (informational); README.md:461 is a 59-character unchanged context line in the other reflowed paragraph (informational). One process finding for the Architect: mid-review FETCH_HEAD in the primary checkout was overwritten by the concurrent issue #180 run and resolved to 603d550, so any verification resolving a branch through FETCH_HEAD during a parallel wave can silently read a sibling issue's tree; the reviewer redid every check against the pinned OID. — commit `d82b6f3510da2362555ae591d9d1e217390c36c7` (2026-08-01T20:58:37Z)
- **codex-before-state-at-5ab6ce1-parent** — pass — `git show 5ab6ce1^ over all four reviewer definitions, grepping both 'ground' and 'grounds'` — Superseding the cycle-2 fail entry, whose subject no longer exists at head. The false claim that Codex's two definitions were given no grounds at all was removed by 54c9a69. The corrected before-state now in the entry was re-derived on both hosts and for both singular and plural forms: at 5ab6ce1^ all four definitions carry the wrong-criterion ground, while only the Claude pair carries the sentence closing the set at exactly two grounds - 'a finding blocks an acceptance criterion, or an acceptance criterion is itself wrong in the sense above' - and neither Codex TOML contains the plural 'grounds' at all. The cycle-1 search that produced the false claim used the plural against text written in the singular. — commit `54c9a69af85e055527736656d98bc0d65003c18f` (2026-08-01T21:32:03Z)
- **review-cycle-2** — request-changes — Cycle 2. All four criteria are now satisfied at head and cycle 1's block is genuinely fixed: the read-only-reviewer invention is gone, and the reworded consequence clause is true of both hosts, which the reviewer verified against 5ab6ce1^ rather than inheriting. Blocked anyway on a defect of comparable severity that the same rewrite introduced, under the widened bar that does not confine request-changes to criterion-blocking findings. README.md:573 now says 'Codex's two were given no grounds at all', and that is false: at 5ab6ce1^ both Codex reviewer definitions already carried a '## When a criterion is itself wrong' section reading 'You may return request-changes on the ground that an acceptance criterion is itself wrong' - the very ground the sentence credits to Claude one clause earlier. The Architect independently confirmed this before accepting the finding: git show 5ab6ce1^:adapters/codex/agents/orch-reviewer.toml contains that section, and git log on that file shows it arrived in 695b044 (#147) and 5a91e48 (#151), both before 5ab6ce1 (#159). What Codex actually lacked was the grounds STATEMENT that closed the set, which is what the executor's own fix-commit message said accurately before the looser wording shipped. The cycle-1 executor's grep missed it because it searched for the plural 'grounds' while the text uses the singular 'ground'. So the sentence manufactures a host difference that did not exist, in a PR whose whole purpose is deleting README claims the tree does not support. Non-blocking findings: 'the safe review downgrade' at README.md:566 is a coinage where the file elsewhere says 'Review downgrade', 'a cheaper review downgrade', 'the downgraded reviewer' and orch-reviewer-safe - unambiguous, consistency nit only (low, medium confidence); the #117 entry at README.md:593-601 says Claude Code's two reviewer agents decide the verdict afterwards as a separate judgment, and at head that sentence is on Codex's two as well since #159 added it, but the entry is accurate as a record of what #117 did and the genuinely Claude-only part stays correctly scoped, since grepping 'Give each finding a severity' returns only the two Claude files (informational, no change requested). The reviewer confirmed the new #159 entry does not blur that asymmetry: it confines its claim to the grounds sentence, which really is on all four definitions. Positive checks worth recording: Fixed-section newest-first ordering holds, with 5ab6ce1 correctly between b4135a4 (#166) and c4840df (#158); the section's 'shipped in v0.6.0' header claim holds, since git tag --contains 5ab6ce1 returns v0.6.0; and the entry's 'now states that' framing keeps it honest that this is agent instruction text rather than an engine-enforced check. — commit `73aa322cdebc07ea61455007f8005325d63e7e4b` (2026-08-01T21:19:35Z)
- **required-ci-observed-green-at-head** — pass — `gh run view 30718979782` — Reviewer-observed, distinct from the engine's own required-ci entry: run 30718979782 reports headSha 54c9a69, status completed, conclusion success, with all six checks passing including test (windows-latest) at 2m32s, which was still pending when this review cycle was dispatched and finished during it. — commit `54c9a69af85e055527736656d98bc0d65003c18f` (2026-08-01T21:32:03Z)
- **review-cycle-3** — approve — Cycle 3. All four criteria satisfied at head, each against a specific observation the reviewer re-derived rather than inherited; scope is one file with nothing unrelated; both required tests pass and all six CI checks are green at 54c9a69, including test (windows-latest), which finished after this review was dispatched. No security concern. The reviewer raised two findings on the same before-state clause and deliberately did not block on them, distinguishing them in kind from what the first two cycles caught: cycle 1 named an artifact that does not exist and cycle 2 asserted something flatly false, whereas this clause is directionally accurate and turns on an interpretive question. Finding 1, medium severity and medium confidence: the entry's 'without ever saying what else could drive request-changes' is arguably contradicted by a sentence in both Codex TOMLs' 'How you look' section at 5ab6ce1^ reading 'If the change needs a fix, that is a request-changes verdict sent back to the executor, not something you do yourself.' The mitigating reading is that this is a role-boundary rule rather than a verdict ground; cutting against it, PR #159's own diff amended exactly that sentence to add 'the verdict grounds below make blocking', which only makes sense if the authors read it as a driver. Finding 2, medium severity and medium-low confidence: the closing clause 'so on neither host did a required test failing outside every criterion's wording have to block the review' is explicit and verified for Claude, whose definitions closed the set at two grounds and said a finding that is neither stays in the report, but for Codex it rests on silence, against which that same needs-a-fix sentence sits. Both are routed to the backlog with the counterexample text quoted, on the reviewer's judgment that no acceptance criterion requires the before-state clause and that a defect of this magnitude is not comparable to a failing required test or a weakened boundary. Also noted and not blocking: the #167 entry's installed-version aside does not name the duplicate-match branch, which also prints the expected version alone when every match has an empty version, arguably covered by 'reports no version' (low, medium). One benign correction to the Architect's own dispatch brief: grepping 'grounds on their own' at head returns seven paths rather than six, because this PR now quotes the sentence verbatim in README.md; at the merge base the count is exactly six. Positive checks recorded: 5ab6ce1 is an ancestor of v0.6.0 so the section header's 'shipped in v0.6.0' claim holds for the new entry; Fixed-section newest-first ordering holds with #159 between #166 and #158; the pre-existing #117 entry is untouched and still correctly scoped to 'Claude Code's two reviewer agents', and the new entry does not blur that asymmetry since it confines its claim to the grounds sentence, which really is on all four definitions; and the word-level reflow of both paragraphs drops nothing. — commit `54c9a69af85e055527736656d98bc0d65003c18f` (2026-08-01T21:32:04Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, lint=pass, scripts (windows-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass — commit `54c9a69af85e055527736656d98bc0d65003c18f` (2026-08-01T21:32:08Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "README.md currently makes three claims that its own code and shipped adapter files do not support, and carries one short line from an earlier reflow. The Fixed section says nothing about what drives a reviewer's request-changes verdict, though PR #159 widened that bar and shipped the widened sentence in all four reviewer definitions on both hosts. The Fixed entry for PR #167 lists four adapter failure cases where internal/cli/doctor.go reports six. The Known-issues entry introducing those same failures closes on a condition narrower than the list that immediately follows it. Bring all three in line with the tree, and reflow the short line.",
  "acceptance_criteria": [
    "README.md's Fixed section carries an entry crediting PR #159 that states a reviewer's request-changes verdict is not limited to findings blocking an acceptance criterion, and names the reviewer definitions on both hosts as where that widened bar shipped.",
    "The Fixed section's entry for PR #167 names every failure case checkAdapter in internal/cli/doctor.go reports, including an adapter that reports no version at all and a Codex adapter marked not installed.",
    "The Known-issues sentence that introduces doctor's adapter failures no longer describes that failure set in terms an enabled, unique, expected-version Codex entry marked not installed would fall outside of.",
    "In README.md's Known-issues entry about changing a role's model, no line other than the paragraph's last is shorter than 60 characters."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test -count=1 ./...",
      "result": "pass",
      "detail": "Re-run uncached at the fixed tree after two count errors reached this record earlier in the run: 23 packages report ok and 3 have no test files (cmd/orch, internal/adaptertest, internal/execx/execxtest), 26 total, exit 0, with no cached line anywhere. adapters/claude and adapters/codex both pass, which is where the grounds sentence is pinned. The cycle-3 reviewer independently established the result carries to head by confirming no Go test reads the repository's own README - every README reference in the suite writes a synthetic fixture into a temp repo, and marketplace_test.go:59 is a comment.",
      "commit_oid": "54c9a69af85e055527736656d98bc0d65003c18f",
      "at": "2026-08-01T21:32:03Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Re-run by the cycle-2 reviewer at the head OID: empty output, exit 0.",
      "commit_oid": "73aa322cdebc07ea61455007f8005325d63e7e4b",
      "at": "2026-08-01T21:19:34Z"
    },
    {
      "name": "reflow-word-diff",
      "command": "git diff --word-diff --ignore-all-space -- README.md",
      "result": "pass",
      "detail": "Run because this commit reflows two paragraphs. Removal markers appear only in the two intentionally reworded spans (the Known-issues summary clause and the PR #167 Fixed entry). Both reflowed paragraphs -- the Known-issues doctor paragraph tail and the model-override paragraph -- produce no removal markers at all, confirming no word was dropped in the rewrap.",
      "commit_oid": "d82b6f3510da2362555ae591d9d1e217390c36c7",
      "at": "2026-08-01T20:48:37Z"
    },
    {
      "name": "criterion-4-line-lengths",
      "command": "Python len over README.md read as utf-8, lines 491-509",
      "result": "pass",
      "detail": "Corrected range, superseding the pr-open entry that recorded 63-71. The measured character range is 62-70, with the paragraph's last line at 7. The pr-open figure was two high on every line containing an em dash because awk's length counts BYTES in this environment and an em dash is 3 bytes in UTF-8; an earlier explanation blaming a line terminator was also wrong, since the file is plain UTF-8 with no CRLF. Criterion 4's result is unaffected either way, and the diff between cycle 1 and head does not touch this paragraph, so the corrected measurement describes the same text the original entry described.",
      "commit_oid": "54c9a69af85e055527736656d98bc0d65003c18f",
      "at": "2026-08-01T21:32:03Z"
    },
    {
      "name": "branch-scope: readme-only-single-commit",
      "command": "git diff --stat 6be2a2b...54c9a69; git log 6be2a2b..54c9a69; gh pr view 181 --json additions,deletions,changedFiles,baseRefOid",
      "result": "pass",
      "detail": "Re-stamped at the cycle-3 head OID 54c9a69 with live figures, superseding the cycle-2 stamp: README.md alone, 35 insertions, 21 deletions, ONE file, and THREE commits ahead of the merge base - d82b6f3, 73aa322 and 54c9a69. gh pr view independently reports additions 35, deletions 21, changedFiles 1, baseRefOid 6be2a2b. Verified against the live PR base rather than a local main ref, which matters because two sibling issues from this wave merged while this PR was open and moved origin/main to 577a1c9. Those merges touched ORCH-PRD.md, both adapter READMEs and internal/guard/guard.go, never the root README, so there is no conflict and the PR reports MERGEABLE.",
      "commit_oid": "54c9a69af85e055527736656d98bc0d65003c18f",
      "at": "2026-08-01T21:32:03Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "README.md:565-577 at head is a Fixed-section bullet ending in the #159 link, and it states the widened bar verbatim as shipped. git grep -l of 'grounds on their own' at the merge base returns exactly six paths - the four reviewer definitions plus the pins at adapters/claude/plugin_test.go:330 and adapters/codex/plugin_test.go:311 - so the sentence really is on all four. The naming element is met by 'Every reviewer agent definition on both hosts - the standard reviewer and the safe review downgrade alike', and git diff 5ab6ce1^ 5ab6ce1 -- adapters/ confirms #159 added that paragraph to all four files.",
      "commit_oid": "54c9a69af85e055527736656d98bc0d65003c18f",
      "at": "2026-08-01T21:32:04Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "README.md:549-551 names absent, listed more than once, disabled, reporting no version at all, at a different version, and on Codex marked not installed. checkAdapter at internal/cli/doctor.go:216 has exactly those six adapter-state branches once the plugin listing decodes. Both cases the criterion names explicitly are present. Judged against the criterion's own clarifier and the objective's 'reports six' rather than the literal 'every failure case' reading, which is the routed-to-backlog item.",
      "commit_oid": "54c9a69af85e055527736656d98bc0d65003c18f",
      "at": "2026-08-01T21:32:04Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "README.md:463-466 now reads 'in any of six states' followed by the six-item list, and the prior closing condition 'anything other than one enabled entry at the version this build ships' is gone from the diff. A unique, enabled, expected-version Codex entry with Installed:false hits the codex-not-installed branch, which runs before the enabled and version checks, and it is now explicitly inside the described set rather than outside it.",
      "commit_oid": "54c9a69af85e055527736656d98bc0d65003c18f",
      "at": "2026-08-01T21:32:04Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "Measured as characters over decoded UTF-8 using Python len on the file read as utf-8, deliberately not awk or bytes, because an em dash is 3 bytes and awk's length counts bytes in this environment. The paragraph is README.md:491-509 with lengths 66, 66, 69, 63, 65, 62, 70, 68, 68, 66, 70, 69, 69, 70, 69, 65, 63, 68, and a last line of 7. The minimum excluding the last line is 62 at line 496, which clears 60.",
      "commit_oid": "54c9a69af85e055527736656d98bc0d65003c18f",
      "at": "2026-08-01T21:32:04Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "Criteria 2, 3 and 4 satisfied, re-derived independently against internal/cli/doctor.go and measured line lengths; scope is one file; both required tests and all six CI checks pass. Blocked on criterion 1: the new PR #159 Fixed entry names the four definitions as 'the standard and the read-only reviewer', and no read-only reviewer exists in the tree. orch-reviewer-safe is the review-downgrade profile (internal/agents/agents.go:49 maps review_downgrade to orch-reviewer-safe; its own heading reads 'Orch Reviewer (Safe Downgrade)'), and both reviewers are equally read-only and only by instruction, since both Claude frontmatters carry the identical 'tools: Read, Grep, Glob, Bash'. The clause both invents a distinction and, by contrast, implies the standard reviewer is not read-only, contradicting README.md:415-419 in the same file. That is a fresh unsupported claim about the shipped adapter files inside a PR whose purpose is deleting unsupported claims about the shipped adapter files, and the second time in three PRs a newly added Fixed entry has carried one. The rest of the entry was verified correct against the four shipped definitions and against git show 5ab6ce1^, so the fix is confined to how the entry names the two definitions per host. Non-blocking findings, filed rather than folded in: the closing consequence clause is inference-from-silence for Codex, whose definitions at 5ab6ce1^ had no grounds paragraph and no report-every-finding paragraph (low, medium confidence); 'in any of six states' is a countable claim stated immediately before the list that already shows it (low, high); criterion 2's literal wording is broader than the entry covers, since checkAdapter also fails on an unreadable manifest, a missing executable, a runner error, a nonzero exit and malformed output (low, high); the criterion-4 line-length verification recorded 63-71 where measured characters are 62-70, an apparent line-terminator miscount (informational); README.md:461 is a 59-character unchanged context line in the other reflowed paragraph (informational). One process finding for the Architect: mid-review FETCH_HEAD in the primary checkout was overwritten by the concurrent issue #180 run and resolved to 603d550, so any verification resolving a branch through FETCH_HEAD during a parallel wave can silently read a sibling issue's tree; the reviewer redid every check against the pinned OID.",
      "commit_oid": "d82b6f3510da2362555ae591d9d1e217390c36c7",
      "at": "2026-08-01T20:58:37Z"
    },
    {
      "name": "codex-before-state-at-5ab6ce1-parent",
      "command": "git show 5ab6ce1^ over all four reviewer definitions, grepping both 'ground' and 'grounds'",
      "result": "pass",
      "detail": "Superseding the cycle-2 fail entry, whose subject no longer exists at head. The false claim that Codex's two definitions were given no grounds at all was removed by 54c9a69. The corrected before-state now in the entry was re-derived on both hosts and for both singular and plural forms: at 5ab6ce1^ all four definitions carry the wrong-criterion ground, while only the Claude pair carries the sentence closing the set at exactly two grounds - 'a finding blocks an acceptance criterion, or an acceptance criterion is itself wrong in the sense above' - and neither Codex TOML contains the plural 'grounds' at all. The cycle-1 search that produced the false claim used the plural against text written in the singular.",
      "commit_oid": "54c9a69af85e055527736656d98bc0d65003c18f",
      "at": "2026-08-01T21:32:03Z"
    },
    {
      "name": "review-cycle-2",
      "result": "request-changes",
      "detail": "Cycle 2. All four criteria are now satisfied at head and cycle 1's block is genuinely fixed: the read-only-reviewer invention is gone, and the reworded consequence clause is true of both hosts, which the reviewer verified against 5ab6ce1^ rather than inheriting. Blocked anyway on a defect of comparable severity that the same rewrite introduced, under the widened bar that does not confine request-changes to criterion-blocking findings. README.md:573 now says 'Codex's two were given no grounds at all', and that is false: at 5ab6ce1^ both Codex reviewer definitions already carried a '## When a criterion is itself wrong' section reading 'You may return request-changes on the ground that an acceptance criterion is itself wrong' - the very ground the sentence credits to Claude one clause earlier. The Architect independently confirmed this before accepting the finding: git show 5ab6ce1^:adapters/codex/agents/orch-reviewer.toml contains that section, and git log on that file shows it arrived in 695b044 (#147) and 5a91e48 (#151), both before 5ab6ce1 (#159). What Codex actually lacked was the grounds STATEMENT that closed the set, which is what the executor's own fix-commit message said accurately before the looser wording shipped. The cycle-1 executor's grep missed it because it searched for the plural 'grounds' while the text uses the singular 'ground'. So the sentence manufactures a host difference that did not exist, in a PR whose whole purpose is deleting README claims the tree does not support. Non-blocking findings: 'the safe review downgrade' at README.md:566 is a coinage where the file elsewhere says 'Review downgrade', 'a cheaper review downgrade', 'the downgraded reviewer' and orch-reviewer-safe - unambiguous, consistency nit only (low, medium confidence); the #117 entry at README.md:593-601 says Claude Code's two reviewer agents decide the verdict afterwards as a separate judgment, and at head that sentence is on Codex's two as well since #159 added it, but the entry is accurate as a record of what #117 did and the genuinely Claude-only part stays correctly scoped, since grepping 'Give each finding a severity' returns only the two Claude files (informational, no change requested). The reviewer confirmed the new #159 entry does not blur that asymmetry: it confines its claim to the grounds sentence, which really is on all four definitions. Positive checks worth recording: Fixed-section newest-first ordering holds, with 5ab6ce1 correctly between b4135a4 (#166) and c4840df (#158); the section's 'shipped in v0.6.0' header claim holds, since git tag --contains 5ab6ce1 returns v0.6.0; and the entry's 'now states that' framing keeps it honest that this is agent instruction text rather than an engine-enforced check.",
      "commit_oid": "73aa322cdebc07ea61455007f8005325d63e7e4b",
      "at": "2026-08-01T21:19:35Z"
    },
    {
      "name": "required-ci-observed-green-at-head",
      "command": "gh run view 30718979782",
      "result": "pass",
      "detail": "Reviewer-observed, distinct from the engine's own required-ci entry: run 30718979782 reports headSha 54c9a69, status completed, conclusion success, with all six checks passing including test (windows-latest) at 2m32s, which was still pending when this review cycle was dispatched and finished during it.",
      "commit_oid": "54c9a69af85e055527736656d98bc0d65003c18f",
      "at": "2026-08-01T21:32:03Z"
    },
    {
      "name": "review-cycle-3",
      "result": "approve",
      "detail": "Cycle 3. All four criteria satisfied at head, each against a specific observation the reviewer re-derived rather than inherited; scope is one file with nothing unrelated; both required tests pass and all six CI checks are green at 54c9a69, including test (windows-latest), which finished after this review was dispatched. No security concern. The reviewer raised two findings on the same before-state clause and deliberately did not block on them, distinguishing them in kind from what the first two cycles caught: cycle 1 named an artifact that does not exist and cycle 2 asserted something flatly false, whereas this clause is directionally accurate and turns on an interpretive question. Finding 1, medium severity and medium confidence: the entry's 'without ever saying what else could drive request-changes' is arguably contradicted by a sentence in both Codex TOMLs' 'How you look' section at 5ab6ce1^ reading 'If the change needs a fix, that is a request-changes verdict sent back to the executor, not something you do yourself.' The mitigating reading is that this is a role-boundary rule rather than a verdict ground; cutting against it, PR #159's own diff amended exactly that sentence to add 'the verdict grounds below make blocking', which only makes sense if the authors read it as a driver. Finding 2, medium severity and medium-low confidence: the closing clause 'so on neither host did a required test failing outside every criterion's wording have to block the review' is explicit and verified for Claude, whose definitions closed the set at two grounds and said a finding that is neither stays in the report, but for Codex it rests on silence, against which that same needs-a-fix sentence sits. Both are routed to the backlog with the counterexample text quoted, on the reviewer's judgment that no acceptance criterion requires the before-state clause and that a defect of this magnitude is not comparable to a failing required test or a weakened boundary. Also noted and not blocking: the #167 entry's installed-version aside does not name the duplicate-match branch, which also prints the expected version alone when every match has an empty version, arguably covered by 'reports no version' (low, medium). One benign correction to the Architect's own dispatch brief: grepping 'grounds on their own' at head returns seven paths rather than six, because this PR now quotes the sentence verbatim in README.md; at the merge base the count is exactly six. Positive checks recorded: 5ab6ce1 is an ancestor of v0.6.0 so the section header's 'shipped in v0.6.0' claim holds for the new entry; Fixed-section newest-first ordering holds with #159 between #166 and #158; the pre-existing #117 entry is untouched and still correctly scoped to 'Claude Code's two reviewer agents', and the new entry does not blur that asymmetry since it confines its claim to the grounds sentence, which really is on all four definitions; and the word-level reflow of both paragraphs drops nothing.",
      "commit_oid": "54c9a69af85e055527736656d98bc0d65003c18f",
      "at": "2026-08-01T21:32:04Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, lint=pass, scripts (windows-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "54c9a69af85e055527736656d98bc0d65003c18f",
      "at": "2026-08-01T21:32:08Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->