### PR TITLE
Settle one label for the four guarded write tools and drop an archaic idiom from the Codex README

### DIFF
--- a/adapters/claude/README.md
+++ b/adapters/claude/README.md
@@ -19,11 +19,12 @@ never re-derives a decision the engine already made.
   `skills/`, `hooks/`) are auto-discovered by Claude Code; there is
   nothing else to declare here yet.
 - `hooks/hooks.json` — two hooks:
-  - `PreToolUse` on `Write|Edit|MultiEdit|NotebookEdit` runs
-    `orch guard claude`, which reads the tool-call event on stdin and
-    denies the write when Orch's policy (Assist read-only, Delivery
-    worktree containment) says so. An allow is silence: guard
-    never bypasses Claude Code's own permission prompts.
+  - `PreToolUse` on `Write|Edit|MultiEdit|NotebookEdit` — the four
+    guarded write tools — runs `orch guard claude`, which reads the
+    tool-call event on stdin and denies the write when Orch's policy
+    (Assist read-only, Delivery worktree containment) says so. An allow
+    is silence: guard never bypasses Claude Code's own permission
+    prompts.
   - `SessionStart` on `startup|resume|clear|compact` runs
     `orch hook claude session-start`, which injects a short context block
     at session start when the current directory is inside an Orch
@@ -124,7 +125,7 @@ These are accepted for this PR and the adapter as a whole, not open
 bugs:
 
 - **Bash-mediated writes are not guarded.** The `PreToolUse` hook only
-  covers the four file-editing tools (`Write`, `Edit`, `MultiEdit`,
+  covers the four guarded write tools (`Write`, `Edit`, `MultiEdit`,
   `NotebookEdit`). A file write made through `Bash` (for example `echo >
   file` or a script) does not go through `orch guard claude`. Claude
   Code's own permission prompts on `Bash` are the backstop here. This

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -169,7 +169,7 @@ bugs:
   `orch-scout`'s read-only-ness fully — `orch-scout` carries no `Bash`
   — but `orch-reviewer` and `orch-reviewer-safe` both carry `Bash`, so
   their whitelist leaves that same Bash-mediated write path open there
-  too, for all that it excludes every guarded write tool; their
+  too, even though it excludes every guarded write tool; their
   read-only discipline for anything Bash-mediated rests on
   instructions, same as this host's.
 - **A missing `orch` binary fails open, not closed.** As described


### PR DESCRIPTION
Delivers issue #180: Settle one label for the four guarded write tools and drop an archaic idiom from the Codex README

Closes #180

**Plan digest:** `sha256:d98d11a0764d1f121185a2eaa3652430fef471f5c3026609799e95222ea431aa`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** adapters/claude/README.md names the set Write, Edit, MultiEdit, NotebookEdit at its hook-matcher bullet, then refers to that set as the four guarded write tools further down and as the four file-editing tools further down still, so a reader meeting the second label has its members named only under a different label far above. Separately, adapters/codex/README.md uses the construction 'for all that' in an otherwise plainly worded document.

**Acceptance criteria:**
- adapters/claude/README.md refers to the set Write, Edit, MultiEdit, NotebookEdit by one consistent label throughout, and that label's members are named at or before its first use.
- adapters/codex/README.md no longer contains the phrase 'for all that', and the sentence that used it still says that the Claude reviewers' whitelist excludes every guarded write tool while leaving Bash.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — Corrected count, re-run by the reviewer: 23 packages report ok and 3 have no test files, 26 total, exit 0. The pr-open entry's '24 packages ok' was wrong on the count only, and its identical 0.646s for both adapter packages looks like a transcription artifact; the substantive claim that everything passes and no prose pin broke is verified true both locally and by CI. — commit `603d5503a559fd37f1ff354301eba55227bb2c42` (2026-08-01T20:58:43Z)
- **gofmt** — pass — `gofmt -l .` — No output, exit 0. — commit `603d5503a559fd37f1ff354301eba55227bb2c42` (2026-08-01T20:48:47Z)
- **reflow-word-diff** — pass — `git diff --word-diff --ignore-all-space` — Only two removal markers, both intended: file-editing to guarded write, and 'for all that' to 'even though'. The rewrapped hook-matcher bullet shows additions only, so the reflow dropped nothing. — commit `603d5503a559fd37f1ff354301eba55227bb2c42` (2026-08-01T20:48:47Z)
- **label-accuracy-against-hook-matcher** — pass — `read adapters/claude/hooks/hooks.json PreToolUse matcher` — The settled label 'the four guarded write tools' was checked against the matcher Write|Edit|MultiEdit|NotebookEdit and describes that set. It makes no claim about any agent whitelist, which matters because MultiEdit appears in the matcher but in no shipped agent whitelist, so a whitelist-flavored label would have been false. — commit `603d5503a559fd37f1ff354301eba55227bb2c42` (2026-08-01T20:48:47Z)
- **no-test-pins-this-prose** — pass — `inspect adapters/claude/doc.go, adapters/codex/embed.go, marketplace_test.go and internal/adaptertest for README references` — Independently confirmed by the reviewer rather than accepted from the executor: adapters/claude/doc.go embeds only .claude-plugin/plugin.json; adapters/codex/embed.go embeds plugin.json and agents/*.toml; marketplace_test.go's only README mention is a comment; internal/adaptertest has one file and no README reference. No test reads either README, so no pin could break on this prose change. — commit `603d5503a559fd37f1ff354301eba55227bb2c42` (2026-08-01T20:58:43Z)
- **branch-scope: adapter-readmes-single-commit** — pass — `git ls-remote for the issue branch; git diff --stat origin/main...603d550; git rev-list --count origin/main..603d550` — Re-stamped at the reviewed head OID and independently reproduced by the reviewer against the live remote: git ls-remote shows refs/heads/orch/issue-180-... at 603d5503a559fd37f1ff354301eba55227bb2c42, matching the head under review; 2 files, both adapter READMEs, 8 insertions, 7 deletions, 1 commit ahead. No sibling-issue file is touched, and the hook-bullet rewrap was compared word for word with nothing dropped. — commit `603d5503a559fd37f1ff354301eba55227bb2c42` (2026-08-01T20:58:43Z)
- **acceptance-criterion-1** — satisfied — A grep for competing phrasings over adapters/claude/README.md at the head OID returns exactly four reference sites - :22-23, :63-64, :128 and :157 - and every one uses the noun phrase 'guarded write tool(s)'; no occurrence of 'file-editing', 'editing tool' or 'write-tool' survives in that file. First use is :22-23, where the members are named immediately before the label on the same line, and nothing above line 22 mentions the set. The label is accurate against fact 86: the hooks.json matcher is Write|Edit|MultiEdit|NotebookEdit and internal/guard/claude.go's claudeToolPathField maps exactly those four, so the label names the matcher and guard-dispatch set and asserts nothing about any agent whitelist. The two whitelist-adjacent uses are both negative and both true against shipped frontmatter. — commit `603d5503a559fd37f1ff354301eba55227bb2c42` (2026-08-01T20:58:45Z)
- **acceptance-criterion-2** — satisfied — A grep for 'for all that' over adapters/codex/README.md at the head OID exits 1 - no occurrence anywhere in the file, not just at the edited line. Lines 169-175 now read that both reviewers carry Bash so their whitelist leaves that same Bash-mediated write path open there too, 'even though' it excludes every guarded write tool. The concessive relation, the exclusion claim and the Bash-left-open claim all survive, and both claims are true against the reviewer frontmatter. — commit `603d5503a559fd37f1ff354301eba55227bb2c42` (2026-08-01T20:58:45Z)
- **review-cycle-1** — approve — Both criteria satisfied by direct observation, and the settled label survives the fact-86 test that decided this issue: 'the four guarded write tools' names the adapters/claude/hooks/hooks.json matcher and the internal/guard/claude.go claudeToolPathField dispatch set, not any agent whitelist, so it stays true despite MultiEdit appearing in the matcher but in no shipped whitelist. Its only two whitelist-adjacent uses are negations that are true of the shipped frontmatter. The reviewer also noted the new prose and the test vocabulary now agree, since plugin_test.go:243's own comment independently calls that set 'the four tools the PreToolUse guard hook mediates'. Scope is three sentence-level edits plus one pure reflow; required tests and all six CI checks pass at the head OID. Non-blocking findings: the pr-open go-test detail said 24 packages where the actual figure is 23 ok plus 3 with no test files, and reported an identical 0.646s for both adapter packages, which reads like a transcription artifact (low, high confidence, corrected in this cycle's re-stamped entry); 'the PreToolUse hook only covers the four guarded write tools' at adapters/claude/README.md:127-128 is near-tautological once guarded is defined by what that hook covers, though the actual point survives in the next sentence (low, medium); adapters/codex/README.md:172 uses 'every guarded write tool' as a term whose members are never named in that file, pre-existing and explicitly out of scope (informational); ORCH-PRD.md:357 uses a third phrasing, 'the file-write tools', for the same idea, correctly untouched here and a candidate follow-up (informational); 'guarded' is unconditional in a document that later documents the hook failing open when the orch binary is missing, adequately qualified by the Known-limitations bullet (informational); adapters/claude/README.md:63-64 could invite the inference that executor roles carry all four, when orch-implementer and orch-specialist carry Write, Edit and NotebookEdit but not MultiEdit, though the text never claims otherwise and the line is byte-identical to origin/main (informational). — commit `603d5503a559fd37f1ff354301eba55227bb2c42` (2026-08-01T20:58:45Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, test (windows-latest)=pass, scripts (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass — commit `603d5503a559fd37f1ff354301eba55227bb2c42` (2026-08-01T20:59:04Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "adapters/claude/README.md names the set Write, Edit, MultiEdit, NotebookEdit at its hook-matcher bullet, then refers to that set as the four guarded write tools further down and as the four file-editing tools further down still, so a reader meeting the second label has its members named only under a different label far above. Separately, adapters/codex/README.md uses the construction 'for all that' in an otherwise plainly worded document.",
  "acceptance_criteria": [
    "adapters/claude/README.md refers to the set Write, Edit, MultiEdit, NotebookEdit by one consistent label throughout, and that label's members are named at or before its first use.",
    "adapters/codex/README.md no longer contains the phrase 'for all that', and the sentence that used it still says that the Claude reviewers' whitelist excludes every guarded write tool while leaving Bash."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Corrected count, re-run by the reviewer: 23 packages report ok and 3 have no test files, 26 total, exit 0. The pr-open entry's '24 packages ok' was wrong on the count only, and its identical 0.646s for both adapter packages looks like a transcription artifact; the substantive claim that everything passes and no prose pin broke is verified true both locally and by CI.",
      "commit_oid": "603d5503a559fd37f1ff354301eba55227bb2c42",
      "at": "2026-08-01T20:58:43Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No output, exit 0.",
      "commit_oid": "603d5503a559fd37f1ff354301eba55227bb2c42",
      "at": "2026-08-01T20:48:47Z"
    },
    {
      "name": "reflow-word-diff",
      "command": "git diff --word-diff --ignore-all-space",
      "result": "pass",
      "detail": "Only two removal markers, both intended: file-editing to guarded write, and 'for all that' to 'even though'. The rewrapped hook-matcher bullet shows additions only, so the reflow dropped nothing.",
      "commit_oid": "603d5503a559fd37f1ff354301eba55227bb2c42",
      "at": "2026-08-01T20:48:47Z"
    },
    {
      "name": "label-accuracy-against-hook-matcher",
      "command": "read adapters/claude/hooks/hooks.json PreToolUse matcher",
      "result": "pass",
      "detail": "The settled label 'the four guarded write tools' was checked against the matcher Write|Edit|MultiEdit|NotebookEdit and describes that set. It makes no claim about any agent whitelist, which matters because MultiEdit appears in the matcher but in no shipped agent whitelist, so a whitelist-flavored label would have been false.",
      "commit_oid": "603d5503a559fd37f1ff354301eba55227bb2c42",
      "at": "2026-08-01T20:48:47Z"
    },
    {
      "name": "no-test-pins-this-prose",
      "command": "inspect adapters/claude/doc.go, adapters/codex/embed.go, marketplace_test.go and internal/adaptertest for README references",
      "result": "pass",
      "detail": "Independently confirmed by the reviewer rather than accepted from the executor: adapters/claude/doc.go embeds only .claude-plugin/plugin.json; adapters/codex/embed.go embeds plugin.json and agents/*.toml; marketplace_test.go's only README mention is a comment; internal/adaptertest has one file and no README reference. No test reads either README, so no pin could break on this prose change.",
      "commit_oid": "603d5503a559fd37f1ff354301eba55227bb2c42",
      "at": "2026-08-01T20:58:43Z"
    },
    {
      "name": "branch-scope: adapter-readmes-single-commit",
      "command": "git ls-remote for the issue branch; git diff --stat origin/main...603d550; git rev-list --count origin/main..603d550",
      "result": "pass",
      "detail": "Re-stamped at the reviewed head OID and independently reproduced by the reviewer against the live remote: git ls-remote shows refs/heads/orch/issue-180-... at 603d5503a559fd37f1ff354301eba55227bb2c42, matching the head under review; 2 files, both adapter READMEs, 8 insertions, 7 deletions, 1 commit ahead. No sibling-issue file is touched, and the hook-bullet rewrap was compared word for word with nothing dropped.",
      "commit_oid": "603d5503a559fd37f1ff354301eba55227bb2c42",
      "at": "2026-08-01T20:58:43Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "A grep for competing phrasings over adapters/claude/README.md at the head OID returns exactly four reference sites - :22-23, :63-64, :128 and :157 - and every one uses the noun phrase 'guarded write tool(s)'; no occurrence of 'file-editing', 'editing tool' or 'write-tool' survives in that file. First use is :22-23, where the members are named immediately before the label on the same line, and nothing above line 22 mentions the set. The label is accurate against fact 86: the hooks.json matcher is Write|Edit|MultiEdit|NotebookEdit and internal/guard/claude.go's claudeToolPathField maps exactly those four, so the label names the matcher and guard-dispatch set and asserts nothing about any agent whitelist. The two whitelist-adjacent uses are both negative and both true against shipped frontmatter.",
      "commit_oid": "603d5503a559fd37f1ff354301eba55227bb2c42",
      "at": "2026-08-01T20:58:45Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "A grep for 'for all that' over adapters/codex/README.md at the head OID exits 1 - no occurrence anywhere in the file, not just at the edited line. Lines 169-175 now read that both reviewers carry Bash so their whitelist leaves that same Bash-mediated write path open there too, 'even though' it excludes every guarded write tool. The concessive relation, the exclusion claim and the Bash-left-open claim all survive, and both claims are true against the reviewer frontmatter.",
      "commit_oid": "603d5503a559fd37f1ff354301eba55227bb2c42",
      "at": "2026-08-01T20:58:45Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Both criteria satisfied by direct observation, and the settled label survives the fact-86 test that decided this issue: 'the four guarded write tools' names the adapters/claude/hooks/hooks.json matcher and the internal/guard/claude.go claudeToolPathField dispatch set, not any agent whitelist, so it stays true despite MultiEdit appearing in the matcher but in no shipped whitelist. Its only two whitelist-adjacent uses are negations that are true of the shipped frontmatter. The reviewer also noted the new prose and the test vocabulary now agree, since plugin_test.go:243's own comment independently calls that set 'the four tools the PreToolUse guard hook mediates'. Scope is three sentence-level edits plus one pure reflow; required tests and all six CI checks pass at the head OID. Non-blocking findings: the pr-open go-test detail said 24 packages where the actual figure is 23 ok plus 3 with no test files, and reported an identical 0.646s for both adapter packages, which reads like a transcription artifact (low, high confidence, corrected in this cycle's re-stamped entry); 'the PreToolUse hook only covers the four guarded write tools' at adapters/claude/README.md:127-128 is near-tautological once guarded is defined by what that hook covers, though the actual point survives in the next sentence (low, medium); adapters/codex/README.md:172 uses 'every guarded write tool' as a term whose members are never named in that file, pre-existing and explicitly out of scope (informational); ORCH-PRD.md:357 uses a third phrasing, 'the file-write tools', for the same idea, correctly untouched here and a candidate follow-up (informational); 'guarded' is unconditional in a document that later documents the hook failing open when the orch binary is missing, adequately qualified by the Known-limitations bullet (informational); adapters/claude/README.md:63-64 could invite the inference that executor roles carry all four, when orch-implementer and orch-specialist carry Write, Edit and NotebookEdit but not MultiEdit, though the text never claims otherwise and the line is byte-identical to origin/main (informational).",
      "commit_oid": "603d5503a559fd37f1ff354301eba55227bb2c42",
      "at": "2026-08-01T20:58:45Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, test (windows-latest)=pass, scripts (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "603d5503a559fd37f1ff354301eba55227bb2c42",
      "at": "2026-08-01T20:59:04Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->