### PR TITLE
Report a Claude routed-model mismatch in orch doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,14 +499,22 @@ the binary now catches: `orch doctor` and Codex plan activation both
 compare the rendered definitions against the effective configuration
 and fail closed naming `orch render-agents`, so activation refuses
 rather than dispatching agents pinned to a stale model. On Claude Code
-nothing in the binary checks this. The Architect's skill instructs it
-to compare the routed model against the installed agent's frontmatter
-and, on a mismatch, to stop and tell you rather than spawn a different
-model — so that stop rests on the Architect following an instruction,
-not on a check the engine performs. Either way, changing a role's
-model — which the Settings section above recommends as ordinary
-tuning — is not finished until the installed agent definitions carry
-it too.
+`orch doctor` reports the same comparison but repairs nothing: it
+resolves the installed plugin root from `claude plugin list --json`,
+reads the model each of the five installed agent definitions pins in
+its frontmatter, and fails as `claude agent definitions`, naming every
+role whose `hosts.claude.roles` model differs together with both
+models — and failing too when those definitions cannot be read at all.
+There is no Claude equivalent of `orch render-agents` to run
+afterwards: you update the installed plugin or change the configured
+model. Claude plan activation does not gate on this, either. The
+Architect's skill still instructs it to compare the routed model
+against the installed agent's frontmatter and, on a mismatch, to stop
+and tell you rather than spawn a different model — so inside a run,
+that stop still rests on the Architect following an instruction, not
+on a check the engine performs. Either way, changing a role's model —
+which the Settings section above recommends as ordinary tuning — is
+not finished until the installed agent definitions carry it too.
 
 **A Codex CLI upgrade that adds a new `apply_patch` directive causes
 denials until `orch` catches up.** The guard's envelope parser treats

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -8,6 +8,13 @@
 // source of truth: this package never carries its own copy of the
 // prose, so the shipped plugin files and this package's rendered
 // output cannot silently diverge from one another.
+//
+// CheckClaude (claude.go) is the one Claude-side member: a read-only
+// comparison of the installed Claude agent definitions' pinned models
+// against the same effective configuration, for `orch doctor`. It
+// shares roleFiles and profileFor with the Codex rendering above
+// because both hosts name their five definitions identically; it
+// renders and writes nothing.
 package agents
 
 import (

--- a/internal/agents/claude.go
+++ b/internal/agents/claude.go
@@ -1,0 +1,101 @@
+package agents
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/kninetimmy/orch/internal/config"
+)
+
+// ClaudeAgentsSubdir is the subdirectory of the installed Claude
+// plugin root that holds the agent definitions, as the plugin lays
+// them out (adapters/claude/agents/*.md).
+const ClaudeAgentsSubdir = "agents"
+
+// claudeModel returns the model pinned in a Claude agent definition's
+// leading `---` frontmatter. Every value in that frontmatter is a
+// single-line scalar (adapters/claude/plugin_test.go's parseFrontmatter
+// relies on the same fact), so a split on the line's first ":" is
+// exact. It fails closed rather than defaulting: no frontmatter, no
+// model line, and an empty model are each an error, because a
+// definition whose model cannot be read is not evidence that the
+// installed pin matches anything.
+func claudeModel(data []byte) (string, error) {
+	lines := strings.Split(string(data), "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return "", errors.New("does not start with a --- frontmatter delimiter")
+	}
+	for _, line := range lines[1:] {
+		if strings.TrimSpace(line) == "---" {
+			break
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok || strings.TrimSpace(key) != "model" {
+			continue
+		}
+		model := strings.TrimSpace(value)
+		if model == "" {
+			return "", errors.New("frontmatter model is empty")
+		}
+		return model, nil
+	}
+	return "", errors.New("frontmatter pins no model")
+}
+
+// CheckClaude compares the model h gives each of the five roles that
+// ship a Claude agent definition against the model the installed
+// definition for that role pins in its frontmatter, and returns an
+// error naming every role whose two models differ. installRoot is the
+// install path the Claude CLI's own plugin listing reports for the
+// Orch Claude plugin; the definitions live in its ClaudeAgentsSubdir.
+// The architect has no agent definition (the Architect is the host
+// session itself, never a dispatched agent) and so is not compared.
+//
+// This is a read-only report: unlike the Codex side, nothing here
+// renders or writes a Claude agent file, so a mismatch is reconciled
+// by updating the installed plugin or the configuration, not by a
+// render verb. It fails closed — an empty installRoot, an absent
+// agents directory, an unreadable definition, and a definition
+// carrying no model are each an error, never a pass.
+func CheckClaude(h *config.Host, installRoot string) error {
+	if h == nil {
+		return errors.New("agents.CheckClaude: claude host is nil")
+	}
+	if installRoot == "" {
+		return errors.New("the `claude plugin list --json` entry for the Orch Claude plugin carries no install path, so the installed agent definitions cannot be located")
+	}
+
+	dir := filepath.Join(installRoot, ClaudeAgentsSubdir)
+	if _, err := os.Stat(dir); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("the installed agents directory %s is absent", dir)
+		}
+		return fmt.Errorf("read the installed agents directory %s: %w", dir, err)
+	}
+
+	var problems []string
+	for _, rf := range roleFiles {
+		path := filepath.Join(dir, rf.stem+".md")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			problems = append(problems, fmt.Sprintf("%s: unreadable definition: %v", rf.role, err))
+			continue
+		}
+		installed, err := claudeModel(data)
+		if err != nil {
+			problems = append(problems, fmt.Sprintf("%s: %s: %v", rf.role, path, err))
+			continue
+		}
+		if configured := profileFor(h.Roles, rf.role).Model; configured != installed {
+			problems = append(problems, fmt.Sprintf("%s: configured %q, installed %s pins %q", rf.role, configured, path, installed))
+		}
+	}
+	if len(problems) > 0 {
+		return fmt.Errorf("%s; update the installed plugin or change hosts.claude.roles so the two agree, then restart Claude Code", strings.Join(problems, "; "))
+	}
+	return nil
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -58,6 +58,15 @@ model  = "claude-sonnet-5"
 effort = "high"
 `
 
+// testClaudeInstallRoot is the install path the default fake `claude
+// plugin list --json` reports for the Orch Claude plugin. Its
+// agents/*.md fixtures pin exactly the models validTOML gives
+// hosts.claude.roles, so doctor's installed-definition check passes by
+// default and a test that wants it to fail says so by scripting its own
+// listing. The path is relative to this package directory, which is
+// where `go test` runs.
+const testClaudeInstallRoot = "testdata/claude-plugin"
+
 // testEnv returns an Env writing to fresh buffers, rooted in an empty
 // temp dir, with every PATH lookup succeeding and a Runner that
 // reports the repo root as a healthy git top level.
@@ -172,7 +181,7 @@ func (f fakeRunner) Run(_ context.Context, c execx.Cmd) (execx.Result, error) {
 				return execx.Result{}, versionErr
 			}
 			if c.Name == "claude" {
-				stdout = fmt.Sprintf(`[{"id":"orch-claude@orch","version":%q,"enabled":true}]`, version)
+				stdout = fmt.Sprintf(`[{"id":"orch-claude@orch","version":%q,"enabled":true,"installPath":%q}]`, version, testClaudeInstallRoot)
 			} else {
 				stdout = fmt.Sprintf(`{"installed":[{"pluginId":"orch@orch","version":%q,"installed":true,"enabled":true}]}`, version)
 			}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -119,10 +119,21 @@ func runDoctor(env Env) error {
 
 	if cfgErr == nil {
 		if cfg.Hosts.Claude != nil {
-			check("claude adapter", checkAdapter(env, claudeAdapter))
+			// The Claude counterpart of the codex agent files check
+			// below. It compares the installed definitions, resolved
+			// from the same listing the adapter check just read, not
+			// this repository's adapters/claude/agents copy: an
+			// installed plugin behind head can still pin an older
+			// model. A failed adapter check leaves no install path, so
+			// this one fails closed rather than reporting a pass it
+			// never established.
+			plugin, adapterErr := checkAdapter(env, claudeAdapter)
+			check("claude adapter", adapterErr)
+			check("claude agent definitions", agents.CheckClaude(cfg.Hosts.Claude, plugin.InstallPath))
 		}
 		if cfg.Hosts.Codex != nil {
-			check("codex adapter", checkAdapter(env, codexAdapter))
+			_, adapterErr := checkAdapter(env, codexAdapter)
+			check("codex adapter", adapterErr)
 		}
 	}
 
@@ -206,16 +217,30 @@ func runDoctor(env Env) error {
 }
 
 type adapterPlugin struct {
-	ID        string `json:"id"`
-	PluginID  string `json:"pluginId"`
-	Version   string `json:"version"`
-	Installed bool   `json:"installed"`
-	Enabled   bool   `json:"enabled"`
+	ID       string `json:"id"`
+	PluginID string `json:"pluginId"`
+	Version  string `json:"version"`
+	// InstallPath is the installed plugin root the Claude CLI reports;
+	// the Codex listing carries no such field and leaves it empty.
+	InstallPath string `json:"installPath"`
+	Installed   bool   `json:"installed"`
+	Enabled     bool   `json:"enabled"`
 }
 
-func checkAdapter(env Env, spec adapterSpec) error {
-	fail := func(detail string) error {
-		return fmt.Errorf("%s; %s", detail, spec.repair)
+// checkAdapter returns the matched plugin entry alongside its verdict,
+// so a caller that needs a field of the installed plugin — the Claude
+// agent-definition check needs its install path — reads it from the
+// listing this call already ran instead of running the listing twice.
+// The returned entry is the zero value whenever no single matching
+// entry was reached.
+func checkAdapter(env Env, spec adapterSpec) (adapterPlugin, error) {
+	// found is the single matching entry once one is established, so a
+	// failure past that point still hands the caller the entry it
+	// failed on — a disabled or stale plugin still has an install path,
+	// and reporting none would be untrue.
+	var found adapterPlugin
+	fail := func(detail string) (adapterPlugin, error) {
+		return found, fmt.Errorf("%s; %s", detail, spec.repair)
 	}
 
 	expected, err := adapterVersion(spec.manifestJSON)
@@ -278,6 +303,7 @@ func checkAdapter(env Env, spec adapterSpec) error {
 	}
 
 	plugin := matches[0]
+	found = plugin
 	versionDetail := fmt.Sprintf("expected %q", expected)
 	if plugin.Version != "" {
 		versionDetail = fmt.Sprintf("installed %q, expected %q", plugin.Version, expected)
@@ -294,7 +320,7 @@ func checkAdapter(env Env, spec adapterSpec) error {
 	if plugin.Version != expected {
 		return fail(fmt.Sprintf("%s version mismatch: installed %q, expected %q", spec.pluginID, plugin.Version, expected))
 	}
-	return nil
+	return plugin, nil
 }
 
 func adapterVersion(manifestJSON string) (string, error) {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -779,6 +779,212 @@ func TestDoctorBothHostsCodexAgentsAbsentFails(t *testing.T) {
 	}
 }
 
+// claudeAgentDefinitionsCheck is the doctor check name the Claude
+// installed-definition assertions below match on.
+const claudeAgentDefinitionsCheck = "claude agent definitions"
+
+// writeClaudeInstall lays out a fake installed Claude plugin root
+// holding one agents/<stem>.md per entry of models, each with just
+// enough frontmatter to be a definition, and returns the root. A stem
+// mapped to the empty string gets a definition with no model line at
+// all — the "definition carrying no model" state.
+func writeClaudeInstall(t *testing.T, models map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, "agents")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for stem, model := range models {
+		body := "---\nname: " + stem + "\ntools: Read\n"
+		if model != "" {
+			body += "model: " + model + "\n"
+		}
+		body += "---\n\nfixture\n"
+		if err := os.WriteFile(filepath.Join(dir, stem+".md"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// claudeListing is a well-formed single-entry `claude plugin list
+// --json` stdout reporting installRoot as the plugin's install path.
+func claudeListing(t *testing.T, installRoot string) string {
+	t.Helper()
+	return fmt.Sprintf(`[{"id":"orch-claude@orch","version":%q,"enabled":true,"installPath":%q}]`,
+		mustAdapterVersion(t, claudeAdapter), installRoot)
+}
+
+// TestDoctorBothHostsClaudeAgentDefinitionsMatchPass runs with both
+// hosts configured — the shape this repository itself uses — so the
+// passing Claude installed-definition check is pinned alongside, not
+// instead of, the Codex agent-file check.
+func TestDoctorBothHostsClaudeAgentDefinitionsMatchPass(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validBothHostsTOML)
+	if code := Run([]string{"render-agents"}, env); code != ExitOK {
+		t.Fatalf("render-agents exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	stdout.Reset()
+
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("doctor exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"ok    " + claudeAgentDefinitionsCheck, "ok    codex agent files"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestDoctorClaudeAgentDefinitionsMismatchFails proves the check names
+// every role whose configured model differs from the model the
+// installed definition pins, with both models, and names no role whose
+// two models agree.
+func TestDoctorClaudeAgentDefinitionsMismatchFails(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	// validTOML: scout and implementer claude-sonnet-5, specialist and
+	// reviewer claude-opus-4-8, review_downgrade claude-sonnet-5.
+	root := writeClaudeInstall(t, map[string]string{
+		"orch-scout":         "claude-opus-9",
+		"orch-implementer":   "claude-sonnet-5",
+		"orch-specialist":    "claude-opus-4-8",
+		"orch-reviewer":      "claude-sonnet-5",
+		"orch-reviewer-safe": "claude-sonnet-5",
+	})
+	env.Runner = fakeRunner{toplevel: env.RepoRoot, claudePluginJSON: claudeListing(t, root)}
+
+	if code := Run([]string{"doctor"}, env); code != ExitError {
+		t.Fatalf("doctor exit = %d, want %d\n%s", code, ExitError, stdout.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "FAIL  "+claudeAgentDefinitionsCheck) {
+		t.Fatalf("stdout missing the installed-definition failure:\n%s", out)
+	}
+	for _, want := range []string{
+		`scout: configured "claude-sonnet-5"`,
+		`pins "claude-opus-9"`,
+		`reviewer: configured "claude-opus-4-8"`,
+		`pins "claude-sonnet-5"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q:\n%s", want, out)
+		}
+	}
+	for _, role := range []string{"implementer:", "specialist:", "review_downgrade:"} {
+		if strings.Contains(out, role) {
+			t.Errorf("stdout names %q, whose configured and installed models agree:\n%s", role, out)
+		}
+	}
+}
+
+// TestDoctorClaudeAgentDefinitionsUnavailableFails walks the four ways
+// the installed definitions can be unavailable. Each must fail naming
+// what it hit, and none may report the check as passing.
+func TestDoctorClaudeAgentDefinitionsUnavailableFails(t *testing.T) {
+	current := map[string]string{
+		"orch-scout":         "claude-sonnet-5",
+		"orch-implementer":   "claude-sonnet-5",
+		"orch-specialist":    "claude-opus-4-8",
+		"orch-reviewer":      "claude-opus-4-8",
+		"orch-reviewer-safe": "claude-sonnet-5",
+	}
+	tests := []struct {
+		name    string
+		listing func(*testing.T) string
+		want    []string
+	}{
+		{
+			name: "no installed root",
+			listing: func(t *testing.T) string {
+				return fmt.Sprintf(`[{"id":"orch-claude@orch","version":%q,"enabled":true}]`,
+					mustAdapterVersion(t, claudeAdapter))
+			},
+			want: []string{"carries no install path"},
+		},
+		{
+			name: "agents directory absent",
+			listing: func(t *testing.T) string {
+				return claudeListing(t, t.TempDir())
+			},
+			want: []string{"agents directory", "is absent"},
+		},
+		{
+			name: "definition unreadable",
+			listing: func(t *testing.T) string {
+				root := writeClaudeInstall(t, current)
+				path := filepath.Join(root, "agents", "orch-scout.md")
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+				// A directory in the definition's place is readable as
+				// a directory entry but never as a file, on every OS.
+				if err := os.Mkdir(path, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				return claudeListing(t, root)
+			},
+			want: []string{"scout: unreadable definition"},
+		},
+		{
+			name: "definition carries no model",
+			listing: func(t *testing.T) string {
+				models := map[string]string{}
+				for stem, model := range current {
+					models[stem] = model
+				}
+				models["orch-reviewer-safe"] = ""
+				return claudeListing(t, writeClaudeInstall(t, models))
+			},
+			want: []string{"review_downgrade:", "frontmatter pins no model"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env, stdout, _ := testEnv(t)
+			writeConfig(t, env.RepoRoot, validTOML)
+			env.Runner = fakeRunner{toplevel: env.RepoRoot, claudePluginJSON: tc.listing(t)}
+
+			if code := Run([]string{"doctor"}, env); code != ExitError {
+				t.Fatalf("doctor exit = %d, want %d\n%s", code, ExitError, stdout.String())
+			}
+			out := stdout.String()
+			if !strings.Contains(out, "FAIL  "+claudeAgentDefinitionsCheck) {
+				t.Fatalf("stdout missing the installed-definition failure:\n%s", out)
+			}
+			if strings.Contains(out, "ok    "+claudeAgentDefinitionsCheck) {
+				t.Fatalf("stdout reports the check as passing too:\n%s", out)
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(out, want) {
+					t.Errorf("stdout missing %q:\n%s", want, out)
+				}
+			}
+		})
+	}
+}
+
+// TestDoctorNoClaudeHostSkipsAgentDefinitionsCheck is the Claude twin
+// of TestDoctorNoCodexHostSkipsAgentCheck above.
+func TestDoctorNoClaudeHostSkipsAgentDefinitionsCheck(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validCodexTOML)
+	if code := Run([]string{"render-agents"}, env); code != ExitOK {
+		t.Fatalf("render-agents exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	stdout.Reset()
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("doctor exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	if strings.Contains(stdout.String(), claudeAgentDefinitionsCheck) {
+		t.Errorf("stdout carries a Claude-only check:\n%s", stdout.String())
+	}
+}
+
 func TestDoctorCodexAgentsCurrentThenAllBadStates(t *testing.T) {
 	env, stdout, _ := testEnv(t)
 	writeConfig(t, env.RepoRoot, validCodexTOML)

--- a/internal/cli/testdata/claude-plugin/agents/orch-implementer.md
+++ b/internal/cli/testdata/claude-plugin/agents/orch-implementer.md
@@ -1,0 +1,14 @@
+---
+name: orch-implementer
+description: Fixture standing in for the installed orch-implementer definition (issue implementation) in internal/cli's doctor tests.
+tools: Read, Grep, Glob
+model: claude-sonnet-5
+---
+
+# Fixture
+
+Not a real agent definition: only the frontmatter model above is read,
+by the installed-definition check `orch doctor` runs for the Claude
+host. The models here match what cli_test.go's validTOML gives
+`hosts.claude.roles`, so the default fake plugin listing reports a
+healthy install.

--- a/internal/cli/testdata/claude-plugin/agents/orch-reviewer-safe.md
+++ b/internal/cli/testdata/claude-plugin/agents/orch-reviewer-safe.md
@@ -1,0 +1,14 @@
+---
+name: orch-reviewer-safe
+description: Fixture standing in for the installed orch-reviewer-safe definition (downgraded pull request review) in internal/cli's doctor tests.
+tools: Read, Grep, Glob
+model: claude-sonnet-5
+---
+
+# Fixture
+
+Not a real agent definition: only the frontmatter model above is read,
+by the installed-definition check `orch doctor` runs for the Claude
+host. The models here match what cli_test.go's validTOML gives
+`hosts.claude.roles`, so the default fake plugin listing reports a
+healthy install.

--- a/internal/cli/testdata/claude-plugin/agents/orch-reviewer.md
+++ b/internal/cli/testdata/claude-plugin/agents/orch-reviewer.md
@@ -1,0 +1,14 @@
+---
+name: orch-reviewer
+description: Fixture standing in for the installed orch-reviewer definition (pull request review) in internal/cli's doctor tests.
+tools: Read, Grep, Glob
+model: claude-opus-4-8
+---
+
+# Fixture
+
+Not a real agent definition: only the frontmatter model above is read,
+by the installed-definition check `orch doctor` runs for the Claude
+host. The models here match what cli_test.go's validTOML gives
+`hosts.claude.roles`, so the default fake plugin listing reports a
+healthy install.

--- a/internal/cli/testdata/claude-plugin/agents/orch-scout.md
+++ b/internal/cli/testdata/claude-plugin/agents/orch-scout.md
@@ -1,0 +1,14 @@
+---
+name: orch-scout
+description: Fixture standing in for the installed orch-scout definition (read-only investigation) in internal/cli's doctor tests.
+tools: Read, Grep, Glob
+model: claude-sonnet-5
+---
+
+# Fixture
+
+Not a real agent definition: only the frontmatter model above is read,
+by the installed-definition check `orch doctor` runs for the Claude
+host. The models here match what cli_test.go's validTOML gives
+`hosts.claude.roles`, so the default fake plugin listing reports a
+healthy install.

--- a/internal/cli/testdata/claude-plugin/agents/orch-specialist.md
+++ b/internal/cli/testdata/claude-plugin/agents/orch-specialist.md
@@ -1,0 +1,14 @@
+---
+name: orch-specialist
+description: Fixture standing in for the installed orch-specialist definition (escalated implementation) in internal/cli's doctor tests.
+tools: Read, Grep, Glob
+model: claude-opus-4-8
+---
+
+# Fixture
+
+Not a real agent definition: only the frontmatter model above is read,
+by the installed-definition check `orch doctor` runs for the Claude
+host. The models here match what cli_test.go's validTOML gives
+`hosts.claude.roles`, so the default fake plugin listing reports a
+healthy install.


### PR DESCRIPTION
Delivers issue #185: Report a Claude routed-model mismatch in orch doctor

Closes #185

**Plan digest:** `sha256:d6f500e8eea09182da627ada019ee9a25201bf4af7c479e59ccab236080b8a9d`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Add a Claude-host counterpart to orch doctor's existing codex agent files check. For each Claude role that ships an agent definition - scout, implementer, specialist, reviewer, and review_downgrade, whose definition is named orch-reviewer-safe; the architect is the host session itself and has no agent definition - compare the model in the effective configuration's hosts.claude.roles against the model the installed Claude agent definition pins in its frontmatter, and report a failing check when they differ. Resolve the installed definitions from the Claude CLI's own plugin listing, which doctor already runs for the claude adapter check and whose entry for the Orch Claude plugin carries the installed root path; the definitions live in that root's agents directory. Compare against the installed copy, not this repository's adapters/claude/agents copy, since an installed plugin behind head can still carry an older pin. Scope note: adapters/claude/plugin_test.go already checks this repository's own agent files against the shipped section 10 profile - that is a different comparison (repo copy vs shipped defaults) and is not what this issue duplicates or replaces.

**Acceptance criteria:**
- With hosts.claude enabled and every Claude role that ships an agent definition holding the same model in the effective configuration as the installed Claude agent definition for that role pins, orch doctor reports a passing check covering the installed Claude agent definitions.
- With hosts.claude enabled and at least one such role holding a different model in the effective configuration than the installed definition pins, orch doctor reports that check as failing and its output names every differing role, the model the effective configuration gives that role, and the model the installed definition pins.
- With hosts.claude absent from the effective configuration, orch doctor's output contains no check about installed Claude agent definitions.
- With hosts.claude enabled and the installed Claude agent definitions unavailable - the plugin listing carrying no installed root, the agents directory absent, a definition file unreadable, or a definition carrying no model - orch doctor reports that check as failing with output naming which of those it hit, and never reports it as passing.
- README.md no longer contains the sentence "On Claude Code nothing in the binary checks this.", and the paragraph beginning "A model override does not reach a dispatched agent by itself, on either host." describes what orch doctor now reports for the Claude host.

**Required tests:**
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **build** — pass — `go build ./...` — No output. — commit `223987d1f8529ab9ce1015c0ab4e70621dc26d16` (2026-08-02T21:18:37Z)
- **test** — pass — `go test ./...` — All 23 packages ok, no failures. New tests: TestDoctorBothHostsClaudeAgentDefinitionsMatchPass, TestDoctorClaudeAgentDefinitionsMismatchFails, TestDoctorClaudeAgentDefinitionsUnavailableFails (4 subtests), TestDoctorNoClaudeHostSkipsAgentDefinitionsCheck. All assert on doctor's observable stdout, none on the presence of a string in a source file. — commit `223987d1f8529ab9ce1015c0ab4e70621dc26d16` (2026-08-02T21:18:37Z)
- **vet** — pass — `go vet ./...` — No output. — commit `223987d1f8529ab9ce1015c0ab4e70621dc26d16` (2026-08-02T21:18:37Z)
- **format** — pass — `gofmt -l .` — Printed nothing. — commit `223987d1f8529ab9ce1015c0ab4e70621dc26d16` (2026-08-02T21:18:37Z)
- **worktree-hazard-does-not-transfer** — pass — `go run ./cmd/orch doctor` — Run by the executor inside the issue-185 worktree against the real installed plugin at the machine-global Claude plugin cache. Printed `ok    claude agent definitions`, while `codex agent files` failed for the pre-existing reason that a worktree carries the tracked configuration but never has the Codex files rendered into it (task 140's third non-blocking finding). Confirms the new check is not subject to that worktree hazard, because the installed Claude plugin is machine-global rather than repo-relative. — commit `223987d1f8529ab9ce1015c0ab4e70621dc26d16` (2026-08-02T21:18:37Z)
- **branch-scope: prose-reflow word diff** — pass — `git diff --word-diff --ignore-all-space main origin/orch/issue-185-report-a-claude-routed-model-mismatch-in -- README.md` — Re-stamped at reviewed head 223987d, and re-run by the reviewer independently of the Architect's original submission. Exactly two removal markers, [-nothing-] and [-binary checks this.-], together the deliberately deleted sentence. The reflowed tail ("Either way, changing a role's model - which the Settings section above recommends as ordinary tuning - is not finished until the installed agent definitions carry it too.") shows no removal marker, so the rewrap dropped no words. This is the check open task 72 exists for. — commit `223987d1f8529ab9ce1015c0ab4e70621dc26d16` (2026-08-02T21:27:48Z)
- **branch-scope: diffstat against main** — pass — `git diff --stat main origin/orch/issue-185-report-a-claude-routed-model-mismatch-in` — Re-stamped at reviewed head 223987d and re-derived by the reviewer. 11 files changed, 447 insertions, 20 deletions, all under internal/agents/, internal/cli/, and README.md. One atomic commit with an accurate message. Nothing renders, writes, or generates a Claude agent file: claude.go calls only os.Stat and os.ReadFile, and render-agents remains cfg.Hosts.Codex-only at internal/cli/renderagents.go:28,42, so decision 66's deferral is intact. — commit `223987d1f8529ab9ce1015c0ab4e70621dc26d16` (2026-08-02T21:27:48Z)
- **reviewer-independent-test-rerun** — pass — `go build ./... && go vet ./... && gofmt -l . && go test ./...` — Re-run by the reviewer in the issue-185 worktree at 223987d rather than inherited from the executor. go build, go vet: no output, exit 0. gofmt -l .: printed nothing. go test ./...: all 26 lines ok or no test files, exit 0. Targeted run `go test ./internal/cli/ -count=1 -run 'ClaudeAgentDefinitions|NoClaudeHost' -v`: 4 tests plus 4 subtests, all PASS. — commit `223987d1f8529ab9ce1015c0ab4e70621dc26d16` (2026-08-02T21:27:48Z)
- **reviewer-live-doctor-run** — pass — `go run ./cmd/orch doctor` — Reviewer's own run inside the issue-185 worktree. Printed `ok    claude adapter`, `ok    claude agent definitions`, `ok    codex adapter`, and `FAIL  codex agent files` for the pre-existing unrendered-in-worktree reason. The reviewer independently confirmed the mechanism: `claude plugin list --json` emits installPath, which for orch-claude@orch resolves to the machine-global plugin cache, and all five installed agents/*.md there pin claude-opus-5, matching hosts.claude.roles. — commit `223987d1f8529ab9ce1015c0ab4e70621dc26d16` (2026-08-02T21:27:48Z)
- **acceptance-criterion-1** — satisfied — TestDoctorBothHostsClaudeAgentDefinitionsMatchPass runs validBothHostsTOML and asserts both `ok    claude agent definitions` and `ok    codex agent files`; it passed in an uncached run. The pass path also runs in every pre-existing doctor test using validTOML, because the default fake listing now points at internal/cli/testdata/claude-plugin whose fixtures pin the same models. Independently, a live `orch doctor` printed `ok    claude agent definitions` against the real install. — commit `223987d1f8529ab9ce1015c0ab4e70621dc26d16` (2026-08-02T21:27:49Z)
- **acceptance-criterion-2** — satisfied — TestDoctorClaudeAgentDefinitionsMismatchFails asserts `FAIL  claude agent definitions` plus the literal substrings `scout: configured "claude-sonnet-5"`, `pins "claude-opus-9"`, `reviewer: configured "claude-opus-4-8"`, `pins "claude-sonnet-5"` - role, configured model, and installed model - and asserts implementer:, specialist:, and review_downgrade: are absent, so the 'every differing role and only those' half is pinned in both directions. The producing line is internal/agents/claude.go:88. Passed. — commit `223987d1f8529ab9ce1015c0ab4e70621dc26d16` (2026-08-02T21:27:49Z)
- **acceptance-criterion-3** — satisfied — internal/cli/doctor.go:121 gates the check on cfg.Hosts.Claude != nil. TestDoctorNoClaudeHostSkipsAgentDefinitionsCheck runs validCodexTOML and asserts the string `claude agent definitions` appears nowhere in stdout. Passed. — commit `223987d1f8529ab9ce1015c0ab4e70621dc26d16` (2026-08-02T21:27:49Z)
- **acceptance-criterion-4** — satisfied — All four subtests passed, and each asserts both that `FAIL  claude agent definitions` is present and that `ok    claude agent definitions` is absent, so none can silently pass. Each maps to a distinct reachable path in internal/agents/claude.go: empty install root at line 60, fs.ErrNotExist on the agents directory at lines 66-68, os.ReadFile failure at lines 76-79, and no model line via claudeModel's final error. The no-model subtest also proves the role name rather than the file stem reaches the output, showing review_downgrade: for orch-reviewer-safe.md. — commit `223987d1f8529ab9ce1015c0ab4e70621dc26d16` (2026-08-02T21:27:49Z)
- **acceptance-criterion-5** — satisfied — grep for 'nothing in the binary checks this' in README.md returns nothing, exit 1. The rewritten paragraph at README.md:493-521 describes the check, and every factual claim in it holds against this branch: it resolves the root from `claude plugin list --json` (doctor.go:130-132), reads five frontmatter models via roleFiles, fails under the name `claude agent definitions`, names both models, fails when definitions cannot be read, and states that Claude plan activation does not gate on this either - confirmed at internal/run/activate.go:186, where the agents.Stale gate is still inside `if plan.Host == "codex"`. — commit `223987d1f8529ab9ce1015c0ab4e70621dc26d16` (2026-08-02T21:27:49Z)
- **review-cycle-1** — approve — All five acceptance criteria satisfied, each on an observation the reviewer made itself rather than inherited from the executor. The four required tests, the targeted new-test run, and CI all pass at the reviewed head; the reviewer re-ran them rather than accepting the executor's claim. The reviewer independently confirmed the mechanism the objective named: `claude plugin list --json` really does emit installPath, and for orch-claude@orch it resolves to a machine-global plugin cache, so the Delivery-worktree hazard task 140 recorded for the Codex check does not transfer - a live `orch doctor` inside the issue worktree printed `ok    claude agent definitions` while `codex agent files` failed for the pre-existing unrendered-in-worktree reason. Scope is clean: 11 files under internal/agents, internal/cli, and README.md, one atomic commit, nothing rendering or writing a Claude agent file, so decision 66's deliberate deferral of a Claude render-agents equivalent stays intact. Security surface is read-only with fixed path components and no shell interpolation. The manifest block is accurate, including that the routed executor claude-opus-5 was the model that actually ran. Seven findings, all low severity or nit, none blocking a criterion or weakening a boundary; they go to the backlog. The two the reviewer would most want picked up are a pair of contradictory comments in internal/cli/doctor.go about a fail-closed property the code does not have, and a no-install-path message that asserts a listing entry which may never have existed - true in only one of the six paths that reach it. — commit `223987d1f8529ab9ce1015c0ab4e70621dc26d16` (2026-08-02T21:27:49Z)
- **required-ci** — passing — test (macos-latest)=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (windows-latest)=pass — commit `223987d1f8529ab9ce1015c0ab4e70621dc26d16` (2026-08-02T21:28:01Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Add a Claude-host counterpart to orch doctor's existing codex agent files check. For each Claude role that ships an agent definition - scout, implementer, specialist, reviewer, and review_downgrade, whose definition is named orch-reviewer-safe; the architect is the host session itself and has no agent definition - compare the model in the effective configuration's hosts.claude.roles against the model the installed Claude agent definition pins in its frontmatter, and report a failing check when they differ. Resolve the installed definitions from the Claude CLI's own plugin listing, which doctor already runs for the claude adapter check and whose entry for the Orch Claude plugin carries the installed root path; the definitions live in that root's agents directory. Compare against the installed copy, not this repository's adapters/claude/agents copy, since an installed plugin behind head can still carry an older pin. Scope note: adapters/claude/plugin_test.go already checks this repository's own agent files against the shipped section 10 profile - that is a different comparison (repo copy vs shipped defaults) and is not what this issue duplicates or replaces.",
  "acceptance_criteria": [
    "With hosts.claude enabled and every Claude role that ships an agent definition holding the same model in the effective configuration as the installed Claude agent definition for that role pins, orch doctor reports a passing check covering the installed Claude agent definitions.",
    "With hosts.claude enabled and at least one such role holding a different model in the effective configuration than the installed definition pins, orch doctor reports that check as failing and its output names every differing role, the model the effective configuration gives that role, and the model the installed definition pins.",
    "With hosts.claude absent from the effective configuration, orch doctor's output contains no check about installed Claude agent definitions.",
    "With hosts.claude enabled and the installed Claude agent definitions unavailable - the plugin listing carrying no installed root, the agents directory absent, a definition file unreadable, or a definition carrying no model - orch doctor reports that check as failing with output naming which of those it hit, and never reports it as passing.",
    "README.md no longer contains the sentence \"On Claude Code nothing in the binary checks this.\", and the paragraph beginning \"A model override does not reach a dispatched agent by itself, on either host.\" describes what orch doctor now reports for the Claude host."
  ],
  "required_tests": [
    "go build ./...",
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "No output.",
      "commit_oid": "223987d1f8529ab9ce1015c0ab4e70621dc26d16",
      "at": "2026-08-02T21:18:37Z"
    },
    {
      "name": "test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All 23 packages ok, no failures. New tests: TestDoctorBothHostsClaudeAgentDefinitionsMatchPass, TestDoctorClaudeAgentDefinitionsMismatchFails, TestDoctorClaudeAgentDefinitionsUnavailableFails (4 subtests), TestDoctorNoClaudeHostSkipsAgentDefinitionsCheck. All assert on doctor's observable stdout, none on the presence of a string in a source file.",
      "commit_oid": "223987d1f8529ab9ce1015c0ab4e70621dc26d16",
      "at": "2026-08-02T21:18:37Z"
    },
    {
      "name": "vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "No output.",
      "commit_oid": "223987d1f8529ab9ce1015c0ab4e70621dc26d16",
      "at": "2026-08-02T21:18:37Z"
    },
    {
      "name": "format",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Printed nothing.",
      "commit_oid": "223987d1f8529ab9ce1015c0ab4e70621dc26d16",
      "at": "2026-08-02T21:18:37Z"
    },
    {
      "name": "worktree-hazard-does-not-transfer",
      "command": "go run ./cmd/orch doctor",
      "result": "pass",
      "detail": "Run by the executor inside the issue-185 worktree against the real installed plugin at the machine-global Claude plugin cache. Printed `ok    claude agent definitions`, while `codex agent files` failed for the pre-existing reason that a worktree carries the tracked configuration but never has the Codex files rendered into it (task 140's third non-blocking finding). Confirms the new check is not subject to that worktree hazard, because the installed Claude plugin is machine-global rather than repo-relative.",
      "commit_oid": "223987d1f8529ab9ce1015c0ab4e70621dc26d16",
      "at": "2026-08-02T21:18:37Z"
    },
    {
      "name": "branch-scope: prose-reflow word diff",
      "command": "git diff --word-diff --ignore-all-space main origin/orch/issue-185-report-a-claude-routed-model-mismatch-in -- README.md",
      "result": "pass",
      "detail": "Re-stamped at reviewed head 223987d, and re-run by the reviewer independently of the Architect's original submission. Exactly two removal markers, [-nothing-] and [-binary checks this.-], together the deliberately deleted sentence. The reflowed tail (\"Either way, changing a role's model - which the Settings section above recommends as ordinary tuning - is not finished until the installed agent definitions carry it too.\") shows no removal marker, so the rewrap dropped no words. This is the check open task 72 exists for.",
      "commit_oid": "223987d1f8529ab9ce1015c0ab4e70621dc26d16",
      "at": "2026-08-02T21:27:48Z"
    },
    {
      "name": "branch-scope: diffstat against main",
      "command": "git diff --stat main origin/orch/issue-185-report-a-claude-routed-model-mismatch-in",
      "result": "pass",
      "detail": "Re-stamped at reviewed head 223987d and re-derived by the reviewer. 11 files changed, 447 insertions, 20 deletions, all under internal/agents/, internal/cli/, and README.md. One atomic commit with an accurate message. Nothing renders, writes, or generates a Claude agent file: claude.go calls only os.Stat and os.ReadFile, and render-agents remains cfg.Hosts.Codex-only at internal/cli/renderagents.go:28,42, so decision 66's deferral is intact.",
      "commit_oid": "223987d1f8529ab9ce1015c0ab4e70621dc26d16",
      "at": "2026-08-02T21:27:48Z"
    },
    {
      "name": "reviewer-independent-test-rerun",
      "command": "go build ./... \u0026\u0026 go vet ./... \u0026\u0026 gofmt -l . \u0026\u0026 go test ./...",
      "result": "pass",
      "detail": "Re-run by the reviewer in the issue-185 worktree at 223987d rather than inherited from the executor. go build, go vet: no output, exit 0. gofmt -l .: printed nothing. go test ./...: all 26 lines ok or no test files, exit 0. Targeted run `go test ./internal/cli/ -count=1 -run 'ClaudeAgentDefinitions|NoClaudeHost' -v`: 4 tests plus 4 subtests, all PASS.",
      "commit_oid": "223987d1f8529ab9ce1015c0ab4e70621dc26d16",
      "at": "2026-08-02T21:27:48Z"
    },
    {
      "name": "reviewer-live-doctor-run",
      "command": "go run ./cmd/orch doctor",
      "result": "pass",
      "detail": "Reviewer's own run inside the issue-185 worktree. Printed `ok    claude adapter`, `ok    claude agent definitions`, `ok    codex adapter`, and `FAIL  codex agent files` for the pre-existing unrendered-in-worktree reason. The reviewer independently confirmed the mechanism: `claude plugin list --json` emits installPath, which for orch-claude@orch resolves to the machine-global plugin cache, and all five installed agents/*.md there pin claude-opus-5, matching hosts.claude.roles.",
      "commit_oid": "223987d1f8529ab9ce1015c0ab4e70621dc26d16",
      "at": "2026-08-02T21:27:48Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "TestDoctorBothHostsClaudeAgentDefinitionsMatchPass runs validBothHostsTOML and asserts both `ok    claude agent definitions` and `ok    codex agent files`; it passed in an uncached run. The pass path also runs in every pre-existing doctor test using validTOML, because the default fake listing now points at internal/cli/testdata/claude-plugin whose fixtures pin the same models. Independently, a live `orch doctor` printed `ok    claude agent definitions` against the real install.",
      "commit_oid": "223987d1f8529ab9ce1015c0ab4e70621dc26d16",
      "at": "2026-08-02T21:27:49Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "TestDoctorClaudeAgentDefinitionsMismatchFails asserts `FAIL  claude agent definitions` plus the literal substrings `scout: configured \"claude-sonnet-5\"`, `pins \"claude-opus-9\"`, `reviewer: configured \"claude-opus-4-8\"`, `pins \"claude-sonnet-5\"` - role, configured model, and installed model - and asserts implementer:, specialist:, and review_downgrade: are absent, so the 'every differing role and only those' half is pinned in both directions. The producing line is internal/agents/claude.go:88. Passed.",
      "commit_oid": "223987d1f8529ab9ce1015c0ab4e70621dc26d16",
      "at": "2026-08-02T21:27:49Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "internal/cli/doctor.go:121 gates the check on cfg.Hosts.Claude != nil. TestDoctorNoClaudeHostSkipsAgentDefinitionsCheck runs validCodexTOML and asserts the string `claude agent definitions` appears nowhere in stdout. Passed.",
      "commit_oid": "223987d1f8529ab9ce1015c0ab4e70621dc26d16",
      "at": "2026-08-02T21:27:49Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "All four subtests passed, and each asserts both that `FAIL  claude agent definitions` is present and that `ok    claude agent definitions` is absent, so none can silently pass. Each maps to a distinct reachable path in internal/agents/claude.go: empty install root at line 60, fs.ErrNotExist on the agents directory at lines 66-68, os.ReadFile failure at lines 76-79, and no model line via claudeModel's final error. The no-model subtest also proves the role name rather than the file stem reaches the output, showing review_downgrade: for orch-reviewer-safe.md.",
      "commit_oid": "223987d1f8529ab9ce1015c0ab4e70621dc26d16",
      "at": "2026-08-02T21:27:49Z"
    },
    {
      "name": "acceptance-criterion-5",
      "result": "satisfied",
      "detail": "grep for 'nothing in the binary checks this' in README.md returns nothing, exit 1. The rewritten paragraph at README.md:493-521 describes the check, and every factual claim in it holds against this branch: it resolves the root from `claude plugin list --json` (doctor.go:130-132), reads five frontmatter models via roleFiles, fails under the name `claude agent definitions`, names both models, fails when definitions cannot be read, and states that Claude plan activation does not gate on this either - confirmed at internal/run/activate.go:186, where the agents.Stale gate is still inside `if plan.Host == \"codex\"`.",
      "commit_oid": "223987d1f8529ab9ce1015c0ab4e70621dc26d16",
      "at": "2026-08-02T21:27:49Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "All five acceptance criteria satisfied, each on an observation the reviewer made itself rather than inherited from the executor. The four required tests, the targeted new-test run, and CI all pass at the reviewed head; the reviewer re-ran them rather than accepting the executor's claim. The reviewer independently confirmed the mechanism the objective named: `claude plugin list --json` really does emit installPath, and for orch-claude@orch it resolves to a machine-global plugin cache, so the Delivery-worktree hazard task 140 recorded for the Codex check does not transfer - a live `orch doctor` inside the issue worktree printed `ok    claude agent definitions` while `codex agent files` failed for the pre-existing unrendered-in-worktree reason. Scope is clean: 11 files under internal/agents, internal/cli, and README.md, one atomic commit, nothing rendering or writing a Claude agent file, so decision 66's deliberate deferral of a Claude render-agents equivalent stays intact. Security surface is read-only with fixed path components and no shell interpolation. The manifest block is accurate, including that the routed executor claude-opus-5 was the model that actually ran. Seven findings, all low severity or nit, none blocking a criterion or weakening a boundary; they go to the backlog. The two the reviewer would most want picked up are a pair of contradictory comments in internal/cli/doctor.go about a fail-closed property the code does not have, and a no-install-path message that asserts a listing entry which may never have existed - true in only one of the six paths that reach it.",
      "commit_oid": "223987d1f8529ab9ce1015c0ab4e70621dc26d16",
      "at": "2026-08-02T21:27:49Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (macos-latest)=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (windows-latest)=pass",
      "commit_oid": "223987d1f8529ab9ce1015c0ab4e70621dc26d16",
      "at": "2026-08-02T21:28:01Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->