### PR TITLE
Reject near-miss typed model ids with a did-you-mean suggestion

### DIFF
--- a/internal/config/renderlocal.go
+++ b/internal/config/renderlocal.go
@@ -121,10 +121,13 @@ func renderLocalHost(b *strings.Builder, host string, overrides map[string]strin
 	return nil
 }
 
-// validateLocalModel enforces the same free-text ingestion rule
-// interview.materialize's validateModelFreeText applies to a committed
-// role answer: non-empty after trimming, and no internal whitespace (an
-// exact model version string never contains any).
+// validateLocalModel enforces the same model-string shape rule
+// interview.materialize's validateModelFreeText applies: non-empty
+// after trimming, and no internal whitespace (an exact model version
+// string never contains any). The interview's extra near-miss check on
+// a newly typed answer (validateModelAnswer) is deliberately not
+// mirrored here: this function also passes judgment on a local file
+// already written, which must keep rendering whatever it holds.
 func validateLocalModel(key, value string) error {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {

--- a/internal/interview/configure.go
+++ b/internal/interview/configure.go
@@ -381,7 +381,7 @@ func applyHostConfigure(cfg *config.Config, host string, answers map[string]stri
 	case toggleKnown && toggleVal == "no":
 		setConfigHost(cfg, host, nil)
 	case hasRoleAnswers:
-		h, err := materializeHost(host, answers)
+		h, err := materializeHost(host, answers, committedHostConfig(cfg, host))
 		if err != nil {
 			return err
 		}

--- a/internal/interview/configure_test.go
+++ b/internal/interview/configure_test.go
@@ -490,3 +490,49 @@ func TestNextConfigureRejectsNearMissModel(t *testing.T) {
 		t.Fatalf("Kind = %q, want %q", doc.Kind, question.DocSummary)
 	}
 }
+
+// TestNextConfigureAcceptsNearMissCommittedDefault proves the same for
+// `orch configure` as TestNextConfigureLocalAcceptsNearMissCommittedDefault
+// does for configure-local: a committed near-miss model is offered as
+// the role question's default (committedRoleDefaults), and accepting it
+// reaches the summary rather than failing the interview at
+// materializeConfigure.
+func TestNextConfigureAcceptsNearMissCommittedDefault(t *testing.T) {
+	root := t.TempDir()
+	cfg := writeCommittedConfigLocal(t, root)
+	cfg.Hosts.Claude.Roles.Architect.Model = "opus-5"
+	writeCommittedConfig(t, root, cfg)
+	writeInstalledBlock(t, root, "CLAUDE.md")
+	writeInstalledBlock(t, root, "AGENTS.md")
+	writeNoMissingGitignore(t, root)
+	facts := configureFacts()
+
+	answers := map[string]string{}
+	overrides := map[string]string{idPickRolesClaude: "yes"}
+	for i := 0; i < 100; i++ {
+		doc, err := NextConfigure(facts, answers, root)
+		if err != nil {
+			t.Fatalf("NextConfigure: %v", err)
+		}
+		if doc.Kind != question.DocQuestions {
+			if got := answers[roleModelID("claude", "architect")]; got != "opus-5" {
+				t.Fatalf("architect model default = %q, want the committed opus-5", got)
+			}
+			if doc.Kind != question.DocSummary {
+				t.Fatalf("Kind = %q, want %q", doc.Kind, question.DocSummary)
+			}
+			return
+		}
+		for _, q := range doc.Questions {
+			if v, ok := overrides[q.ID]; ok {
+				answers[q.ID] = v
+				continue
+			}
+			if q.Default == "" {
+				t.Fatalf("question %s has no default to answer with", q.ID)
+			}
+			answers[q.ID] = q.Default
+		}
+	}
+	t.Fatal("NextConfigure did not reach a non-questions document within 100 steps")
+}

--- a/internal/interview/configure_test.go
+++ b/internal/interview/configure_test.go
@@ -433,3 +433,60 @@ func TestInstructionFilePinned(t *testing.T) {
 		t.Errorf(`InstructionFile("bogus") = %q, want ""`, got)
 	}
 }
+
+// TestNextConfigureRejectsNearMissModel proves issue #207 for
+// `orch configure`: a typed model shortening a known id is rejected
+// with that full id suggested, and the corrected id then reaches the
+// summary — mirroring answerAllConfigureWithDefaults' walk but
+// answering the claude role questions from overrides.
+func TestNextConfigureRejectsNearMissModel(t *testing.T) {
+	root := t.TempDir()
+	writeCommittedConfigLocal(t, root)
+	writeInstalledBlock(t, root, "CLAUDE.md")
+	writeInstalledBlock(t, root, "AGENTS.md")
+	writeNoMissingGitignore(t, root)
+	facts := configureFacts()
+
+	modelID := roleModelID("claude", "architect")
+	walk := func(model string) (question.Document, error) {
+		overrides := map[string]string{idPickRolesClaude: "yes", modelID: model}
+		answers := map[string]string{}
+		for i := 0; i < 100; i++ {
+			doc, err := NextConfigure(facts, answers, root)
+			if err != nil {
+				return question.Document{}, err
+			}
+			if doc.Kind != question.DocQuestions {
+				return doc, nil
+			}
+			for _, q := range doc.Questions {
+				if v, ok := overrides[q.ID]; ok {
+					answers[q.ID] = v
+					continue
+				}
+				if q.Default == "" {
+					t.Fatalf("question %s has no default to answer with", q.ID)
+				}
+				answers[q.ID] = q.Default
+			}
+		}
+		t.Fatal("NextConfigure did not reach a non-questions document within 100 steps")
+		return question.Document{}, nil
+	}
+
+	_, err := walk("opus-5")
+	if !errors.Is(err, ErrBadAnswer) {
+		t.Fatalf("NextConfigure err = %v, want ErrBadAnswer", err)
+	}
+	if !strings.Contains(err.Error(), "claude-opus-5") {
+		t.Errorf("error %q does not suggest the full id claude-opus-5", err)
+	}
+
+	doc, err := walk("claude-opus-5")
+	if err != nil {
+		t.Fatalf("NextConfigure after correction: %v", err)
+	}
+	if doc.Kind != question.DocSummary {
+		t.Fatalf("Kind = %q, want %q", doc.Kind, question.DocSummary)
+	}
+}

--- a/internal/interview/configurelocal.go
+++ b/internal/interview/configurelocal.go
@@ -661,7 +661,11 @@ func materializeLocal(committed *config.Config, seeded map[string]string, answer
 
 // applyRoleAnswers applies host's six answered role questions onto
 // overrides, clearing (setOrClear) each leaf whose answer equals
-// committed's own value.
+// committed's own value. The near-miss model check
+// (validateModelAnswer) is measured against the value the model
+// question defaulted to — the override overrides already carries for
+// that key, or the committed value when it carries none — so leaving a
+// near-miss default alone is not treated as newly typing it.
 func applyRoleAnswers(committed *config.Config, host string, answers, overrides map[string]string) error {
 	h := committedHostConfig(committed, host)
 	for _, rs := range roleSpecs {
@@ -669,10 +673,14 @@ func applyRoleAnswers(committed *config.Config, host string, answers, overrides 
 		effortKey := localRoleEffortID(host, rs.key)
 		modelVal := answers[modelKey]
 		effortVal := answers[effortKey]
-		if err := validateModelFreeText(modelKey, modelVal); err != nil {
+		cp := committedProfile(h, rs.key)
+		current := cp.Model
+		if seeded, ok := overrides[modelKey]; ok {
+			current = seeded
+		}
+		if err := validateModelAnswer(modelKey, modelVal, current); err != nil {
 			return err
 		}
-		cp := committedProfile(h, rs.key)
 		setOrClear(overrides, modelKey, modelVal, cp.Model)
 		setOrClear(overrides, effortKey, effortVal, cp.Effort)
 	}

--- a/internal/interview/configurelocal_test.go
+++ b/internal/interview/configurelocal_test.go
@@ -497,3 +497,56 @@ func TestHostLocalModelsPinsFableFive(t *testing.T) {
 		}
 	}
 }
+
+// TestNextConfigureLocalRejectsNearMissModel proves issue #207 for
+// `orch configure-local`: a typed model shortening a known id — here
+// the local-override-only claude-fable-5 — is rejected with that full
+// id suggested, and the corrected id then reaches the summary, so no
+// config.local.toml is ever written from the near miss.
+func TestNextConfigureLocalRejectsNearMissModel(t *testing.T) {
+	root := t.TempDir()
+	writeCommittedConfigLocal(t, root)
+
+	modelKey := localRoleModelID("claude", "architect")
+	walk := func(model string) (question.Document, error) {
+		overrides := map[string]string{idPickClaude: "yes", modelKey: model}
+		answers := map[string]string{}
+		for i := 0; i < 100; i++ {
+			doc, err := NextConfigureLocal(answers, root)
+			if err != nil {
+				return question.Document{}, err
+			}
+			if doc.Kind != question.DocQuestions {
+				return doc, nil
+			}
+			for _, q := range doc.Questions {
+				if v, ok := overrides[q.ID]; ok {
+					answers[q.ID] = v
+					continue
+				}
+				if q.Default == "" {
+					t.Fatalf("question %s has no default to answer with", q.ID)
+				}
+				answers[q.ID] = q.Default
+			}
+		}
+		t.Fatal("NextConfigureLocal did not reach a non-questions document within 100 steps")
+		return question.Document{}, nil
+	}
+
+	_, err := walk("fable-5")
+	if !errors.Is(err, ErrBadAnswer) {
+		t.Fatalf("NextConfigureLocal err = %v, want ErrBadAnswer", err)
+	}
+	if !strings.Contains(err.Error(), "claude-fable-5") {
+		t.Errorf("error %q does not suggest the full id claude-fable-5", err)
+	}
+
+	doc, err := walk("claude-fable-5")
+	if err != nil {
+		t.Fatalf("NextConfigureLocal after correction: %v", err)
+	}
+	if doc.Kind != question.DocSummary {
+		t.Fatalf("Kind = %q, want %q", doc.Kind, question.DocSummary)
+	}
+}

--- a/internal/interview/configurelocal_test.go
+++ b/internal/interview/configurelocal_test.go
@@ -45,6 +45,16 @@ func writeCommittedConfigLocal(t *testing.T, root string) *config.Config {
 			}},
 		},
 	}
+	writeCommittedConfig(t, root, cfg)
+	return cfg
+}
+
+// writeCommittedConfig revisions, renders, and writes cfg to root's
+// committed configuration path — the tail writeCommittedConfigLocal
+// shares with any test that needs the same fixture carrying one edited
+// value.
+func writeCommittedConfig(t *testing.T, root string, cfg *config.Config) {
+	t.Helper()
 	rev, err := config.Revision(cfg)
 	if err != nil {
 		t.Fatal(err)
@@ -61,7 +71,6 @@ func writeCommittedConfigLocal(t *testing.T, root string) *config.Config {
 	if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(config.Path)), data, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	return cfg
 }
 
 // writeLocalOverrideFile writes content verbatim to root's
@@ -545,6 +554,51 @@ func TestNextConfigureLocalRejectsNearMissModel(t *testing.T) {
 	doc, err := walk("claude-fable-5")
 	if err != nil {
 		t.Fatalf("NextConfigureLocal after correction: %v", err)
+	}
+	if doc.Kind != question.DocSummary {
+		t.Fatalf("Kind = %q, want %q", doc.Kind, question.DocSummary)
+	}
+}
+
+// TestNextConfigureLocalPreservesNearMissOverride proves the near-miss
+// rule leaves an existing config.local.toml alone: a near-miss model
+// override in an area this session does not pick is preserved in the
+// proposed file, exactly as materializeLocal promises for every valid
+// override of an unpicked area.
+func TestNextConfigureLocalPreservesNearMissOverride(t *testing.T) {
+	root := t.TempDir()
+	writeCommittedConfigLocal(t, root)
+	writeLocalOverrideFile(t, root, `[hosts.claude.roles.architect]
+model = "opus-5"
+`)
+
+	codexModel := localRoleModelID("codex", "architect")
+	doc, _ := answerLocalWithOverrides(t, root, map[string]string{idPickCodex: "yes", codexModel: "gpt-5.6-luna"})
+	if doc.Kind != question.DocSummary {
+		t.Fatalf("Kind = %q, want %q", doc.Kind, question.DocSummary)
+	}
+	if len(doc.Summary.Files) == 0 {
+		t.Fatalf("Summary.Files is empty, want the proposed config.local.toml")
+	}
+	if !strings.Contains(doc.Summary.Files[0].NewContent, `model = "opus-5"`) {
+		t.Errorf("proposed file dropped the unpicked area's existing override:\n%s", doc.Summary.Files[0].NewContent)
+	}
+}
+
+// TestNextConfigureLocalAcceptsNearMissCommittedDefault proves a
+// repository initialized before the near-miss rule existed still walks
+// configure-local end to end: the model question defaults to the
+// committed near-miss id, and accepting that default reaches the
+// summary instead of failing the interview.
+func TestNextConfigureLocalAcceptsNearMissCommittedDefault(t *testing.T) {
+	root := t.TempDir()
+	cfg := writeCommittedConfigLocal(t, root)
+	cfg.Hosts.Claude.Roles.Architect.Model = "opus-5"
+	writeCommittedConfig(t, root, cfg)
+
+	doc, answers := answerLocalWithOverrides(t, root, map[string]string{idPickClaude: "yes"})
+	if got := answers[localRoleModelID("claude", "architect")]; got != "opus-5" {
+		t.Fatalf("architect model default = %q, want the committed opus-5", got)
 	}
 	if doc.Kind != question.DocSummary {
 		t.Fatalf("Kind = %q, want %q", doc.Kind, question.DocSummary)

--- a/internal/interview/errors.go
+++ b/internal/interview/errors.go
@@ -24,7 +24,7 @@ var (
 	ErrApprovalBlocked = errors.New("cannot approve while blockers remain")
 	// ErrBadAnswer reports a free-text answer that fails its
 	// ingestion-time semantic check at materialization: a model string
-	// containing whitespace, or a concurrency value that is not an
-	// integer >= 1.
+	// containing whitespace or shortening a known model id, or a
+	// concurrency value that is not an integer >= 1.
 	ErrBadAnswer = errors.New("answer fails its semantic validation")
 )

--- a/internal/interview/interview_test.go
+++ b/internal/interview/interview_test.go
@@ -323,3 +323,33 @@ func TestStatelessnessReAsksExactlyOneQuestion(t *testing.T) {
 		})
 	}
 }
+
+// TestNextRejectsNearMissModelThenAcceptsCorrection proves issue #207
+// for `orch init`: a typed model shortening a known id is rejected
+// with that full id suggested, and resubmitting the same question with
+// the full id walks straight on to the summary — the rejection is a
+// re-ask, never an abort.
+func TestNextRejectsNearMissModelThenAcceptsCorrection(t *testing.T) {
+	facts := bothHostsFacts()
+	root := t.TempDir()
+	answers := answerAllWithDefaults(t, facts, root)
+
+	modelID := roleModelID("claude", "architect")
+	answers[modelID] = "fable-5"
+	_, err := Next(facts, answers, root)
+	if !errors.Is(err, ErrBadAnswer) {
+		t.Fatalf("Next err = %v, want ErrBadAnswer", err)
+	}
+	if !strings.Contains(err.Error(), "claude-fable-5") {
+		t.Errorf("error %q does not suggest the full id claude-fable-5", err)
+	}
+
+	answers[modelID] = "claude-fable-5"
+	doc, err := Next(facts, answers, root)
+	if err != nil {
+		t.Fatalf("Next after correction: %v", err)
+	}
+	if doc.Kind != question.DocSummary {
+		t.Fatalf("Kind = %q, want %q", doc.Kind, question.DocSummary)
+	}
+}

--- a/internal/interview/materialize.go
+++ b/internal/interview/materialize.go
@@ -17,8 +17,8 @@ import (
 // Free-text answers get one more ingestion-time check materialize
 // itself owns, beyond question.ValidateAnswer's generic
 // membership/non-blank contract: a model string must contain no
-// whitespace and must not be a near miss of a known model id
-// (validateModelFreeText), and the concurrency value must parse as an
+// whitespace and must not newly type a near miss of a known model id
+// (validateModelAnswer), and the concurrency value must parse as an
 // integer >= 1.
 // Once the struct is built, Revision computes its content hash, and
 // then Render/Parse round-trip it — the exact artifact bootstrap would
@@ -29,14 +29,14 @@ func materialize(answers map[string]string) (*config.Config, error) {
 	cfg := &config.Config{SchemaVersion: 1}
 
 	if answers[idHostClaudeEnabled] == "yes" {
-		host, err := materializeHost("claude", answers)
+		host, err := materializeHost("claude", answers, nil)
 		if err != nil {
 			return nil, err
 		}
 		cfg.Hosts.Claude = host
 	}
 	if answers[idHostCodexEnabled] == "yes" {
-		host, err := materializeHost("codex", answers)
+		host, err := materializeHost("codex", answers, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -70,12 +70,16 @@ func materialize(answers map[string]string) (*config.Config, error) {
 }
 
 // materializeHost builds host's six-role config.Host from answers.
-func materializeHost(host string, answers map[string]string) (*config.Host, error) {
+// current is host's committed profile set, so an answer left at a
+// committed near-miss model still round-trips (validateModelAnswer);
+// it is nil for init and for any host a session newly enables, neither
+// of which has a committed profile to leave alone.
+func materializeHost(host string, answers map[string]string, current *config.Host) (*config.Host, error) {
 	var roles config.Roles
 	for _, rs := range roleSpecs {
 		modelID := roleModelID(host, rs.key)
 		model := answers[modelID]
-		if err := validateModelFreeText(modelID, model); err != nil {
+		if err := validateModelAnswer(modelID, model, currentModel(current, rs.key)); err != nil {
 			return nil, err
 		}
 		profile := config.RoleProfile{Model: model, Effort: answers[roleEffortID(host, rs.key)]}
@@ -102,10 +106,12 @@ func setRoleProfile(r *config.Roles, role string, p config.RoleProfile) {
 	}
 }
 
-// validateModelFreeText enforces the free-text ingestion rule for a
-// model answer: non-empty after trimming, no internal whitespace (an
-// exact model version string never contains any), and not a near miss
-// of a known model id for the question's host.
+// validateModelFreeText enforces the shape rule every model string
+// must satisfy wherever one is ingested: non-empty after trimming, and
+// no internal whitespace (an exact model version string never contains
+// any). Deliberately not the near-miss rule — this is also the filter
+// seedOverrides runs over a config.local.toml already on disk, which
+// must keep whatever it already holds (validateModelAnswer).
 func validateModelFreeText(id, value string) error {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
@@ -114,11 +120,36 @@ func validateModelFreeText(id, value string) error {
 	if strings.ContainsAny(value, " \t\n\r") {
 		return fmt.Errorf("%w: %s: model %q must not contain whitespace", ErrBadAnswer, id, value)
 	}
+	return nil
+}
+
+// validateModelAnswer is validateModelFreeText plus the near-miss rule,
+// and is what an answered model question goes through. current is the
+// value that key already carries (which is what the question offered as
+// its Default): answering it back is not new input, so a configuration
+// written before this rule existed stays answerable — the interview
+// that could repair it must not be the one thing that wedges on it.
+func validateModelAnswer(id, value, current string) error {
+	if err := validateModelFreeText(id, value); err != nil {
+		return err
+	}
+	if value == current {
+		return nil
+	}
 	if suggestions := nearMissModels(id, value); len(suggestions) > 0 {
-		return fmt.Errorf("%w: %s: model %q looks like a shortened form of a known %s model; did you mean %s?",
+		return fmt.Errorf("%w: %s: model %q looks like a shortened or mis-cased form of a known %s model; did you mean %s?",
 			ErrBadAnswer, id, value, modelHost(id), strings.Join(suggestions, ", "))
 	}
 	return nil
+}
+
+// currentModel returns h's committed model for role, or "" when h is
+// nil — a host with no committed profile at all.
+func currentModel(h *config.Host, role string) string {
+	if h == nil {
+		return ""
+	}
+	return committedProfile(h, role).Model
 }
 
 // nearMissModels returns every known model id for id's host that

--- a/internal/interview/materialize.go
+++ b/internal/interview/materialize.go
@@ -17,7 +17,9 @@ import (
 // Free-text answers get one more ingestion-time check materialize
 // itself owns, beyond question.ValidateAnswer's generic
 // membership/non-blank contract: a model string must contain no
-// whitespace, and the concurrency value must parse as an integer >= 1.
+// whitespace and must not be a near miss of a known model id
+// (validateModelFreeText), and the concurrency value must parse as an
+// integer >= 1.
 // Once the struct is built, Revision computes its content hash, and
 // then Render/Parse round-trip it — the exact artifact bootstrap would
 // commit is proven loadable, and the real validate() enums (which
@@ -101,8 +103,9 @@ func setRoleProfile(r *config.Roles, role string, p config.RoleProfile) {
 }
 
 // validateModelFreeText enforces the free-text ingestion rule for a
-// model answer: non-empty after trimming, and no internal whitespace
-// (an exact model version string never contains any).
+// model answer: non-empty after trimming, no internal whitespace (an
+// exact model version string never contains any), and not a near miss
+// of a known model id for the question's host.
 func validateModelFreeText(id, value string) error {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
@@ -111,7 +114,45 @@ func validateModelFreeText(id, value string) error {
 	if strings.ContainsAny(value, " \t\n\r") {
 		return fmt.Errorf("%w: %s: model %q must not contain whitespace", ErrBadAnswer, id, value)
 	}
+	if suggestions := nearMissModels(id, value); len(suggestions) > 0 {
+		return fmt.Errorf("%w: %s: model %q looks like a shortened form of a known %s model; did you mean %s?",
+			ErrBadAnswer, id, value, modelHost(id), strings.Join(suggestions, ", "))
+	}
 	return nil
+}
+
+// nearMissModels returns every known model id for id's host that
+// carries value as a substring, case-insensitively — the did-you-mean
+// set for a shortened form like "fable-5" or a mis-cased
+// "Claude-Opus-5". The model domain stays otherwise open (routing
+// treats ids as opaque strings): a value equal to a known id is not a
+// near miss, and a value resembling no known id yields no suggestions
+// and so passes.
+func nearMissModels(id, value string) []string {
+	known := hostLocalModels[modelHost(id)]
+	lowered := strings.ToLower(value)
+	var suggestions []string
+	for _, model := range known {
+		if model == value {
+			return nil
+		}
+		if strings.Contains(model, lowered) {
+			suggestions = append(suggestions, model)
+		}
+	}
+	return suggestions
+}
+
+// modelHost returns the host name a model question id carries in its
+// second dotted segment — "host.<host>.role.<role>.model" for init and
+// `orch configure`, "hosts.<host>.roles.<role>.model" for
+// `orch configure-local` — or "" for an id shaped like neither.
+func modelHost(id string) string {
+	parts := strings.Split(id, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[1]
 }
 
 // parseConcurrency enforces the free-text ingestion rule for

--- a/internal/interview/materialize_test.go
+++ b/internal/interview/materialize_test.go
@@ -146,3 +146,63 @@ func TestMaterializeRoundTripsThroughRenderAndParse(t *testing.T) {
 		t.Errorf("ConfigRevision = %q, want a sha256: prefix", cfg.ConfigRevision)
 	}
 }
+
+// TestValidateModelFreeTextNearMiss proves issue #207's shared seam:
+// a typed model that shortens (or mis-cases) a known model id for the
+// question's host is rejected with every matching full id suggested,
+// while a known id and an id resembling nothing known both pass. Both
+// question id shapes are covered — init/`orch configure`'s
+// "host.<host>.role.<role>.model" and configure-local's
+// "hosts.<host>.roles.<role>.model" — since all three interviews reach
+// this one function.
+func TestValidateModelFreeTextNearMiss(t *testing.T) {
+	tests := []struct {
+		id       string
+		value    string
+		wantErr  bool
+		wantText string
+	}{
+		{id: roleModelID("claude", "architect"), value: "fable-5", wantErr: true, wantText: "claude-fable-5"},
+		{id: roleModelID("claude", "architect"), value: "opus-5", wantErr: true, wantText: "claude-opus-5"},
+		{id: roleModelID("claude", "architect"), value: "Claude-Opus-5", wantErr: true, wantText: "claude-opus-5"},
+		{id: roleModelID("codex", "architect"), value: "sol", wantErr: true, wantText: "gpt-5.6-sol"},
+		{id: localRoleModelID("claude", "reviewer"), value: "fable-5", wantErr: true, wantText: "claude-fable-5"},
+		{id: roleModelID("claude", "architect"), value: "claude-opus-5"},
+		{id: roleModelID("claude", "architect"), value: "claude-fable-5"},
+		{id: roleModelID("claude", "architect"), value: "claude-opus-6"},
+		{id: roleModelID("claude", "architect"), value: "claude-opus-4-8"},
+		{id: roleModelID("codex", "architect"), value: "gpt-5.6-sol"},
+		{id: localRoleModelID("codex", "reviewer"), value: "gpt-5.7-nova"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.id+"="+tt.value, func(t *testing.T) {
+			err := validateModelFreeText(tt.id, tt.value)
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("validateModelFreeText(%q, %q) = %v, want nil", tt.id, tt.value, err)
+				}
+				return
+			}
+			if !errors.Is(err, ErrBadAnswer) {
+				t.Fatalf("validateModelFreeText(%q, %q) = %v, want ErrBadAnswer", tt.id, tt.value, err)
+			}
+			if !strings.Contains(err.Error(), tt.wantText) {
+				t.Errorf("error %q does not suggest the full id %q", err, tt.wantText)
+			}
+		})
+	}
+}
+
+// TestValidateModelFreeTextSuggestsEveryMatch proves a value shortening
+// more than one known id names all of them, not just the first.
+func TestValidateModelFreeTextSuggestsEveryMatch(t *testing.T) {
+	err := validateModelFreeText(roleModelID("claude", "architect"), "claude")
+	if !errors.Is(err, ErrBadAnswer) {
+		t.Fatalf("validateModelFreeText err = %v, want ErrBadAnswer", err)
+	}
+	for _, want := range hostLocalModels["claude"] {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not suggest %q", err, want)
+		}
+	}
+}

--- a/internal/interview/materialize_test.go
+++ b/internal/interview/materialize_test.go
@@ -147,7 +147,7 @@ func TestMaterializeRoundTripsThroughRenderAndParse(t *testing.T) {
 	}
 }
 
-// TestValidateModelFreeTextNearMiss proves issue #207's shared seam:
+// TestValidateModelAnswerNearMiss proves issue #207's shared seam:
 // a typed model that shortens (or mis-cases) a known model id for the
 // question's host is rejected with every matching full id suggested,
 // while a known id and an id resembling nothing known both pass. Both
@@ -155,7 +155,7 @@ func TestMaterializeRoundTripsThroughRenderAndParse(t *testing.T) {
 // "host.<host>.role.<role>.model" and configure-local's
 // "hosts.<host>.roles.<role>.model" — since all three interviews reach
 // this one function.
-func TestValidateModelFreeTextNearMiss(t *testing.T) {
+func TestValidateModelAnswerNearMiss(t *testing.T) {
 	tests := []struct {
 		id       string
 		value    string
@@ -176,15 +176,15 @@ func TestValidateModelFreeTextNearMiss(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.id+"="+tt.value, func(t *testing.T) {
-			err := validateModelFreeText(tt.id, tt.value)
+			err := validateModelAnswer(tt.id, tt.value, "")
 			if !tt.wantErr {
 				if err != nil {
-					t.Fatalf("validateModelFreeText(%q, %q) = %v, want nil", tt.id, tt.value, err)
+					t.Fatalf("validateModelAnswer(%q, %q) = %v, want nil", tt.id, tt.value, err)
 				}
 				return
 			}
 			if !errors.Is(err, ErrBadAnswer) {
-				t.Fatalf("validateModelFreeText(%q, %q) = %v, want ErrBadAnswer", tt.id, tt.value, err)
+				t.Fatalf("validateModelAnswer(%q, %q) = %v, want ErrBadAnswer", tt.id, tt.value, err)
 			}
 			if !strings.Contains(err.Error(), tt.wantText) {
 				t.Errorf("error %q does not suggest the full id %q", err, tt.wantText)
@@ -193,16 +193,46 @@ func TestValidateModelFreeTextNearMiss(t *testing.T) {
 	}
 }
 
-// TestValidateModelFreeTextSuggestsEveryMatch proves a value shortening
+// TestValidateModelAnswerSuggestsEveryMatch proves a value shortening
 // more than one known id names all of them, not just the first.
-func TestValidateModelFreeTextSuggestsEveryMatch(t *testing.T) {
-	err := validateModelFreeText(roleModelID("claude", "architect"), "claude")
+func TestValidateModelAnswerSuggestsEveryMatch(t *testing.T) {
+	err := validateModelAnswer(roleModelID("claude", "architect"), "claude", "")
 	if !errors.Is(err, ErrBadAnswer) {
-		t.Fatalf("validateModelFreeText err = %v, want ErrBadAnswer", err)
+		t.Fatalf("validateModelAnswer err = %v, want ErrBadAnswer", err)
 	}
 	for _, want := range hostLocalModels["claude"] {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error %q does not suggest %q", err, want)
 		}
+	}
+}
+
+// TestValidateModelAnswerExemptsCurrentValue proves the near-miss rule
+// targets new input only: the value a key already carries — what its
+// question offered as the Default — answers back unchanged, so a
+// configuration written before the rule existed stays answerable. The
+// shape rule is not exempted with it.
+func TestValidateModelAnswerExemptsCurrentValue(t *testing.T) {
+	id := roleModelID("claude", "architect")
+	if err := validateModelAnswer(id, "opus-5", "opus-5"); err != nil {
+		t.Errorf("validateModelAnswer with value == current = %v, want nil", err)
+	}
+	if err := validateModelAnswer(id, "opus-5", "claude-opus-4-8"); !errors.Is(err, ErrBadAnswer) {
+		t.Errorf("validateModelAnswer with a newly typed near miss = %v, want ErrBadAnswer", err)
+	}
+	if err := validateModelAnswer(id, "", ""); !errors.Is(err, ErrBadAnswer) {
+		t.Errorf("validateModelAnswer with an empty current value = %v, want ErrBadAnswer", err)
+	}
+}
+
+// TestStringifyLeafValueKeepsNearMissModel proves the near-miss rule
+// never reaches seedOverrides' filter: a model already written to
+// config.local.toml classifies as a valid preference whatever it looks
+// like, so an unpicked area's overrides survive materializeLocal
+// untouched.
+func TestStringifyLeafValueKeepsNearMissModel(t *testing.T) {
+	got, ok := stringifyLeafValue(localRoleModelID("claude", "architect"), "opus-5")
+	if !ok || got != "opus-5" {
+		t.Errorf("stringifyLeafValue = (%q, %v), want (\"opus-5\", true)", got, ok)
 	}
 }


### PR DESCRIPTION
Delivers issue #207: Reject near-miss typed model ids with a did-you-mean suggestion

Closes #207

**Plan digest:** `sha256:bc6df79531050f5da0b2822edbecf9a92771230bd37001f0e7ba1748294dc955`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** In the interview engines under internal/interview, reject a typed free-text model answer that looks like a shortened form of a known model id, re-asking with the full id as a suggestion, so a near-miss like fable-5 never lands in a written configuration. All three interviews (orch init, orch configure, orch configure-local) ingest typed model answers through one shared validation seam; the check belongs there so every interview gets it at once. The model domain otherwise stays open: routing treats model ids as opaque strings, and a typed id that resembles no known model must continue to pass.

**Acceptance criteria:**
- In each of the three interviews (orch init, orch configure, orch configure-local), a typed free-text model answer that differs from every known model id for its host, but whose lowercased text occurs as a substring of at least one known id, is rejected with a message naming each matching full id as a did-you-mean suggestion. Known ids for a host are the model choices its interview questions can offer, which for Claude includes claude-fable-5. Examples that must be rejected with the full id suggested: fable-5, opus-5, and Claude-Opus-5 for a Claude role; sol for a Codex role.
- A typed model answer exactly equal to a known id (including claude-fable-5 for a Claude role), or one whose lowercased text occurs as a substring of no known id (for example claude-opus-6), is accepted under exactly the existing free-text rules (non-empty, no whitespace), and selecting an offered option is unaffected.
- After a rejection, resubmitting the same question with a corrected model id proceeds normally: the rejection surfaces as a re-ask of that question, never as an interview abort or a written file.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — Full module suite green in the issue worktree at pushed head 4a48814; executor ran it green and the Architect re-ran it at the exact head after a cosmetic test rename. — commit `4a488145e0639207c765786aae5467482d64e4de` (2026-08-09T22:07:02Z)
- **go-vet** — pass — `go vet ./...` — No output at head 4a48814. — commit `4a488145e0639207c765786aae5467482d64e4de` (2026-08-09T22:07:02Z)
- **gofmt** — pass — `gofmt -l .` — Prints nothing at head 4a48814. — commit `4a488145e0639207c765786aae5467482d64e4de` (2026-08-09T22:07:02Z)
- **branch-scope:diff** — 2 commits, 9 files, +432/-19 — `git diff --shortstat origin/main...HEAD` — Eight files under internal/interview (materialize.go seam split with validateModelAnswer and the current-value exemption; configure.go passes the committed host; configurelocal.go seeded-else-committed current; errors.go doc; four test files) plus internal/config/renderlocal.go (doc-only correction of the sameness claim, cycle-1 F3). Verified by the Architect at the live head. — commit `f9dfa4a01aa49c6209f8f3e77490425efe0b3c31` (2026-08-09T22:33:06Z)
- **reviewer-required-tests** — pass — `go test -count=1 ./... && go vet ./... && gofmt -l .` — Cycle-2 reviewer re-ran all three in the issue worktree at f9dfa4a01aa49c6209f8f3e77490425efe0b3c31: every package ok, vet silent, gofmt printed nothing. CI at the exact head: six of six checks successful. Six-mutation battery in a scratch copy outside the repository all caught. — commit `f9dfa4a01aa49c6209f8f3e77490425efe0b3c31` (2026-08-09T22:33:06Z)
- **acceptance-criterion-1** — satisfied — validateModelAnswer/nearMissModels reject every named example (fable-5, opus-5, Claude-Opus-5 for claude; sol for codex) in both id shapes with the full id in the message, proven by TestValidateModelAnswerNearMiss and end-to-end by the three per-interview tests; TestValidateModelAnswerSuggestsEveryMatch pins that every matching id is named. Noted narrowing: a typed value byte-identical to the key's current committed/seeded value is exempt, which is the resolution of cycle-1 F2 and opens no hole per the reviewer's probes. — commit `f9dfa4a01aa49c6209f8f3e77490425efe0b3c31` (2026-08-09T22:33:07Z)
- **acceptance-criterion-2** — satisfied — validateModelFreeText's body is byte-identical to main, so non-empty/no-whitespace is literally the existing rule; exact-match short-circuits regardless of list position; table rows return nil for claude-opus-5, claude-fable-5, claude-opus-6, claude-opus-4-8, gpt-5.6-sol, gpt-5.7-nova. Option selection untouched: nothing in the diff reaches question.ValidateAnswer or any Options builder, and removing the exact-match return fails 8 pre-existing golden tests, proving those paths run through this seam unaffected. — commit `f9dfa4a01aa49c6209f8f3e77490425efe0b3c31` (2026-08-09T22:33:07Z)
- **acceptance-criterion-3** — satisfied — Each of the three interview tests submits the near-miss, asserts errors.Is(err, ErrBadAnswer), resubmits the corrected id on the same key, and reaches DocSummary. On error the engines return before buildSummary/RenderLocal and the CLI layers emit no document, so no DocAborted and no written file; the re-ask presentation rests on pre-existing adapter prose unchanged by this branch. — commit `f9dfa4a01aa49c6209f8f3e77490425efe0b3c31` (2026-08-09T22:33:07Z)
- **review-cycle-1** — request-changes — All three acceptance criteria are satisfied, the required tests and CI are green at the live head, the diff is exactly the scope the manifest claims, and the new tests are real - every one of five mutations applied in a scratch copy outside the repository was caught. The block is not a criterion failure but two demonstrated behavior changes flowing from one cause: validateModelFreeText is not only the typed-answer seam. It is also the per-leaf filter seedOverrides runs over an existing config.local.toml (F1: a pre-existing model = "opus-5" override is dropped from the proposed file even when the user answers no to picking that host, where main preserves it), and it is reached by answers the engine itself proposed as defaults from the committed config.toml (F2: configure-local offers default opus-5 then fails the whole interview when that default is accepted). Neither is tested or mentioned in the PR body, and F1 falsifies materializeLocal's promise that an unpicked area's overrides are preserved untouched. Either narrow the near-miss rule to the typed-answer callers, or keep the wider behavior deliberately with a test and a before-and-after note; also fix the now-false sameness claim in internal/config/renderlocal.go:113-116 (F3). F4-F7 are non-blocking nits. — commit `4a488145e0639207c765786aae5467482d64e4de` (2026-08-09T22:16:11Z)
- **review-cycle-2** — approve — All three acceptance criteria are satisfied with observations the cycle-2 reviewer made itself rather than inherited: the shared seam rejects every named example in all three interviews with the full id in the message, the exact-match and no-match paths pass under the unchanged shape rule, and each interview's rejection is a re-ask that reaches the summary on correction with no abort and no write. The three cycle-1 findings are each fixed at the mechanism, not the symptom: stringifyLeafValue is back on the shape-only rule so an existing config.local.toml keeps what it holds, the answered-question path exempts only the value a key already carries so the engine can no longer propose a default it then rejects, and the false sameness claim in renderlocal.go is corrected. The reviewer probed the new exemption for holes and found none: scoped per key and per role, nil/empty current cannot exempt anything because the shape check runs first, a different near-miss on the same key is still rejected, and the seeded-override-over-committed precedence matches the question's own Default and is pinned by a mutation-caught test. Six mutations in a scratch copy outside the repository all failed tests. Required tests, vet, gofmt, and all six CI checks are green at f9dfa4a. Non-blocking follow-ups routed to backlog: N1 stale function name in applyHostConfigure's comment, N2 a test comment naming a scenario the test does not run, N4 the value-equal-to-current narrowing documented in code but worth PR-body prose, N5 init's suggestion can name the local-override-only claude-fable-5, N6 naming nit, N7 latent unreachable ordering hazard. — commit `f9dfa4a01aa49c6209f8f3e77490425efe0b3c31` (2026-08-09T22:33:07Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass, lint=pass — commit `f9dfa4a01aa49c6209f8f3e77490425efe0b3c31` (2026-08-09T22:33:11Z)

<!-- orch:manifest:data
{
  "schema_version": 4,
  "objective": "In the interview engines under internal/interview, reject a typed free-text model answer that looks like a shortened form of a known model id, re-asking with the full id as a suggestion, so a near-miss like fable-5 never lands in a written configuration. All three interviews (orch init, orch configure, orch configure-local) ingest typed model answers through one shared validation seam; the check belongs there so every interview gets it at once. The model domain otherwise stays open: routing treats model ids as opaque strings, and a typed id that resembles no known model must continue to pass.",
  "acceptance_criteria": [
    "In each of the three interviews (orch init, orch configure, orch configure-local), a typed free-text model answer that differs from every known model id for its host, but whose lowercased text occurs as a substring of at least one known id, is rejected with a message naming each matching full id as a did-you-mean suggestion. Known ids for a host are the model choices its interview questions can offer, which for Claude includes claude-fable-5. Examples that must be rejected with the full id suggested: fable-5, opus-5, and Claude-Opus-5 for a Claude role; sol for a Codex role.",
    "A typed model answer exactly equal to a known id (including claude-fable-5 for a Claude role), or one whose lowercased text occurs as a substring of no known id (for example claude-opus-6), is accepted under exactly the existing free-text rules (non-empty, no whitespace), and selecting an offered option is unaffected.",
    "After a rejection, resubmitting the same question with a corrected model id proceeds normally: the rejection surfaces as a re-ask of that question, never as an interview abort or a written file."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Full module suite green in the issue worktree at pushed head 4a48814; executor ran it green and the Architect re-ran it at the exact head after a cosmetic test rename.",
      "commit_oid": "4a488145e0639207c765786aae5467482d64e4de",
      "at": "2026-08-09T22:07:02Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "No output at head 4a48814.",
      "commit_oid": "4a488145e0639207c765786aae5467482d64e4de",
      "at": "2026-08-09T22:07:02Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Prints nothing at head 4a48814.",
      "commit_oid": "4a488145e0639207c765786aae5467482d64e4de",
      "at": "2026-08-09T22:07:02Z"
    },
    {
      "name": "branch-scope:diff",
      "command": "git diff --shortstat origin/main...HEAD",
      "result": "2 commits, 9 files, +432/-19",
      "detail": "Eight files under internal/interview (materialize.go seam split with validateModelAnswer and the current-value exemption; configure.go passes the committed host; configurelocal.go seeded-else-committed current; errors.go doc; four test files) plus internal/config/renderlocal.go (doc-only correction of the sameness claim, cycle-1 F3). Verified by the Architect at the live head.",
      "commit_oid": "f9dfa4a01aa49c6209f8f3e77490425efe0b3c31",
      "at": "2026-08-09T22:33:06Z"
    },
    {
      "name": "reviewer-required-tests",
      "command": "go test -count=1 ./... \u0026\u0026 go vet ./... \u0026\u0026 gofmt -l .",
      "result": "pass",
      "detail": "Cycle-2 reviewer re-ran all three in the issue worktree at f9dfa4a01aa49c6209f8f3e77490425efe0b3c31: every package ok, vet silent, gofmt printed nothing. CI at the exact head: six of six checks successful. Six-mutation battery in a scratch copy outside the repository all caught.",
      "commit_oid": "f9dfa4a01aa49c6209f8f3e77490425efe0b3c31",
      "at": "2026-08-09T22:33:06Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "validateModelAnswer/nearMissModels reject every named example (fable-5, opus-5, Claude-Opus-5 for claude; sol for codex) in both id shapes with the full id in the message, proven by TestValidateModelAnswerNearMiss and end-to-end by the three per-interview tests; TestValidateModelAnswerSuggestsEveryMatch pins that every matching id is named. Noted narrowing: a typed value byte-identical to the key's current committed/seeded value is exempt, which is the resolution of cycle-1 F2 and opens no hole per the reviewer's probes.",
      "commit_oid": "f9dfa4a01aa49c6209f8f3e77490425efe0b3c31",
      "at": "2026-08-09T22:33:07Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "validateModelFreeText's body is byte-identical to main, so non-empty/no-whitespace is literally the existing rule; exact-match short-circuits regardless of list position; table rows return nil for claude-opus-5, claude-fable-5, claude-opus-6, claude-opus-4-8, gpt-5.6-sol, gpt-5.7-nova. Option selection untouched: nothing in the diff reaches question.ValidateAnswer or any Options builder, and removing the exact-match return fails 8 pre-existing golden tests, proving those paths run through this seam unaffected.",
      "commit_oid": "f9dfa4a01aa49c6209f8f3e77490425efe0b3c31",
      "at": "2026-08-09T22:33:07Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "Each of the three interview tests submits the near-miss, asserts errors.Is(err, ErrBadAnswer), resubmits the corrected id on the same key, and reaches DocSummary. On error the engines return before buildSummary/RenderLocal and the CLI layers emit no document, so no DocAborted and no written file; the re-ask presentation rests on pre-existing adapter prose unchanged by this branch.",
      "commit_oid": "f9dfa4a01aa49c6209f8f3e77490425efe0b3c31",
      "at": "2026-08-09T22:33:07Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "All three acceptance criteria are satisfied, the required tests and CI are green at the live head, the diff is exactly the scope the manifest claims, and the new tests are real - every one of five mutations applied in a scratch copy outside the repository was caught. The block is not a criterion failure but two demonstrated behavior changes flowing from one cause: validateModelFreeText is not only the typed-answer seam. It is also the per-leaf filter seedOverrides runs over an existing config.local.toml (F1: a pre-existing model = \"opus-5\" override is dropped from the proposed file even when the user answers no to picking that host, where main preserves it), and it is reached by answers the engine itself proposed as defaults from the committed config.toml (F2: configure-local offers default opus-5 then fails the whole interview when that default is accepted). Neither is tested or mentioned in the PR body, and F1 falsifies materializeLocal's promise that an unpicked area's overrides are preserved untouched. Either narrow the near-miss rule to the typed-answer callers, or keep the wider behavior deliberately with a test and a before-and-after note; also fix the now-false sameness claim in internal/config/renderlocal.go:113-116 (F3). F4-F7 are non-blocking nits.",
      "commit_oid": "4a488145e0639207c765786aae5467482d64e4de",
      "at": "2026-08-09T22:16:11Z"
    },
    {
      "name": "review-cycle-2",
      "result": "approve",
      "detail": "All three acceptance criteria are satisfied with observations the cycle-2 reviewer made itself rather than inherited: the shared seam rejects every named example in all three interviews with the full id in the message, the exact-match and no-match paths pass under the unchanged shape rule, and each interview's rejection is a re-ask that reaches the summary on correction with no abort and no write. The three cycle-1 findings are each fixed at the mechanism, not the symptom: stringifyLeafValue is back on the shape-only rule so an existing config.local.toml keeps what it holds, the answered-question path exempts only the value a key already carries so the engine can no longer propose a default it then rejects, and the false sameness claim in renderlocal.go is corrected. The reviewer probed the new exemption for holes and found none: scoped per key and per role, nil/empty current cannot exempt anything because the shape check runs first, a different near-miss on the same key is still rejected, and the seeded-override-over-committed precedence matches the question's own Default and is pinned by a mutation-caught test. Six mutations in a scratch copy outside the repository all failed tests. Required tests, vet, gofmt, and all six CI checks are green at f9dfa4a. Non-blocking follow-ups routed to backlog: N1 stale function name in applyHostConfigure's comment, N2 a test comment naming a scenario the test does not run, N4 the value-equal-to-current narrowing documented in code but worth PR-body prose, N5 init's suggestion can name the local-override-only claude-fable-5, N6 naming nit, N7 latent unreachable ordering hazard.",
      "commit_oid": "f9dfa4a01aa49c6209f8f3e77490425efe0b3c31",
      "at": "2026-08-09T22:33:07Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass, lint=pass",
      "commit_oid": "f9dfa4a01aa49c6209f8f3e77490425efe0b3c31",
      "at": "2026-08-09T22:33:11Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->