### PR TITLE
Bump the adapter and marketplace version to 0.6.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "kninetimmy" },
   "metadata": {
     "description": "Host adapters for the Orch development orchestrator",
-    "version": "0.6.2"
+    "version": "0.6.3"
   },
   "plugins": [
     {

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Claude Code host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -78,8 +78,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.6.2" {
-		t.Errorf("version = %q, want 0.6.2", m.Version)
+	if m.Version != "0.6.3" {
+		t.Errorf("version = %q, want 0.6.3", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Codex CLI host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -79,8 +79,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.6.2" {
-		t.Errorf("version = %q, want 0.6.2", m.Version)
+	if m.Version != "0.6.3" {
+		t.Errorf("version = %q, want 0.6.3", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")


### PR DESCRIPTION
Delivers issue #205: Bump the adapter and marketplace version to 0.6.3

Closes #205

**Plan digest:** `sha256:186097509ef149e855ceb214834f0bdc54ae214ea8c46b11ab4195f7493503a4`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Replace the 0.6.2 literal at every tracked version-identity site with 0.6.3: both adapter plugin manifests, the marketplace manifest, and the hardcoded expectations in both adapter plugin tests. The plugin tests and the root marketplace test pin these literals against each other, so a partial bump fails the suite. No behavior changes ride along.

**Acceptance criteria:**
- Every tracked version-identity site states 0.6.3: both adapter plugin manifests, the marketplace manifest, and the adapter plugin tests that pin those version literals; a git grep for the 0.6.2 literal over tracked JSON and Go files finds no remaining version-identity site.
- go test ./... passes, including the plugin and marketplace tests that pin the version literals against each other.
- The branch diff contains only version-identity literal replacements; no other prose, code, or behavior changes.

**Required tests:**
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `gpt-5.6-terra` — effort `max` |
| Reviewer | `gpt-5.6-sol` — effort `medium` |
| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **build** — pass — `go build ./...` — Exit 0 at commit 70fc2412f635693d830afbd49addc6e1782d0225. — commit `70fc2412f635693d830afbd49addc6e1782d0225` (2026-08-09T18:01:47Z)
- **vet** — pass — `go vet ./...` — Exit 0 at commit 70fc2412f635693d830afbd49addc6e1782d0225. — commit `70fc2412f635693d830afbd49addc6e1782d0225` (2026-08-09T18:01:47Z)
- **test** — pass — `go test ./...` — Exit 0 in 114.6 seconds; root marketplace and both adapter packages passed at commit 70fc2412f635693d830afbd49addc6e1782d0225. — commit `70fc2412f635693d830afbd49addc6e1782d0225` (2026-08-09T18:01:47Z)
- **gofmt** — pass — `gofmt -l .` — Exit 0 with no output at commit 70fc2412f635693d830afbd49addc6e1782d0225. — commit `70fc2412f635693d830afbd49addc6e1782d0225` (2026-08-09T18:01:47Z)
- **no-old-literal** — pass — `git grep -n -- '0.6.2' -- '*.json' '*.go'` — No matches at commit 70fc2412f635693d830afbd49addc6e1782d0225. — commit `70fc2412f635693d830afbd49addc6e1782d0225` (2026-08-09T18:01:47Z)
- **branch-scope:five-file-literal-bump** — pass — `git diff --name-only HEAD^ HEAD; git diff --check HEAD^ HEAD; git diff --word-diff --ignore-all-space HEAD^ HEAD` — Exactly the five authorized version-identity files changed; diff check was clean and the word diff showed only seven 0.6.2-to-0.6.3 substitutions with no prose changes. — commit `70fc2412f635693d830afbd49addc6e1782d0225` (2026-08-09T18:01:47Z)
- **review-head** — pass — `verify live PR head and worktree status` — Live PR head and reviewed worktree both equal 70fc2412f635693d830afbd49addc6e1782d0225; worktree is clean and synchronized with origin. — commit `70fc2412f635693d830afbd49addc6e1782d0225` (2026-08-09T18:07:22Z)
- **review-build** — pass — `go build ./...` — Exit 0 at the reviewed head. — commit `70fc2412f635693d830afbd49addc6e1782d0225` (2026-08-09T18:07:22Z)
- **review-vet** — pass — `go vet ./...` — Exit 0 at the reviewed head. — commit `70fc2412f635693d830afbd49addc6e1782d0225` (2026-08-09T18:07:22Z)
- **review-test** — pass — `go test ./...` — All packages passed at the reviewed head. — commit `70fc2412f635693d830afbd49addc6e1782d0225` (2026-08-09T18:07:22Z)
- **review-gofmt** — pass — `gofmt -l .` — No output at the reviewed head. — commit `70fc2412f635693d830afbd49addc6e1782d0225` (2026-08-09T18:07:22Z)
- **review-targeted** — pass — `go test -count=1 . ./adapters/claude ./adapters/codex` — Root, Claude adapter, and Codex adapter packages passed uncached. — commit `70fc2412f635693d830afbd49addc6e1782d0225` (2026-08-09T18:07:22Z)
- **review-diff** — pass — `git diff --stat e9cdbb9...70fc2412; git diff --check e9cdbb9...70fc2412` — Five files, seven insertions and seven deletions; diff check clean; full diff read as version-literal replacements only. — commit `70fc2412f635693d830afbd49addc6e1782d0225` (2026-08-09T18:07:22Z)
- **review-ci** — pass — `inspect live PR #206 checks` — All six checks passed: lint, scripts on Ubuntu and Windows, and tests on Ubuntu, macOS, and Windows. GitHub reports the PR merge state clean. — commit `70fc2412f635693d830afbd49addc6e1782d0225` (2026-08-09T18:07:22Z)
- **acceptance-criterion-1** — satisfied — The three manifests and both adapter tests state 0.6.3; git grep over tracked JSON/Go files and a broader tracked-file grep found no remaining 0.6.2 matches. — commit `70fc2412f635693d830afbd49addc6e1782d0225` (2026-08-09T18:07:24Z)
- **acceptance-criterion-2** — satisfied — go test ./... passed, including the root marketplace and both adapter packages; a fresh targeted uncached run over those three packages also passed. — commit `70fc2412f635693d830afbd49addc6e1782d0225` (2026-08-09T18:07:24Z)
- **acceptance-criterion-3** — satisfied — The full diff contains exactly the five authorized files and seven 0.6.2-to-0.6.3 substitutions, with no other prose or behavior changes; git diff --check passed. — commit `70fc2412f635693d830afbd49addc6e1782d0225` (2026-08-09T18:07:24Z)
- **review-cycle-1** — approve — All three acceptance criteria are satisfied at the live PR head. The change is exactly seven 0.6.2-to-0.6.3 substitutions across the five authorized version-identity files, full and targeted tests pass, all six required CI checks pass, the PR is cleanly mergeable, and there are no blocking or non-blocking findings. — commit `70fc2412f635693d830afbd49addc6e1782d0225` (2026-08-09T18:07:24Z)
- **required-ci** — passing — scripts (windows-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass — commit `70fc2412f635693d830afbd49addc6e1782d0225` (2026-08-09T18:07:41Z)

<!-- orch:manifest:data
{
  "schema_version": 4,
  "objective": "Replace the 0.6.2 literal at every tracked version-identity site with 0.6.3: both adapter plugin manifests, the marketplace manifest, and the hardcoded expectations in both adapter plugin tests. The plugin tests and the root marketplace test pin these literals against each other, so a partial bump fails the suite. No behavior changes ride along.",
  "acceptance_criteria": [
    "Every tracked version-identity site states 0.6.3: both adapter plugin manifests, the marketplace manifest, and the adapter plugin tests that pin those version literals; a git grep for the 0.6.2 literal over tracked JSON and Go files finds no remaining version-identity site.",
    "go test ./... passes, including the plugin and marketplace tests that pin the version literals against each other.",
    "The branch diff contains only version-identity literal replacements; no other prose, code, or behavior changes."
  ],
  "required_tests": [
    "go build ./...",
    "go vet ./...",
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "gpt-5.6-terra",
    "effort": "max"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "gpt-5.6-sol",
    "effort": "medium"
  },
  "effort_delivery": "parameter",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "Exit 0 at commit 70fc2412f635693d830afbd49addc6e1782d0225.",
      "commit_oid": "70fc2412f635693d830afbd49addc6e1782d0225",
      "at": "2026-08-09T18:01:47Z"
    },
    {
      "name": "vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Exit 0 at commit 70fc2412f635693d830afbd49addc6e1782d0225.",
      "commit_oid": "70fc2412f635693d830afbd49addc6e1782d0225",
      "at": "2026-08-09T18:01:47Z"
    },
    {
      "name": "test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Exit 0 in 114.6 seconds; root marketplace and both adapter packages passed at commit 70fc2412f635693d830afbd49addc6e1782d0225.",
      "commit_oid": "70fc2412f635693d830afbd49addc6e1782d0225",
      "at": "2026-08-09T18:01:47Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Exit 0 with no output at commit 70fc2412f635693d830afbd49addc6e1782d0225.",
      "commit_oid": "70fc2412f635693d830afbd49addc6e1782d0225",
      "at": "2026-08-09T18:01:47Z"
    },
    {
      "name": "no-old-literal",
      "command": "git grep -n -- '0.6.2' -- '*.json' '*.go'",
      "result": "pass",
      "detail": "No matches at commit 70fc2412f635693d830afbd49addc6e1782d0225.",
      "commit_oid": "70fc2412f635693d830afbd49addc6e1782d0225",
      "at": "2026-08-09T18:01:47Z"
    },
    {
      "name": "branch-scope:five-file-literal-bump",
      "command": "git diff --name-only HEAD^ HEAD; git diff --check HEAD^ HEAD; git diff --word-diff --ignore-all-space HEAD^ HEAD",
      "result": "pass",
      "detail": "Exactly the five authorized version-identity files changed; diff check was clean and the word diff showed only seven 0.6.2-to-0.6.3 substitutions with no prose changes.",
      "commit_oid": "70fc2412f635693d830afbd49addc6e1782d0225",
      "at": "2026-08-09T18:01:47Z"
    },
    {
      "name": "review-head",
      "command": "verify live PR head and worktree status",
      "result": "pass",
      "detail": "Live PR head and reviewed worktree both equal 70fc2412f635693d830afbd49addc6e1782d0225; worktree is clean and synchronized with origin.",
      "commit_oid": "70fc2412f635693d830afbd49addc6e1782d0225",
      "at": "2026-08-09T18:07:22Z"
    },
    {
      "name": "review-build",
      "command": "go build ./...",
      "result": "pass",
      "detail": "Exit 0 at the reviewed head.",
      "commit_oid": "70fc2412f635693d830afbd49addc6e1782d0225",
      "at": "2026-08-09T18:07:22Z"
    },
    {
      "name": "review-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "Exit 0 at the reviewed head.",
      "commit_oid": "70fc2412f635693d830afbd49addc6e1782d0225",
      "at": "2026-08-09T18:07:22Z"
    },
    {
      "name": "review-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All packages passed at the reviewed head.",
      "commit_oid": "70fc2412f635693d830afbd49addc6e1782d0225",
      "at": "2026-08-09T18:07:22Z"
    },
    {
      "name": "review-gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No output at the reviewed head.",
      "commit_oid": "70fc2412f635693d830afbd49addc6e1782d0225",
      "at": "2026-08-09T18:07:22Z"
    },
    {
      "name": "review-targeted",
      "command": "go test -count=1 . ./adapters/claude ./adapters/codex",
      "result": "pass",
      "detail": "Root, Claude adapter, and Codex adapter packages passed uncached.",
      "commit_oid": "70fc2412f635693d830afbd49addc6e1782d0225",
      "at": "2026-08-09T18:07:22Z"
    },
    {
      "name": "review-diff",
      "command": "git diff --stat e9cdbb9...70fc2412; git diff --check e9cdbb9...70fc2412",
      "result": "pass",
      "detail": "Five files, seven insertions and seven deletions; diff check clean; full diff read as version-literal replacements only.",
      "commit_oid": "70fc2412f635693d830afbd49addc6e1782d0225",
      "at": "2026-08-09T18:07:22Z"
    },
    {
      "name": "review-ci",
      "command": "inspect live PR #206 checks",
      "result": "pass",
      "detail": "All six checks passed: lint, scripts on Ubuntu and Windows, and tests on Ubuntu, macOS, and Windows. GitHub reports the PR merge state clean.",
      "commit_oid": "70fc2412f635693d830afbd49addc6e1782d0225",
      "at": "2026-08-09T18:07:22Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "The three manifests and both adapter tests state 0.6.3; git grep over tracked JSON/Go files and a broader tracked-file grep found no remaining 0.6.2 matches.",
      "commit_oid": "70fc2412f635693d830afbd49addc6e1782d0225",
      "at": "2026-08-09T18:07:24Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "go test ./... passed, including the root marketplace and both adapter packages; a fresh targeted uncached run over those three packages also passed.",
      "commit_oid": "70fc2412f635693d830afbd49addc6e1782d0225",
      "at": "2026-08-09T18:07:24Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "The full diff contains exactly the five authorized files and seven 0.6.2-to-0.6.3 substitutions, with no other prose or behavior changes; git diff --check passed.",
      "commit_oid": "70fc2412f635693d830afbd49addc6e1782d0225",
      "at": "2026-08-09T18:07:24Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "All three acceptance criteria are satisfied at the live PR head. The change is exactly seven 0.6.2-to-0.6.3 substitutions across the five authorized version-identity files, full and targeted tests pass, all six required CI checks pass, the PR is cleanly mergeable, and there are no blocking or non-blocking findings.",
      "commit_oid": "70fc2412f635693d830afbd49addc6e1782d0225",
      "at": "2026-08-09T18:07:24Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "scripts (windows-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "70fc2412f635693d830afbd49addc6e1782d0225",
      "at": "2026-08-09T18:07:41Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->