### PR TITLE
Have orch doctor say when an enabled host's instruction file carries no project conventions

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/kninetimmy/orch/adapters/claude"
@@ -15,6 +16,8 @@ import (
 	"github.com/kninetimmy/orch/internal/execx"
 	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/gitops"
+	"github.com/kninetimmy/orch/internal/instructions"
+	"github.com/kninetimmy/orch/internal/interview"
 	"github.com/kninetimmy/orch/internal/lockfile"
 	"github.com/kninetimmy/orch/internal/memhub"
 	"github.com/kninetimmy/orch/internal/metrics"
@@ -150,6 +153,30 @@ func runDoctor(env Env) error {
 			check("codex agent files", staleErr)
 		default:
 			check("codex agent files", nil)
+		}
+	}
+
+	// A root instruction file holding the Orch managed block and
+	// nothing else leaves that host's agents with no project
+	// conventions at all: Orch writes only its own block and never
+	// carries a repository's conventions across from the other host's
+	// file (interview.InstructionFile maps one file per host). A note,
+	// not a failure — Orch cannot author a repository's conventions,
+	// and a repository with genuinely none to state is not broken.
+	if cfgErr == nil {
+		for _, host := range cfg.EnabledHosts() {
+			file := interview.InstructionFile(host)
+			// PlanRemove's DeleteWholeFile already answers exactly this
+			// question: what is left once the managed region is
+			// stripped is otherwise empty. An unreadable file or
+			// structurally broken markers are not this check's subject
+			// — `orch init`/`configure` already block on those — so
+			// they stay silent here rather than borrowing this note.
+			ch, err := instructions.PlanRemoveFile(filepath.Join(env.RepoRoot, file))
+			if err != nil || !ch.DeleteWholeFile {
+				continue
+			}
+			fmt.Fprintf(env.Stdout, "note  %s holds the Orch managed block and nothing else; %s agents see no project conventions — add them outside the block\n", file, host)
 		}
 	}
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kninetimmy/orch/internal/agents"
 	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/instructions"
 	"github.com/kninetimmy/orch/internal/lockfile"
 	"github.com/kninetimmy/orch/internal/state"
 )
@@ -1029,5 +1030,98 @@ func TestDoctorCodexAgentsCurrentThenAllBadStates(t *testing.T) {
 	}
 	if !strings.Contains(out, "orch render-agents") {
 		t.Errorf("stdout does not name the repair:\n%s", out)
+	}
+}
+
+// managedBlock is the canonical managed block this build renders — the
+// only content a "block and nothing else" instruction file holds.
+func managedBlock(t *testing.T) string {
+	t.Helper()
+	block, err := instructions.Render(instructions.CurrentVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return block
+}
+
+// writeInstructionFile writes name (CLAUDE.md or AGENTS.md) at the
+// repository root with content.
+func writeInstructionFile(t *testing.T, root, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDoctorNotesInstructionFileWithOnlyManagedBlock walks the four
+// states a host's root instruction file can be in. Only the block-and-
+// nothing-else state earns the advisory — the one that leaves that
+// host's agents with no project conventions at all — and it never
+// fails doctor.
+func TestDoctorNotesInstructionFileWithOnlyManagedBlock(t *testing.T) {
+	block := managedBlock(t)
+	tests := []struct {
+		name string
+		// content "" writes no CLAUDE.md at all.
+		content string
+		want    bool
+	}{
+		{name: "managed block alone", content: block + "\n", want: true},
+		{name: "conventions outside the block", content: "# Repo\n\nFail loudly.\n\n" + block + "\n"},
+		{name: "no managed block", content: "# Repo\n\nFail loudly.\n"},
+		{name: "absent"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env, stdout, _ := testEnv(t)
+			writeConfig(t, env.RepoRoot, validTOML)
+			if tt.content != "" {
+				writeInstructionFile(t, env.RepoRoot, "CLAUDE.md", tt.content)
+			}
+			if code := Run([]string{"doctor"}, env); code != ExitOK {
+				t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+			}
+			got := strings.Contains(stdout.String(), "note  CLAUDE.md holds the Orch managed block and nothing else; claude agents see no project conventions")
+			if got != tt.want {
+				t.Errorf("advisory present = %v, want %v:\n%s", got, tt.want, stdout.String())
+			}
+		})
+	}
+}
+
+// TestDoctorInstructionAdvisoryFollowsEnabledHosts pins the advisory to
+// the hosts the configuration enables: both root instruction files hold
+// nothing but the managed block in every case, and only an enabled
+// host's file is reported.
+func TestDoctorInstructionAdvisoryFollowsEnabledHosts(t *testing.T) {
+	block := managedBlock(t)
+	tests := []struct {
+		name       string
+		config     string
+		wantClaude bool
+		wantCodex  bool
+	}{
+		{name: "claude only", config: validTOML, wantClaude: true},
+		{name: "codex only", config: validCodexTOML, wantCodex: true},
+		{name: "both hosts", config: validBothHostsTOML, wantClaude: true, wantCodex: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env, stdout, _ := testEnv(t)
+			writeConfig(t, env.RepoRoot, tt.config)
+			writeInstructionFile(t, env.RepoRoot, "CLAUDE.md", block+"\n")
+			writeInstructionFile(t, env.RepoRoot, "AGENTS.md", block+"\n")
+			// Exit code is deliberately not asserted here: a Codex host
+			// with no rendered agent files fails doctor for its own
+			// unrelated reason (TestDoctorBothHostsCodexAgentsAbsentFails).
+			Run([]string{"doctor"}, env)
+			out := stdout.String()
+			if got := strings.Contains(out, "note  CLAUDE.md holds the Orch managed block"); got != tt.wantClaude {
+				t.Errorf("CLAUDE.md advisory present = %v, want %v:\n%s", got, tt.wantClaude, out)
+			}
+			if got := strings.Contains(out, "note  AGENTS.md holds the Orch managed block"); got != tt.wantCodex {
+				t.Errorf("AGENTS.md advisory present = %v, want %v:\n%s", got, tt.wantCodex, out)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Delivers issue #188: Have orch doctor say when an enabled host's instruction file carries no project conventions

Closes #188

**Plan digest:** `sha256:cd241f13635d50dd4d9a513f198d03681f5e77ffaa1063071e1157ea01721e62`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Orch owns one root instruction file per host: CLAUDE.md for the claude host and AGENTS.md for the codex host, mapped in internal/interview/summary.go. Orch writes only its own managed block into each and never carries a repository's own conventions across. A repository that keeps its conventions in one of those two files and lets Orch create the other gets a file holding the managed block and nothing else, so every agent on that host runs without the conventions the other host's agents see, and nothing anywhere reports it. Orch cannot author a repository's conventions, but it can say the file has none. This is a report, not a repair: doctor's existing note form is the right register, since a repository with genuinely nothing to state is not broken.

**Acceptance criteria:**
- orch doctor prints one advisory line for each enabled host whose root instruction file exists and holds the Orch managed block with nothing else outside it, naming the host, the file, and the consequence that agents on that host see no project conventions.
- That advisory line does not make orch doctor exit non-zero, and doctor's existing reporting is unchanged for a file that carries content outside the managed block, for an absent file, and for a file with no managed block.
- Run against this repository, the new advisory line is absent, because both root instruction files here carry content outside the managed block.

**Required tests:**
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.

**Escalations:** _none_

**Verification:**
- **build** — pass — `go build ./...` — No output. Run in the issue-188 worktree. — commit `583547e3f08a7dfa59e90a1bc6499165abf343e3` (2026-08-02T23:22:36Z)
- **tests** — pass — `go test ./...` — Re-run by the reviewer at head 583547e with -count=1: exit 0. Corrects the pr-open detail's 'all 26 packages reported ok' - the run is 22 packages ok plus 4 reporting no test files. — commit `583547e3f08a7dfa59e90a1bc6499165abf343e3` (2026-08-02T23:29:37Z)
- **vet** — pass — `go vet ./...` — No output. Run in the issue-188 worktree. — commit `583547e3f08a7dfa59e90a1bc6499165abf343e3` (2026-08-02T23:22:36Z)
- **format** — pass — `gofmt -l .` — No files listed. Run in the issue-188 worktree. — commit `583547e3f08a7dfa59e90a1bc6499165abf343e3` (2026-08-02T23:22:36Z)
- **new-tests** — pass — `go test ./internal/cli/ -run 'TestDoctorNotesInstructionFileWithOnlyManagedBlock|TestDoctorInstructionAdvisoryFollowsEnabledHosts' -v` — Four subtests covering managed block alone, conventions outside the block, no managed block, and an absent file; plus three subtests covering claude only, codex only, and both hosts enabled. Each of the four states asserts doctor still exits ok, which is the half of criterion 2 that says the advisory never fails doctor. — commit `583547e3f08a7dfa59e90a1bc6499165abf343e3` (2026-08-02T23:22:36Z)
- **criterion-3-live-doctor** — pass — `go run ./cmd/orch doctor` — The new advisory line is absent in both the worktree and the main checkout; in the main checkout the binary exits 0 across 16 lines. Corrects the pr-open detail's quotation of the worktree's pre-existing unrelated failure: the FAIL codex agent files line names five absent .codex/agents/*.toml files, not only orch-scout.toml. The cause is unchanged - .codex/agents/ is gitignored, so a fresh worktree never carries the rendered files. — commit `583547e3f08a7dfa59e90a1bc6499165abf343e3` (2026-08-02T23:29:37Z)
- **branch-scope: additions-only** — pass — `git diff --stat main...HEAD` — Re-checked by the reviewer at head 583547e: 2 files changed, 121 insertions(+), zero deletions. The change adds lines only and modifies no existing doctor output line and no existing test. — commit `583547e3f08a7dfa59e90a1bc6499165abf343e3` (2026-08-02T23:29:37Z)
- **reviewer-required-tests** — pass — `go build ./... && go test ./... && go vet ./... && gofmt -l .` — All four required tests re-run by the reviewer in the issue-188 worktree at head 583547e rather than inherited from the executor's report: build no output exit 0, tests exit 0, vet no output exit 0, gofmt listed no files. The new tests re-run with -count=1 -v gave 7 subtests all PASS. The worktree was clean and at 583547e, one commit above main. — commit `583547e3f08a7dfa59e90a1bc6499165abf343e3` (2026-08-02T23:29:37Z)
- **acceptance-criterion-1** — satisfied — The reviewer built the PR binary and ran it against a scratch repository outside this checkout carrying .orchestrator/config.toml with both hosts enabled plus a CLAUDE.md and AGENTS.md each holding only the managed block. Output contained exactly two new lines, one per host, each naming the file, the host, and the consequence: 'note  CLAUDE.md holds the Orch managed block and nothing else; claude agents see no project conventions - add them outside the block' and the AGENTS.md/codex counterpart. Code at internal/cli/doctor.go lines 166-181. TestDoctorInstructionAdvisoryFollowsEnabledHosts passed across claude-only, codex-only and both-hosts, pinning the line to enabled hosts specifically. — commit `583547e3f08a7dfa59e90a1bc6499165abf343e3` (2026-08-02T23:29:39Z)
- **acceptance-criterion-2** — satisfied — doctor.go:179 writes with fmt.Fprintf directly and never calls the check helper, so the failed flag at line 55 is untouched; the managed_block_alone subtest requires Run(doctor) == ExitOK while simultaneously asserting the advisory is present, and passed. git diff --stat main...HEAD prints 2 files changed, 121 insertions(+) with zero deletions, so no existing doctor output line and no existing test was modified, and the whole existing suite passes. All three protected states print no advisory and exit ok: the conventions_outside_the_block, no_managed_block and absent subtests all passed. — commit `583547e3f08a7dfa59e90a1bc6499165abf343e3` (2026-08-02T23:29:39Z)
- **acceptance-criterion-3** — satisfied — The reviewer ran the PR-built binary with cwd at the main checkout: 16 output lines, exit 0, no line containing 'holds the Orch managed block'. It checked the criterion's premise independently rather than accepting it, with grep -n orchestrator:managed CLAUDE.md AGENTS.md placing the markers at lines 24 and 34 of each file, so lines 1-23 of both are content outside the block. It also ran the binary in the worktree, where the advisory is likewise absent and the exit 1 comes from the pre-existing codex agent files check, confirmed unrelated because the identical binary exits 0 in the main checkout and .codex/agents/ is in baseGitignoreLines so a fresh worktree never carries rendered agent files. — commit `583547e3f08a7dfa59e90a1bc6499165abf343e3` (2026-08-02T23:29:39Z)
- **review-cycle-1** — approve — First-cycle approve at head 583547e, on observations the reviewer made itself rather than inheriting from the executor. It rebuilt the PR binary and ran it against a scratch repository outside this checkout holding both hosts enabled plus a CLAUDE.md and AGENTS.md containing only the managed block, reproducing the memdolt scenario, and got exactly the two expected advisory lines. It confirmed the advisory is absent against this repository and independently checked the criterion's premise, finding the managed markers at lines 24 and 34 of both root files so lines 1-23 of each are content outside the block. It re-ran all four required tests and the new tests with -count=1, and confirmed all six CI checks green. Six findings, all low-severity or informational, none blocking: unreadable or structurally malformed instruction files stay silent, which the reviewer agrees is correct because nothing breaks from the silence and orch init/configure already fail closed on those states; a zero-byte instruction file also gets no advisory, which sits outside criterion 1's wording and is pinned silent by criterion 2's absent case; a drifted block-alone file does earn the advisory, which the reviewer judges correct since a user who put conventions inside the block is exactly who needs to move them outside it; no README entry, raised because three recent PRs documented their doctor checks, though no criterion asks for it and nothing in README or the PRD is falsified; the note line leads with the file name rather than a subject-colon, within existing house-style variation; and two imprecisions in the pr-open verification details, corrected in this cycle's record. Security: nothing touched, the check reads and plans but never writes, and the path comes from filepath.Join over a closed host-to-filename map with no external input. Scope: two files, 121 insertions, zero deletions, one atomic commit, reusing instructions.PlanRemoveFile's DeleteWholeFile and interview.InstructionFile rather than adding a parallel notion of block-only, with no new dependency edge. — commit `583547e3f08a7dfa59e90a1bc6499165abf343e3` (2026-08-02T23:29:39Z)
- **required-ci** — passing — test (windows-latest)=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (windows-latest)=pass — commit `583547e3f08a7dfa59e90a1bc6499165abf343e3` (2026-08-02T23:29:53Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Orch owns one root instruction file per host: CLAUDE.md for the claude host and AGENTS.md for the codex host, mapped in internal/interview/summary.go. Orch writes only its own managed block into each and never carries a repository's own conventions across. A repository that keeps its conventions in one of those two files and lets Orch create the other gets a file holding the managed block and nothing else, so every agent on that host runs without the conventions the other host's agents see, and nothing anywhere reports it. Orch cannot author a repository's conventions, but it can say the file has none. This is a report, not a repair: doctor's existing note form is the right register, since a repository with genuinely nothing to state is not broken.",
  "acceptance_criteria": [
    "orch doctor prints one advisory line for each enabled host whose root instruction file exists and holds the Orch managed block with nothing else outside it, naming the host, the file, and the consequence that agents on that host see no project conventions.",
    "That advisory line does not make orch doctor exit non-zero, and doctor's existing reporting is unchanged for a file that carries content outside the managed block, for an absent file, and for a file with no managed block.",
    "Run against this repository, the new advisory line is absent, because both root instruction files here carry content outside the managed block."
  ],
  "required_tests": [
    "go build ./...",
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "No output. Run in the issue-188 worktree.",
      "commit_oid": "583547e3f08a7dfa59e90a1bc6499165abf343e3",
      "at": "2026-08-02T23:22:36Z"
    },
    {
      "name": "tests",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Re-run by the reviewer at head 583547e with -count=1: exit 0. Corrects the pr-open detail's 'all 26 packages reported ok' - the run is 22 packages ok plus 4 reporting no test files.",
      "commit_oid": "583547e3f08a7dfa59e90a1bc6499165abf343e3",
      "at": "2026-08-02T23:29:37Z"
    },
    {
      "name": "vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "No output. Run in the issue-188 worktree.",
      "commit_oid": "583547e3f08a7dfa59e90a1bc6499165abf343e3",
      "at": "2026-08-02T23:22:36Z"
    },
    {
      "name": "format",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No files listed. Run in the issue-188 worktree.",
      "commit_oid": "583547e3f08a7dfa59e90a1bc6499165abf343e3",
      "at": "2026-08-02T23:22:36Z"
    },
    {
      "name": "new-tests",
      "command": "go test ./internal/cli/ -run 'TestDoctorNotesInstructionFileWithOnlyManagedBlock|TestDoctorInstructionAdvisoryFollowsEnabledHosts' -v",
      "result": "pass",
      "detail": "Four subtests covering managed block alone, conventions outside the block, no managed block, and an absent file; plus three subtests covering claude only, codex only, and both hosts enabled. Each of the four states asserts doctor still exits ok, which is the half of criterion 2 that says the advisory never fails doctor.",
      "commit_oid": "583547e3f08a7dfa59e90a1bc6499165abf343e3",
      "at": "2026-08-02T23:22:36Z"
    },
    {
      "name": "criterion-3-live-doctor",
      "command": "go run ./cmd/orch doctor",
      "result": "pass",
      "detail": "The new advisory line is absent in both the worktree and the main checkout; in the main checkout the binary exits 0 across 16 lines. Corrects the pr-open detail's quotation of the worktree's pre-existing unrelated failure: the FAIL codex agent files line names five absent .codex/agents/*.toml files, not only orch-scout.toml. The cause is unchanged - .codex/agents/ is gitignored, so a fresh worktree never carries the rendered files.",
      "commit_oid": "583547e3f08a7dfa59e90a1bc6499165abf343e3",
      "at": "2026-08-02T23:29:37Z"
    },
    {
      "name": "branch-scope: additions-only",
      "command": "git diff --stat main...HEAD",
      "result": "pass",
      "detail": "Re-checked by the reviewer at head 583547e: 2 files changed, 121 insertions(+), zero deletions. The change adds lines only and modifies no existing doctor output line and no existing test.",
      "commit_oid": "583547e3f08a7dfa59e90a1bc6499165abf343e3",
      "at": "2026-08-02T23:29:37Z"
    },
    {
      "name": "reviewer-required-tests",
      "command": "go build ./... \u0026\u0026 go test ./... \u0026\u0026 go vet ./... \u0026\u0026 gofmt -l .",
      "result": "pass",
      "detail": "All four required tests re-run by the reviewer in the issue-188 worktree at head 583547e rather than inherited from the executor's report: build no output exit 0, tests exit 0, vet no output exit 0, gofmt listed no files. The new tests re-run with -count=1 -v gave 7 subtests all PASS. The worktree was clean and at 583547e, one commit above main.",
      "commit_oid": "583547e3f08a7dfa59e90a1bc6499165abf343e3",
      "at": "2026-08-02T23:29:37Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "The reviewer built the PR binary and ran it against a scratch repository outside this checkout carrying .orchestrator/config.toml with both hosts enabled plus a CLAUDE.md and AGENTS.md each holding only the managed block. Output contained exactly two new lines, one per host, each naming the file, the host, and the consequence: 'note  CLAUDE.md holds the Orch managed block and nothing else; claude agents see no project conventions - add them outside the block' and the AGENTS.md/codex counterpart. Code at internal/cli/doctor.go lines 166-181. TestDoctorInstructionAdvisoryFollowsEnabledHosts passed across claude-only, codex-only and both-hosts, pinning the line to enabled hosts specifically.",
      "commit_oid": "583547e3f08a7dfa59e90a1bc6499165abf343e3",
      "at": "2026-08-02T23:29:39Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "doctor.go:179 writes with fmt.Fprintf directly and never calls the check helper, so the failed flag at line 55 is untouched; the managed_block_alone subtest requires Run(doctor) == ExitOK while simultaneously asserting the advisory is present, and passed. git diff --stat main...HEAD prints 2 files changed, 121 insertions(+) with zero deletions, so no existing doctor output line and no existing test was modified, and the whole existing suite passes. All three protected states print no advisory and exit ok: the conventions_outside_the_block, no_managed_block and absent subtests all passed.",
      "commit_oid": "583547e3f08a7dfa59e90a1bc6499165abf343e3",
      "at": "2026-08-02T23:29:39Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "The reviewer ran the PR-built binary with cwd at the main checkout: 16 output lines, exit 0, no line containing 'holds the Orch managed block'. It checked the criterion's premise independently rather than accepting it, with grep -n orchestrator:managed CLAUDE.md AGENTS.md placing the markers at lines 24 and 34 of each file, so lines 1-23 of both are content outside the block. It also ran the binary in the worktree, where the advisory is likewise absent and the exit 1 comes from the pre-existing codex agent files check, confirmed unrelated because the identical binary exits 0 in the main checkout and .codex/agents/ is in baseGitignoreLines so a fresh worktree never carries rendered agent files.",
      "commit_oid": "583547e3f08a7dfa59e90a1bc6499165abf343e3",
      "at": "2026-08-02T23:29:39Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "First-cycle approve at head 583547e, on observations the reviewer made itself rather than inheriting from the executor. It rebuilt the PR binary and ran it against a scratch repository outside this checkout holding both hosts enabled plus a CLAUDE.md and AGENTS.md containing only the managed block, reproducing the memdolt scenario, and got exactly the two expected advisory lines. It confirmed the advisory is absent against this repository and independently checked the criterion's premise, finding the managed markers at lines 24 and 34 of both root files so lines 1-23 of each are content outside the block. It re-ran all four required tests and the new tests with -count=1, and confirmed all six CI checks green. Six findings, all low-severity or informational, none blocking: unreadable or structurally malformed instruction files stay silent, which the reviewer agrees is correct because nothing breaks from the silence and orch init/configure already fail closed on those states; a zero-byte instruction file also gets no advisory, which sits outside criterion 1's wording and is pinned silent by criterion 2's absent case; a drifted block-alone file does earn the advisory, which the reviewer judges correct since a user who put conventions inside the block is exactly who needs to move them outside it; no README entry, raised because three recent PRs documented their doctor checks, though no criterion asks for it and nothing in README or the PRD is falsified; the note line leads with the file name rather than a subject-colon, within existing house-style variation; and two imprecisions in the pr-open verification details, corrected in this cycle's record. Security: nothing touched, the check reads and plans but never writes, and the path comes from filepath.Join over a closed host-to-filename map with no external input. Scope: two files, 121 insertions, zero deletions, one atomic commit, reusing instructions.PlanRemoveFile's DeleteWholeFile and interview.InstructionFile rather than adding a parallel notion of block-only, with no new dependency edge.",
      "commit_oid": "583547e3f08a7dfa59e90a1bc6499165abf343e3",
      "at": "2026-08-02T23:29:39Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (windows-latest)=pass",
      "commit_oid": "583547e3f08a7dfa59e90a1bc6499165abf343e3",
      "at": "2026-08-02T23:29:53Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->