### PR TITLE
Bump the adapter and marketplace version to 0.6.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "kninetimmy" },
   "metadata": {
     "description": "Host adapters for the Orch development orchestrator",
-    "version": "0.6.0"
+    "version": "0.6.1"
   },
   "plugins": [
     {

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Claude Code host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -78,8 +78,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.6.0" {
-		t.Errorf("version = %q, want 0.6.0", m.Version)
+	if m.Version != "0.6.1" {
+		t.Errorf("version = %q, want 0.6.1", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Codex CLI host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -79,8 +79,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.6.0" {
-		t.Errorf("version = %q, want 0.6.0", m.Version)
+	if m.Version != "0.6.1" {
+		t.Errorf("version = %q, want 0.6.1", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")


### PR DESCRIPTION
Delivers issue #194: Bump the adapter and marketplace version to 0.6.1

Closes #194

**Plan digest:** `sha256:4944e6da201f18db5bf35c932e045033f70297a57313a0fd6559ff47d612b564`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** PR #190 changed adapter content (both hosts' reviewer agent definitions and orch-delivery skills), so this release ships plugin content and the recorded release discipline applies: the version bump must be the last content-bearing commit before the tag. Replace the version literal 0.6.0 with 0.6.1 at every tracked site that carries it as a version identity: adapters/claude/.claude-plugin/plugin.json, adapters/codex/.codex-plugin/plugin.json, .claude-plugin/marketplace.json, and the hardcoded literals in adapters/claude/plugin_test.go and adapters/codex/plugin_test.go. This issue depends on the README issue so that it is mechanically the final commit of the release.

**Acceptance criteria:**
- Both adapter plugin manifests, the marketplace manifest, and both adapter plugin tests name version 0.6.1, and a repository-wide search over tracked files finds no remaining occurrence of the literal 0.6.0.

**Required tests:**
- `go test ./...`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `medium` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — Required test; all 22 packages ok in the issue worktree at 2ae21a3, including adapters/claude, adapters/codex, and the root marketplace test — the suite cross-pins the manifests against the test literals, so a partial bump would have failed it. — commit `2ae21a3e9481a443841313905962ffa98d29963d` (2026-08-03T01:01:12Z)
- **no-0.6.0-remains** — pass — `git grep -n "0\.6\.0"` — No output, exit 1. Counterpart check: git grep for 0.6.1 over .claude-plugin and adapters returns exactly 7 matches, one per expected site (three manifests, two comparison literals, two t.Errorf want-strings). — commit `2ae21a3e9481a443841313905962ffa98d29963d` (2026-08-03T01:01:12Z)
- **gofmt-vet** — pass — `gofmt -l . ; go vet ./...` — No unformatted files; vet clean. — commit `2ae21a3e9481a443841313905962ffa98d29963d` (2026-08-03T01:01:12Z)
- **branch-scope:version-bump-only** — pass — `git diff --stat HEAD~1 HEAD; git diff --word-diff --ignore-all-space HEAD~1 HEAD` — One commit directly on the merged README commit, 5 files, 7 insertions / 7 deletions, every removal a 0.6.0 version literal — mechanically the final content-bearing commit before the tag. — commit `2ae21a3e9481a443841313905962ffa98d29963d` (2026-08-03T01:01:12Z)
- **acceptance-criterion-1** — satisfied — All five named sites read 0.6.1 at the head OID's tree (both plugin.json line 4, marketplace.json line 6, both plugin_test.go comparison and want-string literals), and git grep -nF 0.6.0 over the head tree prints nothing and exits 1 — a tree-scoped grep covering exactly the tracked files. — commit `2ae21a3e9481a443841313905962ffa98d29963d` (2026-08-03T01:06:05Z)
- **review-cycle-1** — approve — Approved at first review. The reviewer inspected the head from the object store and re-ran go test ./... on a git archive of the head tree extracted outside the repository: pass (23 ok, 3 no-test-files), gofmt and vet clean, all six CI checks green. The diff is exactly the version-literal swap: 5 files, 7 insertions / 7 deletions, every hunk 0.6.0 -&gt; 0.6.1, nothing else. git grep -F 0.6.0 at the head exits 1 with no output; the 7 new 0.6.1 sites plus README's 6 pre-existing references are the only occurrences. The reviewer independently confirmed no other version-identity site exists: doctor reads the expected adapter version from the embedded manifest at runtime, and the binary version is injected by release.yml's ldflags, so neither needs bumping. Release-discipline ordering holds: 2ae21a3 parents directly onto origin/main's head 9a3fab2 with no other open PR or issue, so the bump is mechanically the final content-bearing commit before the v0.6.1 tag. The tests are load-bearing: the marketplace test pins both adapter manifests against metadata.version and each plugin test pins its manifest literal, so any partial bump fails the suite. Two low-severity findings, neither blocking: the audit record's go-test detail says 22 packages where the true count is 23 ok of 26, and the criterion's repository-wide grep is broader than strict version identity (which does not bite — no historical 0.6.0 mention exists). — commit `2ae21a3e9481a443841313905962ffa98d29963d` (2026-08-03T01:06:05Z)
- **required-ci** — passing — lint=pass, test (windows-latest)=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass — commit `2ae21a3e9481a443841313905962ffa98d29963d` (2026-08-03T01:06:09Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "PR #190 changed adapter content (both hosts' reviewer agent definitions and orch-delivery skills), so this release ships plugin content and the recorded release discipline applies: the version bump must be the last content-bearing commit before the tag. Replace the version literal 0.6.0 with 0.6.1 at every tracked site that carries it as a version identity: adapters/claude/.claude-plugin/plugin.json, adapters/codex/.codex-plugin/plugin.json, .claude-plugin/marketplace.json, and the hardcoded literals in adapters/claude/plugin_test.go and adapters/codex/plugin_test.go. This issue depends on the README issue so that it is mechanically the final commit of the release.",
  "acceptance_criteria": [
    "Both adapter plugin manifests, the marketplace manifest, and both adapter plugin tests name version 0.6.1, and a repository-wide search over tracked files finds no remaining occurrence of the literal 0.6.0."
  ],
  "required_tests": [
    "go test ./..."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Required test; all 22 packages ok in the issue worktree at 2ae21a3, including adapters/claude, adapters/codex, and the root marketplace test — the suite cross-pins the manifests against the test literals, so a partial bump would have failed it.",
      "commit_oid": "2ae21a3e9481a443841313905962ffa98d29963d",
      "at": "2026-08-03T01:01:12Z"
    },
    {
      "name": "no-0.6.0-remains",
      "command": "git grep -n \"0\\.6\\.0\"",
      "result": "pass",
      "detail": "No output, exit 1. Counterpart check: git grep for 0.6.1 over .claude-plugin and adapters returns exactly 7 matches, one per expected site (three manifests, two comparison literals, two t.Errorf want-strings).",
      "commit_oid": "2ae21a3e9481a443841313905962ffa98d29963d",
      "at": "2026-08-03T01:01:12Z"
    },
    {
      "name": "gofmt-vet",
      "command": "gofmt -l . ; go vet ./...",
      "result": "pass",
      "detail": "No unformatted files; vet clean.",
      "commit_oid": "2ae21a3e9481a443841313905962ffa98d29963d",
      "at": "2026-08-03T01:01:12Z"
    },
    {
      "name": "branch-scope:version-bump-only",
      "command": "git diff --stat HEAD~1 HEAD; git diff --word-diff --ignore-all-space HEAD~1 HEAD",
      "result": "pass",
      "detail": "One commit directly on the merged README commit, 5 files, 7 insertions / 7 deletions, every removal a 0.6.0 version literal — mechanically the final content-bearing commit before the tag.",
      "commit_oid": "2ae21a3e9481a443841313905962ffa98d29963d",
      "at": "2026-08-03T01:01:12Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "All five named sites read 0.6.1 at the head OID's tree (both plugin.json line 4, marketplace.json line 6, both plugin_test.go comparison and want-string literals), and git grep -nF 0.6.0 over the head tree prints nothing and exits 1 — a tree-scoped grep covering exactly the tracked files.",
      "commit_oid": "2ae21a3e9481a443841313905962ffa98d29963d",
      "at": "2026-08-03T01:06:05Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approved at first review. The reviewer inspected the head from the object store and re-ran go test ./... on a git archive of the head tree extracted outside the repository: pass (23 ok, 3 no-test-files), gofmt and vet clean, all six CI checks green. The diff is exactly the version-literal swap: 5 files, 7 insertions / 7 deletions, every hunk 0.6.0 -\u003e 0.6.1, nothing else. git grep -F 0.6.0 at the head exits 1 with no output; the 7 new 0.6.1 sites plus README's 6 pre-existing references are the only occurrences. The reviewer independently confirmed no other version-identity site exists: doctor reads the expected adapter version from the embedded manifest at runtime, and the binary version is injected by release.yml's ldflags, so neither needs bumping. Release-discipline ordering holds: 2ae21a3 parents directly onto origin/main's head 9a3fab2 with no other open PR or issue, so the bump is mechanically the final content-bearing commit before the v0.6.1 tag. The tests are load-bearing: the marketplace test pins both adapter manifests against metadata.version and each plugin test pins its manifest literal, so any partial bump fails the suite. Two low-severity findings, neither blocking: the audit record's go-test detail says 22 packages where the true count is 23 ok of 26, and the criterion's repository-wide grep is broader than strict version identity (which does not bite — no historical 0.6.0 mention exists).",
      "commit_oid": "2ae21a3e9481a443841313905962ffa98d29963d",
      "at": "2026-08-03T01:06:05Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "lint=pass, test (windows-latest)=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "2ae21a3e9481a443841313905962ffa98d29963d",
      "at": "2026-08-03T01:06:09Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->