### PR TITLE
Init and configure offer to seed a new host's instruction file from the sibling

### DIFF
--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/kninetimmy/orch/internal/execx/execxtest"
 	"github.com/kninetimmy/orch/internal/ghops"
 	"github.com/kninetimmy/orch/internal/gitops"
+	"github.com/kninetimmy/orch/internal/instructions"
+	"github.com/kninetimmy/orch/internal/interview"
 )
 
 func TestExecuteHappyPath(t *testing.T) {
@@ -90,6 +92,59 @@ func TestExecuteHappyPath(t *testing.T) {
 	remoteHead := rawGit(t, root, "rev-parse", "refs/remotes/origin/"+BootstrapBranch)
 	if strings.TrimSpace(remoteHead) != head {
 		t.Errorf("origin/%s = %q, want %q (pushed)", BootstrapBranch, strings.TrimSpace(remoteHead), head)
+	}
+}
+
+// TestExecuteSeedsNewInstructionFileFromSibling proves the seed offer
+// survives the whole bootstrap: stage 0 re-derives the seeded content
+// from the raw answers alone (nothing about the file's bytes travels in
+// the AnswerSet), the seeded file passes the §18.13 mechanical
+// validation, and what lands on the bootstrap branch is CLAUDE.md's
+// conventions followed by exactly one managed block.
+func TestExecuteSeedsNewInstructionFileFromSibling(t *testing.T) {
+	const conventions = "# Fixture\n\nRun `go test ./...` before every push.\n"
+	root := newBootstrapRepo(t)
+	block, err := instructions.Render(instructions.CurrentVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "CLAUDE.md"), []byte(conventions+"\n"+block), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rawGit(t, root, "add", "-A")
+	rawGit(t, root, "commit", "-m", "conventions")
+	rawGit(t, root, "push", "origin", "main")
+
+	facts := interview.Detect(context.Background(), interview.Deps{RepoRoot: root, LookPath: fakeLookPath, Runner: muxRunner{git: execx.Local{}}})
+	answers := fullAnswers(t, facts, root)
+	if answers["seed.instructions.codex"] != "yes" {
+		t.Fatalf("the interview never offered to seed AGENTS.md: %v", answers)
+	}
+
+	calls := taxonomyScript()
+	calls = append(calls, ghIssueCreateCall(1))
+	calls = append(calls, ghCreatePRCall(1))
+	calls = append(calls, ghSetStatusCall(1, ghops.StatusAwaitingReview))
+	script := &execxtest.Script{T: t, Calls: calls}
+	deps := testDeps(root, answers, script, muxRunner{git: execx.Local{}})
+
+	report, err := Execute(context.Background(), deps)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	script.AssertExhausted()
+	for _, v := range report.Validations {
+		if v.Result != "pass" {
+			t.Errorf("validation %s = %+v, want pass", v.Name, v)
+		}
+	}
+
+	agents := rawGit(t, root, "show", BootstrapBranch+":AGENTS.md")
+	if !strings.HasPrefix(agents, conventions) {
+		t.Errorf("committed AGENTS.md does not open with CLAUDE.md's conventions:\n%s", agents)
+	}
+	if n := strings.Count(agents, "orchestrator:managed:start"); n != 1 {
+		t.Errorf("committed AGENTS.md carries %d managed blocks, want exactly 1:\n%s", n, agents)
 	}
 }
 

--- a/internal/interview/configure.go
+++ b/internal/interview/configure.go
@@ -84,7 +84,11 @@ func nextAfterSequenceConfigure(facts Facts, committed *config.Config, committed
 	if err != nil {
 		return question.Document{}, err
 	}
-	summary, err := buildConfigureSummary(cfg, committed, committedRaw, repoRoot)
+	seeds := seedFiles(facts, map[string]bool{
+		"claude": cfg.Hosts.Claude != nil && committedHostConfig(committed, "claude") == nil,
+		"codex":  cfg.Hosts.Codex != nil && committedHostConfig(committed, "codex") == nil,
+	}, answers)
+	summary, err := buildConfigureSummary(cfg, committed, committedRaw, repoRoot, seeds)
 	if err != nil {
 		return question.Document{}, err
 	}
@@ -162,6 +166,12 @@ func readCommittedRaw(repoRoot string) ([]byte, error) {
 // (concurrency/merge/memhub/metrics) is included only when
 // pick.settings is answered "yes", defaulted from the committed
 // configuration's current values (committedSettingsDefaults).
+//
+// Last comes any applicable instruction-file seed question (seedDocs,
+// seed.go). It is offered only for a host this change newly enables —
+// a still-enabled host's file is already there — and only when that
+// host's root instruction file is absent while the other host's carries
+// conventions.
 func buildSequenceConfigure(facts Facts, committed *config.Config, answers map[string]string) ([]docSpec, error) {
 	docs := []docSpec{pickerDocConfigure(committed)}
 
@@ -204,6 +214,11 @@ func buildSequenceConfigure(facts Facts, committed *config.Config, answers map[s
 	if answers[idPickSettings] == "yes" {
 		docs = append(docs, settingsDoc(committedSettingsDefaults(committed)))
 	}
+
+	docs = append(docs, seedDocs(facts, map[string]bool{
+		"claude": claudeEnabled && !claudeCommitted,
+		"codex":  codexEnabled && !codexCommitted,
+	})...)
 
 	return docs, nil
 }
@@ -437,7 +452,8 @@ func allFileChangesUnchanged(files []question.FileChange) bool {
 // buildConfigureSummary materializes cfg's rendered TOML and proposed
 // instruction-file changes into a question.Summary for `orch
 // configure` (PRD §18 steps 7-8 applied to an edit rather than a fresh
-// bootstrap): every host cfg enables gets instructions.PlanFile
+// bootstrap): every host cfg enables gets seededPlanFile — plain
+// instructions.PlanFile unless seeds names its file (seed.go)
 // (install, or — the day a version 2 exists — an upgrade diff, PRD §19
 // "upgrade blocks only through Delivery"); every host this change
 // disables instead gets instructions.PlanRemoveFile, block-only
@@ -448,13 +464,13 @@ func allFileChangesUnchanged(files []question.FileChange) bool {
 // config.toml is never double-written. The no-change blocker compares
 // bytes, not revision, so a hand-denormalized committed file can still
 // be re-canonicalized through an otherwise-empty configure change.
-func buildConfigureSummary(cfg, committed *config.Config, committedRaw []byte, repoRoot string) (question.Summary, error) {
+func buildConfigureSummary(cfg, committed *config.Config, committedRaw []byte, repoRoot string, seeds map[string]string) (question.Summary, error) {
 	rendered, err := config.Render(cfg)
 	if err != nil {
 		return question.Summary{}, fmt.Errorf("render configuration for summary: %w", err)
 	}
 
-	enabledFiles, enabledBlockers, err := planInstructionFiles(repoRoot, applicableInstructionFiles(cfg), instructions.PlanFile)
+	enabledFiles, enabledBlockers, err := planInstructionFiles(repoRoot, applicableInstructionFiles(cfg), seededPlanFile(repoRoot, seeds))
 	if err != nil {
 		return question.Summary{}, err
 	}

--- a/internal/interview/detect.go
+++ b/internal/interview/detect.go
@@ -2,9 +2,14 @@ package interview
 
 import (
 	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/instructions"
 	"github.com/kninetimmy/orch/internal/memhub"
 )
 
@@ -25,11 +30,12 @@ type Deps struct {
 
 // Facts is Detect's pure snapshot of the local environment (PRD §18
 // steps 1-2): which host CLIs are on PATH, whether RepoRoot sits
-// inside a git repository, whether gh is on PATH, and whether memhub
-// is both on PATH and healthy. Facts feeds question defaults and
-// Complete's audit record; it never travels inside an AnswerSet — an
-// adapter cannot spoof detection by editing the answers map, since
-// Next never reads facts back out of it.
+// inside a git repository, whether gh is on PATH, whether memhub is
+// both on PATH and healthy, and how each host's root instruction file
+// already stands (Instructions, keyed by host name). Facts feeds
+// question defaults and Complete's audit record; it never travels
+// inside an AnswerSet — an adapter cannot spoof detection by editing
+// the answers map, since Next never reads facts back out of it.
 type Facts struct {
 	ClaudeCLI bool
 	CodexCLI  bool
@@ -42,6 +48,20 @@ type Facts struct {
 	MemhubCLI     bool
 	MemhubHealthy bool
 	MemhubDetail  string
+
+	Instructions map[string]InstructionFileState
+}
+
+// InstructionFileState is Detect's classification of one host's root
+// instruction file (InstructionFile names it): whether the file exists
+// at all, and whether it carries any content outside the Orch managed
+// block. It is deliberately part of Facts rather than something the
+// summary step reads for itself, so the seed question (seed.go) can be
+// derived while buildSequence stays a pure function of facts and
+// answers alone.
+type InstructionFileState struct {
+	Exists      bool
+	Conventions bool
 }
 
 // Detect probes deps for every Facts field. It never returns an
@@ -55,7 +75,9 @@ type Facts struct {
 // the git root and so cannot hold before initialization exists.
 // memhub is probed through internal/memhub's Client, the shared PRD
 // §20 client that runs `memhub status` with the repo root as an
-// explicit working directory.
+// explicit working directory. The root instruction files are read
+// directly (classifyInstructionFile), the one probe that touches the
+// repository's own content rather than its tooling.
 func Detect(ctx context.Context, deps Deps) Facts {
 	var f Facts
 	f.ClaudeCLI = lookPathOK(deps.LookPath, "claude")
@@ -73,7 +95,45 @@ func Detect(ctx context.Context, deps Deps) Facts {
 		f.MemhubHealthy, f.MemhubDetail = probeMemhub(ctx, deps)
 	}
 
+	root := f.GitRoot
+	if root == "" {
+		root = deps.RepoRoot
+	}
+	f.Instructions = map[string]InstructionFileState{
+		"claude": classifyInstructionFile(root, InstructionFile("claude")),
+		"codex":  classifyInstructionFile(root, InstructionFile("codex")),
+	}
+
 	return f
+}
+
+// classifyInstructionFile reports whether repoRoot/name exists and
+// whether it holds anything outside the Orch managed block. It reuses
+// instructions.PlanRemove because what is left once the managed region
+// is stripped is exactly the question being asked (the same reading
+// `orch doctor` reports this state from). Like every other Detect
+// probe it reports trouble as data, not failure: an unreadable file or
+// structurally broken markers classify as "exists, no conventions", so
+// nothing is ever seeded from a file this build cannot read or parse,
+// and `orch init`/`configure` still block on those files themselves.
+//
+// The root probed is the detected git root, falling back to
+// Deps.RepoRoot — the same resolution the callers apply before handing
+// a root to Next, so the files classified here are the files the
+// summary step later plans against.
+func classifyInstructionFile(repoRoot, name string) InstructionFileState {
+	data, err := os.ReadFile(filepath.Join(repoRoot, name))
+	if errors.Is(err, fs.ErrNotExist) {
+		return InstructionFileState{}
+	}
+	if err != nil {
+		return InstructionFileState{Exists: true}
+	}
+	ch, err := instructions.PlanRemove(string(data))
+	if err != nil {
+		return InstructionFileState{Exists: true}
+	}
+	return InstructionFileState{Exists: true, Conventions: !instructions.IsOtherwiseEmpty(ch.New)}
 }
 
 // lookPathOK reports whether lookPath resolves name; a nil lookPath

--- a/internal/interview/interview.go
+++ b/internal/interview/interview.go
@@ -93,13 +93,20 @@ func Next(facts Facts, answers map[string]string, repoRoot string) (question.Doc
 
 // nextAfterSequence handles Next's tail: every "questions"-kind
 // document is answered, so the engine materializes the configuration,
-// builds the summary, and resolves approval.
+// builds the summary, and resolves approval. Every host `orch init`
+// enables is newly enabled, so the seed offers resolved here
+// (seedFiles, seed.go) are the same ones buildSequence derived from the
+// host toggles.
 func nextAfterSequence(facts Facts, answers map[string]string, repoRoot string) (question.Document, error) {
 	cfg, err := materialize(answers)
 	if err != nil {
 		return question.Document{}, err
 	}
-	summary, err := buildSummary(cfg, repoRoot)
+	seeds := seedFiles(facts, map[string]bool{
+		"claude": cfg.Hosts.Claude != nil,
+		"codex":  cfg.Hosts.Codex != nil,
+	}, answers)
+	summary, err := buildSummary(cfg, repoRoot, seeds)
 	if err != nil {
 		return question.Document{}, err
 	}

--- a/internal/interview/seed.go
+++ b/internal/interview/seed.go
@@ -1,0 +1,162 @@
+package interview
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/kninetimmy/orch/internal/instructions"
+	"github.com/kninetimmy/orch/internal/question"
+)
+
+// seedID builds host's seed question id. Unlike the ids materialize.go
+// ingests, this one names no TOML key: nothing about the answer is
+// committed to the configuration — it only chooses what the summary
+// proposes for one file. `orch configure`'s own pick.hosts and
+// pick.roles.<host> ids are the same kind of non-TOML question id.
+func seedID(host string) string { return "seed.instructions." + host }
+
+// siblingHost returns the other host's name.
+func siblingHost(host string) string {
+	if host == "claude" {
+		return "codex"
+	}
+	return "claude"
+}
+
+// seedOffer names one host whose root instruction file this session
+// creates, together with the sibling host's existing file the new one
+// may be seeded from.
+type seedOffer struct {
+	host    string
+	file    string // host's root instruction file, absent today
+	sibling string // the other host's file, which carries conventions
+}
+
+// seedOffers lists, in claude-then-codex order (applicableInstructionFiles'
+// fixed order, so documents and summary rows stay deterministic), every
+// host newlyEnabled marks whose own root instruction file is absent
+// while the other host's file carries content outside the Orch managed
+// block. That is the exact condition the seed question is asked under:
+// without it Orch creates a file holding nothing but the managed block,
+// leaving that host's agents with no project conventions at all — the
+// state `orch doctor` reports after the fact.
+//
+// The sibling need not itself be an enabled host. A repository that
+// states its conventions in AGENTS.md and enables only Claude Code has
+// exactly the same problem, and the same answer.
+//
+// seedOffers reads nothing: facts.Instructions is Detect's snapshot, so
+// the question sequence stays a pure function of facts and answers.
+func seedOffers(facts Facts, newlyEnabled map[string]bool) []seedOffer {
+	var offers []seedOffer
+	for _, host := range []string{"claude", "codex"} {
+		sibling := siblingHost(host)
+		if !newlyEnabled[host] || facts.Instructions[host].Exists || !facts.Instructions[sibling].Conventions {
+			continue
+		}
+		offers = append(offers, seedOffer{host: host, file: InstructionFile(host), sibling: InstructionFile(sibling)})
+	}
+	return offers
+}
+
+// seedDocs turns every applicable offer into its own single-question
+// document, appended last in both interviews' sequences — the file
+// question sits closest to the summary that shows its result.
+func seedDocs(facts Facts, newlyEnabled map[string]bool) []docSpec {
+	var docs []docSpec
+	for _, o := range seedOffers(facts, newlyEnabled) {
+		docs = append(docs, docSpec{questions: []question.Question{seedQuestion(o)}})
+	}
+	return docs
+}
+
+// seedQuestion is o's yes/no question, naming both files and defaulting
+// to yes: a repository that already states its conventions somewhere
+// almost always wants the file being created to carry them too, and
+// either answer's full proposed content is shown as the summary's file
+// diff before anything is written.
+//
+// The seeded content is a verbatim copy rather than an import
+// directive: an import is host-specific syntax, and Orch does not
+// author a host's instruction dialect.
+func seedQuestion(o seedOffer) question.Question {
+	return question.Question{
+		ID:     seedID(o.host),
+		Header: "Conventions",
+		Prompt: fmt.Sprintf("Seed %s from %s?", o.file, o.sibling),
+		Preamble: fmt.Sprintf(
+			"%s already states this repository's conventions outside its own Orch managed block, while %s does not exist yet. Seeding copies that content verbatim into the new file, above a fresh managed block, so %s agents read the same conventions; answering no creates %s holding the managed block alone.",
+			o.sibling, o.file, hostLabels[o.host], o.file),
+		Kind:    question.KindSelect,
+		Default: "yes",
+		Options: yesNoOptions("yes"),
+	}
+}
+
+// seedFiles maps each proposed instruction file name to the sibling
+// file name it is seeded from, for every offer this session's answers
+// accepted — buildSummary's and buildConfigureSummary's seeds argument.
+// An unanswered or declined offer is simply absent, which is what makes
+// "no" identical to the behavior before seeding existed.
+func seedFiles(facts Facts, newlyEnabled map[string]bool, answers map[string]string) map[string]string {
+	seeds := map[string]string{}
+	for _, o := range seedOffers(facts, newlyEnabled) {
+		if answers[seedID(o.host)] == "yes" {
+			seeds[o.file] = o.sibling
+		}
+	}
+	return seeds
+}
+
+// seededPlanFile returns planInstructionFiles' plan function for a
+// session carrying seeds: instructions.PlanFile for every file, except
+// that a file seeds names is planned from the sibling's conventions
+// (planSeeded) instead of from nothing. With no seeds it is
+// instructions.PlanFile itself, so every path that never offered
+// seeding plans exactly as it did before.
+func seededPlanFile(repoRoot string, seeds map[string]string) func(string) (instructions.Change, error) {
+	if len(seeds) == 0 {
+		return instructions.PlanFile
+	}
+	return func(path string) (instructions.Change, error) {
+		sibling, ok := seeds[filepath.Base(path)]
+		if !ok {
+			return instructions.PlanFile(path)
+		}
+		return planSeeded(filepath.Join(repoRoot, sibling), path)
+	}
+}
+
+// planSeeded proposes path's content as siblingPath's content outside
+// its own managed block, followed by a fresh managed block — exactly
+// one managed block by construction, since PlanRemove strips whatever
+// block the sibling carried and Plan then appends the current one to a
+// remainder that provably carries no markers (locate rejects a second
+// pair as malformed).
+//
+// The offer is only ever made for a path Detect found absent, so the
+// change is an install against nothing: Old is "" and the diff shows
+// the whole proposed file, seeded lines included, rather than the block
+// alone against borrowed context. A path that exists after all falls
+// back to the ordinary plan — seeding must never overwrite a file
+// somebody already wrote.
+func planSeeded(siblingPath, path string) (instructions.Change, error) {
+	if _, err := os.Stat(path); !errors.Is(err, fs.ErrNotExist) {
+		return instructions.PlanFile(path)
+	}
+	base, err := instructions.PlanRemoveFile(siblingPath)
+	if err != nil {
+		return instructions.Change{}, err
+	}
+	ch, err := instructions.Plan(base.New)
+	if err != nil {
+		return instructions.Change{}, err
+	}
+	ch.FileExisted = false
+	ch.Old = ""
+	ch.Diff = instructions.UnifiedDiff("", ch.New)
+	return ch, nil
+}

--- a/internal/interview/seed_test.go
+++ b/internal/interview/seed_test.go
@@ -1,0 +1,294 @@
+package interview
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/instructions"
+	"github.com/kninetimmy/orch/internal/question"
+)
+
+// seedConventions is a fixture repository's conventions: the content
+// that lives outside a root instruction file's managed block and that a
+// newly created sibling file would otherwise be missing entirely.
+const seedConventions = "# Fixture\n\nRun `go test ./...` before every push.\n"
+
+// managedBlock is the current Orch managed block, rendered exactly as
+// instructions.Plan installs it.
+func managedBlock(t *testing.T) string {
+	t.Helper()
+	block, err := instructions.Render(instructions.CurrentVersion)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	return block
+}
+
+// writeInstructionFile writes name into root.
+func writeInstructionFile(t *testing.T, root, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+// withInstructions classifies root's two root instruction files onto
+// facts the way Detect does, so a walk over a fixture directory sees
+// the same instruction facts a real run would.
+func withInstructions(facts Facts, root string) Facts {
+	facts.Instructions = map[string]InstructionFileState{
+		"claude": classifyInstructionFile(root, InstructionFile("claude")),
+		"codex":  classifyInstructionFile(root, InstructionFile("codex")),
+	}
+	return facts
+}
+
+// checkSeedQuestion asserts q is a well-formed seed question: it passes
+// the shared spec check, names both files in its prompt, and defaults
+// to yes.
+func checkSeedQuestion(t *testing.T, q question.Question, file, sibling string) {
+	t.Helper()
+	if err := question.SpecCheck(q); err != nil {
+		t.Errorf("SpecCheck(%s): %v", q.ID, err)
+	}
+	if q.Default != "yes" {
+		t.Errorf("%s: Default = %q, want %q", q.ID, q.Default, "yes")
+	}
+	if !strings.Contains(q.Prompt, file) || !strings.Contains(q.Prompt, sibling) {
+		t.Errorf("%s: Prompt = %q, want it to name both %s and %s", q.ID, q.Prompt, file, sibling)
+	}
+}
+
+// walkSeed drives next (Next or NextConfigure) from an empty answer set
+// to its first non-questions document, answering every question with
+// its Default unless overrides names it, and answering any seed
+// question with seedAnswer. It returns that document's summary and
+// whether a seed question was asked at all.
+func walkSeed(t *testing.T, next func(Facts, map[string]string, string) (question.Document, error), facts Facts, root, seedAnswer string, overrides map[string]string) (question.Summary, bool) {
+	t.Helper()
+	answers := map[string]string{}
+	asked := false
+	for step := 1; step <= 100; step++ {
+		doc, err := next(facts, answers, root)
+		if err != nil {
+			t.Fatalf("step %d: %v", step, err)
+		}
+		if doc.Kind != question.DocQuestions {
+			if doc.Summary == nil {
+				t.Fatalf("step %d: document %q carries no summary", step, doc.Kind)
+			}
+			return *doc.Summary, asked
+		}
+		for _, q := range doc.Questions {
+			switch {
+			case q.ID == seedID("claude"):
+				asked = true
+				checkSeedQuestion(t, q, InstructionFile("claude"), InstructionFile("codex"))
+				answers[q.ID] = seedAnswer
+			case q.ID == seedID("codex"):
+				asked = true
+				checkSeedQuestion(t, q, InstructionFile("codex"), InstructionFile("claude"))
+				answers[q.ID] = seedAnswer
+			default:
+				if v, ok := overrides[q.ID]; ok {
+					answers[q.ID] = v
+					continue
+				}
+				if q.Default == "" {
+					t.Fatalf("step %d: question %s has no default", step, q.ID)
+				}
+				answers[q.ID] = q.Default
+			}
+		}
+	}
+	t.Fatal("the interview did not reach a summary within 100 steps")
+	return question.Summary{}, false
+}
+
+// TestDetectClassifiesInstructionFiles proves Detect reports the three
+// states the seed question keys on — absent, block-only, and carrying
+// conventions — reading them from the repository root it was pointed
+// at (git undetected here, so the fallback to Deps.RepoRoot applies).
+func TestDetectClassifiesInstructionFiles(t *testing.T) {
+	block := managedBlock(t)
+	root := t.TempDir()
+	writeInstructionFile(t, root, "CLAUDE.md", seedConventions+"\n"+block)
+	writeInstructionFile(t, root, "AGENTS.md", block)
+
+	facts := Detect(context.Background(), Deps{RepoRoot: root, LookPath: fakeLookPath()})
+
+	if got := facts.Instructions["claude"]; !got.Exists || !got.Conventions {
+		t.Errorf("claude = %+v, want a file that exists and carries conventions", got)
+	}
+	if got := facts.Instructions["codex"]; !got.Exists || got.Conventions {
+		t.Errorf("codex = %+v, want a file that exists with no conventions", got)
+	}
+
+	bare := Detect(context.Background(), Deps{RepoRoot: t.TempDir(), LookPath: fakeLookPath()})
+	for host, got := range bare.Instructions {
+		if got.Exists || got.Conventions {
+			t.Errorf("%s = %+v, want absent in a bare directory", host, got)
+		}
+	}
+}
+
+// TestSeedAcceptedCarriesSiblingConventions is the flagship walk: a
+// repository whose conventions live in CLAUDE.md enables both hosts,
+// and the new AGENTS.md is proposed as those conventions followed by a
+// single fresh managed block.
+func TestSeedAcceptedCarriesSiblingConventions(t *testing.T) {
+	root := t.TempDir()
+	writeInstructionFile(t, root, "CLAUDE.md", seedConventions+"\n"+managedBlock(t))
+
+	summary, asked := walkSeed(t, Next, withInstructions(bothHostsFacts(), root), root, "yes", nil)
+	if !asked {
+		t.Fatal("the seed question was never asked")
+	}
+
+	ch := findFileChange(summary.Files, "AGENTS.md")
+	if ch == nil {
+		t.Fatalf("Files = %v, want an AGENTS.md entry", summary.Files)
+	}
+	if ch.Existed {
+		t.Error("Existed = true, want false (AGENTS.md did not exist)")
+	}
+	if !strings.HasPrefix(ch.NewContent, seedConventions) {
+		t.Errorf("NewContent does not open with CLAUDE.md's conventions:\n%s", ch.NewContent)
+	}
+	if n := strings.Count(ch.NewContent, "orchestrator:managed:start"); n != 1 {
+		t.Errorf("NewContent carries %d managed blocks, want exactly 1:\n%s", n, ch.NewContent)
+	}
+	if report := instructions.Inspect(ch.NewContent); report.Status != instructions.StatusCurrent {
+		t.Errorf("Inspect(NewContent).Status = %v, want StatusCurrent (%v): %s", report.Status, instructions.StatusCurrent, report.Detail)
+	}
+
+	// Every line of the proposed file is visible as an addition in the
+	// diff a human approves, seeded lines included.
+	for _, line := range strings.Split(strings.TrimSuffix(ch.NewContent, "\n"), "\n") {
+		if !strings.Contains(ch.Diff, "\n+"+line+"\n") && !strings.HasPrefix(ch.Diff, "+"+line+"\n") {
+			t.Errorf("Diff does not show %q as an added line:\n%s", line, ch.Diff)
+		}
+	}
+
+	// The sibling it was seeded from is itself unchanged.
+	sibling := findFileChange(summary.Files, "CLAUDE.md")
+	if sibling == nil {
+		t.Fatalf("Files = %v, want a CLAUDE.md entry", summary.Files)
+	}
+	if sibling.Diff != "" {
+		t.Errorf("CLAUDE.md Diff = %q, want empty (it already carries a current block)", sibling.Diff)
+	}
+}
+
+// TestSeedDeclinedKeepsBlockOnlyProposal proves answering no leaves the
+// proposal exactly what it was before seeding existed.
+func TestSeedDeclinedKeepsBlockOnlyProposal(t *testing.T) {
+	root := t.TempDir()
+	writeInstructionFile(t, root, "CLAUDE.md", seedConventions+"\n"+managedBlock(t))
+
+	summary, asked := walkSeed(t, Next, withInstructions(bothHostsFacts(), root), root, "no", nil)
+	if !asked {
+		t.Fatal("the seed question was never asked")
+	}
+	ch := findFileChange(summary.Files, "AGENTS.md")
+	if ch == nil {
+		t.Fatalf("Files = %v, want an AGENTS.md entry", summary.Files)
+	}
+	if ch.NewContent != managedBlock(t) {
+		t.Errorf("NewContent = %q, want the managed block alone", ch.NewContent)
+	}
+}
+
+// TestSeedNotOffered walks every condition under which the question
+// must stay silent. The golden transcripts pin the fourth (a bare
+// repository) by running unmodified.
+func TestSeedNotOffered(t *testing.T) {
+	block := managedBlock(t)
+	cases := []struct {
+		name  string
+		files map[string]string
+	}{
+		{"sibling absent", nil},
+		{"sibling holds only the managed block", map[string]string{"CLAUDE.md": block}},
+		{"the host's own file already exists", map[string]string{
+			"CLAUDE.md": seedConventions + "\n" + block,
+			"AGENTS.md": "# Codex\n",
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			for name, content := range tc.files {
+				writeInstructionFile(t, root, name, content)
+			}
+			if _, asked := walkSeed(t, Next, withInstructions(bothHostsFacts(), root), root, "yes", nil); asked {
+				t.Error("the seed question was asked")
+			}
+		})
+	}
+}
+
+// TestSeedOfferedForConfigureNewlyEnabledHost proves an `orch
+// configure` change that newly enables Codex gets the same offer, and
+// that the newly created AGENTS.md carries CLAUDE.md's conventions.
+func TestSeedOfferedForConfigureNewlyEnabledHost(t *testing.T) {
+	root := t.TempDir()
+	writeCommittedConfigClaudeOnly(t, root)
+	writeInstructionFile(t, root, "CLAUDE.md", seedConventions+"\n"+managedBlock(t))
+
+	overrides := map[string]string{idPickHosts: "yes", idHostCodexEnabled: "yes"}
+	summary, asked := walkSeed(t, NextConfigure, withInstructions(configureFacts(), root), root, "yes", overrides)
+	if !asked {
+		t.Fatal("the seed question was never asked")
+	}
+	ch := findFileChange(summary.Files, "AGENTS.md")
+	if ch == nil {
+		t.Fatalf("Files = %v, want an AGENTS.md entry", summary.Files)
+	}
+	if !strings.HasPrefix(ch.NewContent, seedConventions) {
+		t.Errorf("NewContent does not open with CLAUDE.md's conventions:\n%s", ch.NewContent)
+	}
+	if report := instructions.Inspect(ch.NewContent); report.Status != instructions.StatusCurrent {
+		t.Errorf("Inspect(NewContent).Status = %v, want StatusCurrent (%v): %s", report.Status, instructions.StatusCurrent, report.Detail)
+	}
+}
+
+// TestSeedNotOfferedForStillEnabledConfigureHost proves the offer is
+// scoped to a host this change newly enables: a committed-enabled host
+// whose file happens to be missing is not seeded behind the human's
+// back — `orch doctor` reports that state instead.
+func TestSeedNotOfferedForStillEnabledConfigureHost(t *testing.T) {
+	root := t.TempDir()
+	writeCommittedConfigLocal(t, root)
+	writeInstructionFile(t, root, "CLAUDE.md", seedConventions+"\n"+managedBlock(t))
+
+	overrides := map[string]string{idPickHosts: "yes"}
+	if _, asked := walkSeed(t, NextConfigure, withInstructions(configureFacts(), root), root, "yes", overrides); asked {
+		t.Error("the seed question was asked for a host that was already committed-enabled")
+	}
+}
+
+// TestSeedNeverOverwritesAnExistingFile pins planSeeded's fail-safe: if
+// the target file exists after all — the interview's facts and the
+// summary's root having disagreed — the ordinary plan runs and the
+// file's own content is preserved, rather than being replaced by a copy
+// of the sibling's.
+func TestSeedNeverOverwritesAnExistingFile(t *testing.T) {
+	root := t.TempDir()
+	writeInstructionFile(t, root, "CLAUDE.md", seedConventions+"\n"+managedBlock(t))
+	writeInstructionFile(t, root, "AGENTS.md", "# Codex only\n")
+
+	ch, err := planSeeded(filepath.Join(root, "CLAUDE.md"), filepath.Join(root, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("planSeeded: %v", err)
+	}
+	if !strings.HasPrefix(ch.New, "# Codex only\n") {
+		t.Errorf("New = %q, want AGENTS.md's own content preserved", ch.New)
+	}
+	if strings.Contains(ch.New, seedConventions) {
+		t.Errorf("New carries the sibling's conventions, overwriting the existing file:\n%s", ch.New)
+	}
+}

--- a/internal/interview/sequence.go
+++ b/internal/interview/sequence.go
@@ -174,7 +174,10 @@ func (d docSpec) allAnswered(answers map[string]string) bool {
 // in answers (PRD §18 steps 3-6, fixed order, claude before codex).
 // Role documents for a host are included only once that host's
 // enabled toggle is answered "yes"; the settings document (doc 14) is
-// included only once both toggles are answered at all. It returns
+// included only once both toggles are answered at all, followed by any
+// applicable instruction-file seed question (seedDocs, seed.go), which
+// fires only for an enabled host whose root instruction file is absent
+// while the other host's carries conventions. It returns
 // ErrNoHostEnabled as soon as both toggles are known and both are
 // "no" — the same rule config.validate enforces on the committed file,
 // checked here before any role question is ever asked.
@@ -198,6 +201,7 @@ func buildSequence(facts Facts, answers map[string]string) ([]docSpec, error) {
 	}
 	if claudeKnown && codexKnown {
 		docs = append(docs, settingsDoc(initSettingsDefaults(facts)))
+		docs = append(docs, seedDocs(facts, map[string]bool{"claude": claudeEnabled, "codex": codexEnabled})...)
 	}
 	return docs, nil
 }

--- a/internal/interview/summary.go
+++ b/internal/interview/summary.go
@@ -81,13 +81,17 @@ const metricsGitignoreLine = ".orchestrator/metrics/"
 // rather than aborting Next outright — the human sees the whole
 // summary with the blocker named (PRD §19: stop on conflicting
 // instructions), not a bare error.
-func buildSummary(cfg *config.Config, repoRoot string) (question.Summary, error) {
+//
+// seeds maps a proposed instruction file to the sibling file whose
+// conventions it is seeded from (seedFiles, seed.go); an empty seeds
+// plans every file exactly as it did before seeding existed.
+func buildSummary(cfg *config.Config, repoRoot string, seeds map[string]string) (question.Summary, error) {
 	rendered, err := config.Render(cfg)
 	if err != nil {
 		return question.Summary{}, fmt.Errorf("render configuration for summary: %w", err)
 	}
 
-	files, blockers, err := planInstructionFiles(repoRoot, applicableInstructionFiles(cfg), instructions.PlanFile)
+	files, blockers, err := planInstructionFiles(repoRoot, applicableInstructionFiles(cfg), seededPlanFile(repoRoot, seeds))
 	if err != nil {
 		return question.Summary{}, err
 	}
@@ -125,9 +129,10 @@ func buildSummary(cfg *config.Config, repoRoot string) (question.Summary, error)
 // blocking Plan error into a Blockers entry rather than aborting —
 // buildSummary and interview's own buildConfigureSummary
 // (`orch configure`, configure.go) both share this loop: init only
-// ever calls it with instructions.PlanFile, while configure calls it
-// once with PlanFile (for the hosts it enables) and once more with
-// PlanRemoveFile (for the hosts it disables).
+// ever calls it with seededPlanFile (instructions.PlanFile itself
+// unless this session seeds a file, seed.go), while configure calls it
+// once with seededPlanFile (for the hosts it enables) and once more
+// with PlanRemoveFile (for the hosts it disables).
 func planInstructionFiles(repoRoot string, names []string, planFunc func(string) (instructions.Change, error)) ([]question.FileChange, []string, error) {
 	var files []question.FileChange
 	var blockers []string

--- a/internal/interview/summary_test.go
+++ b/internal/interview/summary_test.go
@@ -57,7 +57,7 @@ func TestBuildSummaryFreshRepo(t *testing.T) {
 	}
 	root := t.TempDir()
 
-	summary, err := buildSummary(cfg, root)
+	summary, err := buildSummary(cfg, root, nil)
 	if err != nil {
 		t.Fatalf("buildSummary: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestBuildSummaryGitignoreLineUnconditional(t *testing.T) {
 	if cfg.Metrics.Enabled {
 		t.Fatal("fullAnswers' metrics answer is not disabled; fixture drifted")
 	}
-	summary, err := buildSummary(cfg, t.TempDir())
+	summary, err := buildSummary(cfg, t.TempDir(), nil)
 	if err != nil {
 		t.Fatalf("buildSummary: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestBuildSummaryPreservesExistingUserContent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	summary, err := buildSummary(cfg, root)
+	summary, err := buildSummary(cfg, root, nil)
 	if err != nil {
 		t.Fatalf("buildSummary: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestBuildSummaryDriftedBlockIsABlocker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	summary, err := buildSummary(cfg, root)
+	summary, err := buildSummary(cfg, root, nil)
 	if err != nil {
 		t.Fatalf("buildSummary: %v", err)
 	}
@@ -230,7 +230,7 @@ func TestBuildSummaryNestedConflict(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	summary, err := buildSummary(cfg, root)
+	summary, err := buildSummary(cfg, root, nil)
 	if err != nil {
 		t.Fatalf("buildSummary: %v", err)
 	}
@@ -253,7 +253,7 @@ func TestBuildSummaryFiltersExistingGitignoreLines(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	summary, err := buildSummary(cfg, root)
+	summary, err := buildSummary(cfg, root, nil)
 	if err != nil {
 		t.Fatalf("buildSummary: %v", err)
 	}


### PR DESCRIPTION
Delivers issue #191: Init and configure offer to seed a new host's instruction file from the sibling

Closes #191

**Plan digest:** `sha256:e6d422c928d86e77dd4c341db9c306afa245920cdad92a23dd5da9e7ed4c9353`

The approved objective and acceptance criteria are in the audit record below.

## Blast radius (acceptance criterion 5)

Every consumer of the interview's sequence and summary, accounted for by name. The installed binary predates the engine-contributed criterion from #187, so this account is written by hand, as it was on PR #190.

### Behavior holds — eight consumers

| Consumer | Site | Why the prior behavior still holds |
| --- | --- | --- |
| Init step loop | `internal/cli/init.go` (`runInitStep` → `interview.Next`) | No signature or protocol change; it renders whatever documents `Next` emits and sees one extra `questions` document only under the new condition. |
| Configure step loop | `internal/cli/configure.go` (→ `interview.NextConfigure`) | Same reasoning. |
| `bootstrap.Execute` stage-0 re-derivation | `internal/bootstrap/bootstrap.go:203` | No new parameter; it still re-runs `interview.Detect` + `Next` from raw answers. Because the file classification lives in `Facts` (Detect), the seeded content is re-derived, never carried in the AnswerSet — an adapter still cannot forge file content. Pinned end to end by `TestExecuteSeedsNewInstructionFileFromSibling`. |
| `bootstrap.ExecuteConfigure` stage-0 | `internal/bootstrap/configure.go:110` | Same shape via `NextConfigure`. |
| Golden transcripts | `internal/interview/testdata/transcript*` | Zero recorded documents modified (`git status -- internal/interview/testdata` is empty). They run against bare temporary directories, so the classification is absent and the question never fires. |
| Summary-consuming file writer | `internal/bootstrap/write.go` (`writeFiles`) | Still writes `FileChange.NewContent` verbatim; only that content differs when seeding was approved. |
| `orch doctor`'s block-only note | `internal/cli/doctor.go` | Still reports the state after the fact — including when a human declines the seeding offer. |
| Adapters | `adapters/`, `internal/adaptertest` | No files touched. The `orch-setup` skill renders questions generically; no question inventory or id is pinned there. |

### What changes — three internal signatures

`buildSummary(cfg, repoRoot, seeds)`, `buildConfigureSummary(…, seeds)`, and `Facts` gains `Instructions map[string]InstructionFileState`. `Facts` is never compared with `==` nor marshaled, and `buildComplete`'s `Detection` map is deliberately untouched — adding keys there would have changed the golden transcripts.

### Design notes worth the record

- Classification lives in `Detect`, keeping `buildSequence` a pure function of facts and answers. It reuses `instructions.PlanRemove` + `IsOtherwiseEmpty` — the same reading PR #189's doctor check uses — and reports trouble as data: an unreadable file or malformed markers classify as "exists, no conventions", so nothing is ever seeded from a file this build cannot parse.
- `Detect` classifies at `GitRoot` falling back to `Deps.RepoRoot`, the identical resolution `initRoot` and stage 0 apply before handing a root to `Next`, so detection and planning see the same files.
- `planSeeded` stats the target and falls back to the plain proposal if the file exists after all, so seeding can never overwrite a file somebody already wrote. Pinned by `TestSeedNeverOverwritesAnExistingFile`.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** During orch init, and during an orch configure change that newly enables a host, Orch creates the host's root instruction file (CLAUDE.md for claude, AGENTS.md for codex, mapped in internal/interview/summary.go) containing only the managed block. A repository that keeps its conventions in the sibling host's file gets a new file with no conventions, which is the condition orch doctor reports since PR #189 but nothing prevents. The interviews are the right place to prevent it: detection already probes the repository root, the question engine already batches conditional documents, and the summary step already shows every proposed file as a full diff a human approves before the bootstrap flow writes anything. Add one conditional yes/no question offering to seed the new file from the sibling's conventions. The seeded content is a verbatim copy of the sibling's content outside its own managed block, followed by a fresh managed block; the copy is deliberate scope, an import directive is a host-specific syntax Orch does not author. The interview engine's invariants must hold: the question sequence stays a pure function of detection facts and answers, the golden transcripts run against bare temporary directories and must pass unmodified, and bootstrap's stage-0 anti-forgery re-derivation must accept the same answers it re-derives.

**Acceptance criteria:**
- During orch init, when a host being enabled has no root instruction file and the other host's root instruction file exists carrying content outside the Orch managed block, the interview asks one additional yes-or-no question naming both files, defaulting to yes; the same question appears, under the same conditions, during an orch configure change that newly enables a host.
- Answering yes makes the summary's proposed new file consist of the sibling's content outside its own managed block followed by the current Orch managed block, with exactly one managed block in the result; answering no keeps today's block-only proposal. Either way the full proposed content is visible as the summary's file diff before approval.
- When the sibling file is absent, when the sibling holds only the managed block, when the host's own file already exists, or when the host is not being newly enabled, the question is not asked and every interview document is byte-identical to today's - pinned by the existing golden transcript tests passing without modification to their recorded documents.
- A seeded file passes the existing bootstrap mechanical validation - instructions.Inspect reports the managed block Current - and bootstrap's stage-0 re-derivation from raw answers reproduces the seeded content, so an adapter still cannot forge file content the interview did not derive.
- The pull request states, for every consumer of the interview's sequence and summary - the init step loop, the configure step loop, bootstrap Execute's and ExecuteConfigure's stage-0 re-derivation, the golden transcripts, and the summary-consuming file writer - whether the behavior it had before this change still holds, and names each one that changes.

**Required tests:**
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **build** — pass — `go build ./...` — No output. Run in the issue-191 worktree. — commit `b0738b21da26bf5378be2da71f831456b7bad928` (2026-08-03T00:21:27Z)
- **tests** — pass — `go test ./...` — All packages ok, zero failures. Run in the issue-191 worktree. — commit `b0738b21da26bf5378be2da71f831456b7bad928` (2026-08-03T00:21:27Z)
- **vet** — pass — `go vet ./...` — No output. Run in the issue-191 worktree. — commit `b0738b21da26bf5378be2da71f831456b7bad928` (2026-08-03T00:21:27Z)
- **format** — pass — `gofmt -l .` — No files listed. Run in the issue-191 worktree. — commit `b0738b21da26bf5378be2da71f831456b7bad928` (2026-08-03T00:21:27Z)
- **new-tests** — pass — `go test ./internal/interview/ -run 'TestSeed|TestDetectClassifies' -v; go test ./internal/bootstrap/ -run TestExecuteSeeds -v` — Seven new interview tests plus three subtests covering the seed question's conditions and the seeded summary content, all PASS, plus TestExecuteSeedsNewInstructionFileFromSibling pinning the bootstrap stage-0 re-derivation end to end. TestSeedNeverOverwritesAnExistingFile pins that seeding falls back to the plain proposal when the target file exists after all. — commit `b0738b21da26bf5378be2da71f831456b7bad928` (2026-08-03T00:21:27Z)
- **golden-transcripts-untouched** — pass — `git status -- internal/interview/testdata` — Empty output: zero recorded transcript documents were modified. The transcripts run against bare temporary directories where no instruction files exist, so the conditional question never fires there - criterion 3's pin, satisfied without regenerating anything. — commit `b0738b21da26bf5378be2da71f831456b7bad928` (2026-08-03T00:21:27Z)
- **branch-scope: prose-reflow-accounted** — pass — `git diff --word-diff --ignore-all-space` — Three files carried reflowed doc comments (detect.go, summary.go, configure.go). Every removal marker is accounted for: a deliberate serial-and removal when a list gained a fourth item, deliberate renames to seededPlanFile, one word moved to the following line with its matching addition present, and comment-prefix repositioning. No unmatched removal markers anywhere. — commit `b0738b21da26bf5378be2da71f831456b7bad928` (2026-08-03T00:21:27Z)
- **reviewer-required-tests** — pass — `go build ./... && go vet ./... && gofmt -l . && go test ./...` — All four required tests re-run by the reviewer at head b0738b2 rather than inherited, plus -count=1 reruns of internal/interview, internal/bootstrap, internal/question and internal/instructions, all ok. All pre-existing interview test files are untouched and pass against the new code; summary_test.go's only edits are six call-site arity changes. — commit `b0738b21da26bf5378be2da71f831456b7bad928` (2026-08-03T00:34:11Z)
- **differential-document-streams** — pass — `identical interview walk compiled against main and b0738b2 in scratch copies outside the repository, 12 fixtures (6 file layouts x init and configure), outputs diffed` — Every difference between the two builds falls inside exactly the two walks where a seed offer legitimately fires. The four non-seeding layouts - both files with conventions, sibling block-only, host's own file present, bare directory - emit byte-identical document streams in both interviews, which is criterion 3's assertion verified directly rather than through the transcripts' bare-directory case. — commit `b0738b21da26bf5378be2da71f831456b7bad928` (2026-08-03T00:34:11Z)
- **anti-forgery-attacks** — pass — `three adversarial AnswerSet probes against Next in a scratch copy: un-offered seed answer, path-traversal answer value, stale yes after sibling deletion` — All three fail closed: the un-offered id fails as not currently applicable, the traversal string fails ValidateAnswer since the question carries FreeText off and accepts only yes or no, and the stale answer fails as unknown once the offer is no longer derivable. No path exists by which an adapter supplies seeded content through the AnswerSet. — commit `b0738b21da26bf5378be2da71f831456b7bad928` (2026-08-03T00:34:11Z)
- **odd-sibling-robustness** — pass — `seed from a CRLF sibling, a no-trailing-newline sibling, a BOM-prefixed sibling, and a sibling with its block above its conventions, in a scratch copy` — Each produces a seeded file whose Inspect status is Current with exactly one managed block and no summary blocker. The CRLF sibling yields a mixed-ending file, matching internal/instructions' documented existing behavior that bytes outside the region are preserved verbatim regardless of line endings. — commit `b0738b21da26bf5378be2da71f831456b7bad928` (2026-08-03T00:34:11Z)
- **branch-scope: nine-files-interview-only** — pass — `git diff --stat main...HEAD` — One commit, nine files, all under internal/interview/ plus internal/bootstrap/bootstrap_test.go. Zero transcript files, zero adapter files, zero doc files. The doc-comment reflows in detect.go, summary.go and configure.go all describe the new behavior; no unrelated refactoring. — commit `b0738b21da26bf5378be2da71f831456b7bad928` (2026-08-03T00:34:11Z)
- **acceptance-criterion-1** — satisfied — The reviewer's differential walk on the init fixture with CLAUDE.md holding conventions plus block and AGENTS.md absent emits exactly one extra questions document carrying one question: id seed.instructions.codex, prompt 'Seed AGENTS.md from CLAUDE.md?' - both files named - with default yes and options yes (recommended) and no. Default is concrete in the wire contract: internal/question/question.go documents that Option.Recommended does not make an option the answer, Question.Default does, and seed.go:94 sets it. For configure, TestSeedOfferedForConfigureNewlyEnabledHost drives NextConfigure on a claude-only committed config newly enabling codex and asserts the question appears, with the newly-enabled gate at configure.go:218-221 and TestSeedNotOfferedForStillEnabledConfigureHost pinning the negative. All passed under -count=1. — commit `b0738b21da26bf5378be2da71f831456b7bad928` (2026-08-03T00:34:12Z)
- **acceptance-criterion-2** — satisfied — On the yes path the differential output's AGENTS.md FileChange carries the fixture's conventions followed by the managed block with exactly one occurrence of the begin marker, where the identical walk on main yields the block alone. On the no path TestSeedDeclinedKeepsBlockOnlyProposal asserts NewContent equals the managed block exactly. Visibility: the FileChange diff is a single hunk with every line plus-prefixed, Summary.Files rides in the summary-kind document that embeds the approval question (interview.go:126-133) so the content is on screen before approval, and seed_test.go:170-174 asserts every line of NewContent appears as an added diff line. — commit `b0738b21da26bf5378be2da71f831456b7bad928` (2026-08-03T00:34:12Z)
- **acceptance-criterion-3** — satisfied — git diff --name-only main...HEAD over internal/interview/testdata prints nothing and all five golden transcript tests pass under -count=1 - but the reviewer noted that alone only covers the bare-directory condition, so it verified the assertion directly: across its twelve differential fixtures, the four non-seeding layouts (both files carrying conventions, sibling block-only, host's own file present, bare directory) produce byte-identical document streams between main and the branch, in both init and configure. Structural corroboration: grep finds exactly one reader of Facts.Instructions (seed.go:57), buildComplete's Detection map is unchanged, runInitReport prints named fields only, and seededPlanFile returns instructions.PlanFile itself when no seeds apply, so the non-seeding path is the same function value as before. The finding that the criterion's evidence clause under-describes where the pin actually lives is recorded, with TestSeedNotOffered covering the other three conditions at the question level. — commit `b0738b21da26bf5378be2da71f831456b7bad928` (2026-08-03T00:34:12Z)
- **acceptance-criterion-4** — satisfied — TestExecuteSeedsNewInstructionFileFromSibling runs the real bootstrap Execute with Deps carrying only Answers, asserts every validation entry passes - the set includes instructions:AGENTS.md, which validate.go:88-93 computes as InspectFile status Current - then reads the file off the orch/bootstrap branch via git show and asserts it opens with CLAUDE.md's conventions and holds exactly one block; passed under -count=1. On forgery the reviewer attacked rather than reasoned: answering the never-offered seed.instructions.claude fails with answer-does-not-match-applicable-question; a path traversal string as the answer fails ValidateAnswer because the question's FreeText is off and the value is not one of yes, no; a stale yes replayed after deleting the sibling fails as an unknown answer. The seeded bytes come only from planSeeded reading the sibling off disk at stage 0's own Detect, so no AnswerSet field can supply content. — commit `b0738b21da26bf5378be2da71f831456b7bad928` (2026-08-03T00:34:12Z)
- **acceptance-criterion-5** — satisfied — The PR body's blast-radius table names all six consumers the criterion requires - init step loop, configure step loop, both bootstrap stage-0 re-derivations, golden transcripts, and the summary-consuming file writer - plus doctor and the adapters, each with a stated reason, and a separate section names the three things that change: buildSummary's and buildConfigureSummary's signatures and Facts gaining Instructions. The reviewer spot-verified three rows rather than accepting the table: write.go:28-36 still writes NewContent verbatim, doctor.go:166-181 has no diff hunk and still fires, and git diff --stat main...HEAD shows zero files under adapters/. — commit `b0738b21da26bf5378be2da71f831456b7bad928` (2026-08-03T00:34:12Z)
- **review-cycle-1** — approve — First-cycle approve at head b0738b2, on observations the reviewer produced itself. Beyond re-running the four required tests and reading the whole non-test diff, it built a differential harness in scratch copies outside the repository: the same interview document-stream walk compiled against main and against the branch, run over twelve fixtures - six file layouts crossed with init and configure - and diffed. Every difference between the two builds falls inside exactly the two walks where a seed offer legitimately fires; the four non-seeding layouts are byte-identical across every emitted document in both interviews, which is criterion 3's actual assertion checked directly rather than through the transcripts' bare-directory case alone. It also attacked the anti-forgery boundary three ways - answering a never-offered seed question, injecting a path traversal string as the answer, and replaying a stale yes after deleting the sibling - and all three fail closed in the answer validator, so no AnswerSet field influences the seeded bytes. Robustness spot-checks passed: CRLF sibling, no-trailing-newline sibling, BOM-prefixed sibling, and a sibling whose block sits above its conventions each seed to StatusCurrent with exactly one block. Eight findings, none blocking: criterion 3's named pin under-covers its own assertion, with the byte-identity confirmed out-of-band rather than by a repo test; a cosmetic doubled blank line in seeded output; a race-only TOCTOU blocker that names the target file when the sibling is the malformed one; a stale seed answer after a mid-interview filesystem change aborting the step loop fail-closed but without saying why, matching the engine's existing stale-answer precedent; the planSeeded overwrite guard being defensive rather than load-bearing given the microsecond window, with its ordering correct regardless; the classification deliberately duplicating doctor's reading because the import direction is unavailable, and being strictly more correct for its own question on a zero-byte file; the robustness checks themselves; and scope consistency with PR #189 in touching no docs. Scope: one commit, nine files, all under internal/interview plus one bootstrap test; zero transcript, adapter, or doc files. Security: no new trust boundary, the one new answer is constrained to yes or no with free text off. CI 6/6 at the reviewed head. Manifest accuracy verified: routed selection matches, all seven verifications stamped at the live head, and the reviewer independently reproduced each one it could. — commit `b0738b21da26bf5378be2da71f831456b7bad928` (2026-08-03T00:34:12Z)
- **required-ci** — passing — scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (windows-latest)=pass — commit `b0738b21da26bf5378be2da71f831456b7bad928` (2026-08-03T00:34:28Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "During orch init, and during an orch configure change that newly enables a host, Orch creates the host's root instruction file (CLAUDE.md for claude, AGENTS.md for codex, mapped in internal/interview/summary.go) containing only the managed block. A repository that keeps its conventions in the sibling host's file gets a new file with no conventions, which is the condition orch doctor reports since PR #189 but nothing prevents. The interviews are the right place to prevent it: detection already probes the repository root, the question engine already batches conditional documents, and the summary step already shows every proposed file as a full diff a human approves before the bootstrap flow writes anything. Add one conditional yes/no question offering to seed the new file from the sibling's conventions. The seeded content is a verbatim copy of the sibling's content outside its own managed block, followed by a fresh managed block; the copy is deliberate scope, an import directive is a host-specific syntax Orch does not author. The interview engine's invariants must hold: the question sequence stays a pure function of detection facts and answers, the golden transcripts run against bare temporary directories and must pass unmodified, and bootstrap's stage-0 anti-forgery re-derivation must accept the same answers it re-derives.",
  "acceptance_criteria": [
    "During orch init, when a host being enabled has no root instruction file and the other host's root instruction file exists carrying content outside the Orch managed block, the interview asks one additional yes-or-no question naming both files, defaulting to yes; the same question appears, under the same conditions, during an orch configure change that newly enables a host.",
    "Answering yes makes the summary's proposed new file consist of the sibling's content outside its own managed block followed by the current Orch managed block, with exactly one managed block in the result; answering no keeps today's block-only proposal. Either way the full proposed content is visible as the summary's file diff before approval.",
    "When the sibling file is absent, when the sibling holds only the managed block, when the host's own file already exists, or when the host is not being newly enabled, the question is not asked and every interview document is byte-identical to today's - pinned by the existing golden transcript tests passing without modification to their recorded documents.",
    "A seeded file passes the existing bootstrap mechanical validation - instructions.Inspect reports the managed block Current - and bootstrap's stage-0 re-derivation from raw answers reproduces the seeded content, so an adapter still cannot forge file content the interview did not derive.",
    "The pull request states, for every consumer of the interview's sequence and summary - the init step loop, the configure step loop, bootstrap Execute's and ExecuteConfigure's stage-0 re-derivation, the golden transcripts, and the summary-consuming file writer - whether the behavior it had before this change still holds, and names each one that changes."
  ],
  "required_tests": [
    "go build ./...",
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "No output. Run in the issue-191 worktree.",
      "commit_oid": "b0738b21da26bf5378be2da71f831456b7bad928",
      "at": "2026-08-03T00:21:27Z"
    },
    {
      "name": "tests",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All packages ok, zero failures. Run in the issue-191 worktree.",
      "commit_oid": "b0738b21da26bf5378be2da71f831456b7bad928",
      "at": "2026-08-03T00:21:27Z"
    },
    {
      "name": "vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "No output. Run in the issue-191 worktree.",
      "commit_oid": "b0738b21da26bf5378be2da71f831456b7bad928",
      "at": "2026-08-03T00:21:27Z"
    },
    {
      "name": "format",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No files listed. Run in the issue-191 worktree.",
      "commit_oid": "b0738b21da26bf5378be2da71f831456b7bad928",
      "at": "2026-08-03T00:21:27Z"
    },
    {
      "name": "new-tests",
      "command": "go test ./internal/interview/ -run 'TestSeed|TestDetectClassifies' -v; go test ./internal/bootstrap/ -run TestExecuteSeeds -v",
      "result": "pass",
      "detail": "Seven new interview tests plus three subtests covering the seed question's conditions and the seeded summary content, all PASS, plus TestExecuteSeedsNewInstructionFileFromSibling pinning the bootstrap stage-0 re-derivation end to end. TestSeedNeverOverwritesAnExistingFile pins that seeding falls back to the plain proposal when the target file exists after all.",
      "commit_oid": "b0738b21da26bf5378be2da71f831456b7bad928",
      "at": "2026-08-03T00:21:27Z"
    },
    {
      "name": "golden-transcripts-untouched",
      "command": "git status -- internal/interview/testdata",
      "result": "pass",
      "detail": "Empty output: zero recorded transcript documents were modified. The transcripts run against bare temporary directories where no instruction files exist, so the conditional question never fires there - criterion 3's pin, satisfied without regenerating anything.",
      "commit_oid": "b0738b21da26bf5378be2da71f831456b7bad928",
      "at": "2026-08-03T00:21:27Z"
    },
    {
      "name": "branch-scope: prose-reflow-accounted",
      "command": "git diff --word-diff --ignore-all-space",
      "result": "pass",
      "detail": "Three files carried reflowed doc comments (detect.go, summary.go, configure.go). Every removal marker is accounted for: a deliberate serial-and removal when a list gained a fourth item, deliberate renames to seededPlanFile, one word moved to the following line with its matching addition present, and comment-prefix repositioning. No unmatched removal markers anywhere.",
      "commit_oid": "b0738b21da26bf5378be2da71f831456b7bad928",
      "at": "2026-08-03T00:21:27Z"
    },
    {
      "name": "reviewer-required-tests",
      "command": "go build ./... \u0026\u0026 go vet ./... \u0026\u0026 gofmt -l . \u0026\u0026 go test ./...",
      "result": "pass",
      "detail": "All four required tests re-run by the reviewer at head b0738b2 rather than inherited, plus -count=1 reruns of internal/interview, internal/bootstrap, internal/question and internal/instructions, all ok. All pre-existing interview test files are untouched and pass against the new code; summary_test.go's only edits are six call-site arity changes.",
      "commit_oid": "b0738b21da26bf5378be2da71f831456b7bad928",
      "at": "2026-08-03T00:34:11Z"
    },
    {
      "name": "differential-document-streams",
      "command": "identical interview walk compiled against main and b0738b2 in scratch copies outside the repository, 12 fixtures (6 file layouts x init and configure), outputs diffed",
      "result": "pass",
      "detail": "Every difference between the two builds falls inside exactly the two walks where a seed offer legitimately fires. The four non-seeding layouts - both files with conventions, sibling block-only, host's own file present, bare directory - emit byte-identical document streams in both interviews, which is criterion 3's assertion verified directly rather than through the transcripts' bare-directory case.",
      "commit_oid": "b0738b21da26bf5378be2da71f831456b7bad928",
      "at": "2026-08-03T00:34:11Z"
    },
    {
      "name": "anti-forgery-attacks",
      "command": "three adversarial AnswerSet probes against Next in a scratch copy: un-offered seed answer, path-traversal answer value, stale yes after sibling deletion",
      "result": "pass",
      "detail": "All three fail closed: the un-offered id fails as not currently applicable, the traversal string fails ValidateAnswer since the question carries FreeText off and accepts only yes or no, and the stale answer fails as unknown once the offer is no longer derivable. No path exists by which an adapter supplies seeded content through the AnswerSet.",
      "commit_oid": "b0738b21da26bf5378be2da71f831456b7bad928",
      "at": "2026-08-03T00:34:11Z"
    },
    {
      "name": "odd-sibling-robustness",
      "command": "seed from a CRLF sibling, a no-trailing-newline sibling, a BOM-prefixed sibling, and a sibling with its block above its conventions, in a scratch copy",
      "result": "pass",
      "detail": "Each produces a seeded file whose Inspect status is Current with exactly one managed block and no summary blocker. The CRLF sibling yields a mixed-ending file, matching internal/instructions' documented existing behavior that bytes outside the region are preserved verbatim regardless of line endings.",
      "commit_oid": "b0738b21da26bf5378be2da71f831456b7bad928",
      "at": "2026-08-03T00:34:11Z"
    },
    {
      "name": "branch-scope: nine-files-interview-only",
      "command": "git diff --stat main...HEAD",
      "result": "pass",
      "detail": "One commit, nine files, all under internal/interview/ plus internal/bootstrap/bootstrap_test.go. Zero transcript files, zero adapter files, zero doc files. The doc-comment reflows in detect.go, summary.go and configure.go all describe the new behavior; no unrelated refactoring.",
      "commit_oid": "b0738b21da26bf5378be2da71f831456b7bad928",
      "at": "2026-08-03T00:34:11Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "The reviewer's differential walk on the init fixture with CLAUDE.md holding conventions plus block and AGENTS.md absent emits exactly one extra questions document carrying one question: id seed.instructions.codex, prompt 'Seed AGENTS.md from CLAUDE.md?' - both files named - with default yes and options yes (recommended) and no. Default is concrete in the wire contract: internal/question/question.go documents that Option.Recommended does not make an option the answer, Question.Default does, and seed.go:94 sets it. For configure, TestSeedOfferedForConfigureNewlyEnabledHost drives NextConfigure on a claude-only committed config newly enabling codex and asserts the question appears, with the newly-enabled gate at configure.go:218-221 and TestSeedNotOfferedForStillEnabledConfigureHost pinning the negative. All passed under -count=1.",
      "commit_oid": "b0738b21da26bf5378be2da71f831456b7bad928",
      "at": "2026-08-03T00:34:12Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "On the yes path the differential output's AGENTS.md FileChange carries the fixture's conventions followed by the managed block with exactly one occurrence of the begin marker, where the identical walk on main yields the block alone. On the no path TestSeedDeclinedKeepsBlockOnlyProposal asserts NewContent equals the managed block exactly. Visibility: the FileChange diff is a single hunk with every line plus-prefixed, Summary.Files rides in the summary-kind document that embeds the approval question (interview.go:126-133) so the content is on screen before approval, and seed_test.go:170-174 asserts every line of NewContent appears as an added diff line.",
      "commit_oid": "b0738b21da26bf5378be2da71f831456b7bad928",
      "at": "2026-08-03T00:34:12Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "git diff --name-only main...HEAD over internal/interview/testdata prints nothing and all five golden transcript tests pass under -count=1 - but the reviewer noted that alone only covers the bare-directory condition, so it verified the assertion directly: across its twelve differential fixtures, the four non-seeding layouts (both files carrying conventions, sibling block-only, host's own file present, bare directory) produce byte-identical document streams between main and the branch, in both init and configure. Structural corroboration: grep finds exactly one reader of Facts.Instructions (seed.go:57), buildComplete's Detection map is unchanged, runInitReport prints named fields only, and seededPlanFile returns instructions.PlanFile itself when no seeds apply, so the non-seeding path is the same function value as before. The finding that the criterion's evidence clause under-describes where the pin actually lives is recorded, with TestSeedNotOffered covering the other three conditions at the question level.",
      "commit_oid": "b0738b21da26bf5378be2da71f831456b7bad928",
      "at": "2026-08-03T00:34:12Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "TestExecuteSeedsNewInstructionFileFromSibling runs the real bootstrap Execute with Deps carrying only Answers, asserts every validation entry passes - the set includes instructions:AGENTS.md, which validate.go:88-93 computes as InspectFile status Current - then reads the file off the orch/bootstrap branch via git show and asserts it opens with CLAUDE.md's conventions and holds exactly one block; passed under -count=1. On forgery the reviewer attacked rather than reasoned: answering the never-offered seed.instructions.claude fails with answer-does-not-match-applicable-question; a path traversal string as the answer fails ValidateAnswer because the question's FreeText is off and the value is not one of yes, no; a stale yes replayed after deleting the sibling fails as an unknown answer. The seeded bytes come only from planSeeded reading the sibling off disk at stage 0's own Detect, so no AnswerSet field can supply content.",
      "commit_oid": "b0738b21da26bf5378be2da71f831456b7bad928",
      "at": "2026-08-03T00:34:12Z"
    },
    {
      "name": "acceptance-criterion-5",
      "result": "satisfied",
      "detail": "The PR body's blast-radius table names all six consumers the criterion requires - init step loop, configure step loop, both bootstrap stage-0 re-derivations, golden transcripts, and the summary-consuming file writer - plus doctor and the adapters, each with a stated reason, and a separate section names the three things that change: buildSummary's and buildConfigureSummary's signatures and Facts gaining Instructions. The reviewer spot-verified three rows rather than accepting the table: write.go:28-36 still writes NewContent verbatim, doctor.go:166-181 has no diff hunk and still fires, and git diff --stat main...HEAD shows zero files under adapters/.",
      "commit_oid": "b0738b21da26bf5378be2da71f831456b7bad928",
      "at": "2026-08-03T00:34:12Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "First-cycle approve at head b0738b2, on observations the reviewer produced itself. Beyond re-running the four required tests and reading the whole non-test diff, it built a differential harness in scratch copies outside the repository: the same interview document-stream walk compiled against main and against the branch, run over twelve fixtures - six file layouts crossed with init and configure - and diffed. Every difference between the two builds falls inside exactly the two walks where a seed offer legitimately fires; the four non-seeding layouts are byte-identical across every emitted document in both interviews, which is criterion 3's actual assertion checked directly rather than through the transcripts' bare-directory case alone. It also attacked the anti-forgery boundary three ways - answering a never-offered seed question, injecting a path traversal string as the answer, and replaying a stale yes after deleting the sibling - and all three fail closed in the answer validator, so no AnswerSet field influences the seeded bytes. Robustness spot-checks passed: CRLF sibling, no-trailing-newline sibling, BOM-prefixed sibling, and a sibling whose block sits above its conventions each seed to StatusCurrent with exactly one block. Eight findings, none blocking: criterion 3's named pin under-covers its own assertion, with the byte-identity confirmed out-of-band rather than by a repo test; a cosmetic doubled blank line in seeded output; a race-only TOCTOU blocker that names the target file when the sibling is the malformed one; a stale seed answer after a mid-interview filesystem change aborting the step loop fail-closed but without saying why, matching the engine's existing stale-answer precedent; the planSeeded overwrite guard being defensive rather than load-bearing given the microsecond window, with its ordering correct regardless; the classification deliberately duplicating doctor's reading because the import direction is unavailable, and being strictly more correct for its own question on a zero-byte file; the robustness checks themselves; and scope consistency with PR #189 in touching no docs. Scope: one commit, nine files, all under internal/interview plus one bootstrap test; zero transcript, adapter, or doc files. Security: no new trust boundary, the one new answer is constrained to yes or no with free text off. CI 6/6 at the reviewed head. Manifest accuracy verified: routed selection matches, all seven verifications stamped at the live head, and the reviewer independently reproduced each one it could.",
      "commit_oid": "b0738b21da26bf5378be2da71f831456b7bad928",
      "at": "2026-08-03T00:34:12Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (windows-latest)=pass",
      "commit_oid": "b0738b21da26bf5378be2da71f831456b7bad928",
      "at": "2026-08-03T00:34:28Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->
