### PR TITLE
Offer effort options that include the default and label them with literal enum tokens

### DIFF
--- a/internal/interview/configurelocal.go
+++ b/internal/interview/configurelocal.go
@@ -527,17 +527,19 @@ func modelOptionsLocal(host, committedVal, effectiveVal string) []question.Optio
 	return opts
 }
 
-// effortOptionsLocal lists host's offered effort subset
-// (effortsOffered), marking committedVal's option "(committed)" in its
-// Label and effectiveVal Recommended. Neither value need be among
-// these options — the question's FreeText escape hatch admits any
-// other value in host's full effort enum (hostEfforts), validated by
+// effortOptionsLocal lists the effort window offered around
+// effectiveVal (effortsOffered), labelling each option with the
+// literal enum token it submits, marking committedVal's option
+// "(committed)" in its Label and effectiveVal Recommended. The window
+// always contains effectiveVal; committedVal need not be among these
+// options — the question's FreeText escape hatch admits any other
+// value in host's full effort enum (hostEfforts), validated by
 // validEffort wherever a typed value is ingested.
 func effortOptionsLocal(host, committedVal, effectiveVal string) []question.Option {
-	efforts := effortsOffered(host)
+	efforts := effortsOffered(host, effectiveVal)
 	opts := make([]question.Option, len(efforts))
 	for i, e := range efforts {
-		label := effortLabel(e)
+		label := e
 		if e == committedVal {
 			label += " (committed)"
 		}

--- a/internal/interview/sequence.go
+++ b/internal/interview/sequence.go
@@ -2,7 +2,7 @@ package interview
 
 import (
 	"fmt"
-	"strings"
+	"slices"
 
 	"github.com/kninetimmy/orch/internal/question"
 )
@@ -109,10 +109,11 @@ var hostModels = map[string][]string{
 
 // hostEfforts lists each host's full closed effort enum — every value
 // internal/config's effortsByHost accepts for that host, in the same
-// order validate.go's effortList documents — not just the subset
-// offered as literal select options (effortsOffered). validEffort
-// (configurelocal.go) checks a typed value against this full list, so
-// it stays the single full-domain source of truth the interview owns.
+// order validate.go's effortList documents — not just the window any
+// one question offers as literal select options (effortsOffered).
+// validEffort (configurelocal.go) checks a typed value against this
+// full list, so it stays the single full-domain source of truth the
+// interview owns.
 var hostEfforts = map[string][]string{
 	"codex":  {"low", "medium", "high", "xhigh", "max", "ultra"},
 	"claude": {"low", "medium", "high", "xhigh", "max"},
@@ -124,19 +125,28 @@ var hostEfforts = map[string][]string{
 // for the FreeText escape hatch to cover the rest.
 const maxOfferedEfforts = 4
 
-// effortsOffered returns the leading maxOfferedEfforts values of
-// host's full effort enum (hostEfforts) — the subset an effort
-// question offers as literal Options. Every level hostEfforts lists
-// beyond this subset remains expressible only through that question's
-// FreeText escape hatch, validated against hostEfforts' full domain
-// wherever a typed value is ingested (validEffort, and internal/config's
-// own Parse/RenderLocal round-trip checks).
-func effortsOffered(host string) []string {
+// effortsOffered returns the contiguous window of host's full effort
+// enum (hostEfforts) an effort question whose default is def offers as
+// literal Options: the leading maxOfferedEfforts values, or — when def
+// sits past them — the maxOfferedEfforts values ending at def, so a
+// question never recommends a level it does not itself offer. The
+// window is therefore per-question, not per-host: the Codex roles
+// defaulting to "max" (defaultProfiles) offer a higher window than
+// those defaulting to "xhigh". Every level outside the window remains
+// expressible only through that question's FreeText escape hatch,
+// validated against hostEfforts' full domain wherever a typed value is
+// ingested (validEffort, and internal/config's own Parse/RenderLocal
+// round-trip checks).
+func effortsOffered(host, def string) []string {
 	efforts := hostEfforts[host]
-	if len(efforts) > maxOfferedEfforts {
-		return efforts[:maxOfferedEfforts]
+	if len(efforts) <= maxOfferedEfforts {
+		return efforts
 	}
-	return efforts
+	end := maxOfferedEfforts
+	if i := slices.Index(efforts, def); i >= end {
+		end = i + 1
+	}
+	return efforts[end-maxOfferedEfforts : end]
 }
 
 // hostLabels is each host key's human-readable display name.
@@ -298,26 +308,19 @@ func modelOptions(host, def string) []question.Option {
 	return opts
 }
 
-// effortOptions lists host's offered effort subset (effortsOffered),
-// marking def as Recommended. def need not be among these options —
-// the question's FreeText escape hatch admits any other value in
-// host's full effort enum (hostEfforts); SpecCheck permits a Default
-// outside Options exactly when FreeText is set.
+// effortOptions lists host's offered effort window (effortsOffered),
+// marking def as Recommended. Each option is labelled with the literal
+// enum token it submits — the same token config.toml, the routing
+// table, and the FreeText escape hatch use — rather than a prose gloss
+// that would hide it. Values outside the window stay reachable through
+// that hatch.
 func effortOptions(host, def string) []question.Option {
-	efforts := effortsOffered(host)
+	efforts := effortsOffered(host, def)
 	opts := make([]question.Option, len(efforts))
 	for i, e := range efforts {
-		opts[i] = question.Option{Value: e, Label: effortLabel(e), Recommended: e == def}
+		opts[i] = question.Option{Value: e, Label: e, Recommended: e == def}
 	}
 	return opts
-}
-
-// effortLabel title-cases an effort enum value for display.
-func effortLabel(effort string) string {
-	if effort == "xhigh" {
-		return "Extra high"
-	}
-	return strings.ToUpper(effort[:1]) + effort[1:]
 }
 
 // settingsDefaults holds settingsDoc's four question defaults, so init

--- a/internal/interview/sequence_test.go
+++ b/internal/interview/sequence_test.go
@@ -1,6 +1,8 @@
 package interview
 
 import (
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/kninetimmy/orch/internal/question"
@@ -135,20 +137,43 @@ func TestHostEffortsAcceptedByConfig(t *testing.T) {
 // within question.SpecCheck's 2-4-option cap and never offers a value
 // hostEfforts does not itself list for that host — combined with
 // TestHostEffortsAcceptedByConfig, this closes issue #124 criterion 5
-// for every interview-offered effort option too.
+// for every interview-offered effort option too. It also proves the
+// window is a contiguous run of the host enum that contains the
+// question's own default, whatever that default is (issue #208): the
+// Codex roles defaulting to "max" must be able to select it.
 func TestEffortsOfferedIsSubsetOfHostEfforts(t *testing.T) {
-	for host := range hostEfforts {
-		offered := effortsOffered(host)
-		if len(offered) < 2 || len(offered) > 4 {
-			t.Fatalf("effortsOffered(%s) = %v, want 2-4 options", host, offered)
+	for host, efforts := range hostEfforts {
+		for _, def := range efforts {
+			offered := effortsOffered(host, def)
+			if len(offered) < 2 || len(offered) > 4 {
+				t.Fatalf("effortsOffered(%s, %s) = %v, want 2-4 options", host, def, offered)
+			}
+			if !slices.Contains(offered, def) {
+				t.Errorf("effortsOffered(%s, %s) = %v, does not offer its own default", host, def, offered)
+			}
+			if i := slices.Index(efforts, offered[0]); i < 0 || !slices.Equal(efforts[i:i+len(offered)], offered) {
+				t.Errorf("effortsOffered(%s, %s) = %v, not a contiguous run of hostEfforts[%s] = %v", host, def, offered, host, efforts)
+			}
 		}
-		full := map[string]bool{}
-		for _, e := range hostEfforts[host] {
-			full[e] = true
-		}
-		for _, e := range offered {
-			if !full[e] {
-				t.Errorf("effortsOffered(%s) offers %q, not in hostEfforts[%s]", host, e, host)
+	}
+}
+
+// TestEffortOptionsLabelLiteralTokens proves every effort option an
+// interview surface offers is labelled with the literal enum token it
+// submits, not a prose gloss that hides it (issue #208) — the token
+// config.toml and the FreeText escape hatch both use.
+func TestEffortOptionsLabelLiteralTokens(t *testing.T) {
+	for host, efforts := range hostEfforts {
+		for _, def := range efforts {
+			for _, o := range effortOptions(host, def) {
+				if !strings.Contains(o.Label, o.Value) {
+					t.Errorf("effortOptions(%s, %s): label %q omits token %q", host, def, o.Label, o.Value)
+				}
+			}
+			for _, o := range effortOptionsLocal(host, def, def) {
+				if !strings.Contains(o.Label, o.Value) {
+					t.Errorf("effortOptionsLocal(%s, %s): label %q omits token %q", host, def, o.Label, o.Value)
+				}
 			}
 		}
 	}

--- a/internal/interview/testdata/transcript/step_02.json
+++ b/internal/interview/testdata/transcript/step_02.json
@@ -34,20 +34,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High",
+          "label": "high",
           "recommended": true
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript/step_03.json
+++ b/internal/interview/testdata/transcript/step_03.json
@@ -34,20 +34,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low",
+          "label": "low",
           "recommended": true
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript/step_04.json
+++ b/internal/interview/testdata/transcript/step_04.json
@@ -34,20 +34,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium",
+          "label": "medium",
           "recommended": true
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript/step_05.json
+++ b/internal/interview/testdata/transcript/step_05.json
@@ -34,20 +34,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High",
+          "label": "high",
           "recommended": true
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript/step_06.json
+++ b/internal/interview/testdata/transcript/step_06.json
@@ -34,20 +34,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High",
+          "label": "high",
           "recommended": true
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript/step_07.json
+++ b/internal/interview/testdata/transcript/step_07.json
@@ -34,20 +34,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium",
+          "label": "medium",
           "recommended": true
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript/step_08.json
+++ b/internal/interview/testdata/transcript/step_08.json
@@ -37,19 +37,19 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high",
+          "label": "xhigh",
           "recommended": true
         }
       ],

--- a/internal/interview/testdata/transcript/step_09.json
+++ b/internal/interview/testdata/transcript/step_09.json
@@ -36,20 +36,21 @@
       "kind": "select",
       "options": [
         {
-          "value": "low",
-          "label": "Low"
-        },
-        {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
+        },
+        {
+          "value": "max",
+          "label": "max",
+          "recommended": true
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript/step_10.json
+++ b/internal/interview/testdata/transcript/step_10.json
@@ -36,20 +36,21 @@
       "kind": "select",
       "options": [
         {
-          "value": "low",
-          "label": "Low"
-        },
-        {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
+        },
+        {
+          "value": "max",
+          "label": "max",
+          "recommended": true
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript/step_11.json
+++ b/internal/interview/testdata/transcript/step_11.json
@@ -36,20 +36,21 @@
       "kind": "select",
       "options": [
         {
-          "value": "low",
-          "label": "Low"
-        },
-        {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
+        },
+        {
+          "value": "max",
+          "label": "max",
+          "recommended": true
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript/step_12.json
+++ b/internal/interview/testdata/transcript/step_12.json
@@ -37,19 +37,19 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high",
+          "label": "xhigh",
           "recommended": true
         }
       ],

--- a/internal/interview/testdata/transcript/step_13.json
+++ b/internal/interview/testdata/transcript/step_13.json
@@ -37,20 +37,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High",
+          "label": "high",
           "recommended": true
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_03.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_03.json
@@ -37,19 +37,19 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high",
+          "label": "xhigh",
           "recommended": true
         }
       ],

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_04.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_04.json
@@ -36,20 +36,21 @@
       "kind": "select",
       "options": [
         {
-          "value": "low",
-          "label": "Low"
-        },
-        {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
+        },
+        {
+          "value": "max",
+          "label": "max",
+          "recommended": true
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_05.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_05.json
@@ -36,20 +36,21 @@
       "kind": "select",
       "options": [
         {
-          "value": "low",
-          "label": "Low"
-        },
-        {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
+        },
+        {
+          "value": "max",
+          "label": "max",
+          "recommended": true
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_06.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_06.json
@@ -36,20 +36,21 @@
       "kind": "select",
       "options": [
         {
-          "value": "low",
-          "label": "Low"
-        },
-        {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
+        },
+        {
+          "value": "max",
+          "label": "max",
+          "recommended": true
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_07.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_07.json
@@ -37,19 +37,19 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high",
+          "label": "xhigh",
           "recommended": true
         }
       ],

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_08.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_08.json
@@ -37,20 +37,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High",
+          "label": "high",
           "recommended": true
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_configure/merge_and_model/step_02.json
+++ b/internal/interview/testdata/transcript_configure/merge_and_model/step_02.json
@@ -33,19 +33,19 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high",
+          "label": "xhigh",
           "recommended": true
         }
       ],

--- a/internal/interview/testdata/transcript_configure/merge_and_model/step_03.json
+++ b/internal/interview/testdata/transcript_configure/merge_and_model/step_03.json
@@ -34,20 +34,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low",
+          "label": "low",
           "recommended": true
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_configure/merge_and_model/step_04.json
+++ b/internal/interview/testdata/transcript_configure/merge_and_model/step_04.json
@@ -34,19 +34,19 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high",
+          "label": "xhigh",
           "recommended": true
         }
       ],

--- a/internal/interview/testdata/transcript_configure/merge_and_model/step_05.json
+++ b/internal/interview/testdata/transcript_configure/merge_and_model/step_05.json
@@ -33,20 +33,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High",
+          "label": "high",
           "recommended": true
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_configure/merge_and_model/step_06.json
+++ b/internal/interview/testdata/transcript_configure/merge_and_model/step_06.json
@@ -33,20 +33,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High",
+          "label": "high",
           "recommended": true
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_configure/merge_and_model/step_07.json
+++ b/internal/interview/testdata/transcript_configure/merge_and_model/step_07.json
@@ -34,20 +34,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High",
+          "label": "high",
           "recommended": true
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/clear_all/step_02.json
+++ b/internal/interview/testdata/transcript_local/clear_all/step_02.json
@@ -37,19 +37,19 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high (committed)",
+          "label": "xhigh (committed)",
           "recommended": true
         }
       ],

--- a/internal/interview/testdata/transcript_local/clear_all/step_03.json
+++ b/internal/interview/testdata/transcript_local/clear_all/step_03.json
@@ -37,20 +37,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low (committed)",
+          "label": "low (committed)",
           "recommended": true
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/clear_all/step_04.json
+++ b/internal/interview/testdata/transcript_local/clear_all/step_04.json
@@ -37,19 +37,19 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high (committed)",
+          "label": "xhigh (committed)",
           "recommended": true
         }
       ],

--- a/internal/interview/testdata/transcript_local/clear_all/step_05.json
+++ b/internal/interview/testdata/transcript_local/clear_all/step_05.json
@@ -36,20 +36,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High (committed)",
+          "label": "high (committed)",
           "recommended": true
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/clear_all/step_06.json
+++ b/internal/interview/testdata/transcript_local/clear_all/step_06.json
@@ -36,20 +36,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High (committed)",
+          "label": "high (committed)",
           "recommended": true
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/clear_all/step_07.json
+++ b/internal/interview/testdata/transcript_local/clear_all/step_07.json
@@ -37,20 +37,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High (committed)",
+          "label": "high (committed)",
           "recommended": true
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/flagship/step_02.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_02.json
@@ -37,19 +37,19 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high (committed)",
+          "label": "xhigh (committed)",
           "recommended": true
         }
       ],

--- a/internal/interview/testdata/transcript_local/flagship/step_03.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_03.json
@@ -37,20 +37,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low (committed)",
+          "label": "low (committed)",
           "recommended": true
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/flagship/step_04.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_04.json
@@ -37,19 +37,19 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high (committed)",
+          "label": "xhigh (committed)",
           "recommended": true
         }
       ],

--- a/internal/interview/testdata/transcript_local/flagship/step_05.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_05.json
@@ -36,20 +36,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High (committed)",
+          "label": "high (committed)",
           "recommended": true
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/flagship/step_06.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_06.json
@@ -36,20 +36,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High (committed)",
+          "label": "high (committed)",
           "recommended": true
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/flagship/step_07.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_07.json
@@ -37,20 +37,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High (committed)",
+          "label": "high (committed)",
           "recommended": true
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/flagship/step_08.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_08.json
@@ -37,20 +37,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High (committed)",
+          "label": "high (committed)",
           "recommended": true
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/flagship/step_09.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_09.json
@@ -37,20 +37,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low (committed)",
+          "label": "low (committed)",
           "recommended": true
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/flagship/step_10.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_10.json
@@ -37,20 +37,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High (committed)",
+          "label": "high (committed)",
           "recommended": true
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/flagship/step_11.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_11.json
@@ -37,20 +37,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium (committed)",
+          "label": "medium (committed)",
           "recommended": true
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/flagship/step_12.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_12.json
@@ -37,20 +37,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium (committed)",
+          "label": "medium (committed)",
           "recommended": true
         },
         {
           "value": "high",
-          "label": "High"
+          "label": "high"
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/flagship/step_13.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_13.json
@@ -37,20 +37,20 @@
       "options": [
         {
           "value": "low",
-          "label": "Low"
+          "label": "low"
         },
         {
           "value": "medium",
-          "label": "Medium"
+          "label": "medium"
         },
         {
           "value": "high",
-          "label": "High (committed)",
+          "label": "high (committed)",
           "recommended": true
         },
         {
           "value": "xhigh",
-          "label": "Extra high"
+          "label": "xhigh"
         }
       ],
       "free_text": true,


### PR DESCRIPTION
Delivers issue #208: Offer effort options that include the default and label them with literal enum tokens

Closes #208

**Plan digest:** `sha256:bc6df79531050f5da0b2822edbecf9a92771230bd37001f0e7ba1748294dc955`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Fix the two interview effort-question defects task 173 recorded from the wirex init audit. The interview offers at most four effort levels as selectable options and currently always shows the leading four of the host's enum, so the Codex scout, implementer, and specialist questions ship a recommended default of max that is not among the options and must be typed into Other; max and ultra are never selectable for any role. Separately, option labels prose-gloss the enum values (xhigh displays as Extra high), hiding the literal token every other surface and the free-text hatch use. Choose the offered window so it always contains the question's default, and label options with their literal tokens. Update the golden interview transcripts to match.

**Acceptance criteria:**
- Every effort question's default value is among that question's offered options, for every role on both hosts, in orch init, orch configure, and orch configure-local - including the Codex roles whose default effort is max.
- Each offered effort option's label contains the literal enum token the option submits; in particular xhigh is labeled with the token xhigh rather than only a prose gloss.
- Every value in a host's full effort enum remains accepted when typed as free text, and a value outside that enum remains rejected, exactly as today.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — Full module suite green in the issue worktree at pushed head 06a6c82. Before the 42 golden transcripts were regenerated, exactly the 5 golden-transcript tests failed, confirming transcripts were the only fixture surface affected. — commit `06a6c821c2abc8250db91c5ad9736f2157c79c68` (2026-08-09T22:22:46Z)
- **go-vet** — pass — `go vet ./...` — No output at head 06a6c82. — commit `06a6c821c2abc8250db91c5ad9736f2157c79c68` (2026-08-09T22:22:46Z)
- **gofmt** — pass — `gofmt -l .` — Prints nothing at head 06a6c82. — commit `06a6c821c2abc8250db91c5ad9736f2157c79c68` (2026-08-09T22:22:46Z)
- **branch-scope:diff** — 1 commit, 45 files, +272/-236, all under internal/interview — `git diff --stat origin/main..HEAD` — Three Go files (sequence.go: per-question default-inclusive effort window and literal token labels, effortLabel removed; configurelocal.go: effortOptionsLocal passes the effective value; sequence_test.go: window sweep + literal-label tests) plus 42 regenerated golden transcripts under internal/interview/testdata/. — commit `06a6c821c2abc8250db91c5ad9736f2157c79c68` (2026-08-09T22:22:46Z)
- **reviewer-required-tests** — pass — `go test -count=1 ./... && go vet ./... && gofmt -l .` — Reviewer re-ran all three in the issue worktree at 06a6c821c2abc8250db91c5ad9736f2157c79c68: all packages ok uncached, vet silent, gofmt printed nothing. CI six of six green. Golden-transcript aggregate check: all changed lines across the 42 regenerated files are option label/value/recommended/brace lines - no unrelated drift. — commit `06a6c821c2abc8250db91c5ad9736f2157c79c68` (2026-08-09T22:33:52Z)
- **acceptance-criterion-1** — satisfied — effortQ.Default and effortOptions read the same variable in roleDocSpecs (the single builder init and configure share), effortOptionsLocal keys the window on the effective value it also offers as Default, TestEffortsOfferedIsSubsetOfHostEfforts sweeps every enum value as default asserting containment and contiguity, and the transcript sweep shows zero default-outside-options effort questions at head against six at base. Windows are exactly the intended slices: codex max yields medium/high/xhigh/max, codex ultra yields high/xhigh/max/ultra, claude max yields medium/high/xhigh/max, all four wide so SpecCheck's cap holds. — commit `06a6c821c2abc8250db91c5ad9736f2157c79c68` (2026-08-09T22:33:53Z)
- **acceptance-criterion-2** — satisfied — Options are labeled with the literal token (Label: e; configure-local appends ' (committed)'), effortLabel is deleted with no residual reference to it or to 'Extra high' anywhere in the repo, step_09's golden now carries label xhigh, and a scratch-copy mutation upper-casing labels fails TestEffortOptionsLabelLiteralTokens on its own. — commit `06a6c821c2abc8250db91c5ad9736f2157c79c68` (2026-08-09T22:33:53Z)
- **acceptance-criterion-3** — satisfied — The hostEfforts literal, validEffort, question.ValidateAnswer, and FreeText on every effort question are all untouched by the diff; hostEfforts matches config's effortsByHost verbatim; acceptance of every enum value is pinned by TestHostEffortsAcceptedByConfig and rejection of out-of-enum values by TestEffortDomainPerHost and TestNextConfigureLocalInvalidFileSeeding, all green. — commit `06a6c821c2abc8250db91c5ad9736f2157c79c68` (2026-08-09T22:33:53Z)
- **review-cycle-1** — approve — PR #210 replaces the fixed leading-four effort window with a per-question contiguous window ending at the question's own default, and swaps prose-glossed option labels for the literal enum tokens. All three acceptance criteria are satisfied on direct observation: a jq sweep of all 64 golden transcripts shows six effort questions with a default outside their options at base and zero at head, TestEffortsOfferedIsSubsetOfHostEfforts proves containment and contiguity for every enum value as default on both hosts, TestEffortOptionsLabelLiteralTokens independently catches a reintroduced prose gloss, and the free-text accept/reject domain is untouched code still covered by TestHostEffortsAcceptedByConfig, TestEffortDomainPerHost, and TestNextConfigureLocalInvalidFileSeeding. Scope is tight: 45 files entirely under internal/interview, no new dependencies, and the regenerated goldens changed only option label/value/recommended lines. Required tests and CI are green at the live head. The one substantive finding is a coverage gap the executor disclosed and the reviewer confirmed by mutation: swapping effortsOffered(host, effectiveVal) for committedVal in effortOptionsLocal passes the whole suite, because no transcript_local fixture has a committed effort outside the leading four; the shipped code is correct, so this does not block - a one-line fixture bump closes it on a later pass. Also noted non-blocking: the (committed) label decoration can be absent when the committed value falls outside the window (documented honestly in the code), the out-of-enum default fallback is unreachable today but the hostEfforts-equals-config-domain invariant is only pinned in one direction, and codex low is no longer selectable for the max-default roles (inherent to the 4-option cap; free text still accepts it). — commit `06a6c821c2abc8250db91c5ad9736f2157c79c68` (2026-08-09T22:33:53Z)
- **required-ci** — passing — test (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `06a6c821c2abc8250db91c5ad9736f2157c79c68` (2026-08-09T22:33:57Z)

<!-- orch:manifest:data
{
  "schema_version": 4,
  "objective": "Fix the two interview effort-question defects task 173 recorded from the wirex init audit. The interview offers at most four effort levels as selectable options and currently always shows the leading four of the host's enum, so the Codex scout, implementer, and specialist questions ship a recommended default of max that is not among the options and must be typed into Other; max and ultra are never selectable for any role. Separately, option labels prose-gloss the enum values (xhigh displays as Extra high), hiding the literal token every other surface and the free-text hatch use. Choose the offered window so it always contains the question's default, and label options with their literal tokens. Update the golden interview transcripts to match.",
  "acceptance_criteria": [
    "Every effort question's default value is among that question's offered options, for every role on both hosts, in orch init, orch configure, and orch configure-local - including the Codex roles whose default effort is max.",
    "Each offered effort option's label contains the literal enum token the option submits; in particular xhigh is labeled with the token xhigh rather than only a prose gloss.",
    "Every value in a host's full effort enum remains accepted when typed as free text, and a value outside that enum remains rejected, exactly as today."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Full module suite green in the issue worktree at pushed head 06a6c82. Before the 42 golden transcripts were regenerated, exactly the 5 golden-transcript tests failed, confirming transcripts were the only fixture surface affected.",
      "commit_oid": "06a6c821c2abc8250db91c5ad9736f2157c79c68",
      "at": "2026-08-09T22:22:46Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "No output at head 06a6c82.",
      "commit_oid": "06a6c821c2abc8250db91c5ad9736f2157c79c68",
      "at": "2026-08-09T22:22:46Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "Prints nothing at head 06a6c82.",
      "commit_oid": "06a6c821c2abc8250db91c5ad9736f2157c79c68",
      "at": "2026-08-09T22:22:46Z"
    },
    {
      "name": "branch-scope:diff",
      "command": "git diff --stat origin/main..HEAD",
      "result": "1 commit, 45 files, +272/-236, all under internal/interview",
      "detail": "Three Go files (sequence.go: per-question default-inclusive effort window and literal token labels, effortLabel removed; configurelocal.go: effortOptionsLocal passes the effective value; sequence_test.go: window sweep + literal-label tests) plus 42 regenerated golden transcripts under internal/interview/testdata/.",
      "commit_oid": "06a6c821c2abc8250db91c5ad9736f2157c79c68",
      "at": "2026-08-09T22:22:46Z"
    },
    {
      "name": "reviewer-required-tests",
      "command": "go test -count=1 ./... \u0026\u0026 go vet ./... \u0026\u0026 gofmt -l .",
      "result": "pass",
      "detail": "Reviewer re-ran all three in the issue worktree at 06a6c821c2abc8250db91c5ad9736f2157c79c68: all packages ok uncached, vet silent, gofmt printed nothing. CI six of six green. Golden-transcript aggregate check: all changed lines across the 42 regenerated files are option label/value/recommended/brace lines - no unrelated drift.",
      "commit_oid": "06a6c821c2abc8250db91c5ad9736f2157c79c68",
      "at": "2026-08-09T22:33:52Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "effortQ.Default and effortOptions read the same variable in roleDocSpecs (the single builder init and configure share), effortOptionsLocal keys the window on the effective value it also offers as Default, TestEffortsOfferedIsSubsetOfHostEfforts sweeps every enum value as default asserting containment and contiguity, and the transcript sweep shows zero default-outside-options effort questions at head against six at base. Windows are exactly the intended slices: codex max yields medium/high/xhigh/max, codex ultra yields high/xhigh/max/ultra, claude max yields medium/high/xhigh/max, all four wide so SpecCheck's cap holds.",
      "commit_oid": "06a6c821c2abc8250db91c5ad9736f2157c79c68",
      "at": "2026-08-09T22:33:53Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "Options are labeled with the literal token (Label: e; configure-local appends ' (committed)'), effortLabel is deleted with no residual reference to it or to 'Extra high' anywhere in the repo, step_09's golden now carries label xhigh, and a scratch-copy mutation upper-casing labels fails TestEffortOptionsLabelLiteralTokens on its own.",
      "commit_oid": "06a6c821c2abc8250db91c5ad9736f2157c79c68",
      "at": "2026-08-09T22:33:53Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "The hostEfforts literal, validEffort, question.ValidateAnswer, and FreeText on every effort question are all untouched by the diff; hostEfforts matches config's effortsByHost verbatim; acceptance of every enum value is pinned by TestHostEffortsAcceptedByConfig and rejection of out-of-enum values by TestEffortDomainPerHost and TestNextConfigureLocalInvalidFileSeeding, all green.",
      "commit_oid": "06a6c821c2abc8250db91c5ad9736f2157c79c68",
      "at": "2026-08-09T22:33:53Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "PR #210 replaces the fixed leading-four effort window with a per-question contiguous window ending at the question's own default, and swaps prose-glossed option labels for the literal enum tokens. All three acceptance criteria are satisfied on direct observation: a jq sweep of all 64 golden transcripts shows six effort questions with a default outside their options at base and zero at head, TestEffortsOfferedIsSubsetOfHostEfforts proves containment and contiguity for every enum value as default on both hosts, TestEffortOptionsLabelLiteralTokens independently catches a reintroduced prose gloss, and the free-text accept/reject domain is untouched code still covered by TestHostEffortsAcceptedByConfig, TestEffortDomainPerHost, and TestNextConfigureLocalInvalidFileSeeding. Scope is tight: 45 files entirely under internal/interview, no new dependencies, and the regenerated goldens changed only option label/value/recommended lines. Required tests and CI are green at the live head. The one substantive finding is a coverage gap the executor disclosed and the reviewer confirmed by mutation: swapping effortsOffered(host, effectiveVal) for committedVal in effortOptionsLocal passes the whole suite, because no transcript_local fixture has a committed effort outside the leading four; the shipped code is correct, so this does not block - a one-line fixture bump closes it on a later pass. Also noted non-blocking: the (committed) label decoration can be absent when the committed value falls outside the window (documented honestly in the code), the out-of-enum default fallback is unreachable today but the hostEfforts-equals-config-domain invariant is only pinned in one direction, and codex low is no longer selectable for the max-default roles (inherent to the 4-option cap; free text still accepts it).",
      "commit_oid": "06a6c821c2abc8250db91c5ad9736f2157c79c68",
      "at": "2026-08-09T22:33:53Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "06a6c821c2abc8250db91c5ad9736f2157c79c68",
      "at": "2026-08-09T22:33:57Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->