### PR TITLE
Offer to seed an existing block-only instruction file from the sibling

### DIFF
--- a/internal/bootstrap/configure_test.go
+++ b/internal/bootstrap/configure_test.go
@@ -419,6 +419,75 @@ func TestExecuteConfigureHappyPath(t *testing.T) {
 	}
 }
 
+// TestExecuteConfigureRepairsBlockOnlyInstructionFile proves the repair
+// offer survives the whole configure flow: AGENTS.md sits holding
+// nothing but the managed block while CLAUDE.md states the repository's
+// conventions, stage 0 re-derives the seeded content from the raw
+// answers alone (nothing about either file's bytes travels in the
+// AnswerSet), the repaired file passes validateConfigure's
+// StatusCurrent check, and what lands on the configure branch is
+// CLAUDE.md's conventions followed by exactly one managed block — with
+// the primary checkout's own AGENTS.md never written.
+func TestExecuteConfigureRepairsBlockOnlyInstructionFile(t *testing.T) {
+	const conventions = "# Fixture\n\nRun `go test ./...` before every push.\n"
+	root := newConfiguredRepo(t) // both hosts enabled, both files block-only
+	block, err := instructions.Render(instructions.CurrentVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "CLAUDE.md"), []byte(conventions+"\n"+block), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rawGit(t, root, "add", "-A")
+	rawGit(t, root, "commit", "-m", "conventions")
+	rawGit(t, root, "push", "origin", "main")
+
+	// Facts come from a real Detect: the repair offer keys on its
+	// block-only classification, and stage 0 re-runs the same probe.
+	facts := interview.Detect(context.Background(), interview.Deps{RepoRoot: root, LookPath: fakeLookPath, Runner: muxRunner{git: execx.Local{}}})
+	answers := fullConfigureAnswers(t, facts, root, nil)
+	if answers["seed.instructions.codex"] != "yes" {
+		t.Fatalf("the interview never offered to repair AGENTS.md: %v", answers)
+	}
+
+	calls := taxonomyScriptConfigure()
+	calls = append(calls, ghConfigureIssueCreateCall(1))
+	calls = append(calls, ghConfigurePRCreateCall(1))
+	calls = append(calls, ghSetStatusCall(1, ghops.StatusAwaitingReview))
+	script := &execxtest.Script{T: t, Calls: calls}
+	deps := testDeps(root, answers, script, muxRunner{git: execx.Local{}})
+
+	report, err := ExecuteConfigure(context.Background(), deps)
+	if err != nil {
+		t.Fatalf("ExecuteConfigure: %v", err)
+	}
+	script.AssertExhausted()
+	for _, v := range report.Validations {
+		if v.Result != "pass" {
+			t.Errorf("validation %s = %+v, want pass", v.Name, v)
+		}
+	}
+
+	agents := rawGit(t, root, "show", ConfigureBranch+":AGENTS.md")
+	if !strings.HasPrefix(agents, conventions) {
+		t.Errorf("committed AGENTS.md does not open with CLAUDE.md's conventions:\n%s", agents)
+	}
+	if n := strings.Count(agents, "orchestrator:managed:start"); n != 1 {
+		t.Errorf("committed AGENTS.md carries %d managed blocks, want exactly 1:\n%s", n, agents)
+	}
+
+	// The primary checkout was never written: the repair lands on the
+	// configure branch through the disposable worktree, like every other
+	// configure change.
+	primary, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(primary) != block {
+		t.Errorf("primary checkout's AGENTS.md = %q, want the block-only content it started with", primary)
+	}
+}
+
 func TestExecuteConfigureNotComplete(t *testing.T) {
 	root := newConfiguredRepo(t)
 	deps := testDeps(root, map[string]string{}, &execxtest.Script{T: t}, muxRunner{git: execx.Local{}})

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -158,11 +158,20 @@ func runDoctor(env Env) error {
 
 	// A root instruction file holding the Orch managed block and
 	// nothing else leaves that host's agents with no project
-	// conventions at all: Orch writes only its own block and never
-	// carries a repository's conventions across from the other host's
-	// file (interview.InstructionFile maps one file per host). A note,
-	// not a failure — Orch cannot author a repository's conventions,
-	// and a repository with genuinely none to state is not broken.
+	// conventions at all: Orch writes only its own block, and it
+	// authors no repository's conventions of its own. A note, not a
+	// failure — a repository with genuinely none to state is not broken.
+	//
+	// This note used to add that Orch never carries a repository's
+	// conventions across from the other host's file either
+	// (interview.InstructionFile maps one file per host), which is why
+	// the only advice it could give was to add them by hand. That is the
+	// before; the after is that `orch configure` offers to repair
+	// exactly this state, copying the sibling file's conventions in when
+	// that file has any outside its own block, with a human approving
+	// the whole resulting file first (interview's seed.go). So the note
+	// names that command — reporting a state nothing could repair is
+	// what it used to do.
 	if cfgErr == nil {
 		for _, host := range cfg.EnabledHosts() {
 			file := interview.InstructionFile(host)
@@ -172,11 +181,19 @@ func runDoctor(env Env) error {
 			// structurally broken markers are not this check's subject
 			// — `orch init`/`configure` already block on those — so
 			// they stay silent here rather than borrowing this note.
+			//
+			// Deliberately still the looser reading of "block-only" than
+			// the one seeding will repair (interview's isBlockOnly also
+			// requires the block itself to be current): a drifted or
+			// newer-versioned block-only file is worth reporting here
+			// all the same, and `orch configure` names it as a blocker
+			// rather than silently replacing a body this build cannot
+			// vouch for.
 			ch, err := instructions.PlanRemoveFile(filepath.Join(env.RepoRoot, file))
 			if err != nil || !ch.DeleteWholeFile {
 				continue
 			}
-			fmt.Fprintf(env.Stdout, "note  %s holds the Orch managed block and nothing else; %s agents see no project conventions — add them outside the block\n", file, host)
+			fmt.Fprintf(env.Stdout, "note  %s holds the Orch managed block and nothing else; %s agents see no project conventions — add them outside the block, or run `orch configure`, which offers to seed them from %s when that file has them\n", file, host, interview.SiblingInstructionFile(host))
 		}
 	}
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1085,6 +1085,14 @@ func TestDoctorNotesInstructionFileWithOnlyManagedBlock(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("advisory present = %v, want %v:\n%s", got, tt.want, stdout.String())
 			}
+			// The advisory names its repair path: `orch configure` offers
+			// to seed a block-only file from the sibling that has the
+			// conventions (interview's seed.go). Reporting this state
+			// without naming the command that fixes it is what task 168
+			// was filed about.
+			if tt.want && !strings.Contains(stdout.String(), "run `orch configure`, which offers to seed them from AGENTS.md") {
+				t.Errorf("advisory does not name `orch configure` as the repair path:\n%s", stdout.String())
+			}
 		})
 	}
 }

--- a/internal/interview/configure.go
+++ b/internal/interview/configure.go
@@ -84,10 +84,7 @@ func nextAfterSequenceConfigure(facts Facts, committed *config.Config, committed
 	if err != nil {
 		return question.Document{}, err
 	}
-	seeds := seedFiles(facts, map[string]bool{
-		"claude": cfg.Hosts.Claude != nil && committedHostConfig(committed, "claude") == nil,
-		"codex":  cfg.Hosts.Codex != nil && committedHostConfig(committed, "codex") == nil,
-	}, answers)
+	seeds := seedFiles(facts, configureSeedScope(committed, cfg.Hosts.Claude != nil, cfg.Hosts.Codex != nil), answers)
 	summary, err := buildConfigureSummary(cfg, committed, committedRaw, repoRoot, seeds)
 	if err != nil {
 		return question.Document{}, err
@@ -168,10 +165,15 @@ func readCommittedRaw(repoRoot string) ([]byte, error) {
 // configuration's current values (committedSettingsDefaults).
 //
 // Last comes any applicable instruction-file seed question (seedDocs,
-// seed.go). It is offered only for a host this change newly enables —
-// a still-enabled host's file is already there — and only when that
-// host's root instruction file is absent while the other host's carries
-// conventions.
+// seed.go), offered in either of two shapes, both requiring that the
+// other host's file carry conventions outside its own managed block:
+// creating a file this change newly enables a host for, when that file
+// is absent, or repairing any enabled host's file that already exists
+// holding nothing but the managed block. The second is why this
+// sequence, unlike buildSequence, passes a repaired scope at all: a
+// still-enabled host's file is already there, and until now that meant
+// nothing about it could be offered — including the one state `orch
+// doctor` reports and nothing could fix.
 func buildSequenceConfigure(facts Facts, committed *config.Config, answers map[string]string) ([]docSpec, error) {
 	docs := []docSpec{pickerDocConfigure(committed)}
 
@@ -215,12 +217,29 @@ func buildSequenceConfigure(facts Facts, committed *config.Config, answers map[s
 		docs = append(docs, settingsDoc(committedSettingsDefaults(committed)))
 	}
 
-	docs = append(docs, seedDocs(facts, map[string]bool{
-		"claude": claudeEnabled && !claudeCommitted,
-		"codex":  codexEnabled && !codexCommitted,
-	})...)
+	docs = append(docs, seedDocs(facts, configureSeedScope(committed, claudeEnabled, codexEnabled))...)
 
 	return docs, nil
+}
+
+// configureSeedScope is `orch configure`'s seed scope for a session that
+// leaves claudeEnabled/codexEnabled enabled: a host this change newly
+// enables (enabled now, absent from committed) may have its file
+// created seeded, and every host it leaves enabled may have a
+// block-only file repaired. Both of configure's seed call sites
+// (buildSequenceConfigure's question and nextAfterSequenceConfigure's
+// seeds) build it here, so the question asked and the answer honored
+// can never disagree about which offers applied — the asymmetry that
+// would otherwise let a seed be planned for a file no question was ever
+// shown for.
+func configureSeedScope(committed *config.Config, claudeEnabled, codexEnabled bool) seedScope {
+	return seedScope{
+		created: map[string]bool{
+			"claude": claudeEnabled && committedHostConfig(committed, "claude") == nil,
+			"codex":  codexEnabled && committedHostConfig(committed, "codex") == nil,
+		},
+		repaired: map[string]bool{"claude": claudeEnabled, "codex": codexEnabled},
+	}
 }
 
 // pickerDocConfigure is `orch configure`'s doc 1: whether to review or
@@ -455,8 +474,10 @@ func allFileChangesUnchanged(files []question.FileChange) bool {
 // bootstrap): every host cfg enables gets seededPlanFile — plain
 // instructions.PlanFile unless seeds names its file (seed.go)
 // (install, or — the day a version 2 exists — an upgrade diff, PRD §19
-// "upgrade blocks only through Delivery"); every host this change
-// disables instead gets instructions.PlanRemoveFile, block-only
+// "upgrade blocks only through Delivery"); a seeded file is instead
+// proposed whole, as the sibling's conventions above a fresh block,
+// whether it is being created or repaired from block-only; every host
+// this change disables instead gets instructions.PlanRemoveFile, block-only
 // (DeleteWholeFile is deliberately never consulted here: whole-file
 // deletion / deinit is out of scope, contract call 3). ConfigDiff
 // carries the committed-vs-new TOML diff for display; it is kept out

--- a/internal/interview/detect.go
+++ b/internal/interview/detect.go
@@ -54,14 +54,23 @@ type Facts struct {
 
 // InstructionFileState is Detect's classification of one host's root
 // instruction file (InstructionFile names it): whether the file exists
-// at all, and whether it carries any content outside the Orch managed
-// block. It is deliberately part of Facts rather than something the
-// summary step reads for itself, so the seed question (seed.go) can be
-// derived while buildSequence stays a pure function of facts and
-// answers alone.
+// at all, whether it carries any content outside the Orch managed
+// block, and whether it is nothing but that block. It is deliberately
+// part of Facts rather than something the summary step reads for
+// itself, so the seed question (seed.go) can be derived while
+// buildSequence stays a pure function of facts and answers alone.
+//
+// BlockOnly is strictly narrower than "Exists && !Conventions", and the
+// difference is load-bearing: the seed question's repair case proposes
+// replacing this file's bytes, so it keys on BlockOnly alone. Every
+// classification this build cannot fully vouch for — an unreadable
+// file, a structurally broken marker pair, a drifted or newer-versioned
+// block, and a file carrying no managed block at all (an empty one
+// included) — reports Exists without Conventions and without BlockOnly.
 type InstructionFileState struct {
 	Exists      bool
 	Conventions bool
+	BlockOnly   bool
 }
 
 // Detect probes deps for every Facts field. It never returns an
@@ -107,15 +116,17 @@ func Detect(ctx context.Context, deps Deps) Facts {
 	return f
 }
 
-// classifyInstructionFile reports whether repoRoot/name exists and
-// whether it holds anything outside the Orch managed block. It reuses
+// classifyInstructionFile reports whether repoRoot/name exists, whether
+// it holds anything outside the Orch managed block, and whether it is
+// nothing but that block (isBlockOnly, seed.go). It reuses
 // instructions.PlanRemove because what is left once the managed region
 // is stripped is exactly the question being asked (the same reading
 // `orch doctor` reports this state from). Like every other Detect
 // probe it reports trouble as data, not failure: an unreadable file or
-// structurally broken markers classify as "exists, no conventions", so
-// nothing is ever seeded from a file this build cannot read or parse,
-// and `orch init`/`configure` still block on those files themselves.
+// structurally broken markers classify as "exists, no conventions, not
+// block-only", so nothing is ever seeded from — or, in the repair case,
+// over — a file this build cannot read or parse, and `orch init`/
+// `configure` still block on those files themselves.
 //
 // The root probed is the detected git root, falling back to
 // Deps.RepoRoot — the same resolution the callers apply before handing
@@ -133,7 +144,11 @@ func classifyInstructionFile(repoRoot, name string) InstructionFileState {
 	if err != nil {
 		return InstructionFileState{Exists: true}
 	}
-	return InstructionFileState{Exists: true, Conventions: !instructions.IsOtherwiseEmpty(ch.New)}
+	return InstructionFileState{
+		Exists:      true,
+		Conventions: !instructions.IsOtherwiseEmpty(ch.New),
+		BlockOnly:   isBlockOnly(string(data)),
+	}
 }
 
 // lookPathOK reports whether lookPath resolves name; a nil lookPath

--- a/internal/interview/interview.go
+++ b/internal/interview/interview.go
@@ -95,17 +95,14 @@ func Next(facts Facts, answers map[string]string, repoRoot string) (question.Doc
 // document is answered, so the engine materializes the configuration,
 // builds the summary, and resolves approval. Every host `orch init`
 // enables is newly enabled, so the seed offers resolved here
-// (seedFiles, seed.go) are the same ones buildSequence derived from the
-// host toggles.
+// (seedFiles over initSeedScope, seed.go) are the same ones
+// buildSequence derived from the host toggles.
 func nextAfterSequence(facts Facts, answers map[string]string, repoRoot string) (question.Document, error) {
 	cfg, err := materialize(answers)
 	if err != nil {
 		return question.Document{}, err
 	}
-	seeds := seedFiles(facts, map[string]bool{
-		"claude": cfg.Hosts.Claude != nil,
-		"codex":  cfg.Hosts.Codex != nil,
-	}, answers)
+	seeds := seedFiles(facts, initSeedScope(cfg.Hosts.Claude != nil, cfg.Hosts.Codex != nil), answers)
 	summary, err := buildSummary(cfg, repoRoot, seeds)
 	if err != nil {
 		return question.Document{}, err

--- a/internal/interview/seed.go
+++ b/internal/interview/seed.go
@@ -27,22 +27,63 @@ func siblingHost(host string) string {
 }
 
 // seedOffer names one host whose root instruction file this session
-// creates, together with the sibling host's existing file the new one
-// may be seeded from.
+// proposes seeding from the sibling host's file, together with that
+// sibling. repair distinguishes the two shapes seedOffers admits: false
+// for a file this session creates (absent today), true for one that
+// already exists holding nothing but the Orch managed block.
 type seedOffer struct {
 	host    string
-	file    string // host's root instruction file, absent today
+	file    string // host's root instruction file
 	sibling string // the other host's file, which carries conventions
+	repair  bool   // file exists holding only the managed block
+}
+
+// seedScope licenses, per host, which of seedOffers' two offers a
+// session may make. Both are keyed by host name, so a host absent from
+// (or false in) a map is simply never offered that shape.
+type seedScope struct {
+	// created marks each host whose root instruction file this session
+	// creates: the create offer applies when that file is absent.
+	created map[string]bool
+	// repaired marks each host whose already-present root instruction
+	// file this session may rewrite: the repair offer applies when that
+	// file holds nothing but the current managed block. `orch init`
+	// leaves it nil (initSeedScope) — it runs before any host is
+	// configured, and the repair offer is deliberately `orch configure`'s
+	// alone, the command `orch doctor` names as this state's repair path.
+	repaired map[string]bool
+}
+
+// initSeedScope is `orch init`'s scope: every enabled host's file is one
+// init creates, and none is one init repairs. Both of init's seed call
+// sites (buildSequence's question and nextAfterSequence's seeds) build
+// it here, so the question asked and the answer honored can never
+// disagree about which offers applied.
+func initSeedScope(claudeEnabled, codexEnabled bool) seedScope {
+	return seedScope{created: map[string]bool{"claude": claudeEnabled, "codex": codexEnabled}}
 }
 
 // seedOffers lists, in claude-then-codex order (applicableInstructionFiles'
 // fixed order, so documents and summary rows stay deterministic), every
-// host newlyEnabled marks whose own root instruction file is absent
-// while the other host's file carries content outside the Orch managed
-// block. That is the exact condition the seed question is asked under:
-// without it Orch creates a file holding nothing but the managed block,
-// leaving that host's agents with no project conventions at all — the
-// state `orch doctor` reports after the fact.
+// host that scope licenses an offer for and whose sibling's file
+// carries content outside its own Orch managed block. Two shapes
+// qualify, and they are mutually exclusive per host — one requires an
+// absent file, the other an existing one:
+//
+//   - create (scope.created, both interviews): the host's own file is
+//     absent. Without the offer Orch creates a file holding nothing but
+//     the managed block, leaving that host's agents with no project
+//     conventions at all — the state `orch doctor` reports after the
+//     fact.
+//   - repair (scope.repaired, `orch configure` only): the host's own
+//     file already exists and its entire content is the current managed
+//     block (InstructionFileState.BlockOnly, deliberately narrower than
+//     "exists and carries no conventions"). Before this offer existed
+//     that state had no mechanical repair path at all — seeding fired
+//     only for an absent file and planSeeded refused every path that
+//     existed, so doctor reported it and the only fix was to edit the
+//     file by hand; now doctor names `orch configure`, which offers
+//     exactly this.
 //
 // The sibling need not itself be an enabled host. A repository that
 // states its conventions in AGENTS.md and enables only Claude Code has
@@ -50,14 +91,19 @@ type seedOffer struct {
 //
 // seedOffers reads nothing: facts.Instructions is Detect's snapshot, so
 // the question sequence stays a pure function of facts and answers.
-func seedOffers(facts Facts, newlyEnabled map[string]bool) []seedOffer {
+func seedOffers(facts Facts, scope seedScope) []seedOffer {
 	var offers []seedOffer
 	for _, host := range []string{"claude", "codex"} {
 		sibling := siblingHost(host)
-		if !newlyEnabled[host] || facts.Instructions[host].Exists || !facts.Instructions[sibling].Conventions {
+		if !facts.Instructions[sibling].Conventions {
 			continue
 		}
-		offers = append(offers, seedOffer{host: host, file: InstructionFile(host), sibling: InstructionFile(sibling)})
+		create := scope.created[host] && !facts.Instructions[host].Exists
+		repair := scope.repaired[host] && facts.Instructions[host].BlockOnly
+		if !create && !repair {
+			continue
+		}
+		offers = append(offers, seedOffer{host: host, file: InstructionFile(host), sibling: InstructionFile(sibling), repair: repair})
 	}
 	return offers
 }
@@ -65,9 +111,9 @@ func seedOffers(facts Facts, newlyEnabled map[string]bool) []seedOffer {
 // seedDocs turns every applicable offer into its own single-question
 // document, appended last in both interviews' sequences — the file
 // question sits closest to the summary that shows its result.
-func seedDocs(facts Facts, newlyEnabled map[string]bool) []docSpec {
+func seedDocs(facts Facts, scope seedScope) []docSpec {
 	var docs []docSpec
-	for _, o := range seedOffers(facts, newlyEnabled) {
+	for _, o := range seedOffers(facts, scope) {
 		docs = append(docs, docSpec{questions: []question.Question{seedQuestion(o)}})
 	}
 	return docs
@@ -75,24 +121,34 @@ func seedDocs(facts Facts, newlyEnabled map[string]bool) []docSpec {
 
 // seedQuestion is o's yes/no question, naming both files and defaulting
 // to yes: a repository that already states its conventions somewhere
-// almost always wants the file being created to carry them too, and
-// either answer's full proposed content is shown as the summary's file
-// diff before anything is written.
+// almost always wants this host's file to carry them too, and either
+// answer's full proposed content is shown as the summary's file diff
+// before anything is written. A repair offer says so — the file it names
+// exists, and answering yes rewrites it — while an absent file's
+// wording stays exactly what it was before repair existed.
 //
 // The seeded content is a verbatim copy rather than an import
 // directive: an import is host-specific syntax, and Orch does not
 // author a host's instruction dialect.
 func seedQuestion(o seedOffer) question.Question {
+	prompt := fmt.Sprintf("Seed %s from %s?", o.file, o.sibling)
+	preamble := fmt.Sprintf(
+		"%s already states this repository's conventions outside its own Orch managed block, while %s does not exist yet. Seeding copies that content verbatim into the new file, above a fresh managed block, so %s agents read the same conventions; answering no creates %s holding the managed block alone.",
+		o.sibling, o.file, hostLabels[o.host], o.file)
+	if o.repair {
+		prompt = fmt.Sprintf("Repair %s from %s?", o.file, o.sibling)
+		preamble = fmt.Sprintf(
+			"%s holds the Orch managed block and nothing else, so %s agents see none of this repository's conventions, while %s states them outside its own block. Seeding copies that content verbatim above %s's managed block, and the whole proposed file is shown as a diff for approval first; answering no leaves %s exactly as it is.",
+			o.file, hostLabels[o.host], o.sibling, o.file, o.file)
+	}
 	return question.Question{
-		ID:     seedID(o.host),
-		Header: "Conventions",
-		Prompt: fmt.Sprintf("Seed %s from %s?", o.file, o.sibling),
-		Preamble: fmt.Sprintf(
-			"%s already states this repository's conventions outside its own Orch managed block, while %s does not exist yet. Seeding copies that content verbatim into the new file, above a fresh managed block, so %s agents read the same conventions; answering no creates %s holding the managed block alone.",
-			o.sibling, o.file, hostLabels[o.host], o.file),
-		Kind:    question.KindSelect,
-		Default: "yes",
-		Options: yesNoOptions("yes"),
+		ID:       seedID(o.host),
+		Header:   "Conventions",
+		Prompt:   prompt,
+		Preamble: preamble,
+		Kind:     question.KindSelect,
+		Default:  "yes",
+		Options:  yesNoOptions("yes"),
 	}
 }
 
@@ -101,9 +157,9 @@ func seedQuestion(o seedOffer) question.Question {
 // accepted — buildSummary's and buildConfigureSummary's seeds argument.
 // An unanswered or declined offer is simply absent, which is what makes
 // "no" identical to the behavior before seeding existed.
-func seedFiles(facts Facts, newlyEnabled map[string]bool, answers map[string]string) map[string]string {
+func seedFiles(facts Facts, scope seedScope, answers map[string]string) map[string]string {
 	seeds := map[string]string{}
-	for _, o := range seedOffers(facts, newlyEnabled) {
+	for _, o := range seedOffers(facts, scope) {
 		if answers[seedID(o.host)] == "yes" {
 			seeds[o.file] = o.sibling
 		}
@@ -114,9 +170,9 @@ func seedFiles(facts Facts, newlyEnabled map[string]bool, answers map[string]str
 // seededPlanFile returns planInstructionFiles' plan function for a
 // session carrying seeds: instructions.PlanFile for every file, except
 // that a file seeds names is planned from the sibling's conventions
-// (planSeeded) instead of from nothing. With no seeds it is
-// instructions.PlanFile itself, so every path that never offered
-// seeding plans exactly as it did before.
+// (planSeeded) instead of from its own content or absence. With no
+// seeds it is instructions.PlanFile itself, so every path that never
+// offered seeding plans exactly as it did before.
 func seededPlanFile(repoRoot string, seeds map[string]string) func(string) (instructions.Change, error) {
 	if len(seeds) == 0 {
 		return instructions.PlanFile
@@ -137,14 +193,26 @@ func seededPlanFile(repoRoot string, seeds map[string]string) func(string) (inst
 // remainder that provably carries no markers (locate rejects a second
 // pair as malformed).
 //
-// The offer is only ever made for a path Detect found absent, so the
-// change is an install against nothing: Old is "" and the diff shows
-// the whole proposed file, seeded lines included, rather than the block
-// alone against borrowed context. A path that exists after all falls
-// back to the ordinary plan — seeding must never overwrite a file
-// somebody already wrote.
+// Whether path may be seeded at all is decided by seedable, from disk,
+// here — not trusted from Detect's snapshot, and not from the answer,
+// which only ever says yes or no. Before repair existed this guard was
+// simply "the path must not exist"; it is now "the path must not exist,
+// or must hold nothing but the current managed block". Every other
+// existing path still falls back to the ordinary plan: seeding must
+// never overwrite a file somebody already wrote, and a file that gained
+// content between the question and the summary keeps it.
+//
+// Either way the change is displayed against nothing: Old is "" and the
+// diff shows the whole proposed file, seeded lines included, rather
+// than the block alone against borrowed context. For a repaired file
+// that costs nothing in honesty — every line the diff shows as added is
+// a line the approved file holds, and the only ones it re-shows are the
+// managed block Orch wrote itself — while FileExisted keeps reporting
+// what was actually found on disk, so the record bootstrap renders into
+// the PR body never calls a repaired file newly created.
 func planSeeded(siblingPath, path string) (instructions.Change, error) {
-	if _, err := os.Stat(path); !errors.Is(err, fs.ErrNotExist) {
+	existed, ok := seedable(path)
+	if !ok {
 		return instructions.PlanFile(path)
 	}
 	base, err := instructions.PlanRemoveFile(siblingPath)
@@ -155,8 +223,53 @@ func planSeeded(siblingPath, path string) (instructions.Change, error) {
 	if err != nil {
 		return instructions.Change{}, err
 	}
-	ch.FileExisted = false
+	ch.FileExisted = existed
 	ch.Old = ""
 	ch.Diff = instructions.UnifiedDiff("", ch.New)
 	return ch, nil
+}
+
+// seedable reports whether path may be seeded over, and whether it
+// exists at all. Exactly two states qualify: an absent path, where
+// there is nothing to overwrite, and a path holding nothing but the
+// current managed block (isBlockOnly). Everything else fails closed to
+// ok == false, a path that cannot even be read included — the caller
+// then plans it the ordinary way, which surfaces that read failure as
+// an error instead of seeding over bytes this build never saw.
+func seedable(path string) (existed, ok bool) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, true
+	}
+	if err != nil {
+		return true, false
+	}
+	return true, isBlockOnly(string(data))
+}
+
+// isBlockOnly reports whether content is nothing but the current Orch
+// managed block: one unambiguous marker pair, a body matching this
+// build's canonical render, and only whitespace around it. It is the
+// single classification on which a seed may replace an existing file's
+// bytes, so every other shape is false — any content outside the block,
+// a drifted or newer-versioned or structurally broken block, and
+// content carrying no block at all (an empty file included, which has
+// no managed block to be "only").
+//
+// PlanRemove's DeleteWholeFile answers the "nothing but" half exactly:
+// it is set only for a located marker pair whose remainder
+// IsOtherwiseEmpty — the same reading `orch doctor`'s block-only
+// advisory reports from. Inspect's StatusCurrent then adds what a
+// repair needs beyond that advisory: PlanRemove is deliberately
+// indifferent to a drifted or newer-versioned body, because removal
+// needs only the marker lines, and replacing bytes this build cannot
+// vouch for is exactly what must not happen here. So a drifted
+// block-only file is reported by doctor and refused by seeding — `orch
+// configure` names it as a blocker instead (isBlockingPlanError).
+func isBlockOnly(content string) bool {
+	ch, err := instructions.PlanRemove(content)
+	if err != nil || !ch.DeleteWholeFile {
+		return false
+	}
+	return instructions.Inspect(content).Status == instructions.StatusCurrent
 }

--- a/internal/interview/seed_test.go
+++ b/internal/interview/seed_test.go
@@ -353,12 +353,23 @@ func TestSeedNotOfferedForStillEnabledConfigureHost(t *testing.T) {
 	}
 }
 
-// TestSeedNeverOverwritesAnExistingFile pins planSeeded's fail-safe: if
-// the target file exists carrying content of its own — the interview's
-// facts and the summary's root having disagreed — the ordinary plan runs
-// and the file's own content is preserved, rather than being replaced by
-// a copy of the sibling's.
-func TestSeedNeverOverwritesAnExistingFile(t *testing.T) {
+// TestSeedNeverOverwritesAFileWithConventionsOfItsOwn pins planSeeded's
+// fail-safe: if the target file exists carrying content of its own — the
+// interview's facts and the summary's root having disagreed — the
+// ordinary plan runs and the file's own content is preserved, rather
+// than being replaced by a copy of the sibling's.
+//
+// Before the repair offer existed this test was named
+// TestSeedNeverOverwritesAnExistingFile, and its comment said an
+// existing target file meant the ordinary plan runs and its content is
+// preserved — of ANY existing file, with no qualification. That is the
+// before. The after is narrower: a file whose entire content is the
+// current managed block IS overwritten, by a proposal a human approves
+// first (TestPlanSeededOnlySeedsOverAnAbsentOrBlockOnlyFile pins both
+// halves of the new contract). So the invariant this test pins holds for
+// a file carrying conventions of its own, and the name says that rather
+// than restating an invariant seeding no longer has.
+func TestSeedNeverOverwritesAFileWithConventionsOfItsOwn(t *testing.T) {
 	root := t.TempDir()
 	writeInstructionFile(t, root, "CLAUDE.md", seedConventions+"\n"+managedBlock(t))
 	writeInstructionFile(t, root, "AGENTS.md", "# Codex only\n")

--- a/internal/interview/seed_test.go
+++ b/internal/interview/seed_test.go
@@ -2,6 +2,7 @@ package interview
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -120,18 +121,90 @@ func TestDetectClassifiesInstructionFiles(t *testing.T) {
 
 	facts := Detect(context.Background(), Deps{RepoRoot: root, LookPath: fakeLookPath()})
 
-	if got := facts.Instructions["claude"]; !got.Exists || !got.Conventions {
+	if got := facts.Instructions["claude"]; !got.Exists || !got.Conventions || got.BlockOnly {
 		t.Errorf("claude = %+v, want a file that exists and carries conventions", got)
 	}
-	if got := facts.Instructions["codex"]; !got.Exists || got.Conventions {
-		t.Errorf("codex = %+v, want a file that exists with no conventions", got)
+	if got := facts.Instructions["codex"]; !got.Exists || got.Conventions || !got.BlockOnly {
+		t.Errorf("codex = %+v, want a file that exists holding only the managed block", got)
 	}
 
 	bare := Detect(context.Background(), Deps{RepoRoot: t.TempDir(), LookPath: fakeLookPath()})
 	for host, got := range bare.Instructions {
-		if got.Exists || got.Conventions {
+		if got.Exists || got.Conventions || got.BlockOnly {
 			t.Errorf("%s = %+v, want absent in a bare directory", host, got)
 		}
+	}
+}
+
+// driftedBlock is the current managed block with one body line
+// hand-edited: PlanRemove still finds its markers (removal needs only
+// those), so it is "block-only" by `orch doctor`'s reading, while
+// Inspect classifies it StatusDrifted.
+func driftedBlock(t *testing.T) string {
+	t.Helper()
+	block := managedBlock(t)
+	drifted := strings.Replace(block, "This file is partially managed by Orch", "This file is entirely mine", 1)
+	if drifted == block {
+		t.Fatal("the drift fixture changed nothing; the canonical body must have moved")
+	}
+	return drifted
+}
+
+// newerBlock is a block declaring a version this build cannot render.
+func newerBlock(t *testing.T) string {
+	t.Helper()
+	block := managedBlock(t)
+	newer := strings.Replace(block, "version=1", "version=2", 1)
+	if newer == block {
+		t.Fatal("the newer-version fixture changed nothing; the marker grammar must have moved")
+	}
+	return newer
+}
+
+// TestBlockOnlyIsNarrowerThanNoConventions pins the classification the
+// repair offer keys on, as Detect reports it and as isBlockOnly
+// re-derives it at plan time. Only a file whose entire content is the
+// current managed block qualifies: every state this build cannot fully
+// vouch for reports Exists with neither Conventions nor BlockOnly, so
+// "carries no conventions" alone can never license replacing a file's
+// bytes.
+func TestBlockOnlyIsNarrowerThanNoConventions(t *testing.T) {
+	block := managedBlock(t)
+	cases := []struct {
+		name          string
+		content       string
+		wantBlockOnly bool
+	}{
+		{name: "the managed block alone", content: block, wantBlockOnly: true},
+		{name: "the managed block with surrounding blank lines", content: "\n" + block + "\n\n", wantBlockOnly: true},
+		{name: "conventions above the block", content: seedConventions + "\n" + block},
+		{name: "conventions below the block", content: block + "\n\n" + seedConventions},
+		{name: "a drifted block alone", content: driftedBlock(t)},
+		{name: "a newer-versioned block alone", content: newerBlock(t)},
+		{name: "malformed markers", content: block + "\n" + block},
+		{name: "an empty file", content: ""},
+		{name: "whitespace alone", content: "\n\n"},
+		{name: "no managed block at all", content: seedConventions},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeInstructionFile(t, root, "AGENTS.md", tc.content)
+
+			got := classifyInstructionFile(root, "AGENTS.md")
+			if !got.Exists {
+				t.Fatalf("Exists = false, want true (the file was written)")
+			}
+			if got.BlockOnly != tc.wantBlockOnly {
+				t.Errorf("Detect BlockOnly = %v, want %v (%+v)", got.BlockOnly, tc.wantBlockOnly, got)
+			}
+			if isBlockOnly(tc.content) != tc.wantBlockOnly {
+				t.Errorf("isBlockOnly = %v, want %v", isBlockOnly(tc.content), tc.wantBlockOnly)
+			}
+			if got.BlockOnly && got.Conventions {
+				t.Error("BlockOnly and Conventions are both set; a block-only file carries no conventions")
+			}
+		})
 	}
 }
 
@@ -272,10 +345,10 @@ func TestSeedNotOfferedForStillEnabledConfigureHost(t *testing.T) {
 }
 
 // TestSeedNeverOverwritesAnExistingFile pins planSeeded's fail-safe: if
-// the target file exists after all — the interview's facts and the
-// summary's root having disagreed — the ordinary plan runs and the
-// file's own content is preserved, rather than being replaced by a copy
-// of the sibling's.
+// the target file exists carrying content of its own — the interview's
+// facts and the summary's root having disagreed — the ordinary plan runs
+// and the file's own content is preserved, rather than being replaced by
+// a copy of the sibling's.
 func TestSeedNeverOverwritesAnExistingFile(t *testing.T) {
 	root := t.TempDir()
 	writeInstructionFile(t, root, "CLAUDE.md", seedConventions+"\n"+managedBlock(t))
@@ -290,5 +363,316 @@ func TestSeedNeverOverwritesAnExistingFile(t *testing.T) {
 	}
 	if strings.Contains(ch.New, seedConventions) {
 		t.Errorf("New carries the sibling's conventions, overwriting the existing file:\n%s", ch.New)
+	}
+}
+
+// TestPlanSeededOnlySeedsOverAnAbsentOrBlockOnlyFile is the destructive
+// half of the repair carve-out, checked at the layer that actually
+// composes the bytes: planSeeded seeds over an absent file and over one
+// holding nothing but the current managed block, and preserves every
+// other file's own content verbatim — including the states Detect also
+// refuses (drifted, newer-versioned, malformed), so a fact that somehow
+// said "block-only" for one of them still could not destroy it.
+func TestPlanSeededOnlySeedsOverAnAbsentOrBlockOnlyFile(t *testing.T) {
+	block := managedBlock(t)
+	cases := []struct {
+		name string
+		// content "" writes no AGENTS.md at all.
+		content  string
+		wantSeed bool
+	}{
+		{name: "absent", wantSeed: true},
+		{name: "the managed block alone", content: block, wantSeed: true},
+		{name: "conventions of its own above the block", content: "# Codex only\n\n" + block},
+		{name: "conventions of its own and no block", content: "# Codex only\n"},
+		{name: "a drifted block alone", content: driftedBlock(t)},
+		{name: "a newer-versioned block alone", content: newerBlock(t)},
+		{name: "an empty file", content: "\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeInstructionFile(t, root, "CLAUDE.md", seedConventions+"\n"+block)
+			if tc.content != "" {
+				writeInstructionFile(t, root, "AGENTS.md", tc.content)
+			}
+			target := filepath.Join(root, "AGENTS.md")
+
+			ch, err := planSeeded(filepath.Join(root, "CLAUDE.md"), target)
+			switch {
+			case tc.wantSeed:
+				if err != nil {
+					t.Fatalf("planSeeded: %v", err)
+				}
+				if !strings.HasPrefix(ch.New, seedConventions) {
+					t.Errorf("New does not open with the sibling's conventions:\n%s", ch.New)
+				}
+				if ch.FileExisted != (tc.content != "") {
+					t.Errorf("FileExisted = %v, want %v — the record the PR body renders must say which", ch.FileExisted, tc.content != "")
+				}
+			case err != nil:
+				// A blocking structural error is a refusal too: the
+				// summary names it as a blocker and writes nothing.
+				if !isBlockingPlanError(err) {
+					t.Fatalf("planSeeded: %v, want a blocking plan error or a preserved file", err)
+				}
+			default:
+				if strings.Contains(ch.New, seedConventions) {
+					t.Errorf("New carries the sibling's conventions, overwriting content this build does not own:\n%s", ch.New)
+				}
+				if !strings.Contains(ch.New, strings.TrimSpace(tc.content)) {
+					t.Errorf("New does not preserve the file's own content:\n%s", ch.New)
+				}
+			}
+
+			// planSeeded proposes; it never writes.
+			after, readErr := os.ReadFile(target)
+			if tc.content == "" {
+				if readErr == nil {
+					t.Errorf("AGENTS.md was created on disk by planning alone: %q", after)
+				}
+				return
+			}
+			if readErr != nil {
+				t.Fatalf("read back AGENTS.md: %v", readErr)
+			}
+			if string(after) != tc.content {
+				t.Errorf("AGENTS.md on disk = %q, want it untouched by planning", after)
+			}
+		})
+	}
+}
+
+// TestConfigureRepairsBlockOnlyFileFromSibling is the repair flagship:
+// a repository whose CLAUDE.md states its conventions while AGENTS.md
+// holds nothing but the Orch managed block gets one offer to repair
+// AGENTS.md from CLAUDE.md, the whole resulting file is shown as the
+// summary's diff, and nothing is written until that summary is
+// approved.
+func TestConfigureRepairsBlockOnlyFileFromSibling(t *testing.T) {
+	block := managedBlock(t)
+	root := t.TempDir()
+	writeCommittedConfigLocal(t, root)
+	writeInstructionFile(t, root, "CLAUDE.md", seedConventions+"\n"+block)
+	writeInstructionFile(t, root, "AGENTS.md", block)
+
+	summary, asked := walkSeed(t, NextConfigure, withInstructions(configureFacts(), root), root, "yes", nil)
+	if !asked {
+		t.Fatal("the repair question was never asked")
+	}
+
+	ch := findFileChange(summary.Files, "AGENTS.md")
+	if ch == nil {
+		t.Fatalf("Files = %v, want an AGENTS.md entry", summary.Files)
+	}
+	if !ch.Existed {
+		t.Error("Existed = false, want true (AGENTS.md was already there, holding the block)")
+	}
+	if !strings.HasPrefix(ch.NewContent, seedConventions) {
+		t.Errorf("NewContent does not open with CLAUDE.md's conventions:\n%s", ch.NewContent)
+	}
+	if n := strings.Count(ch.NewContent, "orchestrator:managed:start"); n != 1 {
+		t.Errorf("NewContent carries %d managed blocks, want exactly 1:\n%s", n, ch.NewContent)
+	}
+	if report := instructions.Inspect(ch.NewContent); report.Status != instructions.StatusCurrent {
+		t.Errorf("Inspect(NewContent).Status = %v, want StatusCurrent (%v): %s", report.Status, instructions.StatusCurrent, report.Detail)
+	}
+
+	// Every line of the file the human is approving is visible in the
+	// diff, the block it already held included — not the seeded lines
+	// against three lines of borrowed context.
+	for _, line := range strings.Split(strings.TrimSuffix(ch.NewContent, "\n"), "\n") {
+		if !strings.Contains(ch.Diff, "\n+"+line+"\n") && !strings.HasPrefix(ch.Diff, "+"+line+"\n") {
+			t.Errorf("Diff does not show %q as an added line:\n%s", line, ch.Diff)
+		}
+	}
+
+	// The sibling it was seeded from is itself unchanged, and neither
+	// file has been written: the summary is a proposal.
+	sibling := findFileChange(summary.Files, "CLAUDE.md")
+	if sibling == nil {
+		t.Fatalf("Files = %v, want a CLAUDE.md entry", summary.Files)
+	}
+	if sibling.Diff != "" {
+		t.Errorf("CLAUDE.md Diff = %q, want empty (it already carries a current block)", sibling.Diff)
+	}
+	for name, want := range map[string]string{"AGENTS.md": block, "CLAUDE.md": seedConventions + "\n" + block} {
+		got, err := os.ReadFile(filepath.Join(root, name))
+		if err != nil {
+			t.Fatalf("read back %s: %v", name, err)
+		}
+		if string(got) != want {
+			t.Errorf("%s on disk = %q, want it untouched until the summary is approved", name, got)
+		}
+	}
+}
+
+// TestConfigureRepairDeclinedChangesNothing proves answering no leaves
+// the block-only file exactly as it was — the same proposal `orch
+// configure` made for it before the repair offer existed.
+func TestConfigureRepairDeclinedChangesNothing(t *testing.T) {
+	block := managedBlock(t)
+	root := t.TempDir()
+	writeCommittedConfigLocal(t, root)
+	writeInstructionFile(t, root, "CLAUDE.md", seedConventions+"\n"+block)
+	writeInstructionFile(t, root, "AGENTS.md", block)
+
+	summary, asked := walkSeed(t, NextConfigure, withInstructions(configureFacts(), root), root, "no", nil)
+	if !asked {
+		t.Fatal("the repair question was never asked")
+	}
+	ch := findFileChange(summary.Files, "AGENTS.md")
+	if ch == nil {
+		t.Fatalf("Files = %v, want an AGENTS.md entry", summary.Files)
+	}
+	if ch.NewContent != block || ch.Diff != "" {
+		t.Errorf("NewContent/Diff = %q/%q, want the block alone and no diff", ch.NewContent, ch.Diff)
+	}
+}
+
+// TestConfigureRepairNotOffered walks every condition under which the
+// repair offer must stay silent. The golden configure transcripts pin
+// the "no facts at all" case by running unmodified.
+func TestConfigureRepairNotOffered(t *testing.T) {
+	block := managedBlock(t)
+	cases := []struct {
+		name  string
+		files map[string]string
+	}{
+		{"the block-only file carries conventions of its own", map[string]string{
+			"CLAUDE.md": seedConventions + "\n" + block,
+			"AGENTS.md": "# Codex only\n\n" + block,
+		}},
+		{"the sibling holds only the managed block too", map[string]string{
+			"CLAUDE.md": block,
+			"AGENTS.md": block,
+		}},
+		{"the sibling is absent", map[string]string{"AGENTS.md": block}},
+		{"the block-only file's block has drifted", map[string]string{
+			"CLAUDE.md": seedConventions + "\n" + block,
+			"AGENTS.md": driftedBlock(t),
+		}},
+		{"the block-only file's block is newer than this build", map[string]string{
+			"CLAUDE.md": seedConventions + "\n" + block,
+			"AGENTS.md": newerBlock(t),
+		}},
+		{"the block-only file's markers are malformed", map[string]string{
+			"CLAUDE.md": seedConventions + "\n" + block,
+			"AGENTS.md": block + "\n" + block,
+		}},
+		{"the file holds no managed block at all", map[string]string{
+			"CLAUDE.md": seedConventions + "\n" + block,
+			"AGENTS.md": "",
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeCommittedConfigLocal(t, root)
+			for name, content := range tc.files {
+				writeInstructionFile(t, root, name, content)
+			}
+			if _, asked := walkSeed(t, NextConfigure, withInstructions(configureFacts(), root), root, "yes", nil); asked {
+				t.Error("the repair question was asked")
+			}
+		})
+	}
+}
+
+// TestRepairNotOfferedByInit pins the offer to `orch configure`: init
+// runs in an uninitialized repository, and a block-only file there is
+// left exactly as init has always left it.
+func TestRepairNotOfferedByInit(t *testing.T) {
+	block := managedBlock(t)
+	root := t.TempDir()
+	writeInstructionFile(t, root, "CLAUDE.md", seedConventions+"\n"+block)
+	writeInstructionFile(t, root, "AGENTS.md", block)
+
+	summary, asked := walkSeed(t, Next, withInstructions(bothHostsFacts(), root), root, "yes", nil)
+	if asked {
+		t.Error("init asked a seed question for an existing block-only file")
+	}
+	ch := findFileChange(summary.Files, "AGENTS.md")
+	if ch == nil {
+		t.Fatalf("Files = %v, want an AGENTS.md entry", summary.Files)
+	}
+	if ch.Diff != "" || ch.NewContent != block {
+		t.Errorf("NewContent/Diff = %q/%q, want the existing block untouched", ch.NewContent, ch.Diff)
+	}
+}
+
+// TestConfigureRepairStaleYesRejectedOnceTheFileHasConventions is the
+// repair case's leg of the anti-forgery boundary PR #192 established: a
+// yes answer replayed after the file stopped being block-only is an
+// answer to a question the sequence no longer derives, and fails closed
+// like every other unreachable id.
+func TestConfigureRepairStaleYesRejectedOnceTheFileHasConventions(t *testing.T) {
+	block := managedBlock(t)
+	root := t.TempDir()
+	writeCommittedConfigLocal(t, root)
+	writeInstructionFile(t, root, "CLAUDE.md", seedConventions+"\n"+block)
+	writeInstructionFile(t, root, "AGENTS.md", block)
+
+	answers := map[string]string{
+		idPickHosts:       "no",
+		idPickRolesClaude: "no",
+		idPickRolesCodex:  "no",
+		idPickSettings:    "no",
+		seedID("codex"):   "yes",
+	}
+	if _, err := NextConfigure(withInstructions(configureFacts(), root), answers, root); err != nil {
+		t.Fatalf("NextConfigure with the offer still applicable: %v", err)
+	}
+
+	writeInstructionFile(t, root, "AGENTS.md", "# Codex only\n\n"+block)
+	_, err := NextConfigure(withInstructions(configureFacts(), root), answers, root)
+	if !errors.Is(err, ErrUnknownAnswer) {
+		t.Fatalf("NextConfigure err = %v, want ErrUnknownAnswer", err)
+	}
+}
+
+// TestConfigureRepairNeverOverwritesContentWrittenAfterTheAnswer is the
+// same race the other way round: the facts still say block-only (they
+// were snapshotted before), the answer still says yes, and the file has
+// since been given conventions of its own. planSeeded re-derives the
+// classification from disk, so the summary proposes the file's own
+// content untouched rather than a copy of the sibling's.
+func TestConfigureRepairNeverOverwritesContentWrittenAfterTheAnswer(t *testing.T) {
+	block := managedBlock(t)
+	root := t.TempDir()
+	writeCommittedConfigLocal(t, root)
+	writeInstructionFile(t, root, "CLAUDE.md", seedConventions+"\n"+block)
+	writeInstructionFile(t, root, "AGENTS.md", block)
+	staleFacts := withInstructions(configureFacts(), root)
+
+	const own = "# Codex only\n\nUse tabs.\n"
+	writeInstructionFile(t, root, "AGENTS.md", own+"\n"+block)
+
+	answers := map[string]string{
+		idPickHosts:       "no",
+		idPickRolesClaude: "no",
+		idPickRolesCodex:  "no",
+		idPickSettings:    "no",
+		seedID("codex"):   "yes",
+	}
+	doc, err := NextConfigure(staleFacts, answers, root)
+	if err != nil {
+		t.Fatalf("NextConfigure: %v", err)
+	}
+	if doc.Summary == nil {
+		t.Fatalf("document %q carries no summary", doc.Kind)
+	}
+	ch := findFileChange(doc.Summary.Files, "AGENTS.md")
+	if ch == nil {
+		t.Fatalf("Files = %v, want an AGENTS.md entry", doc.Summary.Files)
+	}
+	if !strings.HasPrefix(ch.NewContent, own) {
+		t.Errorf("NewContent does not open with AGENTS.md's own content:\n%s", ch.NewContent)
+	}
+	if strings.Contains(ch.NewContent, seedConventions) {
+		t.Errorf("NewContent carries the sibling's conventions, overwriting content written since the answer:\n%s", ch.NewContent)
+	}
+	if ch.Diff != "" {
+		t.Errorf("Diff = %q, want empty (the file already carries a current block)", ch.Diff)
 	}
 }

--- a/internal/interview/seed_test.go
+++ b/internal/interview/seed_test.go
@@ -329,10 +329,19 @@ func TestSeedOfferedForConfigureNewlyEnabledHost(t *testing.T) {
 	}
 }
 
-// TestSeedNotOfferedForStillEnabledConfigureHost proves the offer is
-// scoped to a host this change newly enables: a committed-enabled host
-// whose file happens to be missing is not seeded behind the human's
-// back — `orch doctor` reports that state instead.
+// TestSeedNotOfferedForStillEnabledConfigureHost proves the CREATE
+// offer is scoped to a host this change newly enables: a
+// committed-enabled host whose file happens to be missing does not get
+// one created behind the human's back — `orch doctor` reports that state
+// instead.
+//
+// Before the repair offer existed that restriction covered seeding as a
+// whole: a still-enabled host was never offered anything. After it, a
+// still-enabled host IS offered a seed when its file exists holding
+// nothing but the managed block (TestConfigureRepairsBlockOnlyFileFromSibling),
+// so the restriction this test pins now holds for the create offer
+// alone — which is exactly why the fixture leaves AGENTS.md absent
+// rather than block-only.
 func TestSeedNotOfferedForStillEnabledConfigureHost(t *testing.T) {
 	root := t.TempDir()
 	writeCommittedConfigLocal(t, root)

--- a/internal/interview/sequence.go
+++ b/internal/interview/sequence.go
@@ -177,7 +177,9 @@ func (d docSpec) allAnswered(answers map[string]string) bool {
 // included only once both toggles are answered at all, followed by any
 // applicable instruction-file seed question (seedDocs, seed.go), which
 // fires only for an enabled host whose root instruction file is absent
-// while the other host's carries conventions. It returns
+// while the other host's carries conventions — init offers no repair of
+// an existing block-only file (initSeedScope), which is `orch
+// configure`'s alone. It returns
 // ErrNoHostEnabled as soon as both toggles are known and both are
 // "no" — the same rule config.validate enforces on the committed file,
 // checked here before any role question is ever asked.
@@ -201,7 +203,7 @@ func buildSequence(facts Facts, answers map[string]string) ([]docSpec, error) {
 	}
 	if claudeKnown && codexKnown {
 		docs = append(docs, settingsDoc(initSettingsDefaults(facts)))
-		docs = append(docs, seedDocs(facts, map[string]bool{"claude": claudeEnabled, "codex": codexEnabled})...)
+		docs = append(docs, seedDocs(facts, initSeedScope(claudeEnabled, codexEnabled))...)
 	}
 	return docs, nil
 }

--- a/internal/interview/summary.go
+++ b/internal/interview/summary.go
@@ -42,6 +42,16 @@ func InstructionFile(host string) string {
 	return instructionFileFor[host]
 }
 
+// SiblingInstructionFile returns the root instruction file name of the
+// host that is not host — the file seeding copies conventions from
+// (seed.go). Exported for the same reason InstructionFile is: `orch
+// doctor`'s block-only advisory names that file as the one `orch
+// configure` can seed from, and the claude/codex pairing itself stays
+// owned here (siblingHost) rather than being restated per caller.
+func SiblingInstructionFile(host string) string {
+	return instructionFileFor[siblingHost(host)]
+}
+
 // baseGitignoreLines are the repo-relative ignore patterns every
 // initialized repository needs, mirroring (as literal strings —
 // Detect's execProber-duplication precedent, so this pre-init-safe

--- a/internal/question/question.go
+++ b/internal/question/question.go
@@ -149,6 +149,13 @@ type Summary struct {
 // repo-relative with forward slashes regardless of host OS. The
 // bootstrap executor writes NewContent verbatim; Diff is display-only
 // (a unified diff against the file's current content, or its absence).
+// One exception is deliberate: a seeded instruction file (internal/
+// interview's seed.go) is always diffed against absence, so what a
+// human approves is the whole proposed file rather than the changed
+// lines against borrowed context. That covers the case where the file
+// exists holding nothing but the Orch managed block, which the proposal
+// reproduces verbatim; Existed still reports what was found on disk
+// either way.
 // Delete is emit-only: configure-local sets it when clearing the last
 // machine-local override deletes config.local.toml outright rather than
 // writing an empty file (an empty override file would make


### PR DESCRIPTION
Delivers issue #198: Offer to seed an existing block-only instruction file from the sibling

Closes #198

**Plan digest:** `sha256:d5596bc10c111556c64143f708a651618b56cfccd6bde617821ef6ba5d66309e`

The approved objective and acceptance criteria are in the audit record below.

## Blast radius

Every element of the seeding / interview / doctor structure this change
touches, each with a verdict on whether the behavior it had before still
holds. Head commit `cc3c67e72ec265eb11b155084caffc19a77cefb0`.

### Detection

| Element | Before → after |
| --- | --- |
| `interview.InstructionFileState` | **Before:** two fields, `Exists` and `Conventions`. **After:** both keep exactly their old meaning, producers and consumers; a third field `BlockOnly` is added. Nothing removed. Its doc records that `BlockOnly` is strictly narrower than `Exists && !Conventions`. |
| `interview.classifyInstructionFile` | **Before:** returned `Exists` plus `Conventions` (`!IsOtherwiseEmpty` of the `PlanRemove` remainder), reporting trouble as data — an unreadable file or broken markers classified as "exists, no conventions". **After:** identical for those two fields, including every trouble row, and additionally sets `BlockOnly` from `isBlockOnly`. Every trouble row reports `BlockOnly: false`, so the fail-closed property is preserved and extended to the new field. |

### The seed offer

| Element | Before → after |
| --- | --- |
| `seedOffer` | **Before:** `host`, `file` (documented "absent today"), `sibling`. **After:** same three fields, plus `repair`; `file`'s comment corrected because the file may now already exist. |
| `seedOffers` | **Before:** offered iff `newlyEnabled[host] && !Instructions[host].Exists && Instructions[sibling].Conventions`. **After:** that create case is unchanged bit for bit, and a second, mutually exclusive repair case is admitted: `scope.repaired[host] && Instructions[host].BlockOnly`. The `Conventions(sibling)` gate is unchanged and still required by both. The removed statement ("the offer is only ever made for an absent file") is recorded as a before-and-after in `seedOffers`' own doc comment rather than deleted. |
| `seedOffers` / `seedDocs` / `seedFiles` signatures | **Before:** each took `newlyEnabled map[string]bool`. **After:** each takes `seedScope`. A signature change only — every call site was updated, and for the create path the derived offers, questions and seeds are identical to before (the golden transcripts for both interviews pass unmodified). |
| `seedQuestion` | **Before:** one wording, for a file that does not exist yet. **After:** that wording is byte-unchanged and still used for every create offer; a repair offer gets new prompt and preamble text naming the file that exists and saying that yes rewrites it and no leaves it as it is. `ID`, `Header`, `Kind`, `Default: "yes"` and `Options` are unchanged for both shapes. |
| `planSeeded` | **Before:** any path that existed fell back to `instructions.PlanFile`; `FileExisted` was hardcoded `false`. **After:** an existing path is seeded if and only if `seedable`/`isBlockOnly`, re-derived from disk at plan time, agrees it holds nothing but the current managed block; every other existing path still falls back to `PlanFile`, and `FileExisted` now reports the truth from the read. `Old = ""` and `Diff = UnifiedDiff("", New)` are unchanged. The removed "the path must not exist" guard is recorded as a before-and-after in `planSeeded`'s doc, and the statement it qualified ("seeding must never overwrite a file somebody already wrote") is retained, not deleted. |
| `seededPlanFile` | Unchanged behavior: an empty `seeds` still returns `instructions.PlanFile` itself, so every session that offers no seeding plans exactly as before. Doc wording widened from "instead of from nothing" to "instead of from its own content or absence". |

### New symbols

| Element | Before → after |
| --- | --- |
| `seedScope` (new) | No prior behavior. Two host-keyed sets, `created` and `repaired`, replacing the single `newlyEnabled` map so the two offers can be licensed independently. |
| `initSeedScope` (new) | No prior behavior. Fills `created` only, leaving `repaired` nil, which is what keeps `orch init` byte-identical. |
| `configureSeedScope` (new) | No prior behavior. Replaces two duplicated map literals — previously `nextAfterSequenceConfigure` and `buildSequenceConfigure` each built the newly-enabled set inline. Both now build the scope here, so the question asked and the answer honored cannot disagree about which offers applied. |
| `seedable` (new) | No prior behavior. Extracts `planSeeded`'s former inline `os.Stat` guard and widens it: absent, or block-only, is seedable; a path that cannot be read at all fails closed to not-seedable, so it is planned the ordinary way and that read failure surfaces as an error instead of being seeded over. |
| `isBlockOnly` (new) | No prior behavior. `PlanRemove` succeeds **and** `DeleteWholeFile` **and** `Inspect(content).Status == StatusCurrent`. The third conjunct is what excludes a drifted or newer-versioned block-only file from repair, and it is the only predicate in the change that can license replacing an existing file's bytes. Shared by `classifyInstructionFile` and `seedable`, so tightening it tightens both paths at once. |

### The two interviews

| Element | Before → after |
| --- | --- |
| `buildSequence` + `nextAfterSequence` (`orch init`) | **Behavior unchanged**, despite both call sites changing shape from a `map[string]bool` literal to `initSeedScope(...)`. `orch init` passes no `repaired` set, so it offers creation alone exactly as before; its golden transcript test passes unmodified. |
| `buildSequenceConfigure` + `nextAfterSequenceConfigure` | **Before:** a seed doc only for a host this change newly enables, so a still-enabled host was offered nothing. **After:** that create offer is unchanged, plus a repair offer for every host the resulting configuration leaves enabled whose file is block-only. Recorded as a before-and-after in `buildSequenceConfigure`'s doc. The three existing configure golden transcripts pass unmodified. |
| `buildSummary` / `buildConfigureSummary` / `planInstructionFiles` | No code change. `buildConfigureSummary`'s doc gains a clause for the whole-file seeded proposal. A repair-only run produces a non-empty file diff, so `allFileChangesUnchanged` correctly does **not** raise the "nothing to deliver" blocker — which is what makes a repair deliverable in a repository whose configuration is otherwise unchanged. |
| `interview.SiblingInstructionFile` (new, exported) | No prior behavior. A thin wrapper over the existing unexported `siblingHost` so `internal/cli` need not restate the claude/codex pairing. `interview.InstructionFile` is untouched. |
| `bootstrap.writeFiles` / `validateConfigure` / `ExecuteConfigure` | **No code change, behavior unchanged.** A repaired file is overwritten inside the disposable worktree like any upgrade, and validates `StatusCurrent`. Proven end to end by `TestExecuteConfigureRepairsBlockOnlyInstructionFile`, which also asserts the primary checkout is never written. |

### Contracts and reporting

| Element | Before → after |
| --- | --- |
| `question.FileChange.Diff` | **Before:** documented as "a unified diff against the file's current content, or its absence"; a seeded file (create case) was already diffed against absence. **After:** the same, now also covering a file that exists holding nothing but the managed block, which the proposal reproduces verbatim. The doc states the exception explicitly rather than leaving the old sentence imprecise. |
| `question.FileChange.Existed` | **Unchanged.** Still the truth from disk, which is why `planSeeded` sets `FileExisted` from the read instead of hardcoding `false`: `bootstrap.renderRecord` prints `- \`AGENTS.md\` (existed: %t)` into the issue and PR body, and a repaired file must not be described there as newly created. |
| `orch doctor`'s block-only advisory | **Before:** fired on `PlanRemoveFile` succeeding with `DeleteWholeFile`, and said "— add them outside the block". **After:** the firing condition is byte-identical; only the message changes, to also name `orch configure` and the sibling file it can seed from. The removed clause ("Orch never carries a repository's conventions across from the other host's file") is recorded as a before-and-after in the comment above the check rather than deleted. The looser reading of block-only is kept deliberately: a drifted or newer-versioned block-only file is still worth reporting, and `orch configure` names it as a blocker rather than replacing a body this build cannot vouch for. |
| `README.md` | **Not touched.** Its `## Fixed` entry for PR #192 is a release note for v0.6.1 and is accurate for that release; this repository's convention (PR #192 itself, brought current later by PR #195) is that a feature PR does not edit it. Nothing there was deleted or rewritten. |

### Restriction scope: one symbol, or every symbol of its kind

1. **"The repair offer is `orch configure`'s alone."** This is a property of **`initSeedScope` alone**, not of `seedScope` or of every scope of its kind. `seedScope` is perfectly capable of licensing a repair — `configureSeedScope` does exactly that — and nothing in `seedOffers` privileges either caller. What confines the offer to `orch configure` is only that `initSeedScope` returns a scope whose `repaired` set is nil. Any future caller building a scope with a non-nil `repaired` set gets the repair offer, so the restriction lives in that one constructor and its doc comment says so.

2. **"Always diffed against absence."** This is true of **seeded instruction files only**, not of every `question.FileChange`. Ordinary `PlanFile`/`PlanRemoveFile` changes, and `configure-local`'s own file change, still carry a real diff against their current content; `planSeeded` is the single producer that sets `Old = ""` and diffs against absence, and it does so for both its create and its repair case. `Existed` remains the disk truth for every `FileChange` without exception, including the seeded ones.

3. A third scope verdict, for completeness: **"must not overwrite an existing file"** was attributed to `planSeeded`. It holds for **`planSeeded` alone**, not for every plan function of its kind — `instructions.PlanFile` and `PlanRemoveFile` splice an existing file's managed region by design — and the new carve-out is `planSeeded`'s only.

### Behavior removed, and where each removal is recorded

| Removed behavior | Recorded as a before-and-after in |
| --- | --- |
| Seeding is only ever offered for an absent file | `internal/interview/seed.go`, `seedOffers`' doc comment |
| `planSeeded` refuses every path that exists | `internal/interview/seed.go`, `planSeeded`'s doc comment |
| Orch never carries conventions across from the other host's file | `internal/cli/doctor.go`, the comment above the advisory |
| Configure's seed offer applies only to a newly enabled host | `internal/interview/configure.go`, `buildSequenceConfigure`'s doc comment |
| The still-enabled-host restriction covers seeding as a whole | `internal/interview/seed_test.go`, `TestSeedNotOfferedForStillEnabledConfigureHost`'s doc comment |
| `TestSeedNeverOverwritesAnExistingFile`: an existing target file always falls back to the ordinary plan, so seeding never overwrites any existing file | `internal/interview/seed_test.go`, the renamed `TestSeedNeverOverwritesAFileWithConventionsOfItsOwn`'s doc comment — the rename is itself part of the record, since the old name asserted the removed invariant in general form |

Every statement of old behavior this change invalidates is now recorded as a before-and-after in place, and none was deleted. The last row above was the exception until cycle 2: that test's comment had been reworded to describe only the case that still holds, which narrowed the old unqualified statement away instead of recording it, and its name went on asserting the removed invariant in general form — contradicting `TestPlanSeededOnlySeedsOverAnAbsentOrBlockOnlyFile` four functions below it, so two passing tests carried opposing names. Both are fixed in commit `cc3c67e`: the test is renamed to the invariant it actually pins, and its comment now carries the old name and the old statement as an explicit before-and-after.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Instruction-file seeding fires only for a newly enabled host whose root instruction file does not exist, and the planner deliberately refuses to touch an existing file. A file that already exists holding only the Orch managed block therefore has no repair path: doctor reports it, and the only fix today is a manual Delivery run in the affected repository. Extend the configure interview to offer seeding for exactly that block-only case, from a sibling instruction file that carries conventions outside its own block, so the state doctor warns about is repairable where the seeding machinery already lives.

**Acceptance criteria:**
- In a repository where an enabled host's root instruction file holds only the Orch managed block while the sibling instruction file carries conventions outside its own block, the orch configure interview offers to repair the block-only file by seeding it from the sibling, with the full resulting file shown as a diff before approval and nothing written until the summary is approved.
- A file carrying any content outside its own managed block is never offered for repair and is never modified by seeding; repair applies only to a file whose entire content is the managed block.
- Declining the offer, or running in a repository with no block-only instruction file, leaves every configure and init interview walk byte-identical to today's.
- orch doctor's existing block-only advisory names orch configure as the repair path.
- Blast radius (contributed by Orch because this issue declares a risk domain, not by the plan document): name every element of the structure this change touches and state, for each, whether the behavior it had before this change still holds; record a behavior this change removes as a before-and-after in the same document that stated the old behavior, rather than deleting that statement; and where a restriction is attributed to one named symbol, establish whether it holds for that symbol alone or for every symbol of its kind, and say which.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `specialist` |
| Executor | `claude-opus-5` — effort `high` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to a specialist with a strong reviewer because risk domains (destructive-operations).

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test -count=1 ./...` — Re-run at the final head cc3c67e by the executor after the rename (23 packages ok, renamed test passes) and independently by the cycle-3 reviewer in a scratch clone; CI run 31278581011 green at exactly this sha. — commit `cc3c67e72ec265eb11b155084caffc19a77cefb0` (2026-08-08T21:18:00Z)
- **go-vet** — pass — `go vet ./...` — Re-run at cc3c67e by executor and cycle-3 reviewer; no output. — commit `cc3c67e72ec265eb11b155084caffc19a77cefb0` (2026-08-08T21:18:00Z)
- **gofmt** — pass — `gofmt -l .` — Re-run at cc3c67e by executor and cycle-3 reviewer; printed nothing. — commit `cc3c67e72ec265eb11b155084caffc19a77cefb0` (2026-08-08T21:18:00Z)
- **prose-reflow-word-diff** — pass — `git diff --word-diff --ignore-all-space` — Every removal marker in prose-touched files inspected; all are intentional rewrites, no dropped words. Correction from cycle 1: the doctor advisory's removed clause is restated faithfully and with attribution in place, but reworded, not verbatim. — commit `241fd08ba362cc3a583ad201b2a3bdb781ee9ad8` (2026-08-08T21:05:56Z)
- **acceptance-criterion-1** — satisfied — The flagship interview test asserts the offer, Existed true, sibling conventions leading NewContent, exactly one managed block at StatusCurrent, every NewContent line as an addition in the diff, and disk unchanged after the walk; the bootstrap end-to-end test drives real Detect through ExecuteConfigure and asserts the configure branch carries the seeded file while the primary checkout still holds the bare block. — commit `cc3c67e72ec265eb11b155084caffc19a77cefb0` (2026-08-08T21:18:01Z)
- **acceptance-criterion-2** — satisfied — isBlockOnly is the single predicate licensing byte replacement, shared by offer-time classification and plan-time re-derivation from disk so the gates cannot diverge; the seven-shape refusal matrix, both stale-answer race legs, and ten fresh reviewer probes all refuse; the only tolerated variant is a CRLF block-only file holding no user content outside the block. — commit `cc3c67e72ec265eb11b155084caffc19a77cefb0` (2026-08-08T21:18:01Z)
- **acceptance-criterion-3** — satisfied — No testdata file in the whole-PR diff and all seven golden transcripts pass unmodified; a declined offer yields the identical proposal configure made before (NewContent equals the block, empty diff); init never asks because initSeedScope leaves repaired nil. Satisfied on the proposal/outcome reading; the literal wording cannot hold once the offer document exists, noted as looseness rather than a defect. — commit `cc3c67e72ec265eb11b155084caffc19a77cefb0` (2026-08-08T21:18:01Z)
- **acceptance-criterion-4** — satisfied — The advisory names orch configure with the sibling file supplied by SiblingInstructionFile, the doctor test pins the exact substring, and the firing condition is unchanged. — commit `cc3c67e72ec265eb11b155084caffc19a77cefb0` (2026-08-08T21:18:01Z)
- **acceptance-criterion-5** — satisfied — All 21 production hunks map to enumeration rows; the six-row removed-behavior table points each removal at the document that stated the old behavior, two rows verified at source; three restriction-scope verdicts present with two independently checked (diff-against-absence is planSeeded's alone; the repair confinement lives in initSeedScope's nil repaired set, not in seedOffers); the cycle-2 gap is closed in code and in the settling artifact, whose corrected closing claim now states the exception and cites the fix commit. — commit `cc3c67e72ec265eb11b155084caffc19a77cefb0` (2026-08-08T21:18:01Z)
- **review-cycle-1** — request-changes — Blocking on criterion 5 alone: the PR body carries no blast-radius enumeration (criterion says the enumeration in the PR body is what settles it; tests do not). Code-level before-and-afters are done well. Reviewer independently reproduced all three required tests, confirmed 6/6 CI, and attacked the destructive-operations boundary seven ways (three PR #192 replay attacks plus BOM, directory-as-file, marker-whitespace, NBSP probes) without finding a path that overwrites content outside a managed block. Secondary findings: a stale doc comment on TestSeedNotOfferedForStillEnabledConfigureHost attributes the newly-enabled-only restriction to the offer generally when it now holds for the create offer alone (F2); the prose-reflow verification's word 'verbatim' overstates the doctor-advisory restatement, which is faithful and attributed but reworded (F3). — commit `2e122576f563c9e3ed36af9beabeeaeaaccadf66` (2026-08-08T20:53:07Z)
- **review-cycle-2** — request-changes — Cycle 2. F1 substantially cleared (the PR-body enumeration is genuine - roughly 30 elements, load-bearing rows spot-verified against source, all three restriction-scope verdicts present and honest) and F2 cleared. One narrow criterion-5 gap remains: TestSeedNeverOverwritesAnExistingFile in internal/interview/seed_test.go had its doc comment reworded in this PR, silently narrowing away the old-behavior statement (for a block-only existing file the ordinary plan no longer runs), its name still states the old invariant in a general form the change made false, and the PR body asserts at line 80 that no statement of old behavior was deleted anywhere - a false universal in the settling artifact - while the removed-behavior table omits this element. The delta commit touches only what F2 required; CI 6/6 green at the reviewed head; the audit record parses through the engine's own parser with no drift; the reviewer re-attacked the destructive boundary with fresh probes (NBSP, ideographic space, BOM, zero-width space, trailing HTML comment, drifted, newer, malformed, empty) and all refuse. Fix is a comment rewrite, a name reconciliation, and two PR-body corrections - no production code. — commit `241fd08ba362cc3a583ad201b2a3bdb781ee9ad8` (2026-08-08T21:05:57Z)
- **review-cycle-3** — approve — Cycle 3 approve. The delta since cycle 2 is exactly the required fix: one file, the test renamed to TestSeedNeverOverwritesAFileWithConventionsOfItsOwn with a before-and-after doc comment naming the old name and old unqualified claim, test body unchanged, nothing referencing the old name; plus the PR-body corrections (removed-behavior row added, the false universal replaced by a true statement citing the fix commit). The reviewer mapped all 21 production hunks to enumeration rows with full coverage, verified two removed-behavior rows and two restriction-scope verdicts at source, re-derived criteria 1-4 independently, ran ten fresh malformed-input probes against the overwrite boundary (soft hyphen, NEL, U+2028, indented markers, injected blank line, form feed, doubled block, conventions below block, trailing comment, CRLF) - every one refuses except the CRLF block-only file, which holds no user content outside the block and is normalized on repair, informational. Required tests green at the head in a scratch clone; CI 6/6 at exactly cc3c67e. Non-blocking: two additively-tightened pre-existing tests absent from the enumeration (owed no removal record); criterion 3's literal byte-identical-walk wording unsatisfiable once the offer exists, satisfied on the proposal/outcome reading the tests pin. — commit `cc3c67e72ec265eb11b155084caffc19a77cefb0` (2026-08-08T21:18:01Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `cc3c67e72ec265eb11b155084caffc19a77cefb0` (2026-08-08T21:18:05Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Instruction-file seeding fires only for a newly enabled host whose root instruction file does not exist, and the planner deliberately refuses to touch an existing file. A file that already exists holding only the Orch managed block therefore has no repair path: doctor reports it, and the only fix today is a manual Delivery run in the affected repository. Extend the configure interview to offer seeding for exactly that block-only case, from a sibling instruction file that carries conventions outside its own block, so the state doctor warns about is repairable where the seeding machinery already lives.",
  "acceptance_criteria": [
    "In a repository where an enabled host's root instruction file holds only the Orch managed block while the sibling instruction file carries conventions outside its own block, the orch configure interview offers to repair the block-only file by seeding it from the sibling, with the full resulting file shown as a diff before approval and nothing written until the summary is approved.",
    "A file carrying any content outside its own managed block is never offered for repair and is never modified by seeding; repair applies only to a file whose entire content is the managed block.",
    "Declining the offer, or running in a repository with no block-only instruction file, leaves every configure and init interview walk byte-identical to today's.",
    "orch doctor's existing block-only advisory names orch configure as the repair path.",
    "Blast radius (contributed by Orch because this issue declares a risk domain, not by the plan document): name every element of the structure this change touches and state, for each, whether the behavior it had before this change still holds; record a behavior this change removes as a before-and-after in the same document that stated the old behavior, rather than deleting that statement; and where a restriction is attributed to one named symbol, establish whether it holds for that symbol alone or for every symbol of its kind, and say which."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "specialist",
  "executor": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "routing_rationale": "Routed to a specialist with a strong reviewer because risk domains (destructive-operations).",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test -count=1 ./...",
      "result": "pass",
      "detail": "Re-run at the final head cc3c67e by the executor after the rename (23 packages ok, renamed test passes) and independently by the cycle-3 reviewer in a scratch clone; CI run 31278581011 green at exactly this sha.",
      "commit_oid": "cc3c67e72ec265eb11b155084caffc19a77cefb0",
      "at": "2026-08-08T21:18:00Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Re-run at cc3c67e by executor and cycle-3 reviewer; no output.",
      "commit_oid": "cc3c67e72ec265eb11b155084caffc19a77cefb0",
      "at": "2026-08-08T21:18:00Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Re-run at cc3c67e by executor and cycle-3 reviewer; printed nothing.",
      "commit_oid": "cc3c67e72ec265eb11b155084caffc19a77cefb0",
      "at": "2026-08-08T21:18:00Z"
    },
    {
      "name": "prose-reflow-word-diff",
      "command": "git diff --word-diff --ignore-all-space",
      "result": "pass",
      "detail": "Every removal marker in prose-touched files inspected; all are intentional rewrites, no dropped words. Correction from cycle 1: the doctor advisory's removed clause is restated faithfully and with attribution in place, but reworded, not verbatim.",
      "commit_oid": "241fd08ba362cc3a583ad201b2a3bdb781ee9ad8",
      "at": "2026-08-08T21:05:56Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "The flagship interview test asserts the offer, Existed true, sibling conventions leading NewContent, exactly one managed block at StatusCurrent, every NewContent line as an addition in the diff, and disk unchanged after the walk; the bootstrap end-to-end test drives real Detect through ExecuteConfigure and asserts the configure branch carries the seeded file while the primary checkout still holds the bare block.",
      "commit_oid": "cc3c67e72ec265eb11b155084caffc19a77cefb0",
      "at": "2026-08-08T21:18:01Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "isBlockOnly is the single predicate licensing byte replacement, shared by offer-time classification and plan-time re-derivation from disk so the gates cannot diverge; the seven-shape refusal matrix, both stale-answer race legs, and ten fresh reviewer probes all refuse; the only tolerated variant is a CRLF block-only file holding no user content outside the block.",
      "commit_oid": "cc3c67e72ec265eb11b155084caffc19a77cefb0",
      "at": "2026-08-08T21:18:01Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "No testdata file in the whole-PR diff and all seven golden transcripts pass unmodified; a declined offer yields the identical proposal configure made before (NewContent equals the block, empty diff); init never asks because initSeedScope leaves repaired nil. Satisfied on the proposal/outcome reading; the literal wording cannot hold once the offer document exists, noted as looseness rather than a defect.",
      "commit_oid": "cc3c67e72ec265eb11b155084caffc19a77cefb0",
      "at": "2026-08-08T21:18:01Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "The advisory names orch configure with the sibling file supplied by SiblingInstructionFile, the doctor test pins the exact substring, and the firing condition is unchanged.",
      "commit_oid": "cc3c67e72ec265eb11b155084caffc19a77cefb0",
      "at": "2026-08-08T21:18:01Z"
    },
    {
      "name": "acceptance-criterion-5",
      "result": "satisfied",
      "detail": "All 21 production hunks map to enumeration rows; the six-row removed-behavior table points each removal at the document that stated the old behavior, two rows verified at source; three restriction-scope verdicts present with two independently checked (diff-against-absence is planSeeded's alone; the repair confinement lives in initSeedScope's nil repaired set, not in seedOffers); the cycle-2 gap is closed in code and in the settling artifact, whose corrected closing claim now states the exception and cites the fix commit.",
      "commit_oid": "cc3c67e72ec265eb11b155084caffc19a77cefb0",
      "at": "2026-08-08T21:18:01Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "Blocking on criterion 5 alone: the PR body carries no blast-radius enumeration (criterion says the enumeration in the PR body is what settles it; tests do not). Code-level before-and-afters are done well. Reviewer independently reproduced all three required tests, confirmed 6/6 CI, and attacked the destructive-operations boundary seven ways (three PR #192 replay attacks plus BOM, directory-as-file, marker-whitespace, NBSP probes) without finding a path that overwrites content outside a managed block. Secondary findings: a stale doc comment on TestSeedNotOfferedForStillEnabledConfigureHost attributes the newly-enabled-only restriction to the offer generally when it now holds for the create offer alone (F2); the prose-reflow verification's word 'verbatim' overstates the doctor-advisory restatement, which is faithful and attributed but reworded (F3).",
      "commit_oid": "2e122576f563c9e3ed36af9beabeeaeaaccadf66",
      "at": "2026-08-08T20:53:07Z"
    },
    {
      "name": "review-cycle-2",
      "result": "request-changes",
      "detail": "Cycle 2. F1 substantially cleared (the PR-body enumeration is genuine - roughly 30 elements, load-bearing rows spot-verified against source, all three restriction-scope verdicts present and honest) and F2 cleared. One narrow criterion-5 gap remains: TestSeedNeverOverwritesAnExistingFile in internal/interview/seed_test.go had its doc comment reworded in this PR, silently narrowing away the old-behavior statement (for a block-only existing file the ordinary plan no longer runs), its name still states the old invariant in a general form the change made false, and the PR body asserts at line 80 that no statement of old behavior was deleted anywhere - a false universal in the settling artifact - while the removed-behavior table omits this element. The delta commit touches only what F2 required; CI 6/6 green at the reviewed head; the audit record parses through the engine's own parser with no drift; the reviewer re-attacked the destructive boundary with fresh probes (NBSP, ideographic space, BOM, zero-width space, trailing HTML comment, drifted, newer, malformed, empty) and all refuse. Fix is a comment rewrite, a name reconciliation, and two PR-body corrections - no production code.",
      "commit_oid": "241fd08ba362cc3a583ad201b2a3bdb781ee9ad8",
      "at": "2026-08-08T21:05:57Z"
    },
    {
      "name": "review-cycle-3",
      "result": "approve",
      "detail": "Cycle 3 approve. The delta since cycle 2 is exactly the required fix: one file, the test renamed to TestSeedNeverOverwritesAFileWithConventionsOfItsOwn with a before-and-after doc comment naming the old name and old unqualified claim, test body unchanged, nothing referencing the old name; plus the PR-body corrections (removed-behavior row added, the false universal replaced by a true statement citing the fix commit). The reviewer mapped all 21 production hunks to enumeration rows with full coverage, verified two removed-behavior rows and two restriction-scope verdicts at source, re-derived criteria 1-4 independently, ran ten fresh malformed-input probes against the overwrite boundary (soft hyphen, NEL, U+2028, indented markers, injected blank line, form feed, doubled block, conventions below block, trailing comment, CRLF) - every one refuses except the CRLF block-only file, which holds no user content outside the block and is normalized on repair, informational. Required tests green at the head in a scratch clone; CI 6/6 at exactly cc3c67e. Non-blocking: two additively-tightened pre-existing tests absent from the enumeration (owed no removal record); criterion 3's literal byte-identical-walk wording unsatisfiable once the offer exists, satisfied on the proposal/outcome reading the tests pin.",
      "commit_oid": "cc3c67e72ec265eb11b155084caffc19a77cefb0",
      "at": "2026-08-08T21:18:01Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "cc3c67e72ec265eb11b155084caffc19a77cefb0",
      "at": "2026-08-08T21:18:05Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->

