### PR TITLE
Bump the adapter and marketplace version to 0.6.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "kninetimmy" },
   "metadata": {
     "description": "Host adapters for the Orch development orchestrator",
-    "version": "0.6.1"
+    "version": "0.6.2"
   },
   "plugins": [
     {

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Claude Code host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -78,8 +78,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.6.1" {
-		t.Errorf("version = %q, want 0.6.1", m.Version)
+	if m.Version != "0.6.2" {
+		t.Errorf("version = %q, want 0.6.2", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Codex CLI host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -79,8 +79,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.6.1" {
-		t.Errorf("version = %q, want 0.6.1", m.Version)
+	if m.Version != "0.6.2" {
+		t.Errorf("version = %q, want 0.6.2", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")


### PR DESCRIPTION
Delivers issue #201: Bump the adapter and marketplace version to 0.6.2

Closes #201

**Plan digest:** `sha256:acb1c141b4763f27cba7042f2e4d54316b0ed3692ff23244ae033b77fb3fd9ff`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Replace the 0.6.1 literal at every tracked version-identity site with 0.6.2: both adapter plugin manifests, the marketplace manifest, and the hardcoded expectations in both adapter plugin tests. The plugin tests and the root marketplace test pin these literals against each other, so a partial bump fails the suite. No behavior changes ride along.

**Acceptance criteria:**
- Every tracked version-identity site states 0.6.2: both adapter plugin manifests, the marketplace manifest, and the adapter plugin tests that pin those version literals; a git grep for the 0.6.1 literal over tracked JSON and Go files finds no remaining version-identity site.
- go test ./... passes, including the plugin and marketplace tests that pin the version literals against each other.
- The branch diff contains only version-identity literal replacements; no other prose, code, or behavior changes.

**Required tests:**
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `medium` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **required-tests** — pass — `go build ./... && go vet ./... && go test ./... && gofmt -l .` — All four required tests run from the worktree root at commit 81cad5b: build exit 0 no output, vet exit 0 no output, go test ./... exit 0 with all 23 packages ok including adapters/claude, adapters/codex, and the root package holding the marketplace cross-pin test, gofmt printed nothing. — commit `81cad5b0726a530164557aa38046a47a8612704d` (2026-08-08T22:27:37Z)
- **no-old-literal** — pass — `git grep -nF 0.6.1 -- '*.json' '*.go'` — Exit 1, zero matches at commit 81cad5b. Before the change the same grep returned all 7 expected version-identity sites (5 files), so the site set was complete and is now empty. README's v0.6.1 references are deliberately out of scope. — commit `81cad5b0726a530164557aa38046a47a8612704d` (2026-08-08T22:27:37Z)
- **branch-scope: five-file-literal-bump** — pass — `git diff main...HEAD --stat && git diff --word-diff --ignore-all-space main...HEAD` — 5 files changed, 7 insertions, 7 deletions, matching the PR #196 precedent file set exactly: marketplace.json, both adapter plugin.json manifests, both adapter plugin_test.go pins. Word-diff shows every removal is an intended 0.6.1-to-0.6.2 literal replacement; no other prose, code, or reflow. marketplace_test.go needed no edit because its cross-pin assertion is structural (p.Version != m.Metadata.Version). — commit `81cad5b0726a530164557aa38046a47a8612704d` (2026-08-08T22:27:37Z)
- **acceptance-criterion-1** — satisfied — git grep -nF 0.6.1 -- '*.json' '*.go' exits 1 with zero matches at head; the same grep against main returns exactly 7 hits across the 5 named files, and git grep -nF 0.6.2 at head returns those same 7 sites. Checked for version-identity sites the JSON/Go filter would miss: internal/cli/version.go:12 is var Version = "dev" (ldflags-injected), install.sh and install.ps1 default to latest with no pinned tag. Only README.md's six references remain, deliberately out of scope. — commit `81cad5b0726a530164557aa38046a47a8612704d` (2026-08-08T22:33:38Z)
- **acceptance-criterion-2** — satisfied — go test ./... exit 0, 23 packages ok, re-run by the reviewer at head; the pinning tests re-run uncached via go test -count=1 -run 'Marketplace|Plugin' -v: TestPluginManifestStrict PASS in both adapter packages and all five TestMarketplace* PASS in the root package. The cross-pin is real: marketplace_test.go:169 asserts p.Version != m.Metadata.Version per entry, so a partial bump fails loudly. — commit `81cad5b0726a530164557aa38046a47a8612704d` (2026-08-08T22:33:38Z)
- **acceptance-criterion-3** — satisfied — git diff main...HEAD is 5 files, 7 insertions, 7 deletions, read in full: every hunk is a 0.6.1-to-0.6.2 literal replacement, including both halves of each test pin (condition and t.Errorf want-string). No prose, reflow, or logic change; file set identical to the #196 precedent. — commit `81cad5b0726a530164557aa38046a47a8612704d` (2026-08-08T22:33:38Z)
- **review-cycle-1** — approve — All three acceptance criteria satisfied with independently re-run evidence: git grep -nF 0.6.1 over tracked JSON/Go exits 1 with zero matches while the same grep on main returns the 7 expected sites across 5 files, and the reviewer checked outside the JSON/Go filter (internal/cli/version.go is ldflags-injected dev, install scripts pin no tag) so the filter hides no site; go test ./... passes all 23 packages with the pinning tests re-run uncached (-count=1) and the cross-pin at marketplace_test.go:169 confirmed real; the full diff read hunk-by-hunk is exclusively 0.6.1-to-0.6.2 literals in the exact 5-file set of the #196 precedent. All four required tests re-run at head by the reviewer, all clean. CI: all six checks SUCCESS at the reviewed head. Manifest accurate on every checkable claim. Two informational findings, neither blocking: README's six v0.6.1 references become stale once v0.6.2 is tagged (deliberately out of scope, own-pass precedent PR #195), and the version literal remains at 5 hand-synced sites guarded by the cross-pin test (pre-existing design). The bump is warranted: shipped plugin content moved since b7c041c (both orch-delivery SKILL.md files, +58/-10). — commit `81cad5b0726a530164557aa38046a47a8612704d` (2026-08-08T22:33:38Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass — commit `81cad5b0726a530164557aa38046a47a8612704d` (2026-08-08T22:33:48Z)

<!-- orch:manifest:data
{
  "schema_version": 3,
  "objective": "Replace the 0.6.1 literal at every tracked version-identity site with 0.6.2: both adapter plugin manifests, the marketplace manifest, and the hardcoded expectations in both adapter plugin tests. The plugin tests and the root marketplace test pin these literals against each other, so a partial bump fails the suite. No behavior changes ride along.",
  "acceptance_criteria": [
    "Every tracked version-identity site states 0.6.2: both adapter plugin manifests, the marketplace manifest, and the adapter plugin tests that pin those version literals; a git grep for the 0.6.1 literal over tracked JSON and Go files finds no remaining version-identity site.",
    "go test ./... passes, including the plugin and marketplace tests that pin the version literals against each other.",
    "The branch diff contains only version-identity literal replacements; no other prose, code, or behavior changes."
  ],
  "required_tests": [
    "go build ./...",
    "go vet ./...",
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "required-tests",
      "command": "go build ./... \u0026\u0026 go vet ./... \u0026\u0026 go test ./... \u0026\u0026 gofmt -l .",
      "result": "pass",
      "detail": "All four required tests run from the worktree root at commit 81cad5b: build exit 0 no output, vet exit 0 no output, go test ./... exit 0 with all 23 packages ok including adapters/claude, adapters/codex, and the root package holding the marketplace cross-pin test, gofmt printed nothing.",
      "commit_oid": "81cad5b0726a530164557aa38046a47a8612704d",
      "at": "2026-08-08T22:27:37Z"
    },
    {
      "name": "no-old-literal",
      "command": "git grep -nF 0.6.1 -- '*.json' '*.go'",
      "result": "pass",
      "detail": "Exit 1, zero matches at commit 81cad5b. Before the change the same grep returned all 7 expected version-identity sites (5 files), so the site set was complete and is now empty. README's v0.6.1 references are deliberately out of scope.",
      "commit_oid": "81cad5b0726a530164557aa38046a47a8612704d",
      "at": "2026-08-08T22:27:37Z"
    },
    {
      "name": "branch-scope: five-file-literal-bump",
      "command": "git diff main...HEAD --stat \u0026\u0026 git diff --word-diff --ignore-all-space main...HEAD",
      "result": "pass",
      "detail": "5 files changed, 7 insertions, 7 deletions, matching the PR #196 precedent file set exactly: marketplace.json, both adapter plugin.json manifests, both adapter plugin_test.go pins. Word-diff shows every removal is an intended 0.6.1-to-0.6.2 literal replacement; no other prose, code, or reflow. marketplace_test.go needed no edit because its cross-pin assertion is structural (p.Version != m.Metadata.Version).",
      "commit_oid": "81cad5b0726a530164557aa38046a47a8612704d",
      "at": "2026-08-08T22:27:37Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "git grep -nF 0.6.1 -- '*.json' '*.go' exits 1 with zero matches at head; the same grep against main returns exactly 7 hits across the 5 named files, and git grep -nF 0.6.2 at head returns those same 7 sites. Checked for version-identity sites the JSON/Go filter would miss: internal/cli/version.go:12 is var Version = \"dev\" (ldflags-injected), install.sh and install.ps1 default to latest with no pinned tag. Only README.md's six references remain, deliberately out of scope.",
      "commit_oid": "81cad5b0726a530164557aa38046a47a8612704d",
      "at": "2026-08-08T22:33:38Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "go test ./... exit 0, 23 packages ok, re-run by the reviewer at head; the pinning tests re-run uncached via go test -count=1 -run 'Marketplace|Plugin' -v: TestPluginManifestStrict PASS in both adapter packages and all five TestMarketplace* PASS in the root package. The cross-pin is real: marketplace_test.go:169 asserts p.Version != m.Metadata.Version per entry, so a partial bump fails loudly.",
      "commit_oid": "81cad5b0726a530164557aa38046a47a8612704d",
      "at": "2026-08-08T22:33:38Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "git diff main...HEAD is 5 files, 7 insertions, 7 deletions, read in full: every hunk is a 0.6.1-to-0.6.2 literal replacement, including both halves of each test pin (condition and t.Errorf want-string). No prose, reflow, or logic change; file set identical to the #196 precedent.",
      "commit_oid": "81cad5b0726a530164557aa38046a47a8612704d",
      "at": "2026-08-08T22:33:38Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "All three acceptance criteria satisfied with independently re-run evidence: git grep -nF 0.6.1 over tracked JSON/Go exits 1 with zero matches while the same grep on main returns the 7 expected sites across 5 files, and the reviewer checked outside the JSON/Go filter (internal/cli/version.go is ldflags-injected dev, install scripts pin no tag) so the filter hides no site; go test ./... passes all 23 packages with the pinning tests re-run uncached (-count=1) and the cross-pin at marketplace_test.go:169 confirmed real; the full diff read hunk-by-hunk is exclusively 0.6.1-to-0.6.2 literals in the exact 5-file set of the #196 precedent. All four required tests re-run at head by the reviewer, all clean. CI: all six checks SUCCESS at the reviewed head. Manifest accurate on every checkable claim. Two informational findings, neither blocking: README's six v0.6.1 references become stale once v0.6.2 is tagged (deliberately out of scope, own-pass precedent PR #195), and the version literal remains at 5 hand-synced sites guarded by the cross-pin test (pre-existing design). The bump is warranted: shipped plugin content moved since b7c041c (both orch-delivery SKILL.md files, +58/-10).",
      "commit_oid": "81cad5b0726a530164557aa38046a47a8612704d",
      "at": "2026-08-08T22:33:38Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "81cad5b0726a530164557aa38046a47a8612704d",
      "at": "2026-08-08T22:33:48Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->