### PR TITLE
Append a blast-radius acceptance criterion to every risk-domain issue

### DIFF
--- a/adapters/claude/agents/orch-reviewer-safe.md
+++ b/adapters/claude/agents/orch-reviewer-safe.md
@@ -70,6 +70,32 @@ missing code is the correct outcome and not a gap to fill. A request
 you have not held to that test is how review grows a change past the
 issue that asked for it.
 
+## The criterion Orch contributes
+
+An issue that declares at least one risk domain carries one acceptance
+criterion the engine contributed rather than the plan document. It is
+always last in the list, and you judge it exactly as you judge the
+others. It reads: Blast radius (contributed by Orch because this issue
+declares a risk domain, not by the plan document): name every element of
+the structure this change touches and state, for each, whether the
+behavior it had before this change still holds; record a behavior this
+change removes as a before-and-after in the same document that stated
+the old behavior, rather than deleting that statement; and where a
+restriction is attributed to one named symbol, establish whether it
+holds for that symbol alone or for every symbol of its kind, and say
+which. What settles it is an enumeration in the pull request body naming
+each element the change touched and its before-and-after; passing tests
+do not settle it.
+
+Its subject is what the change reached past what the plan enumerated, so
+an account covering only the elements the other criteria already name
+does not settle it. Judge it unsatisfied when the PR body carries no
+such enumeration, when it names some touched elements and not others, or
+when a statement of old behavior was deleted where a before-and-after
+belonged. Green tests and green CI are not evidence for it: a suite
+covers what someone already thought to check, which is the gap this
+criterion exists to close.
+
 ## How you look
 
 Your `Bash` access is for **read-only** investigation only: `git diff`,

--- a/adapters/claude/agents/orch-reviewer.md
+++ b/adapters/claude/agents/orch-reviewer.md
@@ -62,6 +62,32 @@ missing code is the correct outcome and not a gap to fill. A request
 you have not held to that test is how review grows a change past the
 issue that asked for it.
 
+## The criterion Orch contributes
+
+An issue that declares at least one risk domain carries one acceptance
+criterion the engine contributed rather than the plan document. It is
+always last in the list, and you judge it exactly as you judge the
+others. It reads: Blast radius (contributed by Orch because this issue
+declares a risk domain, not by the plan document): name every element of
+the structure this change touches and state, for each, whether the
+behavior it had before this change still holds; record a behavior this
+change removes as a before-and-after in the same document that stated
+the old behavior, rather than deleting that statement; and where a
+restriction is attributed to one named symbol, establish whether it
+holds for that symbol alone or for every symbol of its kind, and say
+which. What settles it is an enumeration in the pull request body naming
+each element the change touched and its before-and-after; passing tests
+do not settle it.
+
+Its subject is what the change reached past what the plan enumerated, so
+an account covering only the elements the other criteria already name
+does not settle it. Judge it unsatisfied when the PR body carries no
+such enumeration, when it names some touched elements and not others, or
+when a statement of old behavior was deleted where a before-and-after
+belonged. Green tests and green CI are not evidence for it: a suite
+covers what someone already thought to check, which is the gap this
+criterion exists to close.
+
 ## How you look
 
 Your `Bash` access is for **read-only** investigation only: `git diff`,

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -391,6 +391,21 @@ func TestDeliverySkillHasBranchScopeVerificationGuidance(t *testing.T) {
 	adaptertest.CheckBranchScopeVerificationGuidance(t, deliverySkillPath)
 }
 
+// TestBlastRadiusCriterionGuidance holds this host's delivery skill and
+// both shipped reviewer definitions to the criterion the engine
+// contributes to a risk-domain issue. The pin is two-sided (see
+// adaptertest.CheckBlastRadiusCriterionGuidance): rewording
+// run.BlastRadiusCriterion fails it just as deleting the instruction
+// here does, so the standard the binary imposes and the prose telling
+// the executor and reviewer about it cannot drift apart.
+func TestBlastRadiusCriterionGuidance(t *testing.T) {
+	adaptertest.CheckBlastRadiusCriterionGuidance(t,
+		deliverySkillPath,
+		filepath.Join("agents", "orch-reviewer.md"),
+		filepath.Join("agents", "orch-reviewer-safe.md"),
+	)
+}
+
 // These statements keep a wrong acceptance criterion reachable, keep the
 // plan gate from writing one no evidence can settle, and route a rejected
 // criterion to the human inside the review call rather than through a

--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -102,6 +102,28 @@ it: if the honest answer is a proxy, write the criterion against
 something the repository can actually produce evidence for, or leave it
 out of the plan.
 
+When an issue declares at least one entry in `facts.risk_domains`, the
+engine contributes one further acceptance criterion of its own. The
+`GateDoc`, the created issue body, the audit record, and
+`DispatchResult.acceptance_criteria` all carry it, so a risk-domain
+issue's criteria list is one entry longer than the list your `PlanDoc`
+submitted and the contributed entry is always last. Do not write it into
+the `PlanDoc` yourself — a plan that lists it too carries it twice and
+costs a second judgment saying the same thing. It reads: Blast radius
+(contributed by Orch because this issue declares a risk domain, not by
+the plan document): name every element of the structure this change
+touches and state, for each, whether the behavior it had before this
+change still holds; record a behavior this change removes as a
+before-and-after in the same document that stated the old behavior,
+rather than deleting that statement; and where a restriction is
+attributed to one named symbol, establish whether it holds for that
+symbol alone or for every symbol of its kind, and say which. What
+settles it is an enumeration in the pull request body naming each
+element the change touched and its before-and-after; passing tests do
+not settle it. Present it at the plan gate as part of the issue's
+criteria, exactly like the ones you wrote — it is part of the standard
+the human is approving.
+
 Plan text must never reference machine-local or gitignored paths such
 as `.memhub/`, `.orchestrator/state.json`, or
 `.orchestrator/config.local.toml` — an executor sees only the committed
@@ -345,6 +367,9 @@ in flight at once. For each issue:
    supply yourself. The engine counts the criteria from its own state,
    so the request cannot decide how many it is answering — a missing,
    duplicated, or out-of-range criterion is refused before any mutation.
+   On a risk-domain issue that count includes the engine-contributed
+   blast-radius criterion, last in the list and judged on the same terms
+   as every criterion the plan document supplied.
    A `verdict` of `approve` is accepted only when every criterion is
    judged `satisfied`; record `request-changes` otherwise. Transcribe
    the reviewer's per-criterion calls, never your own reading of its

--- a/adapters/codex/agents/orch-reviewer-safe.toml
+++ b/adapters/codex/agents/orch-reviewer-safe.toml
@@ -76,6 +76,32 @@ missing code is the correct outcome and not a gap to fill. A request
 you have not held to that test is how review grows a change past the
 issue that asked for it.
 
+## The criterion Orch contributes
+
+An issue that declares at least one risk domain carries one acceptance
+criterion the engine contributed rather than the plan document. It is
+always last in the list, and you judge it exactly as you judge the
+others. It reads: Blast radius (contributed by Orch because this issue
+declares a risk domain, not by the plan document): name every element of
+the structure this change touches and state, for each, whether the
+behavior it had before this change still holds; record a behavior this
+change removes as a before-and-after in the same document that stated
+the old behavior, rather than deleting that statement; and where a
+restriction is attributed to one named symbol, establish whether it
+holds for that symbol alone or for every symbol of its kind, and say
+which. What settles it is an enumeration in the pull request body naming
+each element the change touched and its before-and-after; passing tests
+do not settle it.
+
+Its subject is what the change reached past what the plan enumerated, so
+an account covering only the elements the other criteria already name
+does not settle it. Judge it unsatisfied when the PR body carries no
+such enumeration, when it names some touched elements and not others, or
+when a statement of old behavior was deleted where a before-and-after
+belonged. Green tests and green CI are not evidence for it: a suite
+covers what someone already thought to check, which is the gap this
+criterion exists to close.
+
 ## How you look
 
 Investigate read-only: `git diff`, `git log`, `gh pr view`, `gh pr

--- a/adapters/codex/agents/orch-reviewer.toml
+++ b/adapters/codex/agents/orch-reviewer.toml
@@ -68,6 +68,32 @@ missing code is the correct outcome and not a gap to fill. A request
 you have not held to that test is how review grows a change past the
 issue that asked for it.
 
+## The criterion Orch contributes
+
+An issue that declares at least one risk domain carries one acceptance
+criterion the engine contributed rather than the plan document. It is
+always last in the list, and you judge it exactly as you judge the
+others. It reads: Blast radius (contributed by Orch because this issue
+declares a risk domain, not by the plan document): name every element of
+the structure this change touches and state, for each, whether the
+behavior it had before this change still holds; record a behavior this
+change removes as a before-and-after in the same document that stated
+the old behavior, rather than deleting that statement; and where a
+restriction is attributed to one named symbol, establish whether it
+holds for that symbol alone or for every symbol of its kind, and say
+which. What settles it is an enumeration in the pull request body naming
+each element the change touched and its before-and-after; passing tests
+do not settle it.
+
+Its subject is what the change reached past what the plan enumerated, so
+an account covering only the elements the other criteria already name
+does not settle it. Judge it unsatisfied when the PR body carries no
+such enumeration, when it names some touched elements and not others, or
+when a statement of old behavior was deleted where a before-and-after
+belonged. Green tests and green CI are not evidence for it: a suite
+covers what someone already thought to check, which is the gap this
+criterion exists to close.
+
 ## How you look
 
 Investigate read-only: `git diff`, `git log`, `gh pr view`, `gh pr

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -283,6 +283,23 @@ func TestDeliverySkillHasBranchScopeVerificationGuidance(t *testing.T) {
 	adaptertest.CheckBranchScopeVerificationGuidance(t, deliverySkillPath)
 }
 
+// TestBlastRadiusCriterionGuidance holds this host's delivery skill and
+// both shipped reviewer definitions to the criterion the engine
+// contributes to a risk-domain issue. The pin is two-sided (see
+// adaptertest.CheckBlastRadiusCriterionGuidance): rewording
+// run.BlastRadiusCriterion fails it just as deleting the instruction
+// here does, so the standard the binary imposes and the prose telling
+// the executor and reviewer about it cannot drift apart. The TOML files
+// are read raw, so the pin covers the prose wherever in the definition
+// it sits.
+func TestBlastRadiusCriterionGuidance(t *testing.T) {
+	adaptertest.CheckBlastRadiusCriterionGuidance(t,
+		deliverySkillPath,
+		filepath.Join("agents", "orch-reviewer.toml"),
+		filepath.Join("agents", "orch-reviewer-safe.toml"),
+	)
+}
+
 // These statements keep a wrong acceptance criterion reachable, keep the
 // plan gate from writing one no evidence can settle, and route a rejected
 // criterion to the human inside the review call rather than through a

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -102,6 +102,28 @@ it: if the honest answer is a proxy, write the criterion against
 something the repository can actually produce evidence for, or leave it
 out of the plan.
 
+When an issue declares at least one entry in `facts.risk_domains`, the
+engine contributes one further acceptance criterion of its own. The
+`GateDoc`, the created issue body, the audit record, and
+`DispatchResult.acceptance_criteria` all carry it, so a risk-domain
+issue's criteria list is one entry longer than the list your `PlanDoc`
+submitted and the contributed entry is always last. Do not write it into
+the `PlanDoc` yourself — a plan that lists it too carries it twice and
+costs a second judgment saying the same thing. It reads: Blast radius
+(contributed by Orch because this issue declares a risk domain, not by
+the plan document): name every element of the structure this change
+touches and state, for each, whether the behavior it had before this
+change still holds; record a behavior this change removes as a
+before-and-after in the same document that stated the old behavior,
+rather than deleting that statement; and where a restriction is
+attributed to one named symbol, establish whether it holds for that
+symbol alone or for every symbol of its kind, and say which. What
+settles it is an enumeration in the pull request body naming each
+element the change touched and its before-and-after; passing tests do
+not settle it. Present it at the plan gate as part of the issue's
+criteria, exactly like the ones you wrote — it is part of the standard
+the human is approving.
+
 Plan text must never reference machine-local or gitignored paths such
 as `.memhub/`, `.orchestrator/state.json`, or
 `.orchestrator/config.local.toml` — an executor sees only the committed
@@ -355,6 +377,9 @@ When capture returns no total, omit the corresponding optional field.
    supply yourself. The engine counts the criteria from its own state,
    so the request cannot decide how many it is answering — a missing,
    duplicated, or out-of-range criterion is refused before any mutation.
+   On a risk-domain issue that count includes the engine-contributed
+   blast-radius criterion, last in the list and judged on the same terms
+   as every criterion the plan document supplied.
    A `verdict` of `approve` is accepted only when every criterion is
    judged `satisfied`; record `request-changes` otherwise. Transcribe
    the reviewer's per-criterion calls, never your own reading of its

--- a/internal/adaptertest/adaptertest.go
+++ b/internal/adaptertest/adaptertest.go
@@ -4,8 +4,10 @@
 // cross-host invariants — the run-verb allowlist, the four
 // anti-forgery statement literals, the plan/merge gate option text, the
 // setup interview's terminal forms, hook command portability, matcher/
-// guard parity, and the routed-selection prompt cue — have exactly one
-// source instead of a copy per adapter that can silently drift apart.
+// guard parity, the routed-selection prompt cue, and the blast-radius
+// acceptance criterion the engine contributes to a risk-domain issue —
+// have exactly one source instead of a copy per adapter that can
+// silently drift apart.
 //
 // This package carries no Test functions and tests nothing of its own;
 // it is test-support only, imported by adapters/claude/plugin_test.go
@@ -362,6 +364,66 @@ func CheckBranchScopeVerificationGuidance(t *testing.T, deliverySkillPath string
 	for _, phrase := range branchScopeGuidancePhrases {
 		if !strings.Contains(content, normalizeWhitespace(phrase)) {
 			t.Errorf("%s does not contain the branch-scope verification guidance phrase %q", deliverySkillPath, phrase)
+		}
+	}
+}
+
+// blastRadiusClauses are the clauses of run.BlastRadiusCriterion every
+// shipped delivery skill and reviewer definition must state verbatim:
+// the criterion's provenance (the engine contributed it, the plan
+// document did not) and each of the three demands it makes.
+//
+// CheckBlastRadiusCriterionGuidance asserts each one against
+// run.BlastRadiusCriterion itself as well as against the shipped files,
+// which is what makes this a two-sided pin rather than another prose
+// presence check: rewording the criterion the binary contributes fails
+// here just as deleting the instruction describing it does, so the
+// engine's demand and the shipped prose cannot drift apart in either
+// direction.
+var blastRadiusClauses = []string{
+	"contributed by Orch because this issue declares a risk domain, not by the plan document",
+	"name every element of the structure this change touches and state, for each, whether the behavior it had before this change still holds",
+	"record a behavior this change removes as a before-and-after in the same document that stated the old behavior, rather than deleting that statement",
+	"where a restriction is attributed to one named symbol, establish whether it holds for that symbol alone or for every symbol of its kind, and say which",
+}
+
+// blastRadiusEvidence is the sentence naming what settles the
+// contributed criterion. It is required of the shipped files only, not
+// of run.BlastRadiusCriterion: the criterion states what to do, and this
+// states what a reviewer accepts as having done it — a criterion is not
+// its own evidence rule.
+const blastRadiusEvidence = "What settles it is an enumeration in the pull request body naming each element the change touched and its before-and-after; passing tests do not settle it."
+
+// CheckBlastRadiusCriterionGuidance pins each path's whole text against
+// run.BlastRadiusCriterion's clauses and the evidence sentence above.
+// Callers pass their own host's delivery skill and both reviewer agent
+// definitions; the files are read raw, so a Codex definition's prose
+// inside a TOML string is checked the same way a Claude definition's
+// markdown body is.
+//
+// Comparison runs on whitespace-normalized text on both sides, so a
+// clause a markdown reflow or a TOML line wrap happens to split across a
+// line break still counts as present. As with every pin in this package,
+// it catches deletion or rewording of the words and nothing more: no
+// check here observes whether an executor or reviewer that reads the
+// criterion acts on it.
+func CheckBlastRadiusCriterionGuidance(t *testing.T, paths ...string) {
+	t.Helper()
+	criterion := normalizeWhitespace(run.BlastRadiusCriterion)
+	for _, clause := range blastRadiusClauses {
+		if !strings.Contains(criterion, normalizeWhitespace(clause)) {
+			t.Errorf("run.BlastRadiusCriterion no longer states %q; the engine's criterion and the shipped prose pinned to it have diverged", clause)
+		}
+	}
+	for _, path := range paths {
+		content := normalizeWhitespace(readFile(t, path))
+		for _, clause := range blastRadiusClauses {
+			if !strings.Contains(content, normalizeWhitespace(clause)) {
+				t.Errorf("%s does not state the blast-radius criterion clause %q", path, clause)
+			}
+		}
+		if !strings.Contains(content, normalizeWhitespace(blastRadiusEvidence)) {
+			t.Errorf("%s does not state what evidence settles the blast-radius criterion: %q", path, blastRadiusEvidence)
 		}
 	}
 }

--- a/internal/run/activate.go
+++ b/internal/run/activate.go
@@ -247,7 +247,10 @@ func Activate(ctx context.Context, env Env, reqJSON []byte) (*ActivationResult, 
 		// Persist the plan's dependency edges, wave, approved work text,
 		// and the derived routing decision so the PR B verbs can enforce
 		// dependencies and spawn executors on approved text without
-		// re-taking the plan document.
+		// re-taking the plan document. The criteria are
+		// issueAcceptanceCriteria's list, so dispatch hands the executor
+		// and review measures the reviewer against the same standard the
+		// gate showed the human.
 		stateIssues[i] = state.Issue{
 			PlanID:             pi.ID,
 			Title:              pi.Title,
@@ -255,7 +258,7 @@ func Activate(ctx context.Context, env Env, reqJSON []byte) (*ActivationResult, 
 			DependsOn:          pi.DependsOn,
 			Wave:               pi.Wave,
 			Objective:          pi.Objective,
-			AcceptanceCriteria: pi.AcceptanceCriteria,
+			AcceptanceCriteria: issueAcceptanceCriteria(pi),
 			RequiredTests:      pi.RequiredTests,
 			Decision:           fromRoutingDecision(decisionByID[pi.ID]),
 		}
@@ -283,7 +286,7 @@ func Activate(ctx context.Context, env Env, reqJSON []byte) (*ActivationResult, 
 		body, err = manifest.Upsert(body, manifest.Manifest{
 			SchemaVersion:      manifest.SchemaVersion,
 			Objective:          pi.Objective,
-			AcceptanceCriteria: pi.AcceptanceCriteria,
+			AcceptanceCriteria: issueAcceptanceCriteria(pi),
 			RequiredTests:      pi.RequiredTests,
 			Role:               d.Role,
 			Executor:           d.Executor,
@@ -380,12 +383,16 @@ func planAreaLabels(p *PlanDoc) []string {
 // dependencies named by plan id and wave, usage class, and the plan
 // digest. manifest.Upsert appends the machine-readable audit record
 // after it.
+//
+// The acceptance criteria are issueAcceptanceCriteria's list, matching
+// the audit record rendered directly below them: a reader comparing the
+// two halves of one issue body must not find two different standards.
 func issueBody(pi PlanIssue, waveByID map[string]int, digest string) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "**Objective**\n\n%s\n\n", pi.Objective)
 
 	b.WriteString("**Acceptance criteria**\n\n")
-	for _, ac := range pi.AcceptanceCriteria {
+	for _, ac := range issueAcceptanceCriteria(pi) {
 		fmt.Fprintf(&b, "- %s\n", ac)
 	}
 	b.WriteString("\n**Required tests**\n\n")

--- a/internal/run/activate_test.go
+++ b/internal/run/activate_test.go
@@ -358,6 +358,38 @@ func TestActivateRecordsApprovedWork(t *testing.T) {
 	if b.Objective != "Do B" {
 		t.Errorf("issue b objective = %q, want the plan's", b.Objective)
 	}
+
+	// Issue a declares no risk domain, so every place carries exactly the
+	// plan's one criterion — the created issue body included.
+	bodyA := script.StdinAt(len(taxonomy))
+	if strings.Contains(bodyA, BlastRadiusCriterion) {
+		t.Error("issue a's created body carries the contributed criterion; a declares no risk domain")
+	}
+
+	// Issue b declares one, so all four sites carry the contributed
+	// criterion last: run state, the audit record, and the issue body's
+	// human-prose acceptance-criteria list. (The gate document is the
+	// fourth, asserted in TestPlanGoldenTwoIssue against this same plan.)
+	if len(b.AcceptanceCriteria) != 2 || b.AcceptanceCriteria[0] != "B works" || b.AcceptanceCriteria[1] != BlastRadiusCriterion {
+		t.Errorf("issue b state criteria = %q, want the plan's plus the contributed criterion", b.AcceptanceCriteria)
+	}
+	bodyB := script.StdinAt(len(taxonomy) + 1)
+	mb, err := manifest.Parse(bodyB)
+	if err != nil {
+		t.Fatalf("Parse issue b's created body: %v", err)
+	}
+	if len(mb.AcceptanceCriteria) != 2 || mb.AcceptanceCriteria[0] != "B works" || mb.AcceptanceCriteria[1] != BlastRadiusCriterion {
+		t.Errorf("issue b audit record criteria = %q, want the plan's plus the contributed criterion", mb.AcceptanceCriteria)
+	}
+	if got := strings.Count(bodyB, BlastRadiusCriterion); got != 3 {
+		t.Errorf("issue b body states the contributed criterion %d time(s), want 3: issueBody's prose list, and the audit record's human bullet and canonical JSON", got)
+	}
+	// Run state and the audit record agree exactly, so resume's
+	// state-vs-manifest comparison (sameWork) finds no divergence to
+	// report on a risk-domain issue.
+	if !sameWork(&b, approvedWork{objective: mb.Objective, acceptanceCriteria: mb.AcceptanceCriteria, requiredTests: mb.RequiredTests}) {
+		t.Errorf("issue b state %+v diverges from its audit record %+v; resume would rewrite it", b, mb)
+	}
 }
 
 // areaPlanJSON is a single-issue plan declaring two area labels,

--- a/internal/run/derive.go
+++ b/internal/run/derive.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 
 	"github.com/kninetimmy/orch/internal/config"
@@ -122,6 +123,49 @@ func deriveRisk(i PlanIssue) ghops.Risk {
 		return ghops.RiskCritical
 	}
 	return ghops.RiskStandard
+}
+
+// BlastRadiusCriterion is the one acceptance criterion the engine
+// contributes itself, appended to every plan issue that declares a risk
+// domain (issueAcceptanceCriteria). A plan document's criteria are the
+// whole standard the executor optimizes against and the reviewer is
+// measured against — checkJudgments requires one judgment per criterion
+// and refuses an approve verdict over any unsatisfied one — so a
+// preservation clause naming one thing to protect protects that one
+// thing and nothing adjacent to it. This criterion is what puts
+// "account for what the change actually touched" into that standard
+// rather than leaving it to what the planner happened to enumerate.
+//
+// It is a package-level constant, not prose duplicated per call site,
+// because internal/adaptertest pins both hosts' delivery skills and all
+// four shipped reviewer definitions against this exact text: the
+// engine's demand and the shipped instructions describing it cannot
+// drift apart without failing a test.
+const BlastRadiusCriterion = "Blast radius (contributed by Orch because this issue declares a risk domain, not by the plan document): name every element of the structure this change touches and state, for each, whether the behavior it had before this change still holds; record a behavior this change removes as a before-and-after in the same document that stated the old behavior, rather than deleting that statement; and where a restriction is attributed to one named symbol, establish whether it holds for that symbol alone or for every symbol of its kind, and say which."
+
+// issueAcceptanceCriteria is one issue's full approved criteria list:
+// the plan document's entries, plus BlastRadiusCriterion last when the
+// issue declares at least one risk domain. It is the single source every
+// consumer of a plan issue's criteria reads — the gate document, run
+// state, the audit record, and the created issue body — so dispatch,
+// review, and resume, which all read one of those, see the same list
+// without knowing this function exists. An issue declaring no risk
+// domain gets exactly what its plan document listed.
+//
+// Risk domains are the trigger for the same reason deriveRisk uses them:
+// they are declared facts, already computed, and already what routes an
+// issue to the specialist role.
+//
+// It never mutates i, and appends into a fresh slice rather than onto
+// the plan's own backing array: PlanDoc.Digest marshals the submitted
+// plan struct, so a criterion that reached i.AcceptanceCriteria would
+// make `orch run plan` and `orch run activate` compute different digests
+// for the same document.
+func issueAcceptanceCriteria(i PlanIssue) []string {
+	if len(i.Facts.RiskDomains) == 0 {
+		return i.AcceptanceCriteria
+	}
+	return slices.Concat(i.AcceptanceCriteria, []string{BlastRadiusCriterion})
 }
 
 // issueLabels assembles the full PRD §13 taxonomy for one issue: ready

--- a/internal/run/derive_test.go
+++ b/internal/run/derive_test.go
@@ -167,6 +167,112 @@ func TestDeriveRisk(t *testing.T) {
 	}
 }
 
+// TestIssueAcceptanceCriteriaFollowsRiskDomains pins the trigger and the
+// position: a risk-domain issue's list is the plan's plus
+// BlastRadiusCriterion last, and an issue declaring no domain gets
+// exactly what the plan listed and nothing more.
+func TestIssueAcceptanceCriteriaFollowsRiskDomains(t *testing.T) {
+	plain := PlanIssue{AcceptanceCriteria: []string{"one", "two"}}
+	got := issueAcceptanceCriteria(plain)
+	if len(got) != 2 || got[0] != "one" || got[1] != "two" {
+		t.Errorf("no risk domains = %q, want exactly the plan's two criteria", got)
+	}
+
+	risky := PlanIssue{
+		AcceptanceCriteria: []string{"one", "two"},
+		Facts:              PlanFacts{RiskDomains: []string{"data-integrity"}},
+	}
+	got = issueAcceptanceCriteria(risky)
+	if len(got) != 3 {
+		t.Fatalf("with a risk domain = %q, want the plan's two plus one contributed", got)
+	}
+	if got[0] != "one" || got[1] != "two" {
+		t.Errorf("plan criteria = %q, want them preserved in order and unaltered", got[:2])
+	}
+	if got[2] != BlastRadiusCriterion {
+		t.Errorf("contributed criterion = %q, want BlastRadiusCriterion last", got[2])
+	}
+}
+
+// TestIssueAcceptanceCriteriaDoesNotMutatePlan is the digest guard:
+// PlanDoc.Digest marshals the submitted plan struct, so a contributed
+// criterion that leaked into the plan's own slice would make `orch run
+// plan` and `orch run activate` compute different digests for the same
+// document — the failure ActivationRequest's approval check would then
+// report as a plan the human never approved.
+func TestIssueAcceptanceCriteriaDoesNotMutatePlan(t *testing.T) {
+	p, err := DecodePlan([]byte(twoIssuePlanJSON()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := p.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, iss := range p.Issues {
+		_ = issueAcceptanceCriteria(iss)
+	}
+	after, err := p.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before != after {
+		t.Errorf("digest changed after reading criteria: %q -> %q", before, after)
+	}
+	// The risky issue's own slice is the plan's, untouched: reading it a
+	// second time must not accumulate a second copy.
+	if b := p.Issues[1]; len(b.AcceptanceCriteria) != 1 || b.AcceptanceCriteria[0] != "B works" {
+		t.Errorf("plan issue b criteria = %q, want the submitted list untouched", b.AcceptanceCriteria)
+	}
+}
+
+// TestBlastRadiusCriterionStatesItsThreeDemands pins the criterion's
+// substance, not just its presence: internal/adaptertest holds both
+// hosts' shipped prose to these same clauses, so a reworded criterion
+// that dropped one would otherwise ship as a silently weaker standard.
+func TestBlastRadiusCriterionStatesItsThreeDemands(t *testing.T) {
+	for _, clause := range []string{
+		"contributed by Orch because this issue declares a risk domain, not by the plan document",
+		"name every element of the structure this change touches and state, for each, whether the behavior it had before this change still holds",
+		"record a behavior this change removes as a before-and-after in the same document that stated the old behavior, rather than deleting that statement",
+		"where a restriction is attributed to one named symbol, establish whether it holds for that symbol alone or for every symbol of its kind, and say which",
+	} {
+		if !strings.Contains(BlastRadiusCriterion, clause) {
+			t.Errorf("BlastRadiusCriterion does not state %q", clause)
+		}
+	}
+}
+
+// TestReviewJudgesTheContributedCriterion proves the contributed
+// criterion is enforced on exactly the terms every plan-supplied one is:
+// Review counts the criteria from state (issue.AcceptanceCriteria), so a
+// review that judges only the plan's is refused for missing coverage,
+// and an approve verdict over the contributed criterion judged
+// unsatisfied is refused as a self-contradiction.
+func TestReviewJudgesTheContributedCriterion(t *testing.T) {
+	criteria := issueAcceptanceCriteria(PlanIssue{
+		AcceptanceCriteria: []string{"B works"},
+		Facts:              PlanFacts{RiskDomains: []string{"data-integrity"}},
+	})
+
+	planOnly := []CriterionJudgment{{Criterion: 1, Judgment: JudgmentSatisfied, Reason: "read it"}}
+	err := checkJudgments(planOnly, VerdictApprove, criteria)
+	if !errors.Is(err, ErrBadRequest) {
+		t.Fatalf("err = %v, want ErrBadRequest for the unjudged contributed criterion", err)
+	}
+	if !strings.Contains(err.Error(), "acceptance criterion 2 carries no judgment") {
+		t.Errorf("err = %v, want it to name criterion 2", err)
+	}
+
+	unsatisfied := append(planOnly, CriterionJudgment{Criterion: 2, Judgment: JudgmentUnsatisfied, Reason: "no enumeration in the PR body"})
+	if err := checkJudgments(unsatisfied, VerdictApprove, criteria); !errors.Is(err, ErrBadRequest) {
+		t.Fatalf("err = %v, want ErrBadRequest refusing approve over an unsatisfied contributed criterion", err)
+	}
+	if err := checkJudgments(unsatisfied, VerdictRequestChanges, criteria); err != nil {
+		t.Errorf("request-changes over an unsatisfied contributed criterion = %v, want accepted", err)
+	}
+}
+
 func TestIssueLabelsRolePerDecision(t *testing.T) {
 	i := PlanIssue{Type: "bug", AreaLabels: []string{"core"}}
 

--- a/internal/run/gate.go
+++ b/internal/run/gate.go
@@ -36,6 +36,11 @@ type GateDoc struct {
 // routing the engine derived for it. Executor and Reviewer reuse
 // manifest.Selection — the same exact model/effort pairing the audit
 // record carries.
+//
+// AcceptanceCriteria is issueAcceptanceCriteria's list, not the plan
+// document's field: a risk-domain issue shows one more entry here than
+// the plan submitted, because the human approving this gate is
+// approving the standard the reviewer will actually be held to.
 type GateIssue struct {
 	ID                 string             `json:"id"`
 	Title              string             `json:"title"`
@@ -107,7 +112,7 @@ func Plan(ctx context.Context, env Env, planJSON []byte) (*GateDoc, error) {
 			ID:                 i.ID,
 			Title:              i.Title,
 			Objective:          i.Objective,
-			AcceptanceCriteria: i.AcceptanceCriteria,
+			AcceptanceCriteria: issueAcceptanceCriteria(i),
 			Role:               d.Role,
 			Executor:           d.Executor,
 			Reviewer:           d.Reviewer,

--- a/internal/run/gate_test.go
+++ b/internal/run/gate_test.go
@@ -127,6 +127,9 @@ func TestPlanGoldenTwoIssue(t *testing.T) {
 	if a.Risk != "standard" {
 		t.Errorf("issue a risk = %q, want standard", a.Risk)
 	}
+	if len(a.AcceptanceCriteria) != 1 || a.AcceptanceCriteria[0] != "A works" {
+		t.Errorf("issue a criteria = %q, want exactly the plan's — a declares no risk domain", a.AcceptanceCriteria)
+	}
 	wantLabelsA := []string{"ready", "feature", "implementer", "standard"}
 	if strings.Join(a.Labels, ",") != strings.Join(wantLabelsA, ",") {
 		t.Errorf("issue a labels = %v, want %v", a.Labels, wantLabelsA)
@@ -144,6 +147,12 @@ func TestPlanGoldenTwoIssue(t *testing.T) {
 	}
 	if b.Risk != "critical" {
 		t.Errorf("issue b risk = %q, want critical", b.Risk)
+	}
+	// b declares a risk domain, so the gate the human approves shows the
+	// engine-contributed criterion alongside the plan's own — and the
+	// digest asserted above is still the submitted plan's, unchanged.
+	if len(b.AcceptanceCriteria) != 2 || b.AcceptanceCriteria[0] != "B works" || b.AcceptanceCriteria[1] != BlastRadiusCriterion {
+		t.Errorf("issue b criteria = %q, want the plan's plus the contributed blast-radius criterion", b.AcceptanceCriteria)
 	}
 	wantLabelsB := []string{"ready", "feature", "specialist", "critical"}
 	if strings.Join(b.Labels, ",") != strings.Join(wantLabelsB, ",") {


### PR DESCRIPTION
Delivers issue #187: Append a blast-radius acceptance criterion to every risk-domain issue

Closes #187

**Plan digest:** `sha256:cd241f13635d50dd4d9a513f198d03681f5e77ffaa1063071e1157ea01721e62`

The approved objective and acceptance criteria are in the audit record below.

## Blast radius (acceptance criterion 5)

This issue cannot dogfood its own mechanism: `orch run activate` ran the installed binary, which predates this change, so #187 carries the six criteria the plan document supplied and not the seventh this change adds. The account below is therefore written by hand, and it covers every consumer of a plan issue's acceptance criteria list in this module.

### Behavior changes — four consumers

Each of these reads the criteria list straight from the plan document, and each now receives one further entry when `len(facts.risk_domains) > 0`. All four change identically. An issue declaring no risk domain is byte-identical to before at every one of them.

| Consumer | Site | What changes |
| --- | --- | --- |
| Gate document | `internal/run/gate.go:110` | A risk-domain issue's `GateIssue.acceptance_criteria` is one entry longer, so the human approving the plan gate sees the standard the reviewer will actually be held to. |
| Run state | `internal/run/activate.go:258` | `state.Issue.AcceptanceCriteria` carries the contributed criterion. |
| Audit record | `internal/run/activate.go:286` | `manifest.Manifest.AcceptanceCriteria` carries it. |
| Created issue body | `internal/run/activate.go:388` (`issueBody`) | The rendered prose bullet list carries it. |

### Behavior holds, content follows — seven consumers

| Consumer | Site | Why the prior behavior still holds |
| --- | --- | --- |
| Dispatch | `dispatch.go:130` | Reads run state, code unchanged. `checkApprovedWork`'s `len == 0` guard is unaffected — the list only ever grows. |
| Review | `review.go:186` | `checkJudgments` is untouched code. Because it counts criteria from state rather than from the request, a risk-domain issue now requires N+1 judgments and refuses an `approve` verdict over the contributed criterion unsatisfied, on exactly the same terms as every plan-supplied criterion. Pinned by `TestReviewJudgesTheContributedCriterion`. |
| Resume | `resume.go:807` (read), `:367` (apply), `:388` (`sameWork`'s `slices.Equal`) | Does **not** report divergence: activation writes the same list to both run state and the audit record, so the two stay equal. Asserted through `sameWork` in `TestActivateRecordsApprovedWork`. A run activated by an older build holds N entries in both and remains equal, so there is no migration hazard. |
| `PlanDoc.Validate` | `plandoc.go:172-179` | Still validates only the plan document's own list. The contributed criterion never enters `PlanIssue.AcceptanceCriteria`. |
| `PlanDoc.Digest` | `plandoc.go:93` | Unchanged. The criterion is appended into a fresh slice via `slices.Concat` and never assigned back to the plan struct, which is what keeps the digest identical between `orch run plan` and `orch run activate`. Guarded by `TestIssueAcceptanceCriteriaDoesNotMutatePlan`. |
| `manifest.validateTextList` / `manifest/render.go:80` | unchanged | No count or length cap applies. The audit record renders each criterion twice (human bullet plus canonical JSON), so the created issue body states the contributed criterion three times counting `issueBody`'s own list — pinned at 3 in the test. |
| `acceptance-criterion-<n>` verifications | `manifestbody.go` | Unchanged. These are replace-by-name upserts, so one more criterion is one more entry, bounded by the criteria count however many review cycles run. There is a small new pressure on the body-size rotation, measured by the PR #190 reviewer rather than assumed: the criterion is 544 characters and renders three times in a risk-domain issue body, and its verification detail is capped at 2,000 characters and renders twice, so against the 60,000-byte headroom over the ~12,157-byte base that manifestbody.go measures, it costs roughly half a maximal review cycle. |

### Removals

**Nothing was removed**, so there is no prior behavior to record as a before-and-after.

### Two things worth flagging

1. **Codex operators must re-render.** This change edits `adapters/codex/agents/*.toml`, so a Codex host needs `orch render-agents` before its next activation. `agents.Stale` already fails closed and says so — an existing mechanism, not a new one.
2. **A deliberate non-change.** `PlanDoc.Validate` does *not* reject a plan document that already lists the criterion text itself. Both hosts' skills instruct the Architect not to write it; a duplicate would cost one redundant judgment, not a correctness failure, and rejecting it was outside this issue's approved scope.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** A plan issue's acceptance criteria are supplied entirely by the plan document; internal/run/plandoc.go validates only that the list is non-empty and that no entry is empty. internal/run/review.go requires one reviewer judgment per criterion, counted from run state, and refuses an approve verdict unless every judgment is satisfied. That makes the criteria list the entire standard both the executor optimizes against and the reviewer is measured against, so a preservation clause naming one thing to protect protects one thing and nothing adjacent to it. Have the binary itself append one further criterion to any plan issue that declares at least one risk domain, so the standard includes accounting for what the change touched rather than only what the planner enumerated. Risk domains are the trigger because they are already computed and already route the issue to the specialist role. A plan issue's acceptance criteria are read from the plan document in four places: internal/run/gate.go for the plan gate, and internal/run/activate.go for run state, for the audit record, and for the created GitHub issue body; every other consumer reads one of those.

**Acceptance criteria:**
- A plan issue that declares at least one entry in facts.risk_domains carries one further acceptance criterion, contributed by the binary rather than by the plan document, in the gate document orch run plan returns, in the run state and audit record orch run activate writes, in the GitHub issue body orch run activate creates, and in the acceptance criteria orch run dispatch returns. A plan issue declaring no risk domain carries exactly the criteria its plan document listed, in each of those same places.
- The contributed criterion asks the executor to name every element of the structure the change touches and say, for each, whether the behavior it had before the change still holds; to record a behavior the change removes as a before-and-after in the same document that stated the old behavior, rather than deleting that statement; and, where a restriction is attributed to one named symbol, to establish whether it holds for that symbol alone or for every symbol of its kind, and say which.
- orch run review requires a judgment for the contributed criterion on a risk-domain issue and refuses an approve verdict when that judgment is not satisfied, on the same terms as every criterion the plan document supplied.
- For the same plan document, orch run activate accepts the plan digest orch run plan returned, and orch run resume does not report a risk-domain issue as diverged on account of its acceptance criteria.
- The pull request states, for every consumer of a plan issue's acceptance criteria list in this module, whether the behavior that consumer had before this change still holds, and names each one that changes. The gate document, run state, the audit record, the created issue body, dispatch, review and resume are each accounted for by name.
- Both hosts' orch-delivery skill and all four shipped reviewer agent definitions state that a risk-domain issue carries this engine-contributed criterion and what evidence settles it, and a test in this module fails if that shipped prose stops agreeing with the criterion text the binary contributes.

**Required tests:**
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `specialist` |
| Executor | `claude-opus-5` — effort `high` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to a specialist with a strong reviewer because risk domains (data-integrity).

**Escalations:** _none_

**Verification:**
- **build** — pass — `go build ./...` — Exit 0, no output. Run in the issue-187 worktree. — commit `028f16196d4893faaa5d54c768bff5390d7d0acf` (2026-08-02T23:32:37Z)
- **tests** — pass — `go test -count=1 ./...` — Exit 0, every package ok, no FAIL. Run in the issue-187 worktree with -count=1 so no result came from the test cache. — commit `028f16196d4893faaa5d54c768bff5390d7d0acf` (2026-08-02T23:32:37Z)
- **vet** — pass — `go vet ./...` — Exit 0, no output. Run in the issue-187 worktree. — commit `028f16196d4893faaa5d54c768bff5390d7d0acf` (2026-08-02T23:32:37Z)
- **format** — pass — `gofmt -l .` — Exit 0, no filenames listed. Run in the issue-187 worktree. — commit `028f16196d4893faaa5d54c768bff5390d7d0acf` (2026-08-02T23:32:37Z)
- **pin-bites-constant-reword** — pass — `reword run.BlastRadiusCriterion's tail from 'and say which' to 'and state which', then go test ./adapters/... ./internal/run/` — Reproduced independently by the reviewer in a scratch copy. TestBlastRadiusCriterionGuidance failed in both adapter packages with 'run.BlastRadiusCriterion no longer states "where a restriction is attributed to one named symbol..."', and TestBlastRadiusCriterionStatesItsThreeDemands failed in internal/run as well. — commit `028f16196d4893faaa5d54c768bff5390d7d0acf` (2026-08-02T23:44:46Z)
- **pin-bites-prose-deletion** — pass — `delete the evidence sentence from adapters/codex/agents/orch-reviewer-safe.toml, then go test ./adapters/...` — Reproduced independently by the reviewer in a scratch copy. The codex package failed and the claude package passed, which is the correct per-file isolation. The executor's reported error text reproduced exactly. — commit `028f16196d4893faaa5d54c768bff5390d7d0acf` (2026-08-02T23:44:46Z)
- **branch-scope: no-prose-dropped** — pass — `git diff main...HEAD -U0 | grep '^-[^-]'` — Re-checked by the reviewer at head 028f1619: exactly seven removed lines, being the four reassigned AcceptanceCriteria lines and three comment lines rewritten in place. No prose was dropped from any shipped file. Scope across the branch is 15 files, all of them the four plan-document read sites, the new derivation, the shipped prose criterion 6 required, or tests. — commit `028f16196d4893faaa5d54c768bff5390d7d0acf` (2026-08-02T23:44:46Z)
- **reviewer-required-tests** — pass — `go build ./... && go vet ./... && gofmt -l . && go test -count=1 ./...` — All four required tests re-run by the reviewer in the issue-187 worktree at head 028f1619 rather than inherited: build exit 0 no output, vet exit 0 no output, gofmt exit 0 no filenames, tests exit 0 with every package ok and no FAIL. Both the worktree and the primary checkout were clean at the end, git status --porcelain empty. — commit `028f16196d4893faaa5d54c768bff5390d7d0acf` (2026-08-02T23:44:46Z)
- **pin-bites-third-mutation** — pass — `reword a clause in adapters/claude/skills/orch-delivery/SKILL.md across a hard line break, then go test ./adapters/...` — A third mutation the executor did not run, chosen to attack the pin from the delivery-skill side and across a line break specifically. The claude package failed naming the file and the clause, which shows normalizeWhitespace tolerates reflow without swallowing real rewording. Run in a scratch copy outside the repository, never in the checkout. — commit `028f16196d4893faaa5d54c768bff5390d7d0acf` (2026-08-02T23:44:46Z)
- **acceptance-criterion-1** — satisfied — The run_test.go:88 fixture drives both halves: issue b declares risk_domains [concurrency], issue a declares none. Gate document, gate_test.go:151-156 asserts b's criteria are the plan's plus the constant and :130-132 asserts a's list is exactly [A works]. Run state, activate_test.go:374-376 asserts b's state criteria carry the constant last and :349 asserts a's is length 1. Audit record, activate_test.go:381-383 parses the created body and asserts the same for b, :334 asserts a's is exactly [A works]. Created issue body, activate_test.go:384-386 asserts strings.Count(bodyB, BlastRadiusCriterion) == 3 for the prose list plus human bullet plus canonical JSON, and :365-367 asserts bodyA does not contain it at all. Dispatch is settled by a chain rather than a direct test: dispatch.go:130 returns issue.AcceptanceCriteria from state unfiltered and lifecycle_test.go:255 pins that dispatch returns state's criteria verbatim. All of it ran green under go test -count=1 ./internal/run/. — commit `028f16196d4893faaa5d54c768bff5390d7d0acf` (2026-08-02T23:44:47Z)
- **acceptance-criterion-2** — satisfied — Read at internal/run/derive.go:141. The constant states, in order: contributed by Orch because this issue declares a risk domain rather than by the plan document; name every element of the structure this change touches and state for each whether the behavior it had before this change still holds; record a behavior this change removes as a before-and-after in the same document that stated the old behavior rather than deleting that statement; and where a restriction is attributed to one named symbol, establish whether it holds for that symbol alone or for every symbol of its kind, and say which. That is the criterion's three demands near-verbatim. TestBlastRadiusCriterionStatesItsThreeDemands pins them, and the reviewer's own mutation rewording the tail from 'and say which' to 'and state which' proved that pin fires rather than passing vacuously. — commit `028f16196d4893faaa5d54c768bff5390d7d0acf` (2026-08-02T23:44:47Z)
- **acceptance-criterion-3** — satisfied — checkJudgments at review.go:308-336 has no diff hunk at all - the enforcement code is untouched - and it derives its coverage requirement from the criteria slice it is handed. review.go:186 hands it issue.AcceptanceCriteria read from state, which activate.go:261 wrote from issueAcceptanceCriteria. The new TestReviewJudgesTheContributedCriterion at derive_test.go:247-273 drives that function with a risk-domain criteria list and asserts three things: judging only the plan's criterion returns ErrBadRequest naming 'acceptance criterion 2 carries no judgment'; an approve verdict with criterion 2 unsatisfied returns ErrBadRequest; request-changes over the same is accepted. It passed in the reviewer's run. 'On the same terms' is literally true here because the enforcement code did not change. — commit `028f16196d4893faaa5d54c768bff5390d7d0acf` (2026-08-02T23:44:47Z)
- **acceptance-criterion-4** — satisfied — Checked at the mechanism, not only through the tests. Digest half: gate.go:80 computes the digest before the GateIssue loop and activate.go:148 computes it before Phases 4 and 5, so plan and activate hash the identical struct; independently, issueAcceptanceCriteria takes i by value and slices.Concat allocates a result of the summed length and copies into it, never writing through an input slice header - the load-bearing difference from append(i.AcceptanceCriteria, ...), which could have written into the plan slice's spare capacity. Test-side, gate_test.go:97-105 asserts doc.PlanDigest equals an independently decoded p.Digest(), activate_test.go:204-215 builds the approval from that same p.Digest(), and Activate accepts it on the risk-domain fixture in five separate tests, with TestIssueAcceptanceCriteriaDoesNotMutatePlan adding the direct non-mutation assertion. Resume half: activate.go:261 and :289 write the same issueAcceptanceCriteria(pi) list to state and to the manifest, resume compares those two through sameWork at resume.go:385-389 on work read from the manifest at resume.go:807, and activate_test.go:390-392 calls sameWork on the activate-produced pair and asserts true. A run activated by an older build holds N on both sides and stays equal, so there is no migration hazard. — commit `028f16196d4893faaa5d54c768bff5390d7d0acf` (2026-08-02T23:44:47Z)
- **acceptance-criterion-5** — satisfied — The reviewer grepped the whole module for AcceptanceCriteria and enumerated the consumers itself rather than checking the PR's list against itself: plandoc.go:172-179 and :93, gate.go:115, activate.go:261/289/395, dispatch.go:130 and :153, review.go:186 and :381, resume.go:367/388/809, manifest/manifest.go:194 and render.go:80, state/state.go:158, and manifestbody.go's acceptance-criterion-&lt;n&gt; name shape. Every one appears in the PR body's two tables by name and site, the four that change are marked as changing, and the seven the criterion names explicitly - gate document, run state, audit record, created issue body, dispatch, review, resume - are each their own row. The removals claim checks out independently: git diff main...HEAD -U0 piped through grep '^-[^-]' returns exactly seven lines, the four reassigned AcceptanceCriteria lines and three comments rewritten in place, with no prose dropped. The one accuracy nit inside a row was corrected in the PR body before this cycle was recorded. — commit `028f16196d4893faaa5d54c768bff5390d7d0acf` (2026-08-02T23:44:47Z)
- **acceptance-criterion-6** — satisfied — All six shipped files carry the criterion and the evidence sentence: adapters/claude/skills/orch-delivery/SKILL.md:105-125, adapters/codex/skills/orch-delivery/SKILL.md:105-125, adapters/claude/agents/orch-reviewer.md:65-90, orch-reviewer-safe.md:73-98, adapters/codex/agents/orch-reviewer.toml:71-96, orch-reviewer-safe.toml:79-104. The test is TestBlastRadiusCriterionGuidance in both adapters/claude/plugin_test.go:400 and adapters/codex/plugin_test.go:294, backed by adaptertest.CheckBlastRadiusCriterionGuidance, which asserts each clause against run.BlastRadiusCriterion and against every shipped file, plus the evidence sentence against every file. The reviewer's three mutations confirmed it fires on the engine side, on a reviewer definition, and on a delivery skill independently. This is not the wrong-criterion case: it does not ask for a check on how an agent behaves, it asks that two artifacts that both live in this repository be held to agreeing with each other, a failure mode the reviewer reproduced three times. The executor also documented the limit honestly in adaptertest.go rather than overclaiming - no check there observes whether an executor or reviewer that reads the criterion acts on it. — commit `028f16196d4893faaa5d54c768bff5390d7d0acf` (2026-08-02T23:44:47Z)
- **review-cycle-1** — approve — First-cycle approve at head 028f1619, on observations the reviewer made itself. It re-ran all four required tests in the worktree and confirmed all six CI checks. Against the standing worry that a prose drift pin can pass while the prose is wrong, it ran three independent mutations in a scratch copy outside the repository rather than inheriting the executor's two: rewording the constant's tail failed the guidance test in both adapter packages and the three-demands test in internal/run; deleting the evidence sentence from the codex reviewer-safe definition failed the codex package while the claude package passed, showing correct per-file isolation; and rewording a clause in the claude delivery skill deliberately across a hard line break failed naming the file and the clause, showing that whitespace normalization tolerates reflow without swallowing real rewording. It also checked criterion 4's digest claim at the mechanism rather than the test: both call sites compute the digest before the criterion exists, and slices.Concat allocates a fresh result rather than writing through an input slice header, which is the load-bearing difference from append into the plan slice's spare capacity. Six findings, none blocking: a stale parenthetical in the adaptertest package doc that still says internal/run is imported only for the four statement constants when a fifth symbol is now imported, which is itself the shape the new criterion asks about; an overstated sentence in the PR body's body-size row, since the criterion does cost roughly half a maximal review cycle of headroom, corrected in the PR body before this cycle was recorded; the approval digest not covering the contributed criterion by construction, inherent to the design the issue mandated since folding it into the digest is exactly what would break criterion 4; wrongCriteriaReason not being actionable for a criterion the plan gate offers no lever over; the duplicate-criterion case left unhandled, which the reviewer agrees is correct; and no test asserting the criterion in DispatchResult directly, the property holding through dispatch copying state unfiltered plus an existing pin that dispatch echoes state verbatim. No security finding: nothing touches a trust boundary, no secret, no new dependency, and slices is stdlib. Scope is 15 files, all of them the four read sites, the new derivation, the shipped prose the criterion required, or tests. — commit `028f16196d4893faaa5d54c768bff5390d7d0acf` (2026-08-02T23:44:47Z)
- **required-ci** — passing — test (macos-latest)=pass, lint=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `028f16196d4893faaa5d54c768bff5390d7d0acf` (2026-08-02T23:45:06Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "A plan issue's acceptance criteria are supplied entirely by the plan document; internal/run/plandoc.go validates only that the list is non-empty and that no entry is empty. internal/run/review.go requires one reviewer judgment per criterion, counted from run state, and refuses an approve verdict unless every judgment is satisfied. That makes the criteria list the entire standard both the executor optimizes against and the reviewer is measured against, so a preservation clause naming one thing to protect protects one thing and nothing adjacent to it. Have the binary itself append one further criterion to any plan issue that declares at least one risk domain, so the standard includes accounting for what the change touched rather than only what the planner enumerated. Risk domains are the trigger because they are already computed and already route the issue to the specialist role. A plan issue's acceptance criteria are read from the plan document in four places: internal/run/gate.go for the plan gate, and internal/run/activate.go for run state, for the audit record, and for the created GitHub issue body; every other consumer reads one of those.",
  "acceptance_criteria": [
    "A plan issue that declares at least one entry in facts.risk_domains carries one further acceptance criterion, contributed by the binary rather than by the plan document, in the gate document orch run plan returns, in the run state and audit record orch run activate writes, in the GitHub issue body orch run activate creates, and in the acceptance criteria orch run dispatch returns. A plan issue declaring no risk domain carries exactly the criteria its plan document listed, in each of those same places.",
    "The contributed criterion asks the executor to name every element of the structure the change touches and say, for each, whether the behavior it had before the change still holds; to record a behavior the change removes as a before-and-after in the same document that stated the old behavior, rather than deleting that statement; and, where a restriction is attributed to one named symbol, to establish whether it holds for that symbol alone or for every symbol of its kind, and say which.",
    "orch run review requires a judgment for the contributed criterion on a risk-domain issue and refuses an approve verdict when that judgment is not satisfied, on the same terms as every criterion the plan document supplied.",
    "For the same plan document, orch run activate accepts the plan digest orch run plan returned, and orch run resume does not report a risk-domain issue as diverged on account of its acceptance criteria.",
    "The pull request states, for every consumer of a plan issue's acceptance criteria list in this module, whether the behavior that consumer had before this change still holds, and names each one that changes. The gate document, run state, the audit record, the created issue body, dispatch, review and resume are each accounted for by name.",
    "Both hosts' orch-delivery skill and all four shipped reviewer agent definitions state that a risk-domain issue carries this engine-contributed criterion and what evidence settles it, and a test in this module fails if that shipped prose stops agreeing with the criterion text the binary contributes."
  ],
  "required_tests": [
    "go build ./...",
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "specialist",
  "executor": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "routing_rationale": "Routed to a specialist with a strong reviewer because risk domains (data-integrity).",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "Exit 0, no output. Run in the issue-187 worktree.",
      "commit_oid": "028f16196d4893faaa5d54c768bff5390d7d0acf",
      "at": "2026-08-02T23:32:37Z"
    },
    {
      "name": "tests",
      "command": "go test -count=1 ./...",
      "result": "pass",
      "detail": "Exit 0, every package ok, no FAIL. Run in the issue-187 worktree with -count=1 so no result came from the test cache.",
      "commit_oid": "028f16196d4893faaa5d54c768bff5390d7d0acf",
      "at": "2026-08-02T23:32:37Z"
    },
    {
      "name": "vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Exit 0, no output. Run in the issue-187 worktree.",
      "commit_oid": "028f16196d4893faaa5d54c768bff5390d7d0acf",
      "at": "2026-08-02T23:32:37Z"
    },
    {
      "name": "format",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Exit 0, no filenames listed. Run in the issue-187 worktree.",
      "commit_oid": "028f16196d4893faaa5d54c768bff5390d7d0acf",
      "at": "2026-08-02T23:32:37Z"
    },
    {
      "name": "pin-bites-constant-reword",
      "command": "reword run.BlastRadiusCriterion's tail from 'and say which' to 'and state which', then go test ./adapters/... ./internal/run/",
      "result": "pass",
      "detail": "Reproduced independently by the reviewer in a scratch copy. TestBlastRadiusCriterionGuidance failed in both adapter packages with 'run.BlastRadiusCriterion no longer states \"where a restriction is attributed to one named symbol...\"', and TestBlastRadiusCriterionStatesItsThreeDemands failed in internal/run as well.",
      "commit_oid": "028f16196d4893faaa5d54c768bff5390d7d0acf",
      "at": "2026-08-02T23:44:46Z"
    },
    {
      "name": "pin-bites-prose-deletion",
      "command": "delete the evidence sentence from adapters/codex/agents/orch-reviewer-safe.toml, then go test ./adapters/...",
      "result": "pass",
      "detail": "Reproduced independently by the reviewer in a scratch copy. The codex package failed and the claude package passed, which is the correct per-file isolation. The executor's reported error text reproduced exactly.",
      "commit_oid": "028f16196d4893faaa5d54c768bff5390d7d0acf",
      "at": "2026-08-02T23:44:46Z"
    },
    {
      "name": "branch-scope: no-prose-dropped",
      "command": "git diff main...HEAD -U0 | grep '^-[^-]'",
      "result": "pass",
      "detail": "Re-checked by the reviewer at head 028f1619: exactly seven removed lines, being the four reassigned AcceptanceCriteria lines and three comment lines rewritten in place. No prose was dropped from any shipped file. Scope across the branch is 15 files, all of them the four plan-document read sites, the new derivation, the shipped prose criterion 6 required, or tests.",
      "commit_oid": "028f16196d4893faaa5d54c768bff5390d7d0acf",
      "at": "2026-08-02T23:44:46Z"
    },
    {
      "name": "reviewer-required-tests",
      "command": "go build ./... \u0026\u0026 go vet ./... \u0026\u0026 gofmt -l . \u0026\u0026 go test -count=1 ./...",
      "result": "pass",
      "detail": "All four required tests re-run by the reviewer in the issue-187 worktree at head 028f1619 rather than inherited: build exit 0 no output, vet exit 0 no output, gofmt exit 0 no filenames, tests exit 0 with every package ok and no FAIL. Both the worktree and the primary checkout were clean at the end, git status --porcelain empty.",
      "commit_oid": "028f16196d4893faaa5d54c768bff5390d7d0acf",
      "at": "2026-08-02T23:44:46Z"
    },
    {
      "name": "pin-bites-third-mutation",
      "command": "reword a clause in adapters/claude/skills/orch-delivery/SKILL.md across a hard line break, then go test ./adapters/...",
      "result": "pass",
      "detail": "A third mutation the executor did not run, chosen to attack the pin from the delivery-skill side and across a line break specifically. The claude package failed naming the file and the clause, which shows normalizeWhitespace tolerates reflow without swallowing real rewording. Run in a scratch copy outside the repository, never in the checkout.",
      "commit_oid": "028f16196d4893faaa5d54c768bff5390d7d0acf",
      "at": "2026-08-02T23:44:46Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "The run_test.go:88 fixture drives both halves: issue b declares risk_domains [concurrency], issue a declares none. Gate document, gate_test.go:151-156 asserts b's criteria are the plan's plus the constant and :130-132 asserts a's list is exactly [A works]. Run state, activate_test.go:374-376 asserts b's state criteria carry the constant last and :349 asserts a's is length 1. Audit record, activate_test.go:381-383 parses the created body and asserts the same for b, :334 asserts a's is exactly [A works]. Created issue body, activate_test.go:384-386 asserts strings.Count(bodyB, BlastRadiusCriterion) == 3 for the prose list plus human bullet plus canonical JSON, and :365-367 asserts bodyA does not contain it at all. Dispatch is settled by a chain rather than a direct test: dispatch.go:130 returns issue.AcceptanceCriteria from state unfiltered and lifecycle_test.go:255 pins that dispatch returns state's criteria verbatim. All of it ran green under go test -count=1 ./internal/run/.",
      "commit_oid": "028f16196d4893faaa5d54c768bff5390d7d0acf",
      "at": "2026-08-02T23:44:47Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "Read at internal/run/derive.go:141. The constant states, in order: contributed by Orch because this issue declares a risk domain rather than by the plan document; name every element of the structure this change touches and state for each whether the behavior it had before this change still holds; record a behavior this change removes as a before-and-after in the same document that stated the old behavior rather than deleting that statement; and where a restriction is attributed to one named symbol, establish whether it holds for that symbol alone or for every symbol of its kind, and say which. That is the criterion's three demands near-verbatim. TestBlastRadiusCriterionStatesItsThreeDemands pins them, and the reviewer's own mutation rewording the tail from 'and say which' to 'and state which' proved that pin fires rather than passing vacuously.",
      "commit_oid": "028f16196d4893faaa5d54c768bff5390d7d0acf",
      "at": "2026-08-02T23:44:47Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "checkJudgments at review.go:308-336 has no diff hunk at all - the enforcement code is untouched - and it derives its coverage requirement from the criteria slice it is handed. review.go:186 hands it issue.AcceptanceCriteria read from state, which activate.go:261 wrote from issueAcceptanceCriteria. The new TestReviewJudgesTheContributedCriterion at derive_test.go:247-273 drives that function with a risk-domain criteria list and asserts three things: judging only the plan's criterion returns ErrBadRequest naming 'acceptance criterion 2 carries no judgment'; an approve verdict with criterion 2 unsatisfied returns ErrBadRequest; request-changes over the same is accepted. It passed in the reviewer's run. 'On the same terms' is literally true here because the enforcement code did not change.",
      "commit_oid": "028f16196d4893faaa5d54c768bff5390d7d0acf",
      "at": "2026-08-02T23:44:47Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "Checked at the mechanism, not only through the tests. Digest half: gate.go:80 computes the digest before the GateIssue loop and activate.go:148 computes it before Phases 4 and 5, so plan and activate hash the identical struct; independently, issueAcceptanceCriteria takes i by value and slices.Concat allocates a result of the summed length and copies into it, never writing through an input slice header - the load-bearing difference from append(i.AcceptanceCriteria, ...), which could have written into the plan slice's spare capacity. Test-side, gate_test.go:97-105 asserts doc.PlanDigest equals an independently decoded p.Digest(), activate_test.go:204-215 builds the approval from that same p.Digest(), and Activate accepts it on the risk-domain fixture in five separate tests, with TestIssueAcceptanceCriteriaDoesNotMutatePlan adding the direct non-mutation assertion. Resume half: activate.go:261 and :289 write the same issueAcceptanceCriteria(pi) list to state and to the manifest, resume compares those two through sameWork at resume.go:385-389 on work read from the manifest at resume.go:807, and activate_test.go:390-392 calls sameWork on the activate-produced pair and asserts true. A run activated by an older build holds N on both sides and stays equal, so there is no migration hazard.",
      "commit_oid": "028f16196d4893faaa5d54c768bff5390d7d0acf",
      "at": "2026-08-02T23:44:47Z"
    },
    {
      "name": "acceptance-criterion-5",
      "result": "satisfied",
      "detail": "The reviewer grepped the whole module for AcceptanceCriteria and enumerated the consumers itself rather than checking the PR's list against itself: plandoc.go:172-179 and :93, gate.go:115, activate.go:261/289/395, dispatch.go:130 and :153, review.go:186 and :381, resume.go:367/388/809, manifest/manifest.go:194 and render.go:80, state/state.go:158, and manifestbody.go's acceptance-criterion-\u003cn\u003e name shape. Every one appears in the PR body's two tables by name and site, the four that change are marked as changing, and the seven the criterion names explicitly - gate document, run state, audit record, created issue body, dispatch, review, resume - are each their own row. The removals claim checks out independently: git diff main...HEAD -U0 piped through grep '^-[^-]' returns exactly seven lines, the four reassigned AcceptanceCriteria lines and three comments rewritten in place, with no prose dropped. The one accuracy nit inside a row was corrected in the PR body before this cycle was recorded.",
      "commit_oid": "028f16196d4893faaa5d54c768bff5390d7d0acf",
      "at": "2026-08-02T23:44:47Z"
    },
    {
      "name": "acceptance-criterion-6",
      "result": "satisfied",
      "detail": "All six shipped files carry the criterion and the evidence sentence: adapters/claude/skills/orch-delivery/SKILL.md:105-125, adapters/codex/skills/orch-delivery/SKILL.md:105-125, adapters/claude/agents/orch-reviewer.md:65-90, orch-reviewer-safe.md:73-98, adapters/codex/agents/orch-reviewer.toml:71-96, orch-reviewer-safe.toml:79-104. The test is TestBlastRadiusCriterionGuidance in both adapters/claude/plugin_test.go:400 and adapters/codex/plugin_test.go:294, backed by adaptertest.CheckBlastRadiusCriterionGuidance, which asserts each clause against run.BlastRadiusCriterion and against every shipped file, plus the evidence sentence against every file. The reviewer's three mutations confirmed it fires on the engine side, on a reviewer definition, and on a delivery skill independently. This is not the wrong-criterion case: it does not ask for a check on how an agent behaves, it asks that two artifacts that both live in this repository be held to agreeing with each other, a failure mode the reviewer reproduced three times. The executor also documented the limit honestly in adaptertest.go rather than overclaiming - no check there observes whether an executor or reviewer that reads the criterion acts on it.",
      "commit_oid": "028f16196d4893faaa5d54c768bff5390d7d0acf",
      "at": "2026-08-02T23:44:47Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "First-cycle approve at head 028f1619, on observations the reviewer made itself. It re-ran all four required tests in the worktree and confirmed all six CI checks. Against the standing worry that a prose drift pin can pass while the prose is wrong, it ran three independent mutations in a scratch copy outside the repository rather than inheriting the executor's two: rewording the constant's tail failed the guidance test in both adapter packages and the three-demands test in internal/run; deleting the evidence sentence from the codex reviewer-safe definition failed the codex package while the claude package passed, showing correct per-file isolation; and rewording a clause in the claude delivery skill deliberately across a hard line break failed naming the file and the clause, showing that whitespace normalization tolerates reflow without swallowing real rewording. It also checked criterion 4's digest claim at the mechanism rather than the test: both call sites compute the digest before the criterion exists, and slices.Concat allocates a fresh result rather than writing through an input slice header, which is the load-bearing difference from append into the plan slice's spare capacity. Six findings, none blocking: a stale parenthetical in the adaptertest package doc that still says internal/run is imported only for the four statement constants when a fifth symbol is now imported, which is itself the shape the new criterion asks about; an overstated sentence in the PR body's body-size row, since the criterion does cost roughly half a maximal review cycle of headroom, corrected in the PR body before this cycle was recorded; the approval digest not covering the contributed criterion by construction, inherent to the design the issue mandated since folding it into the digest is exactly what would break criterion 4; wrongCriteriaReason not being actionable for a criterion the plan gate offers no lever over; the duplicate-criterion case left unhandled, which the reviewer agrees is correct; and no test asserting the criterion in DispatchResult directly, the property holding through dispatch copying state unfiltered plus an existing pin that dispatch echoes state verbatim. No security finding: nothing touches a trust boundary, no secret, no new dependency, and slices is stdlib. Scope is 15 files, all of them the four read sites, the new derivation, the shipped prose the criterion required, or tests.",
      "commit_oid": "028f16196d4893faaa5d54c768bff5390d7d0acf",
      "at": "2026-08-02T23:44:47Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (macos-latest)=pass, lint=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "028f16196d4893faaa5d54c768bff5390d7d0acf",
      "at": "2026-08-02T23:45:06Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->

