### PR TITLE
Surface which required tests CI does not run at the plan gate

### DIFF
--- a/adapters/claude/skills/orch-delivery/SKILL.md
+++ b/adapters/claude/skills/orch-delivery/SKILL.md
@@ -60,6 +60,7 @@ a routed selection.
                      "fully_specified": false, "unsurprising": false}
     },
     "depends_on": [], "wave": 1, "required_tests": ["..."],
+    "tests_ci_does_not_run": ["..."],
     "usage_class": "medium"
   }]
 }
@@ -82,6 +83,19 @@ leaves the bar for "done" to be invented later. Each required test names
 the exact command that gates the change (`go test ./...`, `gofmt -l .`);
 it is not an invitation for comprehensive coverage, just the check this
 change must pass.
+
+When the repository's CI does not run one of those required tests — it
+sits behind a build tag no workflow enables, needs a tool or credential
+CI has not got, or no workflow invokes it at all — name that exact
+command in `tests_ci_does_not_run`. Every entry must match one of the
+same issue's `required_tests` strings exactly, or the plan is rejected.
+The engine renders the declaration beside the test it names at the plan
+gate, in the created issue body, and in the dispatch result, so the human
+approves knowing which of the issue's gates CI actually holds and the
+executor knows which check nothing but a local run will ever execute.
+Omit the field unless you checked the repository's workflows yourself: it
+is a claim about that repository, and saying nothing is honest where a
+guess is not. Omitting it never asserts that CI runs everything.
 
 An acceptance criterion describes an observable outcome, and never
 names a function, a control-flow step, or a validity notion the change
@@ -167,14 +181,20 @@ Call `orch run plan` with the `PlanDoc` on stdin. The result is a
 `issues[]` — each with `id`, `title`, `objective`,
 `acceptance_criteria`, `role`, `executor` (`{model, effort}`),
 `reviewer` (`{model, effort}`), `reviewer_downgraded`,
-`routing_rationale`, `depends_on`, `wave`, `required_tests`, `risk`,
-`usage_class`, `labels`.
+`routing_rationale`, `depends_on`, `wave`, `required_tests`,
+`tests_ci_does_not_run`, `risk`, `usage_class`, `labels`.
 
 Render the gate in full prose before asking anything: every field of
 every issue (name the routed model and effort plainly, and explain a
 `reviewer_downgraded` via `routing_rationale`), then the run-level
 fields (`plan_title`, `host`, `merge_strategy`, `config_revision` +
 `config_overrides` if any, `memhub`, `ci`).
+
+Render each entry of `tests_ci_does_not_run` against the required test it
+names, not as a list of its own: the human is approving that command as a
+check nothing but a local run will ever execute. An absent field is the
+plan saying nothing about CI coverage — never report it as a finding that
+CI runs every required test.
 
 Then ask **one** `AskUserQuestion`, header `Plan gate`, exactly these
 four options in order:
@@ -223,9 +243,10 @@ Work issues in wave order, never more than `concurrency.max_subagents`
 in flight at once. For each issue:
 
 1. **Dispatch** — `orch run dispatch` with
-   `{"schema_version": 2, "issue_number": N}`. Result
+   `{"schema_version": 3, "issue_number": N}`. Result
    (`DispatchResult`): `branch`, `worktree`, `executor`, `reviewer`,
-   `rationale`, `objective`, `acceptance_criteria`, `required_tests`.
+   `rationale`, `objective`, `acceptance_criteria`, `required_tests`,
+   `tests_ci_does_not_run`.
 
 2. **Spawn the executor** — spawn `orch-implementer` or
    `orch-specialist` (per the routed role) via the Task tool **by
@@ -266,7 +287,10 @@ in flight at once. For each issue:
    `DispatchResult.objective`, `.acceptance_criteria`, and
    `.required_tests` into the prompt **verbatim** — this is the text a
    human approved at the plan gate, not the Architect's recollection of
-   it — along with the worktree path and branch.
+   it — along with the worktree path and branch. Transcribe each entry of
+   `.tests_ci_does_not_run` against the required test it names, so the
+   executor is told which of its required checks CI will not repeat; drop
+   nothing, an unstated one reads as a check CI holds.
 
    Before spawning, you (the Architect) perform whatever memhub recall
    is relevant to the issue, with the main checkout as cwd — never a

--- a/adapters/codex/skills/orch-delivery/SKILL.md
+++ b/adapters/codex/skills/orch-delivery/SKILL.md
@@ -60,6 +60,7 @@ a routed selection.
                      "fully_specified": false, "unsurprising": false}
     },
     "depends_on": [], "wave": 1, "required_tests": ["..."],
+    "tests_ci_does_not_run": ["..."],
     "usage_class": "medium"
   }]
 }
@@ -82,6 +83,19 @@ leaves the bar for "done" to be invented later. Each required test names
 the exact command that gates the change (`go test ./...`, `gofmt -l .`);
 it is not an invitation for comprehensive coverage, just the check this
 change must pass.
+
+When the repository's CI does not run one of those required tests — it
+sits behind a build tag no workflow enables, needs a tool or credential
+CI has not got, or no workflow invokes it at all — name that exact
+command in `tests_ci_does_not_run`. Every entry must match one of the
+same issue's `required_tests` strings exactly, or the plan is rejected.
+The engine renders the declaration beside the test it names at the plan
+gate, in the created issue body, and in the dispatch result, so the human
+approves knowing which of the issue's gates CI actually holds and the
+executor knows which check nothing but a local run will ever execute.
+Omit the field unless you checked the repository's workflows yourself: it
+is a claim about that repository, and saying nothing is honest where a
+guess is not. Omitting it never asserts that CI runs everything.
 
 An acceptance criterion describes an observable outcome, and never
 names a function, a control-flow step, or a validity notion the change
@@ -167,14 +181,20 @@ Call `orch run plan` with the `PlanDoc` on stdin. The result is a
 `issues[]` — each with `id`, `title`, `objective`,
 `acceptance_criteria`, `role`, `executor` (`{model, effort}`),
 `reviewer` (`{model, effort}`), `reviewer_downgraded`,
-`routing_rationale`, `depends_on`, `wave`, `required_tests`, `risk`,
-`usage_class`, `labels`.
+`routing_rationale`, `depends_on`, `wave`, `required_tests`,
+`tests_ci_does_not_run`, `risk`, `usage_class`, `labels`.
 
 Render the gate in full prose before asking anything: every field of
 every issue (name the routed model and effort plainly, and explain a
 `reviewer_downgraded` via `routing_rationale`), then the run-level
 fields (`plan_title`, `host`, `merge_strategy`, `config_revision` +
 `config_overrides` if any, `memhub`, `ci`).
+
+Render each entry of `tests_ci_does_not_run` against the required test it
+names, not as a list of its own: the human is approving that command as a
+check nothing but a local run will ever execute. An absent field is the
+plan saying nothing about CI coverage — never report it as a finding that
+CI runs every required test.
 
 Then ask, via Codex's `request_user_input` primitive, **one** question
 — header `Plan gate` — offering exactly these four options in order
@@ -261,9 +281,10 @@ child is never a candidate. Capture every completed agent separately:
 When capture returns no total, omit the corresponding optional field.
 
 1. **Dispatch** — `orch run dispatch` with
-   `{"schema_version": 2, "issue_number": N}`. Result
+   `{"schema_version": 3, "issue_number": N}`. Result
    (`DispatchResult`): `branch`, `worktree`, `executor`, `reviewer`,
-   `rationale`, `objective`, `acceptance_criteria`, `required_tests`.
+   `rationale`, `objective`, `acceptance_criteria`, `required_tests`,
+   `tests_ci_does_not_run`.
 
 2. **Dispatch the executor** — dispatch `orch-implementer` or
    `orch-specialist` (per the routed role) by naming the agent in your
@@ -301,7 +322,10 @@ When capture returns no total, omit the corresponding optional field.
    `DispatchResult.objective`, `.acceptance_criteria`, and
    `.required_tests` into the prompt **verbatim** — this is the text a
    human approved at the plan gate, not the Architect's recollection of
-   it — along with the worktree path and branch.
+   it — along with the worktree path and branch. Transcribe each entry of
+   `.tests_ci_does_not_run` against the required test it names, so the
+   executor is told which of its required checks CI will not repeat; drop
+   nothing, an unstated one reads as a check CI holds.
 
    Before dispatching, you (the Architect) perform whatever memhub
    recall is relevant to the issue, with the main checkout as cwd —

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -122,7 +122,7 @@ func TestRunStatusNeverReadsStdin(t *testing.T) {
 // valid document yields ExitError, never ExitUsage.
 func TestRunLifecycleVerbsAreRouted(t *testing.T) {
 	verbs := map[string]string{
-		"dispatch":        `{"schema_version":2,"issue_number":1}`,
+		"dispatch":        `{"schema_version":3,"issue_number":1}`,
 		"pr-open":         `{"schema_version":1,"issue_number":1,"verifications":[{"name":"t","result":"pass"}]}`,
 		"review-worktree": `{"schema_version":1,"issue_number":1,"head_oid":"0123456789abcdef0123456789abcdef01234567"}`,
 		"review":          `{"schema_version":2,"issue_number":1,"reviewed_head_oid":"h","verdict":"approve","summary":"s","reviewer":{"model":"m","effort":"e"},"judgments":[{"criterion":1,"judgment":"satisfied","reason":"r"}]}`,

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -1,13 +1,14 @@
 // Package manifest renders and parses the PRD §13 audit record that
 // every Orch issue and PR body carries: the approved objective,
-// acceptance criteria, and required tests; the selected role, the exact
-// executor/reviewer model+effort and how the host actually delivered
-// that effort; the routing rationale, escalations and substitutions, the
-// config revision, and named verification commands and results with the
-// commit each was gathered at. Resume/recovery (PRD §23: interrupted
-// runs resume) rebuilds run state from these posted bodies, so the
-// record must render into a managed markdown region AND parse back out
-// losslessly.
+// acceptance criteria, and required tests, including which of those
+// tests the plan declared the repository's CI does not run; the selected
+// role, the exact executor/reviewer model+effort and how the host
+// actually delivered that effort; the routing rationale, escalations and
+// substitutions, the config revision, and named verification commands
+// and results with the commit each was gathered at. Resume/recovery (PRD
+// §23: interrupted runs resume) rebuilds run state from these posted
+// bodies, so the record must render into a managed markdown region AND
+// parse back out losslessly.
 //
 // Like gitops and ghops the package is policy-free: it owns the schema,
 // the managed region, and drift detection, while the run engine decides
@@ -29,6 +30,7 @@ package manifest
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -37,20 +39,28 @@ import (
 // markers are locators, never a second source of truth.
 //
 // v2 added the approved work text (objective, acceptance criteria,
-// required tests) and the effort-delivery mechanism. v3 adds the commit
-// OID each verification was gathered at (Verification.CommitOID).
+// required tests) and the effort-delivery mechanism. v3 added the commit
+// OID each verification was gathered at (Verification.CommitOID). v4
+// adds the plan's declaration that the repository's CI does not run a
+// given required test (Manifest.TestsCIDoesNotRun).
 //
 // There is no migration, in either direction. Reading down: a v1 record
 // is missing the approved work, which would silently decode as empty,
 // and a v2 record's verifications would decode as gathered at no commit
 // — which in v3 is a claim about the evidence, not an absence of one —
-// so Parse rejects both through the unsupported-version path. Reading
-// up: an older binary handed a newer record would drop the field it
-// does not know on decode, re-render without it, and fail the drift
+// so Parse rejects both through the unsupported-version path. A v3
+// record is now rejected the same way, though not for that kind of
+// reason: an absent v4 declaration is honest about a plan that made
+// none, so nothing in a v3 record is misread under v4. Before v4, Parse
+// accepted a v3 record; after v4 it does not, and the operator's remedy
+// is the one the message names. The version had to rise anyway because
+// the new field renders, which is the rule the next paragraph states.
+// Reading up: an older binary handed a newer record would drop the field
+// it does not know on decode, re-render without it, and fail the drift
 // compare with ErrDrift, accusing a human of a hand edit nobody made.
 // Raising this constant is what makes the version check fire first and
 // say the true thing, so it must rise with every rendered field.
-const SchemaVersion = 3
+const SchemaVersion = 4
 
 // BeginMarker and EndMarker delimit the managed region. A line is a
 // marker only if, after stripping at most one trailing "\r", it equals
@@ -153,17 +163,27 @@ type Verification struct {
 // mandatory, exactly like internal/state: Render refuses to write and
 // Parse refuses to accept any other version rather than guess.
 //
-// Objective, AcceptanceCriteria, and RequiredTests are the approved plan
-// text verbatim. They belong in the record, not in run state alone,
-// because resume rebuilds an interrupted run's issues from these posted
-// bodies: a field held only in state comes back empty after a resume,
-// and the dispatch that follows would hand an executor an empty
-// objective without saying so.
+// Objective, AcceptanceCriteria, RequiredTests, and TestsCIDoesNotRun
+// are the approved plan text verbatim. They belong in the record, not in
+// run state alone, because resume rebuilds an interrupted run's issues
+// from these posted bodies: a field held only in state comes back empty
+// after a resume, and the dispatch that follows would hand an executor
+// an empty objective without saying so.
+//
+// TestsCIDoesNotRun names the entries of RequiredTests the plan declared
+// the repository's CI does not run, so a required test that only ever
+// runs locally is distinguishable from one CI also holds. It is a
+// declaration the plan author made and a human approved, never something
+// this package or the engine derives: deciding CI coverage mechanically
+// would mean reading workflow definitions and build tags, which nothing
+// in this module does. An empty list is the honest reading of a plan that
+// declared nothing, not a claim that CI runs every required test.
 type Manifest struct {
 	SchemaVersion      int            `json:"schema_version"`
 	Objective          string         `json:"objective"`
 	AcceptanceCriteria []string       `json:"acceptance_criteria"`
 	RequiredTests      []string       `json:"required_tests"`
+	TestsCIDoesNotRun  []string       `json:"tests_ci_does_not_run,omitempty"`
 	Role               Role           `json:"role"`
 	Executor           Selection      `json:"executor"`
 	RoutingRationale   string         `json:"routing_rationale"`
@@ -195,6 +215,9 @@ func (m Manifest) validate() error {
 		return err
 	}
 	if err := validateTextList("required_tests", m.RequiredTests); err != nil {
+		return err
+	}
+	if err := validateTestsCIDoesNotRun(m.RequiredTests, m.TestsCIDoesNotRun); err != nil {
 		return err
 	}
 	if !validRole(m.Role) {
@@ -240,6 +263,31 @@ func validateTextList(field string, values []string) error {
 	for i, v := range values {
 		if v == "" {
 			return fmt.Errorf("%s[%d] is empty", field, i)
+		}
+	}
+	return nil
+}
+
+// validateTestsCIDoesNotRun requires every declared entry to be non-empty
+// and to name one of the record's own required tests by exact command.
+// The human view annotates a required test in place, matching on that
+// exact string, so an entry naming anything else would render nowhere and
+// exist only in the hidden data comment — the one shape the drift check
+// cannot catch, since a re-render of the decoded record reproduces the
+// same invisible field.
+//
+// This referential rule is TestsCIDoesNotRun's alone, not a rule about
+// repeated string lists in a Manifest generally: it is the only list here
+// whose entries name entries of another field. AcceptanceCriteria and
+// RequiredTests are checked for presence and non-emptiness only
+// (validateTextList), and nothing constrains them against each other.
+func validateTestsCIDoesNotRun(required, declared []string) error {
+	for i, t := range declared {
+		if t == "" {
+			return fmt.Errorf("tests_ci_does_not_run[%d] is empty", i)
+		}
+		if !slices.Contains(required, t) {
+			return fmt.Errorf("tests_ci_does_not_run[%d] %q does not name one of required_tests", i, t)
 		}
 	}
 	return nil

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -36,8 +36,15 @@ const (
 	fixtureFixOID    = "c5e70981a3f6b2d4079b1c3e52e40578b2e4a1c3"
 )
 
+// fixtureLocalOnlyTest is the required test the full fixture declares the
+// repository's CI does not run, pinned as a constant so a test can assert
+// the annotated bullet by exact command.
+const fixtureLocalOnlyTest = "go vet ./..."
+
 // fullManifest exercises every optional field and every repeatable one:
-// multi-entry acceptance criteria and required tests, two escalations
+// multi-entry acceptance criteria and required tests, one of them
+// declared as a test CI does not run and the other not (so the golden
+// pins the annotated and the plain bullet side by side), two escalations
 // (an escalation with a role and At, a substitution without), and three
 // verifications, the last a CI-state entry with no command. Two carry a
 // commit OID and disagree about which one; the middle entry carries none,
@@ -48,7 +55,8 @@ func fullManifest() Manifest {
 		"Render and Parse agree on every field.",
 		"A hand-edited region fails closed.",
 	}
-	m.RequiredTests = []string{"go test ./internal/manifest/...", "go vet ./..."}
+	m.RequiredTests = []string{"go test ./internal/manifest/...", fixtureLocalOnlyTest}
+	m.TestsCIDoesNotRun = []string{fixtureLocalOnlyTest}
 	m.EffortDelivery = EffortDeliveryPromptCue
 	m.Escalations = []Escalation{
 		{
@@ -76,15 +84,17 @@ func fullManifest() Manifest {
 
 // hostileManifest packs marker-forging and markdown-breaking content
 // into every free-text field: an objective and an acceptance criterion
-// each smuggling a marker line, a required test that is exactly the
-// data-close; a rationale containing "-->", a line equal to EndMarker, a
-// CRLF pair, and a <script> tag; a command with backticks, pipes, and an
-// ampersand; a model with a pipe; a config revision with all three
-// entity characters; an escalation whose reason is a data-close and
-// whose At smuggles a begin-marker line; and a verification whose name,
-// result, commit OID, and At each smuggle a marker or data-comment line.
-// Render must escape all of it so the region still contains exactly one
-// of each structural line and parses back.
+// each smuggling a marker line; a required test that is exactly the
+// data-close, declared as one CI does not run so its annotation lands
+// after a hostile code span; a rationale containing "-->", a line equal
+// to EndMarker, a CRLF pair, and a <script> tag; a command with
+// backticks, pipes, and an ampersand; a model with a pipe; a config
+// revision with all three entity characters; an escalation whose reason
+// is a data-close and whose At smuggles a begin-marker line; and a
+// verification whose name, result, commit OID, and At each smuggle a
+// marker or data-comment line. Render must escape all of it so the
+// region still contains exactly one of each structural line and parses
+// back.
 func hostileManifest() Manifest {
 	return Manifest{
 		SchemaVersion: SchemaVersion,
@@ -93,9 +103,10 @@ func hostileManifest() Manifest {
 			"Criterion with a marker line\n" + EndMarker,
 			"Criterion with &<> entities and a | pipe.",
 		},
-		RequiredTests: []string{dataClose, "go test -run 'A|B' ./..."},
-		Role:          RoleReviewer,
-		Executor:      Selection{Model: "weird|model", Effort: "high"},
+		RequiredTests:     []string{dataClose, "go test -run 'A|B' ./..."},
+		TestsCIDoesNotRun: []string{dataClose},
+		Role:              RoleReviewer,
+		Executor:          Selection{Model: "weird|model", Effort: "high"},
 		RoutingRationale: "Rationale with a marker attempt -->\r\n" +
 			EndMarker + "\n" +
 			"and a <script>alert(1)</script> tag.",
@@ -130,13 +141,18 @@ func TestValidateRejects(t *testing.T) {
 	}{
 		"original schema version":   {func(m *Manifest) { m.SchemaVersion = 1 }, "schema_version 1 is unsupported"},
 		"superseded schema version": {func(m *Manifest) { m.SchemaVersion = 2 }, "schema_version 2 is unsupported"},
-		"future schema version":     {func(m *Manifest) { m.SchemaVersion = 4 }, "schema_version 4 is unsupported"},
+		"prior schema version":      {func(m *Manifest) { m.SchemaVersion = 3 }, "schema_version 3 is unsupported"},
+		"future schema version":     {func(m *Manifest) { m.SchemaVersion = 5 }, "schema_version 5 is unsupported"},
 		"absent schema version":     {func(m *Manifest) { m.SchemaVersion = 0 }, "schema_version 0 is unsupported"},
 		"empty objective":           {func(m *Manifest) { m.Objective = "" }, "objective is empty"},
 		"no acceptance criteria":    {func(m *Manifest) { m.AcceptanceCriteria = nil }, "acceptance_criteria is empty"},
 		"empty acceptance criteria": {func(m *Manifest) { m.AcceptanceCriteria[1] = "" }, "acceptance_criteria[1] is empty"},
 		"no required tests":         {func(m *Manifest) { m.RequiredTests = nil }, "required_tests is empty"},
 		"empty required test":       {func(m *Manifest) { m.RequiredTests[0] = "" }, "required_tests[0] is empty"},
+		"empty ci declaration": {func(m *Manifest) { m.TestsCIDoesNotRun = []string{""} },
+			"tests_ci_does_not_run[0] is empty"},
+		"ci declaration names no required test": {func(m *Manifest) { m.TestsCIDoesNotRun = []string{"go test -tags golden ./..."} },
+			`tests_ci_does_not_run[0] "go test -tags golden ./..." does not name one of required_tests`},
 		"unknown role":              {func(m *Manifest) { m.Role = "wizard" }, `role "wizard" is not one of`},
 		"empty executor model":      {func(m *Manifest) { m.Executor.Model = "" }, "executor.model is empty"},
 		"empty executor effort":     {func(m *Manifest) { m.Executor.Effort = "" }, "executor.effort is empty"},

--- a/internal/manifest/parse_test.go
+++ b/internal/manifest/parse_test.go
@@ -124,8 +124,8 @@ func TestParseBadManifest(t *testing.T) {
 		"unterminated data":    BeginMarker + "\n" + dataOpen + "\n{}\n" + EndMarker,
 		"double data comment":  BeginMarker + "\n" + dataOpen + "\n{}\n" + dataClose + "\n" + dataOpen + "\n{}\n" + dataClose + "\n" + EndMarker,
 		"bad json":             BeginMarker + "\n" + dataOpen + "\nthis is not json\n" + dataClose + "\n" + EndMarker,
-		"schema version zero":  tamperJSON(valid, `"schema_version": 3`, `"schema_version": 0`),
-		"schema version four":  tamperJSON(valid, `"schema_version": 3`, `"schema_version": 4`),
+		"schema version zero":  tamperJSON(valid, `"schema_version": 4`, `"schema_version": 0`),
+		"schema version five":  tamperJSON(valid, `"schema_version": 4`, `"schema_version": 5`),
 		"schema absent":        BeginMarker + "\n" + dataOpen + "\n{\"role\":\"implementer\"}\n" + dataClose + "\n" + EndMarker,
 		"invalid record":       tamperJSON(valid, `"role": "implementer"`, `"role": "wizard"`),
 	}
@@ -260,12 +260,13 @@ const schemaTwoRegion = BeginMarker + `
 ` + EndMarker
 
 // TestSchemaTwoRegionIsAGenuineRender guards the fixture above against a
-// typo. No verification in it carries a commit OID, so a v2 render and a
-// v3 render of the same record differ in exactly one place — the
-// schema_version line — and re-rendering the frozen region's own decoded
-// record at this build's version must reproduce it byte for byte. Without
-// this check a mangled fixture would still be rejected, and the rejection
-// test below would pass for the wrong reason.
+// typo. No verification in it carries a commit OID and it declares no
+// test CI does not run, so a v2 render and this build's render of the
+// same record differ in exactly one place — the schema_version line —
+// and re-rendering the frozen region's own decoded record at this
+// build's version must reproduce it byte for byte. Without this check a
+// mangled fixture would still be rejected, and the rejection test below
+// would pass for the wrong reason.
 func TestSchemaTwoRegionIsAGenuineRender(t *testing.T) {
 	jsonText, err := extractData(schemaTwoRegion)
 	if err != nil {
@@ -289,15 +290,45 @@ func TestSchemaTwoRegionIsAGenuineRender(t *testing.T) {
 	}
 }
 
-// TestParseRejectsSchemaTwoRecord proves the immediately superseded
-// record fails closed through the same unsupported-version path, before
-// the drift compare, and that the error names a remediation that exists.
+// TestParseRejectsSchemaThreeRecord proves a v3 record — the version
+// every posted body in flight when this build ships carries — fails
+// closed through the unsupported-version path, before the drift compare,
+// with the remediation an operator can actually run.
+//
+// Its body is lowered from this build's own render rather than frozen
+// like schemaOneRegion and schemaTwoRegion above, because that
+// construction is exact for this pair: v4's only added field is optional
+// and renders nothing when the plan declared nothing, so a genuine v3
+// render of a declaration-free record and a v4 render of it differ in
+// exactly the schema_version line. Freezing a copy would assert the same
+// bytes with more of them.
+func TestParseRejectsSchemaThreeRecord(t *testing.T) {
+	body := tamperJSON(mustRender(t, fullManifest()), `"schema_version": 4`, `"schema_version": 3`)
+	_, err := Parse(body)
+	if !errors.Is(err, ErrBadManifest) {
+		t.Fatalf("err = %v, want ErrBadManifest", err)
+	}
+	if !strings.Contains(err.Error(), "schema_version 3 is unsupported") {
+		t.Errorf("err %q does not name the unsupported version", err)
+	}
+	if errors.Is(err, ErrDrift) {
+		t.Error("a v3 record was reported as drift; the version check must come first")
+	}
+	if !strings.Contains(err.Error(), "orch abort") {
+		t.Errorf("err %q does not name a remediation that exists", err)
+	}
+}
+
+// TestParseRejectsSchemaTwoRecord proves an earlier superseded record
+// fails closed through the same unsupported-version path, before the
+// drift compare, and that the error names a remediation that exists.
 //
 // Nothing else would catch it. A v2 record decodes cleanly into this
 // build's struct and re-renders to the same bytes but for the version
 // line, so its verifications would silently read as gathered at no
-// commit — which in v3 is a claim about the evidence, not the absence of
-// one — and the OID they lack cannot be recovered after the fact.
+// commit — which from v3 on is a claim about the evidence, not the
+// absence of one — and the OID they lack cannot be recovered after the
+// fact.
 func TestParseRejectsSchemaTwoRecord(t *testing.T) {
 	_, err := Parse(schemaTwoRegion)
 	if !errors.Is(err, ErrBadManifest) {
@@ -321,8 +352,8 @@ func TestParseDrift(t *testing.T) {
 		"blank line inserted":   strings.Replace(base, "### Orch audit record\n", "### Orch audit record\n\n", 1),
 		"sentence inserted":     strings.Replace(base, "**Verification:**", "An extra human sentence.\n\n**Verification:**", 1),
 		"json keys reordered": strings.Replace(base,
-			"{\n  \"schema_version\": 3,\n  \"objective\": \""+fixtureObjective+"\",",
-			"{\n  \"objective\": \""+fixtureObjective+"\",\n  \"schema_version\": 3,", 1),
+			"{\n  \"schema_version\": 4,\n  \"objective\": \""+fixtureObjective+"\",",
+			"{\n  \"objective\": \""+fixtureObjective+"\",\n  \"schema_version\": 4,", 1),
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/manifest/render.go
+++ b/internal/manifest/render.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -65,9 +66,20 @@ func writeHuman(b *strings.Builder, m Manifest) {
 	writeVerifications(b, m.Verifications)
 }
 
+// CIDoesNotRunNote is the clause rendered after a required test the
+// record names in Manifest.TestsCIDoesNotRun, leading separator
+// included so every renderer emits the same bytes. It is exported
+// because the run engine writes the created issue's prose required-tests
+// list above this managed region and must annotate it identically: a
+// reader comparing the two halves of one issue body must not find one
+// half saying CI does not run a test and the other silent about it.
+const CIDoesNotRunNote = " — CI does not run this test"
+
 // writeWork renders the approved work the record carries: the objective
 // as a paragraph, then the acceptance criteria and the required tests as
-// bullet lists (tests are commands, so they render as code spans).
+// bullet lists (tests are commands, so they render as code spans). A
+// required test the record names in TestsCIDoesNotRun carries
+// CIDoesNotRunNote after its command.
 //
 // It repeats prose the created issue body already carries above the
 // managed region, deliberately: the drift check compares a re-render of
@@ -82,7 +94,11 @@ func writeWork(b *strings.Builder, m Manifest) {
 	}
 	b.WriteString("\n**Required tests:**\n")
 	for _, rt := range m.RequiredTests {
-		fmt.Fprintf(b, "- %s\n", mdCode(rt))
+		fmt.Fprintf(b, "- %s", mdCode(rt))
+		if slices.Contains(m.TestsCIDoesNotRun, rt) {
+			b.WriteString(CIDoesNotRunNote)
+		}
+		b.WriteByte('\n')
 	}
 	b.WriteByte('\n')
 }

--- a/internal/manifest/render_test.go
+++ b/internal/manifest/render_test.go
@@ -70,6 +70,47 @@ func TestRenderShowsCommitOIDInBothViews(t *testing.T) {
 	}
 }
 
+// TestRenderShowsCIDeclarationInBothViews pins the plan's CI declaration
+// into the human markdown as well as the canonical JSON, and pins it
+// beside the test it qualifies rather than as a separate list: a reviewer
+// reads this record on a PR, where the data comment does not display at
+// all, so a declaration living only there would tell nobody that the
+// required test above it is the only thing that will ever run it. It also
+// checks the record says nothing about the tests it did not name, since a
+// note on every bullet would carry no information.
+func TestRenderShowsCIDeclarationInBothViews(t *testing.T) {
+	m := fullManifest()
+	got, err := Render(m)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	human, data, ok := strings.Cut(got, "\n"+dataOpen+"\n")
+	if !ok {
+		t.Fatal("could not split the region into its human and JSON views")
+	}
+	if want := "- " + mdCode(fixtureLocalOnlyTest) + CIDoesNotRunNote + "\n"; !strings.Contains(human, want) {
+		t.Errorf("the human markdown does not annotate the declared test\nwant line: %q\n--- human ---\n%s", want, human)
+	}
+	if !strings.Contains(data, `"tests_ci_does_not_run": [`) {
+		t.Errorf("the canonical JSON does not carry tests_ci_does_not_run\n--- data ---\n%s", data)
+	}
+	if n := strings.Count(human, CIDoesNotRunNote); n != 1 {
+		t.Errorf("the human markdown carries %d CI notes, want exactly one: only %q was declared", n, fixtureLocalOnlyTest)
+	}
+
+	// A record declaring nothing renders no note at all and omits the
+	// field, so a plan that made no statement produces the same bytes it
+	// produced before the declaration existed.
+	m.TestsCIDoesNotRun = nil
+	silent, err := Render(m)
+	if err != nil {
+		t.Fatalf("Render (no declaration): %v", err)
+	}
+	if strings.Contains(silent, CIDoesNotRunNote) || strings.Contains(silent, "tests_ci_does_not_run") {
+		t.Errorf("a record declaring nothing still mentions the declaration:\n%s", silent)
+	}
+}
+
 func TestRenderDeterministic(t *testing.T) {
 	for name, m := range goldenCases() {
 		t.Run(name, func(t *testing.T) {

--- a/internal/manifest/testdata/full.golden.md
+++ b/internal/manifest/testdata/full.golden.md
@@ -9,7 +9,7 @@
 
 **Required tests:**
 - `go test ./internal/manifest/...`
-- `go vet ./...`
+- `go vet ./...` — CI does not run this test
 
 | Field | Value |
 | --- | --- |
@@ -32,7 +32,7 @@
 
 <!-- orch:manifest:data
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "objective": "Ship the manifest round trip.",
   "acceptance_criteria": [
     "Render and Parse agree on every field.",
@@ -40,6 +40,9 @@
   ],
   "required_tests": [
     "go test ./internal/manifest/...",
+    "go vet ./..."
+  ],
+  "tests_ci_does_not_run": [
     "go vet ./..."
   ],
   "role": "implementer",

--- a/internal/manifest/testdata/hostile.golden.md
+++ b/internal/manifest/testdata/hostile.golden.md
@@ -11,7 +11,7 @@ and more.
 - Criterion with &amp;&lt;&gt; entities and a | pipe.
 
 **Required tests:**
-- `-->`
+- `-->` — CI does not run this test
 - `go test -run 'A|B' ./...`
 
 | Field | Value |
@@ -38,7 +38,7 @@ and a &lt;script&gt;alert(1)&lt;/script&gt; tag.
 
 <!-- orch:manifest:data
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "objective": "Objective ending in --\u003e\n\u003c!-- orch:manifest:begin --\u003e\nand more.",
   "acceptance_criteria": [
     "Criterion with a marker line\n\u003c!-- orch:manifest:end --\u003e",
@@ -47,6 +47,9 @@ and a &lt;script&gt;alert(1)&lt;/script&gt; tag.
   "required_tests": [
     "--\u003e",
     "go test -run 'A|B' ./..."
+  ],
+  "tests_ci_does_not_run": [
+    "--\u003e"
   ],
   "role": "reviewer",
   "executor": {

--- a/internal/manifest/testdata/minimal.golden.md
+++ b/internal/manifest/testdata/minimal.golden.md
@@ -25,7 +25,7 @@
 
 <!-- orch:manifest:data
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "objective": "Ship the manifest round trip.",
   "acceptance_criteria": [
     "Render and Parse agree on every field."

--- a/internal/run/activate.go
+++ b/internal/run/activate.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -260,6 +261,7 @@ func Activate(ctx context.Context, env Env, reqJSON []byte) (*ActivationResult, 
 			Objective:          pi.Objective,
 			AcceptanceCriteria: issueAcceptanceCriteria(pi),
 			RequiredTests:      pi.RequiredTests,
+			TestsCIDoesNotRun:  pi.TestsCIDoesNotRun,
 			Decision:           fromRoutingDecision(decisionByID[pi.ID]),
 		}
 	}
@@ -288,6 +290,7 @@ func Activate(ctx context.Context, env Env, reqJSON []byte) (*ActivationResult, 
 			Objective:          pi.Objective,
 			AcceptanceCriteria: issueAcceptanceCriteria(pi),
 			RequiredTests:      pi.RequiredTests,
+			TestsCIDoesNotRun:  pi.TestsCIDoesNotRun,
 			Role:               d.Role,
 			Executor:           d.Executor,
 			RoutingRationale:   d.Rationale,
@@ -387,6 +390,9 @@ func planAreaLabels(p *PlanDoc) []string {
 // The acceptance criteria are issueAcceptanceCriteria's list, matching
 // the audit record rendered directly below them: a reader comparing the
 // two halves of one issue body must not find two different standards.
+// For the same reason a required test the plan declared CI does not run
+// carries manifest.CIDoesNotRunNote here, the exact clause the record's
+// own required-tests list appends below.
 func issueBody(pi PlanIssue, waveByID map[string]int, digest string) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "**Objective**\n\n%s\n\n", pi.Objective)
@@ -397,7 +403,11 @@ func issueBody(pi PlanIssue, waveByID map[string]int, digest string) string {
 	}
 	b.WriteString("\n**Required tests**\n\n")
 	for _, rt := range pi.RequiredTests {
-		fmt.Fprintf(&b, "- `%s`\n", rt)
+		fmt.Fprintf(&b, "- `%s`", rt)
+		if slices.Contains(pi.TestsCIDoesNotRun, rt) {
+			b.WriteString(manifest.CIDoesNotRunNote)
+		}
+		b.WriteByte('\n')
 	}
 
 	b.WriteString("\n**Dependencies**\n\n")

--- a/internal/run/dispatch.go
+++ b/internal/run/dispatch.go
@@ -13,11 +13,22 @@ import (
 )
 
 // DispatchSchemaVersion is the dispatch request/result schema this build
-// accepts and emits. v2 adds the approved objective, acceptance
+// accepts and emits. v2 added the approved objective, acceptance
 // criteria, and required tests to the result, so an adapter's spawn
 // prompt is a transcription of what a human approved rather than the
-// Architect's recollection of it.
-const DispatchSchemaVersion = 2
+// Architect's recollection of it. v3 adds which of those required tests
+// the plan declared the repository's CI does not run.
+//
+// The version rises for a result-only field because the request's
+// version is the one thing that can refuse an adapter predating it. An
+// adapter written against v2 transcribes exactly the three fields v2
+// named; handed a v3 result it would drop the declaration silently, and
+// the executor would never learn that a test the human approved as
+// local-only is local-only — the same nobody-runs-it failure the
+// declaration exists to surface. Before v3, a request carrying
+// schema_version 2 was accepted; this build rejects it with the message
+// below, and the remedy is to update the host adapter.
+const DispatchSchemaVersion = 3
 
 // DispatchRequest asks to hand one worktree-ready issue to its executor.
 type DispatchRequest struct {
@@ -37,13 +48,21 @@ type DispatchResult struct {
 	Executor      manifest.Selection `json:"executor"`
 	Reviewer      manifest.Selection `json:"reviewer"`
 	Rationale     string             `json:"rationale"`
-	// Objective, AcceptanceCriteria, and RequiredTests are the approved
-	// plan text verbatim. The adapter transcribes them into the spawn
-	// prompt; it never paraphrases or re-derives them, because what the
-	// executor is told to build is what the human approved.
+	// Objective, AcceptanceCriteria, RequiredTests, and TestsCIDoesNotRun
+	// are the approved plan text verbatim. The adapter transcribes them
+	// into the spawn prompt; it never paraphrases or re-derives them,
+	// because what the executor is told to build is what the human
+	// approved.
+	//
+	// TestsCIDoesNotRun names entries of RequiredTests, so the adapter
+	// transcribes it against the test it qualifies: the executor is being
+	// told this required test is the only thing that will ever run it. It
+	// is absent when the plan declared nothing, which is not a claim that
+	// CI runs every required test.
 	Objective          string   `json:"objective"`
 	AcceptanceCriteria []string `json:"acceptance_criteria"`
 	RequiredTests      []string `json:"required_tests"`
+	TestsCIDoesNotRun  []string `json:"tests_ci_does_not_run,omitempty"`
 }
 
 // Dispatch moves a worktree-ready issue to dispatched: it enforces the
@@ -129,6 +148,7 @@ func Dispatch(ctx context.Context, env Env, reqJSON []byte) (*DispatchResult, er
 		Objective:          issue.Objective,
 		AcceptanceCriteria: issue.AcceptanceCriteria,
 		RequiredTests:      issue.RequiredTests,
+		TestsCIDoesNotRun:  issue.TestsCIDoesNotRun,
 	}, nil
 }
 

--- a/internal/run/gate.go
+++ b/internal/run/gate.go
@@ -41,6 +41,15 @@ type GateDoc struct {
 // document's field: a risk-domain issue shows one more entry here than
 // the plan submitted, because the human approving this gate is
 // approving the standard the reviewer will actually be held to.
+//
+// TestsCIDoesNotRun is the plan's own declaration, passed through
+// unchanged: the engine derives no part of it. It names entries of
+// RequiredTests, so the adapter rendering this gate presents it beside
+// the test it qualifies rather than as a separate list, and the human
+// approves knowing which required tests only ever run locally. It is
+// absent for a plan that declared nothing, which leaves the gate
+// document byte-identical to what the same plan produced before the
+// declaration existed.
 type GateIssue struct {
 	ID                 string             `json:"id"`
 	Title              string             `json:"title"`
@@ -54,6 +63,7 @@ type GateIssue struct {
 	DependsOn          []string           `json:"depends_on,omitempty"`
 	Wave               int                `json:"wave"`
 	RequiredTests      []string           `json:"required_tests"`
+	TestsCIDoesNotRun  []string           `json:"tests_ci_does_not_run,omitempty"`
 	Risk               string             `json:"risk"`
 	UsageClass         string             `json:"usage_class"`
 	Labels             []string           `json:"labels"`
@@ -121,6 +131,7 @@ func Plan(ctx context.Context, env Env, planJSON []byte) (*GateDoc, error) {
 			DependsOn:          i.DependsOn,
 			Wave:               i.Wave,
 			RequiredTests:      i.RequiredTests,
+			TestsCIDoesNotRun:  i.TestsCIDoesNotRun,
 			Risk:               string(deriveRisk(i)),
 			UsageClass:         i.UsageClass,
 			Labels:             flattenLabels(labels),

--- a/internal/run/gate_test.go
+++ b/internal/run/gate_test.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -160,6 +161,48 @@ func TestPlanGoldenTwoIssue(t *testing.T) {
 	}
 	if len(b.DependsOn) != 1 || b.DependsOn[0] != "a" || b.Wave != 2 {
 		t.Errorf("issue b deps/wave = %v/%d", b.DependsOn, b.Wave)
+	}
+}
+
+// TestPlanGateShowsWhichRequiredTestsCIDoesNotRun proves the gate the
+// human decides on carries the plan's per-test declaration, on the issue
+// that made it and naming the required test it qualifies — so approving
+// the plan is approving a required test known to run nowhere but locally.
+// It also pins the silent case: a plan that declares nothing leaves the
+// field absent rather than reporting an empty declaration as a fact about
+// CI coverage.
+func TestPlanGateShowsWhichRequiredTestsCIDoesNotRun(t *testing.T) {
+	root := setupRepo(t, testConfigTOML)
+	env := Env{RepoRoot: root, Now: fixedNow}
+
+	doc, err := Plan(context.Background(), env, []byte(ciDeclarationPlanJSON()))
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(doc.Issues) != 1 {
+		t.Fatalf("Issues = %+v, want 1", doc.Issues)
+	}
+	iss := doc.Issues[0]
+	if len(iss.RequiredTests) != 2 || iss.RequiredTests[0] != planCITest || iss.RequiredTests[1] != planLocalOnlyTest {
+		t.Fatalf("required_tests = %q, want the plan's two", iss.RequiredTests)
+	}
+	if len(iss.TestsCIDoesNotRun) != 1 || iss.TestsCIDoesNotRun[0] != planLocalOnlyTest {
+		t.Errorf("tests_ci_does_not_run = %q, want just %q", iss.TestsCIDoesNotRun, planLocalOnlyTest)
+	}
+
+	silent, err := Plan(context.Background(), env, []byte(validPlanJSON()))
+	if err != nil {
+		t.Fatalf("Plan (no declaration): %v", err)
+	}
+	if got := silent.Issues[0].TestsCIDoesNotRun; got != nil {
+		t.Errorf("a plan declaring nothing produced tests_ci_does_not_run = %q, want none", got)
+	}
+	gateJSON, err := json.Marshal(silent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(gateJSON), "tests_ci_does_not_run") {
+		t.Errorf("the gate document for a plan declaring nothing still carries the field:\n%s", gateJSON)
 	}
 }
 

--- a/internal/run/lifecycle_test.go
+++ b/internal/run/lifecycle_test.go
@@ -224,6 +224,86 @@ func wantPhase(t *testing.T, root string, number int, want state.Phase) {
 	t.Fatalf("issue #%d not found", number)
 }
 
+// TestCIDeclarationReachesTheExecutorAndReviewer follows one plan's
+// per-test declaration through every place downstream of the gate that
+// states an issue's required tests: the created issue body's prose list,
+// the audit record inside that body (the copy pr-open mirrors onto the
+// PR, which is where a reviewer reads the approved work), run state, and
+// the dispatch result the adapter transcribes into the executor's prompt.
+// Any one of them silently dropping it would tell somebody the required
+// test is a gate CI holds when the human approved it as one nobody holds.
+func TestCIDeclarationReachesTheExecutorAndReviewer(t *testing.T) {
+	root := newLifecycleRepo(t)
+	const title = "Fix the status lock race"
+
+	taxonomy := fullTaxonomyScript()
+	calls := append(taxonomy, ghIssueCreateCall(title, []string{"ready", "bug", "implementer", "standard"}, 1))
+	script := &execxtest.Script{T: t, Calls: calls}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+	if _, err := Activate(context.Background(), env, activationJSON(t, ciDeclarationPlanJSON())); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	script.AssertExhausted()
+
+	// The created issue body: the prose required-tests list above the
+	// managed region and the audit record's own list inside it both
+	// annotate the declared test and only it, so a reader comparing the
+	// two halves of one body finds them saying the same thing.
+	body := script.StdinAt(len(taxonomy))
+	wantProse := "- `" + planLocalOnlyTest + "`" + manifest.CIDoesNotRunNote + "\n"
+	if !strings.Contains(body, wantProse) {
+		t.Errorf("the created issue body's prose list does not annotate the declared test\nwant line: %q\n--- body ---\n%s", wantProse, body)
+	}
+	if strings.Contains(body, "- `"+planCITest+"`"+manifest.CIDoesNotRunNote) {
+		t.Errorf("the created issue body annotates a test the plan did not declare\n--- body ---\n%s", body)
+	}
+	if got := strings.Count(body, manifest.CIDoesNotRunNote); got != 2 {
+		t.Errorf("the body states the CI note %d time(s), want 2: the prose list and the audit record's human bullet", got)
+	}
+	m, err := manifest.Parse(body)
+	if err != nil {
+		t.Fatalf("Parse the created issue body: %v", err)
+	}
+	if len(m.TestsCIDoesNotRun) != 1 || m.TestsCIDoesNotRun[0] != planLocalOnlyTest {
+		t.Errorf("audit record tests_ci_does_not_run = %q, want just %q", m.TestsCIDoesNotRun, planLocalOnlyTest)
+	}
+
+	// Run state, which is what dispatch reads.
+	st := loadRun(t, root)
+	iss := st.Run.Issues[0]
+	if len(iss.TestsCIDoesNotRun) != 1 || iss.TestsCIDoesNotRun[0] != planLocalOnlyTest {
+		t.Errorf("run state tests_ci_does_not_run = %q, want just %q", iss.TestsCIDoesNotRun, planLocalOnlyTest)
+	}
+	// State and the record agree, so a resume of this run finds nothing to
+	// rewrite — and a resume that had to rebuild state from the record
+	// would restore the declaration with the rest of the approved work.
+	if !sameWork(&iss, approvedWork{
+		objective:          m.Objective,
+		acceptanceCriteria: m.AcceptanceCriteria,
+		requiredTests:      m.RequiredTests,
+		testsCIDoesNotRun:  m.TestsCIDoesNotRun,
+	}) {
+		t.Errorf("run state %+v diverges from its audit record %+v", iss, m)
+	}
+
+	// The dispatch result: the adapter's whole spawn brief.
+	dispatched := runVerb(t, root, Dispatch, `{"schema_version":3,"issue_number":1}`,
+		ghAuth(), ghRepoViewCall("main"), ghSetStatusCall(1, ghops.StatusInProgress))
+	if len(dispatched.RequiredTests) != 2 {
+		t.Fatalf("dispatch required tests = %q, want the plan's two", dispatched.RequiredTests)
+	}
+	if len(dispatched.TestsCIDoesNotRun) != 1 || dispatched.TestsCIDoesNotRun[0] != planLocalOnlyTest {
+		t.Errorf("dispatch tests_ci_does_not_run = %q, want just %q", dispatched.TestsCIDoesNotRun, planLocalOnlyTest)
+	}
+	resultJSON, err := json.Marshal(dispatched)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(resultJSON), `"tests_ci_does_not_run":["`+planLocalOnlyTest+`"]`) {
+		t.Errorf("the dispatch result an adapter reads does not carry the declaration:\n%s", resultJSON)
+	}
+}
+
 // TestLifecycleWalk drives one issue from activation through cleanup and
 // run completion in a real git sandbox with scripted gh, asserting the
 // phase after every verb, the exact status transitions (via the scripted
@@ -246,7 +326,7 @@ func TestLifecycleWalk(t *testing.T) {
 
 	// dispatch. The result is the adapter's whole spawn brief, so it must
 	// carry the approved work verbatim alongside the routed selection.
-	dispatched := runVerb(t, root, Dispatch, `{"schema_version":2,"issue_number":1}`,
+	dispatched := runVerb(t, root, Dispatch, `{"schema_version":3,"issue_number":1}`,
 		ghAuth(), ghRepoViewCall("main"), ghSetStatusCall(1, ghops.StatusInProgress))
 	wantPhase(t, root, 1, state.PhaseDispatched)
 	if dispatched.Objective != "Make status reporting race-free" {

--- a/internal/run/metrics_test.go
+++ b/internal/run/metrics_test.go
@@ -314,7 +314,7 @@ func TestPROpenRecordsExecutorRoleWhenEnabled(t *testing.T) {
 	}
 	script.AssertExhausted()
 
-	runVerb(t, root, Dispatch, `{"schema_version":2,"issue_number":1}`,
+	runVerb(t, root, Dispatch, `{"schema_version":3,"issue_number":1}`,
 		ghAuth(), ghRepoViewCall("main"), ghSetStatusCall(1, ghops.StatusInProgress))
 
 	wtDir := filepath.Join(root, ".orchestrator", "worktrees", "issue-1")

--- a/internal/run/plandoc.go
+++ b/internal/run/plandoc.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -30,6 +31,18 @@ type PlanDoc struct {
 }
 
 // PlanIssue is one unit of work in the plan.
+//
+// TestsCIDoesNotRun names the entries of RequiredTests the plan author
+// declares the repository's CI does not run, so the human at the gate
+// approves knowing which of the issue's gates CI actually holds. It is a
+// declaration, never a derivation: nothing here reads workflow
+// definitions or build tags, so an omitted field means the plan made no
+// statement — not that CI runs every required test.
+//
+// Being optional with omitempty is what keeps a plan that makes no
+// statement digest-identical to the same document submitted before this
+// field existed: Digest marshals this struct, and a nil slice is omitted
+// from that marshal entirely.
 type PlanIssue struct {
 	ID                 string    `json:"id"`
 	Title              string    `json:"title"`
@@ -41,6 +54,7 @@ type PlanIssue struct {
 	DependsOn          []string  `json:"depends_on,omitempty"`
 	Wave               int       `json:"wave"`
 	RequiredTests      []string  `json:"required_tests"`
+	TestsCIDoesNotRun  []string  `json:"tests_ci_does_not_run,omitempty"`
 	UsageClass         string    `json:"usage_class"` // light|medium|heavy
 }
 
@@ -183,6 +197,26 @@ func (p *PlanDoc) Validate(cfg *config.Config) error {
 		for j, rt := range iss.RequiredTests {
 			if rt == "" {
 				fail("%s: required_tests[%d] must not be empty", prefix, j)
+			}
+		}
+		// A declared entry must name one of this issue's own required
+		// tests by exact command: every renderer of the declaration
+		// annotates a required test in place, matching on that string, so
+		// an entry naming anything else (a typo, or a test the plan
+		// dropped from required_tests on a later revision) would be a
+		// statement the human never sees at the gate — the failure this
+		// declaration exists to prevent. The rule is this field's alone
+		// among PlanIssue's string lists, not a general rule about them:
+		// acceptance_criteria and required_tests are checked only for
+		// non-emptiness, depends_on resolves against the plan's issue ids,
+		// and area_labels resolve against the repository at activation.
+		for j, t := range iss.TestsCIDoesNotRun {
+			if t == "" {
+				fail("%s: tests_ci_does_not_run[%d] must not be empty", prefix, j)
+				continue
+			}
+			if !slices.Contains(iss.RequiredTests, t) {
+				fail("%s: tests_ci_does_not_run[%d] %q does not name one of this issue's required_tests", prefix, j, t)
 			}
 		}
 		if !usageClasses[iss.UsageClass] {

--- a/internal/run/plandoc_test.go
+++ b/internal/run/plandoc_test.go
@@ -101,6 +101,16 @@ func TestPlanDocValidate(t *testing.T) {
 			mutate: func(p *PlanDoc) { p.Issues[0].UsageClass = "extreme" },
 			wantIn: `usage_class "extreme" is not one of`,
 		},
+		"empty ci declaration": {
+			mutate: func(p *PlanDoc) { p.Issues[0].TestsCIDoesNotRun = []string{""} },
+			wantIn: "tests_ci_does_not_run[0] must not be empty",
+		},
+		"ci declaration names no required test": {
+			mutate: func(p *PlanDoc) {
+				p.Issues[0].TestsCIDoesNotRun = []string{"go test -tags golden ./..."}
+			},
+			wantIn: `tests_ci_does_not_run[0] "go test -tags golden ./..." does not name one of this issue's required_tests`,
+		},
 		"bad wave": {
 			mutate: func(p *PlanDoc) { p.Issues[0].Wave = 0 },
 			wantIn: "wave must be >= 1",
@@ -230,6 +240,66 @@ func TestDigestStableAcrossWhitespaceAndKeyOrder(t *testing.T) {
 	}
 	if !strings.HasPrefix(da, "sha256:") {
 		t.Errorf("Digest = %q, want sha256: prefix", da)
+	}
+}
+
+// preCIDeclarationDigest is validPlanJSON's digest as builds before the
+// tests_ci_does_not_run declaration existed computed it, recomputed
+// independently from that build's PlanDoc/PlanIssue definitions rather
+// than copied from this build's output.
+//
+// It is pinned as a literal on purpose: `orch run plan` and
+// `orch run activate` both recompute the digest from the submitted
+// document, and a plan approved by one build must activate on another, so
+// a plan that declares nothing has to marshal to the same bytes it always
+// did. An optional field with a non-omitempty tag, or one given a
+// non-nil empty default anywhere on the decode path, would break that
+// silently — every existing plan and every replay of a prior one would
+// fail approval with a digest mismatch and nothing would say why.
+const preCIDeclarationDigest = "sha256:00b4d082433c906b228cc85941ea2a16a957253af75e45d96c9b65e73a60902e"
+
+func TestDigestUnchangedForAPlanThatDeclaresNothing(t *testing.T) {
+	p := mustDecodePlan(t, validPlanJSON())
+	if p.Issues[0].TestsCIDoesNotRun != nil {
+		t.Fatalf("a plan declaring nothing decoded to %q, want nil", p.Issues[0].TestsCIDoesNotRun)
+	}
+	got, err := p.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != preCIDeclarationDigest {
+		t.Errorf("Digest = %q, want the pre-declaration digest %q: a plan that declares nothing must marshal to the bytes it always did", got, preCIDeclarationDigest)
+	}
+
+	data, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "tests_ci_does_not_run") {
+		t.Errorf("canonical marshal mentions the declaration a plan never made:\n%s", data)
+	}
+}
+
+// TestDigestCoversTheCIDeclaration is the other half: once a plan does
+// declare, the declaration is part of what the human approved, so it must
+// be inside the digest the approval is tied to rather than a field an
+// adapter could revise between gate and activation.
+func TestDigestCoversTheCIDeclaration(t *testing.T) {
+	silent := mustDecodePlan(t, validPlanJSON())
+	declaring := mustDecodePlan(t, ciDeclarationPlanJSON())
+	if err := declaring.Validate(testConfig()); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	a, err := silent.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := declaring.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Error("declaring a test CI does not run left the digest unchanged; the approval would not cover it")
 	}
 }
 

--- a/internal/run/resume.go
+++ b/internal/run/resume.go
@@ -137,14 +137,16 @@ type issueObservations struct {
 }
 
 // approvedWork is the approved plan text an audit record carries. Run
-// state holds the same three fields, but the record is their durable
+// state holds the same four fields, but the record is their durable
 // home: state.json is machine-local and an interrupted run is rebuilt
 // from the posted bodies, so resume carries them back rather than let a
-// resumed run dispatch an empty objective.
+// resumed run dispatch an empty objective — or dispatch required tests
+// without the plan's declaration that CI runs none of them.
 type approvedWork struct {
 	objective          string
 	acceptanceCriteria []string
 	requiredTests      []string
+	testsCIDoesNotRun  []string
 }
 
 // outcome is reconcileIssue's verdict for one issue: the resulting action
@@ -366,6 +368,7 @@ func applyOutcome(iss *state.Issue, o outcome) bool {
 		iss.Objective = o.work.objective
 		iss.AcceptanceCriteria = o.work.acceptanceCriteria
 		iss.RequiredTests = o.work.requiredTests
+		iss.TestsCIDoesNotRun = o.work.testsCIDoesNotRun
 		changed = true
 	}
 	// A blocked outcome records its reason; every other outcome clears any
@@ -386,7 +389,8 @@ func applyOutcome(iss *state.Issue, o outcome) bool {
 func sameWork(iss *state.Issue, w approvedWork) bool {
 	return iss.Objective == w.objective &&
 		slices.Equal(iss.AcceptanceCriteria, w.acceptanceCriteria) &&
-		slices.Equal(iss.RequiredTests, w.requiredTests)
+		slices.Equal(iss.RequiredTests, w.requiredTests) &&
+		slices.Equal(iss.TestsCIDoesNotRun, w.testsCIDoesNotRun)
 }
 
 // --- classify (pure) ---
@@ -808,6 +812,7 @@ func observeIssue(ctx context.Context, gh *ghops.GH, git *gitops.Git, worktrees 
 				objective:          m.Objective,
 				acceptanceCriteria: m.AcceptanceCriteria,
 				requiredTests:      m.RequiredTests,
+				testsCIDoesNotRun:  m.TestsCIDoesNotRun,
 			}
 		}
 	}

--- a/internal/run/resume_test.go
+++ b/internal/run/resume_test.go
@@ -567,7 +567,7 @@ func TestResumeAdoptsOrphanPR(t *testing.T) {
 	}
 	script.AssertExhausted()
 
-	runVerb(t, root, Dispatch, `{"schema_version":2,"issue_number":1}`,
+	runVerb(t, root, Dispatch, `{"schema_version":3,"issue_number":1}`,
 		ghAuth(), ghRepoViewCall("main"), ghSetStatusCall(1, ghops.StatusInProgress))
 
 	wtDir := filepath.Join(root, ".orchestrator", "worktrees", "issue-1")

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -64,6 +64,41 @@ func validPlanJSON() string {
 }`
 }
 
+// planCITest is the required test ciDeclarationPlanJSON says nothing
+// about, and planLocalOnlyTest the one it declares the repository's CI
+// does not run.
+const (
+	planCITest        = "go test ./..."
+	planLocalOnlyTest = "go test -tags golden ./..."
+)
+
+// ciDeclarationPlanJSON is validPlanJSON plus a second required test the
+// plan declares CI does not run — the fixture for following that
+// declaration from the plan gate through to the executor. The first
+// required test stays undeclared, so no assertion on the second can pass
+// against a renderer that annotates every bullet alike.
+func ciDeclarationPlanJSON() string {
+	return `{
+  "schema_version": 1,
+  "host": "claude",
+  "title": "Fix status lock",
+  "issues": [
+    {
+      "id": "fix-status-lock",
+      "title": "Fix the status lock race",
+      "objective": "Make status reporting race-free",
+      "acceptance_criteria": ["no data race under -race"],
+      "type": "bug",
+      "facts": {"read_only": false},
+      "wave": 1,
+      "required_tests": ["` + planCITest + `", "` + planLocalOnlyTest + `"],
+      "tests_ci_does_not_run": ["` + planLocalOnlyTest + `"],
+      "usage_class": "light"
+    }
+  ]
+}`
+}
+
 // twoIssuePlanJSON is a two-issue, two-wave plan where "b" depends on
 // "a", passing Validate against testConfig().
 func twoIssuePlanJSON() string {

--- a/internal/run/verb_unit_test.go
+++ b/internal/run/verb_unit_test.go
@@ -125,7 +125,7 @@ func TestDispatchDependencyEnforcement(t *testing.T) {
 
 	// Unmet: a is not merged/cleaned.
 	script := &execxtest.Script{T: t}
-	_, err := Dispatch(context.Background(), ghEnv(root, script), []byte(`{"schema_version":2,"issue_number":2}`))
+	_, err := Dispatch(context.Background(), ghEnv(root, script), []byte(`{"schema_version":3,"issue_number":2}`))
 	if !errors.Is(err, ErrDependencyUnmet) {
 		t.Fatalf("err = %v, want ErrDependencyUnmet", err)
 	}
@@ -138,7 +138,7 @@ func TestDispatchDependencyEnforcement(t *testing.T) {
 		t.Fatal(err)
 	}
 	script = &execxtest.Script{T: t}
-	_, err = Dispatch(context.Background(), ghEnv(root, script), []byte(`{"schema_version":2,"issue_number":2}`))
+	_, err = Dispatch(context.Background(), ghEnv(root, script), []byte(`{"schema_version":3,"issue_number":2}`))
 	if !errors.Is(err, ErrDependencyAbandoned) {
 		t.Fatalf("err = %v, want ErrDependencyAbandoned", err)
 	}
@@ -166,7 +166,7 @@ func TestDispatchWithoutApprovedWorkFailsClosed(t *testing.T) {
 			before := stateBytes(t, root)
 
 			script := &execxtest.Script{T: t}
-			_, err := Dispatch(context.Background(), ghEnv(root, script), []byte(`{"schema_version":2,"issue_number":1}`))
+			_, err := Dispatch(context.Background(), ghEnv(root, script), []byte(`{"schema_version":3,"issue_number":1}`))
 			if err == nil {
 				t.Fatal("Dispatch accepted an issue with no approved work")
 			}
@@ -189,7 +189,7 @@ func TestDispatchWithoutApprovedWorkFailsClosed(t *testing.T) {
 func TestConfigDriftFailsClosed(t *testing.T) {
 	root := setupDeliveryRepo(t, "r2", []state.Issue{fixtureIssue("a", 1, state.PhaseWorktreeReady)})
 	script := &execxtest.Script{T: t}
-	_, err := Dispatch(context.Background(), ghEnv(root, script), []byte(`{"schema_version":2,"issue_number":1}`))
+	_, err := Dispatch(context.Background(), ghEnv(root, script), []byte(`{"schema_version":3,"issue_number":1}`))
 	if !errors.Is(err, ErrConfigDrift) {
 		t.Fatalf("err = %v, want ErrConfigDrift", err)
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -140,12 +140,12 @@ type Issue struct {
 	DependsOn []string `json:"depends_on,omitempty"`
 	Wave      int      `json:"wave,omitempty"`
 
-	// Objective, AcceptanceCriteria, and RequiredTests are the approved
-	// plan text, copied at EnterDelivery so dispatch hands the executor a
-	// transcription of what a human approved rather than a recollection
-	// of it. Their durable home is the issue body's audit record, and
-	// `orch resume` repopulates them from it on every phase where it
-	// already parses that record.
+	// Objective, AcceptanceCriteria, RequiredTests, and TestsCIDoesNotRun
+	// are the approved plan text, copied at EnterDelivery so dispatch
+	// hands the executor a transcription of what a human approved rather
+	// than a recollection of it. Their durable home is the issue body's
+	// audit record, and `orch resume` repopulates them from it on every
+	// phase where it already parses that record.
 	//
 	// They are optional in the persisted file rather than required by
 	// validateIssues because a run activated by a build older than the
@@ -154,9 +154,16 @@ type Issue struct {
 	// refuses, so resume takes its failure path and blocks the issue
 	// instead of repopulating anything. The remediation there is abort,
 	// never resume (internal/run/dispatch.go, checkApprovedWork).
+	//
+	// TestsCIDoesNotRun is optional for a second reason of its own, which
+	// does not extend to the three fields above it: an empty list is the
+	// honest reading of a plan that declared nothing, not a gap in a
+	// record, so checkApprovedWork does not require it and no phase
+	// treats its absence as damage.
 	Objective          string   `json:"objective,omitempty"`
 	AcceptanceCriteria []string `json:"acceptance_criteria,omitempty"`
 	RequiredTests      []string `json:"required_tests,omitempty"`
+	TestsCIDoesNotRun  []string `json:"tests_ci_does_not_run,omitempty"`
 
 	// Decision is the current routing for the issue, set at activation
 	// and updated by escalate. Required from the dispatched phase onward.


### PR DESCRIPTION
Delivers issue #197: Surface which required tests CI does not run at the plan gate

Closes #197

**Plan digest:** `sha256:d5596bc10c111556c64143f708a651618b56cfccd6bde617821ef6ba5d66309e`

The approved objective and acceptance criteria are in the audit record below.

## Blast radius

Contributed by Orch because this issue declares a risk domain (criterion
5), and load-bearing here: two schema versions rise, so this section is
where the operator consequences live. Every element the change touches is
named below with whether the behavior it had before this change still
holds.

**Install-order consequences, before anything else:**

- **`manifest.SchemaVersion` 3 → 4** — every in-flight run whose GitHub
  issue bodies carry v3 audit records **must complete on the currently
  installed engine BEFORE a build containing this change is installed**.
  That includes the very run delivering this PR (issues #197/#198): a
  post-install `orch run pr-open`/`review`/`merge` against a v3 body fails
  closed on the version check, and the only remedy the message can offer
  is `orch abort`, then re-plan and re-activate. There is no migration in
  either direction, and nothing regenerates a posted record.
- **`DispatchSchemaVersion` 2 → 3** — the installed **0.6.1** plugins send
  `schema_version: 2` and are rejected from this build onward, so **the
  engine must not ship ahead of the adapter bump**: an adapter release
  carrying the updated `orch-delivery` skills has to land with or before
  it. `orch doctor` will **not** warn about this — it compares version
  strings only, and `plugin.json` did not move in this PR.

| Element | Before → after |
| --- | --- |
| `manifest.SchemaVersion` (`internal/manifest/manifest.go`) | 3 → 4. **Removed behavior:** a v3 record used to parse; it is now refused by the version check, naming the `orch abort` remedy, rather than by the drift compare (which would blame a human for a hand edit nobody made). Recorded as a before-and-after in that constant's own doc comment — the document that stated the old behavior — and pinned by `TestParseRejectsSchemaThreeRecord`. Operator consequence above. |
| `DispatchSchemaVersion` (`internal/run/dispatch.go`) | 2 → 3. **Removed behavior:** a request carrying `schema_version: 2` used to be accepted; this build rejects it. Recorded as a before-and-after in the constant's doc comment, with the reason the version rises for a result-only field: the request's version is the only thing that can refuse an adapter predating the field, and a v2-era adapter handed a v3 result would drop the declaration silently. Operator consequence above. |
| `state.SchemaVersion` (`internal/state/state.go`) | **Deliberately not moved (stays 3) — and this is the one touched element none of my doc comments accounts for.** Consequence: an older binary reading a state.json written by this build accepts it and **silently drops** `tests_ci_does_not_run`; unlike the manifest and dispatch paths, nothing fails closed. It is defensible only under that constant's existing invariant that no real run persists across builds (an out-of-version file on disk is a test artifact), reinforced by the manifest bump already forcing any run that spans an install to abort. Precedent followed: the other approved-work fields (`Objective`, `AcceptanceCriteria`, `RequiredTests`) were also added optional without a state bump. |
| `PlanSchemaVersion` (`internal/run/plandoc.go`) | Stays 1, and that holds: old documents remain valid and the new field is additive-optional. The reverse direction is not silent either — an older engine handed a declaring plan fails closed on `DisallowUnknownFields`. |
| `PlanIssue` | Gains optional `tests_ci_does_not_run` (`omitempty`). Every prior field, rule, and error message is unchanged; a plan omitting it validates exactly as before. |
| `PlanDoc.Digest` | **Unchanged for a plan that declares nothing** — `omitempty` on a nil slice omits it from the canonical marshal, so `orch run plan` and `orch run activate` still agree across an orch upgrade (Decision 108's digest discipline). Pinned to `sha256:00b4d082…902e`, recomputed independently from the pre-change struct definitions rather than copied from this build's output. A declaring plan digests differently, which is correct: the approval must cover the declaration. |
| `DecodePlan` | Unchanged: still `DisallowUnknownFields` at every level, still fails closed naming the unknown field. |
| `PlanDoc.Validate` | Prior checks and their messages unchanged; adds two collected problems for the new field only (an empty entry, and an entry naming no required test of that issue). |
| `GateIssue` / the gate document | Gains the same optional field, passed through from the plan unchanged — the engine derives no part of it. Absent for a plan that declares nothing, so that plan's gate JSON is byte-identical to before. |
| `issueBody` (created-issue prose, `internal/run/activate.go`) | A declared test's bullet gains ` — CI does not run this test`. An undeclared test's bullet, the bullet order, and the dependencies, usage-class, and plan-digest lines are unchanged. |
| `manifest.Manifest` | Gains optional `TestsCIDoesNotRun`. A record declaring nothing renders byte-identically to before apart from the version line — visible in the regenerated `minimal` golden, whose only diff is that line. |
| `Manifest.validate` / new `validateTestsCIDoesNotRun` | All prior checks and their order unchanged; the new referential check runs after `required_tests`, so a record missing required tests still reports that first. |
| `writeWork` / new exported `CIDoesNotRunNote` (`internal/manifest/render.go`) | Annotates a declared required test in place, matching on the exact command; output for a record that declares nothing is unchanged. The clause is a single exported constant precisely so the issue body's prose half and its audit-record half cannot drift apart. |
| `manifest.Render` / `manifest.Parse` | Round-trip, drift compare, HTML escaping, and marker-forgery safety all unchanged; the hostile fixture now declares its data-close required test, so the annotation is pinned to land after a hostile code span. |
| `state.Issue` | Gains optional `tests_ci_does_not_run`. Prior fields and their optionality unchanged. |
| `DispatchResult` | Gains the same optional field, copied from run state. Prior fields unchanged. |
| `checkApprovedWork` (dispatch) | Unchanged, deliberately: it does not require the new field, because an absent declaration is a plan that said nothing, not damage to repair. |
| `resume` — `approvedWork`, `sameWork`, `applyOutcome` | Now compare and carry a fourth field, so a run rebuilt from its posted records dispatches what an unresumed run would. A converged run is still a byte-level no-op, asserted on the new end-to-end fixture. |
| `escalate` / `pr-open` / `review` / `ci` / `merge` / `abandon`, via `readIssueManifest` → `writeManifest` → `upsertCapped` | Unchanged, and they carry the new field with no per-verb code because they round-trip the parsed record. The body-cap rotation still drops only verification detail. |
| `internal/manifest/testdata/{minimal,full,hostile}.golden.md` | Regenerated with `-update`. `minimal` changes in the version line alone; `full` and `hostile` add the annotated bullet and the JSON field. |
| `adapters/claude/skills/orch-delivery/SKILL.md`, `adapters/codex/skills/orch-delivery/SKILL.md` | Both now document how a plan makes the statement, how to render it at the gate beside the test it names, and how to transcribe it into the executor's prompt; both carry the dispatch request's new `schema_version: 3`. No pinned phrase was reworded — every adapter drift-pin test still passes. |

**Restriction scope (criterion 5's third demand):** the rule that every
entry must name one of the same issue's own `required_tests` holds for
`TestsCIDoesNotRun` **alone** — in `PlanDoc.Validate` and in
`Manifest.validate` both — and is not a rule about repeated string lists
in those structs generally. It is the only list in either one whose
entries reference another field's entries: `acceptance_criteria` and
`required_tests` are checked for presence and non-emptiness only,
`depends_on` resolves against the plan's own issue ids, and `area_labels`
resolve against the repository at activation. Both call sites say so in
their comments.

**Not touched, checked:** `ORCH-PRD.md` §8's plan-gate bullet list still
holds. It already lists fewer items than `GateDoc` carried (no labels, no
memhub/ci report), so "Required tests." is not made false by the gate now
also showing which of them CI does not run.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** A plan issue's required tests are commands the executor runs locally; nothing distinguishes one CI also runs from one CI never executes. In kninetimmy/memdolt issue #31 the required golden suite sat behind a build tag CI never enables, so the regression check it mandated fires for nobody, and nothing at the plan gate said so. Deciding CI coverage mechanically means parsing workflow YAML and build tags, which is out of scope; instead, give the plan author a way to declare the distinction per test and render that declaration wherever required tests already appear, so a human approves the plan knowing which of its gates CI actually holds.

**Acceptance criteria:**
- A plan document can state, for an individual required test, that the repository's CI does not run it, and the plan gate document presents that statement alongside the test on the issue that made it, so the human sees the local-only distinction before approving.
- A plan document that makes no such statement validates, renders, and digests exactly as it does today, so existing plans and replays of prior plans are unaffected.
- The statement travels with the required tests where they already appear downstream of the gate, in the created GitHub issue body and the dispatch result, so the executor and reviewer see the same distinction the human approved.
- Both host adapters' Delivery skills document how a plan makes the statement, and every adapter drift-pin test still passes.
- Blast radius (contributed by Orch because this issue declares a risk domain, not by the plan document): name every element of the structure this change touches and state, for each, whether the behavior it had before this change still holds; record a behavior this change removes as a before-and-after in the same document that stated the old behavior, rather than deleting that statement; and where a restriction is attributed to one named symbol, establish whether it holds for that symbol alone or for every symbol of its kind, and say which.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `specialist` |
| Executor | `claude-opus-5` — effort `high` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to a specialist with a strong reviewer because risk domains (data-integrity).

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test -count=1 ./...` — All 23 packages ok, exit 0, uncached, in the issue worktree at the pushed head. — commit `82dbb95580c94cb16a0c077e761b14fbb869afe1` (2026-08-08T20:43:59Z)
- **go-vet** — pass — `go vet ./...` — No output. — commit `82dbb95580c94cb16a0c077e761b14fbb869afe1` (2026-08-08T20:43:59Z)
- **gofmt** — pass — `gofmt -l .` — Printed nothing. — commit `82dbb95580c94cb16a0c077e761b14fbb869afe1` (2026-08-08T20:43:59Z)
- **prose-reflow-word-diff** — pass — `git diff --word-diff --ignore-all-space` — Every removal marker in adapters/ and internal/manifest accounted for as intentional rewrites; no dropped words. — commit `82dbb95580c94cb16a0c077e761b14fbb869afe1` (2026-08-08T20:43:59Z)
- **mutation-check-central-test** — pass — `go test ./internal/run/ (with TestsCIDoesNotRun removed from activate.go audit-record construction)` — Removing the field from the audit-record construction makes TestCIDeclarationReachesTheExecutorAndReviewer fail (note count 1 != 2 plus sameWork divergence); restoring it passes — the end-to-end test is not vacuous. — commit `82dbb95580c94cb16a0c077e761b14fbb869afe1` (2026-08-08T20:43:59Z)
- **acceptance-criterion-1** — satisfied — The declaration rides the same GateIssue that holds the required tests with no engine derivation, and the referential validation rejects any entry not naming that issue's own required test by exact command, so the statement cannot float free of the test it qualifies; the gate test asserts the declaring issue carries exactly the declared entry while the undeclared test is left alone. — commit `82dbb95580c94cb16a0c077e761b14fbb869afe1` (2026-08-08T21:13:29Z)
- **acceptance-criterion-2** — satisfied — The pre-change digest pin was recomputed independently a second time from a separate clone of main and matches byte-for-byte; omitempty keeps an absent or empty declaration out of the canonical marshal; the gate document for a declaring-nothing plan contains no trace of the field; the minimal golden's only diff is the manifest version line, which is outside this criterion's referent and disclosed rather than hidden. — commit `82dbb95580c94cb16a0c077e761b14fbb869afe1` (2026-08-08T21:13:29Z)
- **acceptance-criterion-3** — satisfied — The end-to-end test follows one plan through the issue body prose, the re-parsed audit record, run state, and the marshaled dispatch result; the reviewer reproduced the mutation check independently and got five assertion failures across all four surfaces; the prose and record halves share one exported constant so they cannot drift; resume carries the field through approvedWork, applyOutcome, sameWork, and observeIssue. — commit `82dbb95580c94cb16a0c077e761b14fbb869afe1` (2026-08-08T21:13:29Z)
- **acceptance-criterion-4** — satisfied — A diff-of-diffs proves both hosts' skill changes are identical; the authoring paragraph, gate field list, render instruction, dispatch schema bump, and transcription instruction are all present; every existing drift pin passes and neither plugin_test.go nor adaptertest.go was modified, so no pin was weakened. — commit `82dbb95580c94cb16a0c077e761b14fbb869afe1` (2026-08-08T21:13:29Z)
- **acceptance-criterion-5** — satisfied — The enumeration is genuine and accurate: 21 rows plus install-order callouts and a restriction-scope verdict, 15 rows spot-verified against the diff without finding a misstatement; the operational consequences a test suite could never surface (in-flight v3 records, doctor's silence on the plugin mismatch) are stated where a human will read them; removed-behavior statements were appended-to rather than deleted; the change's weakest spot is volunteered rather than buried. — commit `82dbb95580c94cb16a0c077e761b14fbb869afe1` (2026-08-08T21:13:29Z)
- **review-cycle-1** — request-changes — Blocking on criterion 5 alone: the PR body carries no blast-radius enumeration, and here it is load-bearing - it is where a human would learn that manifest schema v4 refuses every in-flight v3 audit record (including this run's own issues #197/#198, so the current run must complete on the installed engine before a new build is installed) and that DispatchSchemaVersion 2-&gt;3 rejects the installed 0.6.1 plugins until an adapter release ships. Criteria 1-4 satisfied: the reviewer independently recomputed the pre-change digest pin against main (honest, not back-filled), reproduced the activate.go mutation check (5 assertion failures), verified every non-test RequiredTests flow site has a matching TestsCIDoesNotRun site, and confirmed 6/6 CI at head. Non-blocking findings for the backlog: TestDigestCoversTheCIDeclaration is near-vacuous (fixtures differ in required_tests too); no drift pin covers the skills' dispatch schema_version literal (hand-synced across three files, second bump to need it); state.Issue gained a persisted field while state.SchemaVersion stayed 3 (older binary silently drops it - defensible under the no-run-persists-across-builds invariant but unrecorded); two rendering nits (prose bullet lacks codeSpan escaping; occurrence-count assertions spoofable). — commit `82dbb95580c94cb16a0c077e761b14fbb869afe1` (2026-08-08T20:56:46Z)
- **review-cycle-2** — approve — Cycle 2 approve. Head unchanged since cycle 1 (single commit, no force-push; a body edit cannot alter the tree). The blast-radius enumeration now in the PR body was judged on substance: 15 rows spot-verified against the actual diff with every claim accurate, both operational consequences stated in full (manifest v4 refuses in-flight v3 records naming this run's own issues and the orch abort remedy; dispatch v3 rejects the installed 0.6.1 plugins with the engine-must-not-ship-ahead ordering rule and the doctor-will-not-warn disclosure), state.SchemaVersion's deliberate non-bump recorded with the older-binary silent-drop behavior, and the restriction-scope verdict answered at both call sites. Removed-behavior discipline holds: both version-bump doc comments append the before-and-after without deleting the old statement, and the schema-2 rejection test was kept alongside the new schema-3 one. Required tests re-run clean at the head in a scratch clone; CI 6/6; the audit record parses through the pre-change engine's own Parse with no drift. Release-ordering note for the human: this run must complete on the currently installed engine before a build with this change is installed, and an adapter version bump must land with or before the engine release. Non-blocking findings for the backlog: near-vacuous TestDigestCoversTheCIDeclaration; no drift pin on the skills' dispatch schema_version literal; TestParseRejectsSchemaThreeRecord derives its v3 body from the current render; duplicate declaration entries tolerated harmlessly; pre-existing prose/record escaping asymmetry; audit record staleness pending engine append. — commit `82dbb95580c94cb16a0c077e761b14fbb869afe1` (2026-08-08T21:13:29Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass — commit `82dbb95580c94cb16a0c077e761b14fbb869afe1` (2026-08-08T21:13:33Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "A plan issue's required tests are commands the executor runs locally; nothing distinguishes one CI also runs from one CI never executes. In kninetimmy/memdolt issue #31 the required golden suite sat behind a build tag CI never enables, so the regression check it mandated fires for nobody, and nothing at the plan gate said so. Deciding CI coverage mechanically means parsing workflow YAML and build tags, which is out of scope; instead, give the plan author a way to declare the distinction per test and render that declaration wherever required tests already appear, so a human approves the plan knowing which of its gates CI actually holds.",
  "acceptance_criteria": [
    "A plan document can state, for an individual required test, that the repository's CI does not run it, and the plan gate document presents that statement alongside the test on the issue that made it, so the human sees the local-only distinction before approving.",
    "A plan document that makes no such statement validates, renders, and digests exactly as it does today, so existing plans and replays of prior plans are unaffected.",
    "The statement travels with the required tests where they already appear downstream of the gate, in the created GitHub issue body and the dispatch result, so the executor and reviewer see the same distinction the human approved.",
    "Both host adapters' Delivery skills document how a plan makes the statement, and every adapter drift-pin test still passes.",
    "Blast radius (contributed by Orch because this issue declares a risk domain, not by the plan document): name every element of the structure this change touches and state, for each, whether the behavior it had before this change still holds; record a behavior this change removes as a before-and-after in the same document that stated the old behavior, rather than deleting that statement; and where a restriction is attributed to one named symbol, establish whether it holds for that symbol alone or for every symbol of its kind, and say which."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "specialist",
  "executor": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "routing_rationale": "Routed to a specialist with a strong reviewer because risk domains (data-integrity).",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test -count=1 ./...",
      "result": "pass",
      "detail": "All 23 packages ok, exit 0, uncached, in the issue worktree at the pushed head.",
      "commit_oid": "82dbb95580c94cb16a0c077e761b14fbb869afe1",
      "at": "2026-08-08T20:43:59Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "No output.",
      "commit_oid": "82dbb95580c94cb16a0c077e761b14fbb869afe1",
      "at": "2026-08-08T20:43:59Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Printed nothing.",
      "commit_oid": "82dbb95580c94cb16a0c077e761b14fbb869afe1",
      "at": "2026-08-08T20:43:59Z"
    },
    {
      "name": "prose-reflow-word-diff",
      "command": "git diff --word-diff --ignore-all-space",
      "result": "pass",
      "detail": "Every removal marker in adapters/ and internal/manifest accounted for as intentional rewrites; no dropped words.",
      "commit_oid": "82dbb95580c94cb16a0c077e761b14fbb869afe1",
      "at": "2026-08-08T20:43:59Z"
    },
    {
      "name": "mutation-check-central-test",
      "command": "go test ./internal/run/ (with TestsCIDoesNotRun removed from activate.go audit-record construction)",
      "result": "pass",
      "detail": "Removing the field from the audit-record construction makes TestCIDeclarationReachesTheExecutorAndReviewer fail (note count 1 != 2 plus sameWork divergence); restoring it passes — the end-to-end test is not vacuous.",
      "commit_oid": "82dbb95580c94cb16a0c077e761b14fbb869afe1",
      "at": "2026-08-08T20:43:59Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "The declaration rides the same GateIssue that holds the required tests with no engine derivation, and the referential validation rejects any entry not naming that issue's own required test by exact command, so the statement cannot float free of the test it qualifies; the gate test asserts the declaring issue carries exactly the declared entry while the undeclared test is left alone.",
      "commit_oid": "82dbb95580c94cb16a0c077e761b14fbb869afe1",
      "at": "2026-08-08T21:13:29Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "The pre-change digest pin was recomputed independently a second time from a separate clone of main and matches byte-for-byte; omitempty keeps an absent or empty declaration out of the canonical marshal; the gate document for a declaring-nothing plan contains no trace of the field; the minimal golden's only diff is the manifest version line, which is outside this criterion's referent and disclosed rather than hidden.",
      "commit_oid": "82dbb95580c94cb16a0c077e761b14fbb869afe1",
      "at": "2026-08-08T21:13:29Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "The end-to-end test follows one plan through the issue body prose, the re-parsed audit record, run state, and the marshaled dispatch result; the reviewer reproduced the mutation check independently and got five assertion failures across all four surfaces; the prose and record halves share one exported constant so they cannot drift; resume carries the field through approvedWork, applyOutcome, sameWork, and observeIssue.",
      "commit_oid": "82dbb95580c94cb16a0c077e761b14fbb869afe1",
      "at": "2026-08-08T21:13:29Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "A diff-of-diffs proves both hosts' skill changes are identical; the authoring paragraph, gate field list, render instruction, dispatch schema bump, and transcription instruction are all present; every existing drift pin passes and neither plugin_test.go nor adaptertest.go was modified, so no pin was weakened.",
      "commit_oid": "82dbb95580c94cb16a0c077e761b14fbb869afe1",
      "at": "2026-08-08T21:13:29Z"
    },
    {
      "name": "acceptance-criterion-5",
      "result": "satisfied",
      "detail": "The enumeration is genuine and accurate: 21 rows plus install-order callouts and a restriction-scope verdict, 15 rows spot-verified against the diff without finding a misstatement; the operational consequences a test suite could never surface (in-flight v3 records, doctor's silence on the plugin mismatch) are stated where a human will read them; removed-behavior statements were appended-to rather than deleted; the change's weakest spot is volunteered rather than buried.",
      "commit_oid": "82dbb95580c94cb16a0c077e761b14fbb869afe1",
      "at": "2026-08-08T21:13:29Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "Blocking on criterion 5 alone: the PR body carries no blast-radius enumeration, and here it is load-bearing - it is where a human would learn that manifest schema v4 refuses every in-flight v3 audit record (including this run's own issues #197/#198, so the current run must complete on the installed engine before a new build is installed) and that DispatchSchemaVersion 2-\u003e3 rejects the installed 0.6.1 plugins until an adapter release ships. Criteria 1-4 satisfied: the reviewer independently recomputed the pre-change digest pin against main (honest, not back-filled), reproduced the activate.go mutation check (5 assertion failures), verified every non-test RequiredTests flow site has a matching TestsCIDoesNotRun site, and confirmed 6/6 CI at head. Non-blocking findings for the backlog: TestDigestCoversTheCIDeclaration is near-vacuous (fixtures differ in required_tests too); no drift pin covers the skills' dispatch schema_version literal (hand-synced across three files, second bump to need it); state.Issue gained a persisted field while state.SchemaVersion stayed 3 (older binary silently drops it - defensible under the no-run-persists-across-builds invariant but unrecorded); two rendering nits (prose bullet lacks codeSpan escaping; occurrence-count assertions spoofable).",
      "commit_oid": "82dbb95580c94cb16a0c077e761b14fbb869afe1",
      "at": "2026-08-08T20:56:46Z"
    },
    {
      "name": "review-cycle-2",
      "result": "approve",
      "detail": "Cycle 2 approve. Head unchanged since cycle 1 (single commit, no force-push; a body edit cannot alter the tree). The blast-radius enumeration now in the PR body was judged on substance: 15 rows spot-verified against the actual diff with every claim accurate, both operational consequences stated in full (manifest v4 refuses in-flight v3 records naming this run's own issues and the orch abort remedy; dispatch v3 rejects the installed 0.6.1 plugins with the engine-must-not-ship-ahead ordering rule and the doctor-will-not-warn disclosure), state.SchemaVersion's deliberate non-bump recorded with the older-binary silent-drop behavior, and the restriction-scope verdict answered at both call sites. Removed-behavior discipline holds: both version-bump doc comments append the before-and-after without deleting the old statement, and the schema-2 rejection test was kept alongside the new schema-3 one. Required tests re-run clean at the head in a scratch clone; CI 6/6; the audit record parses through the pre-change engine's own Parse with no drift. Release-ordering note for the human: this run must complete on the currently installed engine before a build with this change is installed, and an adapter version bump must land with or before the engine release. Non-blocking findings for the backlog: near-vacuous TestDigestCoversTheCIDeclaration; no drift pin on the skills' dispatch schema_version literal; TestParseRejectsSchemaThreeRecord derives its v3 body from the current render; duplicate declaration entries tolerated harmlessly; pre-existing prose/record escaping asymmetry; audit record staleness pending engine append.",
      "commit_oid": "82dbb95580c94cb16a0c077e761b14fbb869afe1",
      "at": "2026-08-08T21:13:29Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "82dbb95580c94cb16a0c077e761b14fbb869afe1",
      "at": "2026-08-08T21:13:33Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->
