### PR TITLE
Scope ORCH-PRD.md section 15's reviewer read-only claim and correct the guard Row 10 comment

### DIFF
--- a/ORCH-PRD.md
+++ b/ORCH-PRD.md
@@ -353,7 +353,7 @@ Orch fails closed.
 - Read-only roles are held read-only by per-agent tool whitelists on Claude Code and by agent
   instructions on Codex, not by the guard. The Claude whitelist accounts fully only for the Scout,
   which is granted no shell tool; the Reviewer and its safe review downgrade are granted one, so
-  their read-only discipline rests on instructions there too.
+  their read-only discipline for shell-mediated writes rests on instructions there too.
 - Neither closes the shell-write gap: the pre-write hook covers only the file-write tools, so a
   shell-mediated write falls to the host's own approval prompts.
 - No agent may merge.

--- a/internal/guard/guard.go
+++ b/internal/guard/guard.go
@@ -119,9 +119,10 @@ func evaluate(req Request, f facts) Verdict {
 			return deny(f.path, "run stopped: "+f.stopped)
 		}
 		// Row 10: an asserted role outside {implementer, specialist} is
-		// mechanically read-only. This narrows only when an adapter passes
-		// --role; neither shipped adapter does, so read-only roles are held
-		// read-only outside the guard (PRD §15). No assertion falls through.
+		// mechanically read-only. `orch guard check`, `claude` and `codex`
+		// all accept --role from any caller, but neither shipped adapter
+		// passes it, so read-only roles are held read-only outside the
+		// guard (PRD §15). No assertion falls through.
 		if req.Role != "" && req.Role != manifest.RoleImplementer && req.Role != manifest.RoleSpecialist {
 			return deny(f.path, fmt.Sprintf("role %s is mechanically read-only", req.Role))
 		}


### PR DESCRIPTION
Delivers issue #179: Scope ORCH-PRD.md section 15's reviewer read-only claim and correct the guard Row 10 comment

Closes #179

**Plan digest:** `sha256:d98d11a0764d1f121185a2eaa3652430fef471f5c3026609799e95222ea431aa`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** ORCH-PRD.md section 15 says the Reviewer and its safe review downgrade have a read-only discipline that rests on instructions, without the scoping the adapter README carries. Both reviewers still carry none of the four guarded write tools, so the unscoped sentence understates the mechanical coverage that remains. Separately, the Row 10 comment in internal/guard/guard.go says the narrowing applies only when an adapter passes --role, but internal/cli/guard.go exposes --role on orch guard check, claude and codex to any caller.

**Acceptance criteria:**
- ORCH-PRD.md section 15's sentence about the Reviewer and the safe review downgrade scopes their instruction-based read-only discipline to shell-mediated writes.
- The Row 10 comment in internal/guard/guard.go states that orch guard check, claude and codex all accept --role from any caller, while still recording that neither shipped adapter passes it.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — Corrected count, re-run by the reviewer against an archive of the head OID: 23 packages report ok and 3 have no test files (cmd/orch, internal/adaptertest, internal/execx/execxtest), 26 total, exit 0. The pr-open entry's '24 packages ok' was wrong on the count only; the pass result and the no-test-files half were correct. Row 10 behaviour coverage at internal/guard/guard_test.go:74-96 is untouched and passing. — commit `5c53cf6b918755573290994bbf09040ef06d4924` (2026-08-01T20:58:40Z)
- **go-vet** — pass — `go vet ./...` — No output, exit 0. — commit `5c53cf6b918755573290994bbf09040ef06d4924` (2026-08-01T20:48:42Z)
- **gofmt** — pass — `gofmt -l .` — No files listed, exit 0. — commit `5c53cf6b918755573290994bbf09040ef06d4924` (2026-08-01T20:48:42Z)
- **comment-only-change** — pass — `go/parser without ParseComments over internal/guard/guard.go at origin/main and at 5c53cf6b, then printer output compared` — Reviewer-added evidence, stronger than the word-diff submitted at pr-open: parsing both versions with comments stripped and printing them yields identical source. The Row 10 condition and every other executable statement are byte-identical, so no behaviour change is hiding in a comment-only diff. Separately, Row 10 can only tighten - an absent role skips the check and falls through to Rows 11-13, a supplied role can only add a denial. — commit `5c53cf6b918755573290994bbf09040ef06d4924` (2026-08-01T20:58:40Z)
- **flag-reach-verified-at-source** — pass — `read internal/cli/guard.go:17, guardCheck at :47, guardHostHook at :76` — The usage constant lists [--role &lt;role&gt;] on all three verbs, and both guardCheck and guardHostHook (shared by the claude and codex verbs) call the same parseGuardFlags, so the corrected comment's claim about --role's reach is verified at the source rather than inherited from the task note. — commit `5c53cf6b918755573290994bbf09040ef06d4924` (2026-08-01T20:48:42Z)
- **branch-scope: prd-and-guard-comment-single-commit** — pass — `git diff --stat origin/main...5c53cf6b; git rev-list --count origin/main..5c53cf6b` — Re-stamped at the reviewed head OID and independently reproduced by the reviewer: 2 files, ORCH-PRD.md and internal/guard/guard.go only, 5 insertions, 4 deletions, 1 commit ahead of origin/main (6be2a2b, also the merge base). No sibling-issue file rides along. — commit `5c53cf6b918755573290994bbf09040ef06d4924` (2026-08-01T20:58:40Z)
- **acceptance-criterion-1** — satisfied — ORCH-PRD.md:356 at the head OID reads 'their read-only discipline for shell-mediated writes rests on instructions there too', and the diff adds exactly 'for shell-mediated writes' and nothing else in that file. The reviewer checked the claim is true rather than merely present: both adapters/claude/agents/orch-reviewer.md and orch-reviewer-safe.md carry frontmatter 'tools: Read, Grep, Glob, Bash' and none of Write, Edit, MultiEdit or NotebookEdit, which is byte-for-byte the PreToolUse matcher in adapters/claude/hooks/hooks.json - so file-write vectors really are mechanically closed for both reviewers and only the shell path is instruction-governed. No 'Bash' was imported into the host-neutral PRD, and the following bullet at :357-358 is not made redundant: it still carries the hook's coverage boundary and the fallback to host approval prompts, neither of which the edited sentence states. — commit `5c53cf6b918755573290994bbf09040ef06d4924` (2026-08-01T20:58:42Z)
- **acceptance-criterion-2** — satisfied — The Row 10 comment at internal/guard/guard.go:121-125 now states that orch guard check, claude and codex all accept --role from any caller, but that neither shipped adapter passes it. Verified at the source rather than inherited: internal/cli/guard.go:17 lists [--role &lt;role&gt;] on all three verbs; guardCheck (:47) and guardHostHook (:76) both call the same parseGuardFlags (:157); guardClaude (:113) and guardCodex (:118) both delegate to guardHostHook; nothing in that path restricts who may supply the flag, and internal/cli/guard_test.go:252,261 exercises --role on both check and codex. The load-bearing half survives, with both hosts' hooks.json running the bare guard command. The PRD section 15 citation still resolves after this PR's own section 15 edit, since :353-354 still says read-only roles are held not by the guard. — commit `5c53cf6b918755573290994bbf09040ef06d4924` (2026-08-01T20:58:42Z)
- **review-cycle-1** — approve — Both criteria satisfied and backed by observations in the source rather than by the diff's own claims. The single property that could have been dangerous - a behaviour change smuggled into a comment-only diff - was disproven at the AST level: the reviewer parsed both the origin/main and head versions of internal/guard/guard.go with go/parser WITHOUT ParseComments and printed them, getting identical comment-stripped source, so the Row 10 condition and every other executable statement are unchanged. The reviewer also established that --role can only tighten, never loosen: Row 10 denies when a role is asserted and is outside {implementer, specialist}, while an absent role skips the check entirely, so 'accepts --role from any caller' is not an exposure the corrected comment glosses over. Required tests and all six CI checks pass at the head OID. Non-blocking findings: the pr-open go-test detail said 24 packages where the actual figure is 23 ok plus 3 with no test files (low, high confidence, corrected in this cycle's re-stamped entry); backtick inconsistency in the new comment, where the first verb is backticked fully and the other two bare (low nit, high); 'shell-mediated' now appears in consecutive PRD bullets, though the second bullet was judged still non-redundant (low, medium); internal/guard describing internal/cli's flag surface is cross-package coupling in prose, pre-existing and more accurate than what it replaced (low, high). The reviewer also confirmed no sibling-doc contradiction: README.md:410-413 and both adapter READMEs say only that the adapters never pass --role, none claims the flag is unreachable by other callers. — commit `5c53cf6b918755573290994bbf09040ef06d4924` (2026-08-01T20:58:42Z)
- **required-ci** — passing — test (macos-latest)=pass, lint=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `5c53cf6b918755573290994bbf09040ef06d4924` (2026-08-01T20:59:00Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "ORCH-PRD.md section 15 says the Reviewer and its safe review downgrade have a read-only discipline that rests on instructions, without the scoping the adapter README carries. Both reviewers still carry none of the four guarded write tools, so the unscoped sentence understates the mechanical coverage that remains. Separately, the Row 10 comment in internal/guard/guard.go says the narrowing applies only when an adapter passes --role, but internal/cli/guard.go exposes --role on orch guard check, claude and codex to any caller.",
  "acceptance_criteria": [
    "ORCH-PRD.md section 15's sentence about the Reviewer and the safe review downgrade scopes their instruction-based read-only discipline to shell-mediated writes.",
    "The Row 10 comment in internal/guard/guard.go states that orch guard check, claude and codex all accept --role from any caller, while still recording that neither shipped adapter passes it."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Corrected count, re-run by the reviewer against an archive of the head OID: 23 packages report ok and 3 have no test files (cmd/orch, internal/adaptertest, internal/execx/execxtest), 26 total, exit 0. The pr-open entry's '24 packages ok' was wrong on the count only; the pass result and the no-test-files half were correct. Row 10 behaviour coverage at internal/guard/guard_test.go:74-96 is untouched and passing.",
      "commit_oid": "5c53cf6b918755573290994bbf09040ef06d4924",
      "at": "2026-08-01T20:58:40Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "No output, exit 0.",
      "commit_oid": "5c53cf6b918755573290994bbf09040ef06d4924",
      "at": "2026-08-01T20:48:42Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No files listed, exit 0.",
      "commit_oid": "5c53cf6b918755573290994bbf09040ef06d4924",
      "at": "2026-08-01T20:48:42Z"
    },
    {
      "name": "comment-only-change",
      "command": "go/parser without ParseComments over internal/guard/guard.go at origin/main and at 5c53cf6b, then printer output compared",
      "result": "pass",
      "detail": "Reviewer-added evidence, stronger than the word-diff submitted at pr-open: parsing both versions with comments stripped and printing them yields identical source. The Row 10 condition and every other executable statement are byte-identical, so no behaviour change is hiding in a comment-only diff. Separately, Row 10 can only tighten - an absent role skips the check and falls through to Rows 11-13, a supplied role can only add a denial.",
      "commit_oid": "5c53cf6b918755573290994bbf09040ef06d4924",
      "at": "2026-08-01T20:58:40Z"
    },
    {
      "name": "flag-reach-verified-at-source",
      "command": "read internal/cli/guard.go:17, guardCheck at :47, guardHostHook at :76",
      "result": "pass",
      "detail": "The usage constant lists [--role \u003crole\u003e] on all three verbs, and both guardCheck and guardHostHook (shared by the claude and codex verbs) call the same parseGuardFlags, so the corrected comment's claim about --role's reach is verified at the source rather than inherited from the task note.",
      "commit_oid": "5c53cf6b918755573290994bbf09040ef06d4924",
      "at": "2026-08-01T20:48:42Z"
    },
    {
      "name": "branch-scope: prd-and-guard-comment-single-commit",
      "command": "git diff --stat origin/main...5c53cf6b; git rev-list --count origin/main..5c53cf6b",
      "result": "pass",
      "detail": "Re-stamped at the reviewed head OID and independently reproduced by the reviewer: 2 files, ORCH-PRD.md and internal/guard/guard.go only, 5 insertions, 4 deletions, 1 commit ahead of origin/main (6be2a2b, also the merge base). No sibling-issue file rides along.",
      "commit_oid": "5c53cf6b918755573290994bbf09040ef06d4924",
      "at": "2026-08-01T20:58:40Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "ORCH-PRD.md:356 at the head OID reads 'their read-only discipline for shell-mediated writes rests on instructions there too', and the diff adds exactly 'for shell-mediated writes' and nothing else in that file. The reviewer checked the claim is true rather than merely present: both adapters/claude/agents/orch-reviewer.md and orch-reviewer-safe.md carry frontmatter 'tools: Read, Grep, Glob, Bash' and none of Write, Edit, MultiEdit or NotebookEdit, which is byte-for-byte the PreToolUse matcher in adapters/claude/hooks/hooks.json - so file-write vectors really are mechanically closed for both reviewers and only the shell path is instruction-governed. No 'Bash' was imported into the host-neutral PRD, and the following bullet at :357-358 is not made redundant: it still carries the hook's coverage boundary and the fallback to host approval prompts, neither of which the edited sentence states.",
      "commit_oid": "5c53cf6b918755573290994bbf09040ef06d4924",
      "at": "2026-08-01T20:58:42Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "The Row 10 comment at internal/guard/guard.go:121-125 now states that orch guard check, claude and codex all accept --role from any caller, but that neither shipped adapter passes it. Verified at the source rather than inherited: internal/cli/guard.go:17 lists [--role \u003crole\u003e] on all three verbs; guardCheck (:47) and guardHostHook (:76) both call the same parseGuardFlags (:157); guardClaude (:113) and guardCodex (:118) both delegate to guardHostHook; nothing in that path restricts who may supply the flag, and internal/cli/guard_test.go:252,261 exercises --role on both check and codex. The load-bearing half survives, with both hosts' hooks.json running the bare guard command. The PRD section 15 citation still resolves after this PR's own section 15 edit, since :353-354 still says read-only roles are held not by the guard.",
      "commit_oid": "5c53cf6b918755573290994bbf09040ef06d4924",
      "at": "2026-08-01T20:58:42Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Both criteria satisfied and backed by observations in the source rather than by the diff's own claims. The single property that could have been dangerous - a behaviour change smuggled into a comment-only diff - was disproven at the AST level: the reviewer parsed both the origin/main and head versions of internal/guard/guard.go with go/parser WITHOUT ParseComments and printed them, getting identical comment-stripped source, so the Row 10 condition and every other executable statement are unchanged. The reviewer also established that --role can only tighten, never loosen: Row 10 denies when a role is asserted and is outside {implementer, specialist}, while an absent role skips the check entirely, so 'accepts --role from any caller' is not an exposure the corrected comment glosses over. Required tests and all six CI checks pass at the head OID. Non-blocking findings: the pr-open go-test detail said 24 packages where the actual figure is 23 ok plus 3 with no test files (low, high confidence, corrected in this cycle's re-stamped entry); backtick inconsistency in the new comment, where the first verb is backticked fully and the other two bare (low nit, high); 'shell-mediated' now appears in consecutive PRD bullets, though the second bullet was judged still non-redundant (low, medium); internal/guard describing internal/cli's flag surface is cross-package coupling in prose, pre-existing and more accurate than what it replaced (low, high). The reviewer also confirmed no sibling-doc contradiction: README.md:410-413 and both adapter READMEs say only that the adapters never pass --role, none claims the flag is unreachable by other callers.",
      "commit_oid": "5c53cf6b918755573290994bbf09040ef06d4924",
      "at": "2026-08-01T20:58:42Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (macos-latest)=pass, lint=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "5c53cf6b918755573290994bbf09040ef06d4924",
      "at": "2026-08-01T20:59:00Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->