### PR TITLE
Bring README.md current with the four merges since v0.6.0 and reference v0.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/License-MIT-2E7D32?style=flat&logo=opensourceinitiative&logoColor=white" alt="License: MIT"/>
   <img src="https://img.shields.io/badge/Go-1.26%2B-00ADD8?style=flat&logo=go&logoColor=white" alt="Go 1.26+"/>
-  <img src="https://img.shields.io/badge/Release-v0.6.0-24292F?style=flat&logo=github&logoColor=white" alt="Release: v0.6.0"/>
+  <img src="https://img.shields.io/badge/Release-v0.6.1-24292F?style=flat&logo=github&logoColor=white" alt="Release: v0.6.1"/>
   <br/>
   <img src="https://img.shields.io/badge/Platform-Linux%20%C2%B7%20macOS%20%C2%B7%20Windows-607D8B?style=flat" alt="Platform: Linux, macOS, Windows"/>
   <img src="https://img.shields.io/badge/Hosts-Claude%20Code%20%C2%B7%20Codex%20CLI-6E56CF?style=flat" alt="Hosts: Claude Code and Codex CLI"/>
@@ -70,7 +70,7 @@ The full product definition lives in [ORCH-PRD.md](ORCH-PRD.md).
 
 ## Status
 
-Early software. What can be stated as fact: 15 tagged releases, v0.1.0 through v0.6.0, and every pull request merged since PR #40 carries an Orch audit record in its body — apart from the configuration deliveries, which `orch configure` writes in its own body format. Since PR #40, this repository has been built through the pipeline described above: a plan gate, an isolated worktree per issue, a review dispatched separately from the work, CI, and a merge that fails closed unless it carries an approval pinned to the commit `merge-report` recorded.
+Early software. What can be stated as fact: 16 tagged releases, v0.1.0 through v0.6.1, and every pull request merged since PR #40 carries an Orch audit record in its body — apart from the configuration deliveries, which `orch configure` writes in its own body format. Since PR #40, this repository has been built through the pipeline described above: a plan gate, an isolated worktree per issue, a review dispatched separately from the work, CI, and a merge that fails closed unless it carries an approval pinned to the commit `merge-report` recorded.
 
 All of that evidence comes from one repository: this one.
 
@@ -101,7 +101,7 @@ on this machine. Work in a scratch directory, not in one of my projects.
 
 2. Confirm that `orch` resolves on PATH and that `orch status` prints a
    release version on its first line — a line beginning `orch:` and giving
-   a release tag such as v0.6.0. Run it from anywhere: outside an
+   a release tag such as v0.6.1. Run it from anywhere: outside an
    initialized repository it prints that version line first and then exits
    non-zero saying the repository is not initialized, which is expected
    here. On Windows the installer adds its install directory to my user
@@ -189,7 +189,7 @@ your OS and architecture, verify its SHA-256 against the release's
 `SHA256SUMS` **before** installing, and fail closed on any mismatch.
 
 Linux / macOS — installs to `~/.local/bin` (override with
-`ORCH_INSTALL_DIR`); pin a version with `ORCH_VERSION=v0.6.0`:
+`ORCH_INSTALL_DIR`); pin a version with `ORCH_VERSION=v0.6.1`:
 
 ```sh
 curl -fsSLO https://raw.githubusercontent.com/kninetimmy/orch/main/install.sh
@@ -199,7 +199,7 @@ sh install.sh
 
 Windows (PowerShell) — installs to `%LOCALAPPDATA%\Programs\orch` and
 appends that directory to your user `PATH`; skip the `PATH` change with
-`-NoPathUpdate`, pin a version with `-Version v0.6.0`:
+`-NoPathUpdate`, pin a version with `-Version v0.6.1`:
 
 ```powershell
 iwr https://raw.githubusercontent.com/kninetimmy/orch/main/install.ps1 -OutFile install.ps1
@@ -550,9 +550,72 @@ continue, or `orch abort` to end it.
 <details>
 <summary>Defects already corrected, newest first</summary>
 
-Everything here is merged on `main` and shipped in v0.6.0, the latest
+Everything here is merged on `main` and shipped in v0.6.1, the latest
 tagged release.
 
+- `orch init` and `orch configure` now offer to seed a root
+  instruction file this session creates — one yes/no question naming
+  both files, defaulting to yes, asked when a host being newly enabled
+  has no file of its own while the other host's carries content
+  outside its managed block — and answering yes proposes that
+  sibling's content copied verbatim above a fresh managed block, with
+  the whole proposed file shown as the summary's diff before anything
+  is written; answering no proposes the block-only file as before.
+  Before, the created file held the Orch managed block and nothing
+  else, so that host's agents ran with none of the repository's
+  conventions —
+  [#192](https://github.com/kninetimmy/orch/pull/192)
+- An issue declaring at least one risk domain now carries one further
+  acceptance criterion, contributed by the engine rather than by the
+  plan document and always last: it asks for every element of the
+  structure the change touches to be named with a verdict on whether
+  the behavior it had before still holds, for a removed behavior to be
+  recorded as a before-and-after in the document that stated the old
+  behavior instead of that statement being deleted, and for a
+  restriction attributed to one named symbol to be established as
+  holding for that symbol alone or for every symbol of its kind. The
+  gate document, the run state, the audit record and the created issue
+  body all carry it, so the human approves it and the existing
+  one-judgment-per-criterion rule holds the reviewer to it like any
+  other criterion; both hosts' Delivery skills and every shipped
+  reviewer definition — the standard reviewer and the safe review
+  downgrade alike — now quote it and say what settles it: an
+  enumeration in the pull request body of each element touched with
+  its before-and-after, not a passing test suite. Before, a plan
+  issue's criteria were exactly what the plan document listed, so a
+  preservation clause naming one thing to protect left everything
+  adjacent to it outside the standard the executor and the reviewer
+  were measured against —
+  [#190](https://github.com/kninetimmy/orch/pull/190)
+- `orch doctor` now reports, once per enabled host, a root instruction
+  file — `CLAUDE.md` for claude, `AGENTS.md` for codex — that holds
+  the Orch managed block and nothing else, saying that host's agents
+  see no project conventions and that they belong outside the block.
+  It is a note rather than a failure: Orch cannot author a
+  repository's conventions, and a repository with none to state is not
+  broken. Before, a repository that kept its conventions in one host's
+  file and let Orch create the other's got a file holding the managed
+  block alone, with nothing anywhere reporting it —
+  [#189](https://github.com/kninetimmy/orch/pull/189)
+- `orch doctor` gained `claude agent definitions`, the Claude
+  counterpart of the `codex agent files` check: it resolves the
+  installed plugin root from the install path `claude plugin list
+  --json` reports — the same listing the adapter check just ran, not a
+  second one — reads the model each installed agent definition pins in
+  its frontmatter, and fails naming every role whose
+  `hosts.claude.roles` model differs together with both models. It
+  compares the installed copy rather than this repository's, because a
+  plugin behind head can still carry an older pin, and it fails closed:
+  no install path, an absent agents directory, an unreadable
+  definition and a definition pinning no model are each a failure,
+  never a pass. It repairs nothing — there is no Claude equivalent of
+  `orch render-agents`, so you update the installed plugin or change
+  the configured model. Before, nothing in the binary compared the
+  two on Claude Code, and a role whose configured model no longer
+  matched its installed definition went on being dispatched with only
+  the Architect's skill instruction between the routed selection and a
+  mismatched spawn —
+  [#186](https://github.com/kninetimmy/orch/pull/186)
 - `orch doctor` now checks each configured host's installed Orch
   adapter and fails when it is absent, listed more than once, disabled,
   reporting no version at all, at a different version from the one this


### PR DESCRIPTION
Delivers issue #193: Bring README.md current with the four merges since v0.6.0 and reference v0.6.1

Closes #193

**Plan digest:** `sha256:4944e6da201f18db5bf35c932e045033f70297a57313a0fd6559ff47d612b564`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** README.md was last brought current by PR #186, and its Fixed section stops at PR #167. Add Fixed-section entries for the four merges since the section was last updated: PR #186 (orch doctor's new 'claude agent definitions' check comparing each configured Claude role's model against the installed agent definition's frontmatter pin), PR #189 (a doctor advisory when an enabled host's root instruction file holds only the Orch managed block and nothing else), PR #190 (the engine now appends a blast-radius acceptance criterion to every plan issue declaring a risk domain, and a review must judge it like any other criterion), and PR #192 (init and configure now offer to seed a newly created host instruction file from the sibling file's conventions, shown as a full diff before approval). Then move every release reference in README.md from v0.6.0 to v0.6.1, since the release this run produces will be tagged v0.6.1 on the bump commit that follows this issue. Read each PR's actual squash commit (f65b643, 1373c9d, 3fcf9b9, c6d74fb) before writing its entry; every claim must be supported by the diff it describes.

**Acceptance criteria:**
- README.md's Fixed section holds one entry for each of PRs #186, #189, #190, and #192, newest first and above the existing entries, each in the section's established form: what now happens, what happened before, and a link to the PR.
- No occurrence of the literal v0.6.0 remains anywhere in README.md: the release badge, the Status section, the install version-pin examples, the agent install prompt's version example, and the Fixed section's preamble all name v0.6.1, and the Status section counts 16 tagged releases, v0.1.0 through v0.6.1.
- Every factual claim added or changed is supported by the commit or tree it describes; no entry attributes behavior to a PR whose diff did not deliver it.

**Required tests:**
- `go build ./...`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.

**Escalations:** _none_

**Verification:**
- **go-build** — pass — `go build ./...` — Required test; run in the issue worktree at 4884b97, no output. — commit `4884b9745ec24aca173c985dd1be6d2052c0fc27` (2026-08-03T00:49:36Z)
- **no-v0.6.0-remains** — pass — `git grep -n "v0.6.0" -- README.md` — No matches (exit 1). v0.6.1 present at the six release touch-points: badge (line 8), Status (73), agent install prompt (104), ORCH_VERSION pin (192), -Version pin (202), Fixed preamble (553); Status counts 16 tagged releases, verified against git tag (15 today). — commit `4884b9745ec24aca173c985dd1be6d2052c0fc27` (2026-08-03T00:49:36Z)
- **entry-source-check** — pass — `git show f65b643 / 1373c9d / 3fcf9b9 / c6d74fb` — Each of the four new Fixed entries written only from its squash commit's diff; #190's judged-like-any-other claim additionally verified live at internal/run/review.go:186 (checkJudgments over the criteria activate populates). #186's own README change was confirmed to sit in Known issues, so no duplication. — commit `4884b9745ec24aca173c985dd1be6d2052c0fc27` (2026-08-03T00:49:36Z)
- **branch-scope:readme-only** — pass — `git diff --stat main...HEAD; git diff --word-diff --ignore-all-space -- README.md` — One commit, one file (README.md). Word-diff shows the only removals are the five v0.6.0 token swaps and 15-&gt;16; the four Fixed entries are pure additions. — commit `4884b9745ec24aca173c985dd1be6d2052c0fc27` (2026-08-03T00:49:36Z)
- **acceptance-criterion-1** — satisfied — All four entries present, newest first and above the existing #167 entry (entry starts at lines 556/568/590/600, links on their own lines at 567/589/599/618), each in the established shape: a present-tense 'now' clause, a 'Before, ...' clause, and the PR link. — commit `4884b9745ec24aca173c985dd1be6d2052c0fc27` (2026-08-03T00:56:51Z)
- **acceptance-criterion-2** — satisfied — git grep for v0.6.0 (and bare 0.6.0) at the PR head exits 1 with no matches; the six v0.6.1 occurrences cover exactly the named touch-points (badge 8, Status 73, install-prompt example 104, ORCH_VERSION pin 192, -Version pin 202, Fixed preamble 553); Status reads '16 tagged releases, v0.1.0 through v0.6.1', arithmetically right with 15 tags today plus this run's v0.6.1. — commit `4884b9745ec24aca173c985dd1be6d2052c0fc27` (2026-08-03T00:56:51Z)
- **acceptance-criterion-3** — satisfied — Every claim in the four entries traces to its named commit, verified against code at head (doctor.go:137/151, internal/agents/claude.go, internal/run/derive.go, review.go:186, internal/interview/seed.go); no entry attributes behavior a diff did not deliver. The two low-severity precision points are marginal imprecision on claims the diffs support, not contradicted claims. — commit `4884b9745ec24aca173c985dd1be6d2052c0fc27` (2026-08-03T00:56:51Z)
- **review-cycle-1** — approve — Approved at first review. The reviewer inspected the PR head out of the object store, re-ran go build ./... against an extracted copy of the head tree (pass), and confirmed all six CI checks green. The diff is one commit touching README.md only. Each of the four new Fixed entries was traced claim-by-claim to code at its named squash commit rather than commit prose: doctor.go:137/151 for the #186 check name and single plugin listing, the #189 note's Fprintf path that can never fail doctor, run.BlastRadiusCriterion and its four consumers plus review.go:186's checkJudgments for #190, and interview/seed.go's offer/default/whole-file-diff mechanics for #192. The v0.6.1 sweep is complete (git grep for v0.6.0 exits 1; six v0.6.1 touch-points at lines 8/73/104/192/202/553) and 16 tagged releases is arithmetically right given 15 tags today plus the v0.6.1 this run cuts. Five findings, all low-severity or informational, none blocking: the #186 entry's 'every role' reads at the margin as six roles where the check compares the five that ship agent definitions; 'each installed agent definition' describes the five fixed role stems rather than a directory enumeration; the entry restates a Known-issues paragraph #186 itself wrote (no contradiction); the badge/count/preamble describe v0.6.1 before its tag exists, exactly as the approved objective directs; and 'v0.1.0 through v0.6.1' spans a non-contiguous tag series (pre-existing phrasing, only the number changed). — commit `4884b9745ec24aca173c985dd1be6d2052c0fc27` (2026-08-03T00:56:51Z)
- **required-ci** — passing — scripts (windows-latest)=pass, test (ubuntu-latest)=pass, lint=pass, test (windows-latest)=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass — commit `4884b9745ec24aca173c985dd1be6d2052c0fc27` (2026-08-03T00:57:02Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "README.md was last brought current by PR #186, and its Fixed section stops at PR #167. Add Fixed-section entries for the four merges since the section was last updated: PR #186 (orch doctor's new 'claude agent definitions' check comparing each configured Claude role's model against the installed agent definition's frontmatter pin), PR #189 (a doctor advisory when an enabled host's root instruction file holds only the Orch managed block and nothing else), PR #190 (the engine now appends a blast-radius acceptance criterion to every plan issue declaring a risk domain, and a review must judge it like any other criterion), and PR #192 (init and configure now offer to seed a newly created host instruction file from the sibling file's conventions, shown as a full diff before approval). Then move every release reference in README.md from v0.6.0 to v0.6.1, since the release this run produces will be tagged v0.6.1 on the bump commit that follows this issue. Read each PR's actual squash commit (f65b643, 1373c9d, 3fcf9b9, c6d74fb) before writing its entry; every claim must be supported by the diff it describes.",
  "acceptance_criteria": [
    "README.md's Fixed section holds one entry for each of PRs #186, #189, #190, and #192, newest first and above the existing entries, each in the section's established form: what now happens, what happened before, and a link to the PR.",
    "No occurrence of the literal v0.6.0 remains anywhere in README.md: the release badge, the Status section, the install version-pin examples, the agent install prompt's version example, and the Fixed section's preamble all name v0.6.1, and the Status section counts 16 tagged releases, v0.1.0 through v0.6.1.",
    "Every factual claim added or changed is supported by the commit or tree it describes; no entry attributes behavior to a PR whose diff did not deliver it."
  ],
  "required_tests": [
    "go build ./..."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "Required test; run in the issue worktree at 4884b97, no output.",
      "commit_oid": "4884b9745ec24aca173c985dd1be6d2052c0fc27",
      "at": "2026-08-03T00:49:36Z"
    },
    {
      "name": "no-v0.6.0-remains",
      "command": "git grep -n \"v0.6.0\" -- README.md",
      "result": "pass",
      "detail": "No matches (exit 1). v0.6.1 present at the six release touch-points: badge (line 8), Status (73), agent install prompt (104), ORCH_VERSION pin (192), -Version pin (202), Fixed preamble (553); Status counts 16 tagged releases, verified against git tag (15 today).",
      "commit_oid": "4884b9745ec24aca173c985dd1be6d2052c0fc27",
      "at": "2026-08-03T00:49:36Z"
    },
    {
      "name": "entry-source-check",
      "command": "git show f65b643 / 1373c9d / 3fcf9b9 / c6d74fb",
      "result": "pass",
      "detail": "Each of the four new Fixed entries written only from its squash commit's diff; #190's judged-like-any-other claim additionally verified live at internal/run/review.go:186 (checkJudgments over the criteria activate populates). #186's own README change was confirmed to sit in Known issues, so no duplication.",
      "commit_oid": "4884b9745ec24aca173c985dd1be6d2052c0fc27",
      "at": "2026-08-03T00:49:36Z"
    },
    {
      "name": "branch-scope:readme-only",
      "command": "git diff --stat main...HEAD; git diff --word-diff --ignore-all-space -- README.md",
      "result": "pass",
      "detail": "One commit, one file (README.md). Word-diff shows the only removals are the five v0.6.0 token swaps and 15-\u003e16; the four Fixed entries are pure additions.",
      "commit_oid": "4884b9745ec24aca173c985dd1be6d2052c0fc27",
      "at": "2026-08-03T00:49:36Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "All four entries present, newest first and above the existing #167 entry (entry starts at lines 556/568/590/600, links on their own lines at 567/589/599/618), each in the established shape: a present-tense 'now' clause, a 'Before, ...' clause, and the PR link.",
      "commit_oid": "4884b9745ec24aca173c985dd1be6d2052c0fc27",
      "at": "2026-08-03T00:56:51Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "git grep for v0.6.0 (and bare 0.6.0) at the PR head exits 1 with no matches; the six v0.6.1 occurrences cover exactly the named touch-points (badge 8, Status 73, install-prompt example 104, ORCH_VERSION pin 192, -Version pin 202, Fixed preamble 553); Status reads '16 tagged releases, v0.1.0 through v0.6.1', arithmetically right with 15 tags today plus this run's v0.6.1.",
      "commit_oid": "4884b9745ec24aca173c985dd1be6d2052c0fc27",
      "at": "2026-08-03T00:56:51Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "Every claim in the four entries traces to its named commit, verified against code at head (doctor.go:137/151, internal/agents/claude.go, internal/run/derive.go, review.go:186, internal/interview/seed.go); no entry attributes behavior a diff did not deliver. The two low-severity precision points are marginal imprecision on claims the diffs support, not contradicted claims.",
      "commit_oid": "4884b9745ec24aca173c985dd1be6d2052c0fc27",
      "at": "2026-08-03T00:56:51Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approved at first review. The reviewer inspected the PR head out of the object store, re-ran go build ./... against an extracted copy of the head tree (pass), and confirmed all six CI checks green. The diff is one commit touching README.md only. Each of the four new Fixed entries was traced claim-by-claim to code at its named squash commit rather than commit prose: doctor.go:137/151 for the #186 check name and single plugin listing, the #189 note's Fprintf path that can never fail doctor, run.BlastRadiusCriterion and its four consumers plus review.go:186's checkJudgments for #190, and interview/seed.go's offer/default/whole-file-diff mechanics for #192. The v0.6.1 sweep is complete (git grep for v0.6.0 exits 1; six v0.6.1 touch-points at lines 8/73/104/192/202/553) and 16 tagged releases is arithmetically right given 15 tags today plus the v0.6.1 this run cuts. Five findings, all low-severity or informational, none blocking: the #186 entry's 'every role' reads at the margin as six roles where the check compares the five that ship agent definitions; 'each installed agent definition' describes the five fixed role stems rather than a directory enumeration; the entry restates a Known-issues paragraph #186 itself wrote (no contradiction); the badge/count/preamble describe v0.6.1 before its tag exists, exactly as the approved objective directs; and 'v0.1.0 through v0.6.1' spans a non-contiguous tag series (pre-existing phrasing, only the number changed).",
      "commit_oid": "4884b9745ec24aca173c985dd1be6d2052c0fc27",
      "at": "2026-08-03T00:56:51Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "scripts (windows-latest)=pass, test (ubuntu-latest)=pass, lint=pass, test (windows-latest)=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "4884b9745ec24aca173c985dd1be6d2052c0fc27",
      "at": "2026-08-03T00:57:02Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->