### PR TITLE
Bump adapter and marketplace version to 0.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "kninetimmy" },
   "metadata": {
     "description": "Host adapters for the Orch development orchestrator",
-    "version": "0.6.3"
+    "version": "0.7.0"
   },
   "plugins": [
     {

--- a/adapters/claude/.claude-plugin/plugin.json
+++ b/adapters/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Claude Code host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -78,8 +78,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.6.3" {
-		t.Errorf("version = %q, want 0.6.3", m.Version)
+	if m.Version != "0.7.0" {
+		t.Errorf("version = %q, want 0.7.0", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")

--- a/adapters/codex/.codex-plugin/plugin.json
+++ b/adapters/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "orch",
   "description": "Codex CLI host adapter for the Orch development orchestrator. Thin adapter: all policy lives in the orch binary.",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "author": { "name": "kninetimmy" }
 }

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -79,8 +79,8 @@ func TestPluginManifestStrict(t *testing.T) {
 	if m.Description == "" {
 		t.Error("description is empty")
 	}
-	if m.Version != "0.6.3" {
-		t.Errorf("version = %q, want 0.6.3", m.Version)
+	if m.Version != "0.7.0" {
+		t.Errorf("version = %q, want 0.7.0", m.Version)
 	}
 	if m.Author.Name == "" {
 		t.Error("author.name is empty")


### PR DESCRIPTION
Delivers issue #212: Bump adapter and marketplace version to 0.7.0

Closes #212

**Plan digest:** `sha256:901c6a44071a2f946706460b8039c8814b9bae713c5581c6491d895b68b10b78`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Raise the released adapter and marketplace version from 0.6.3 to 0.7.0, in the same shape as the previous release bump: the marketplace manifest, both host plugin manifests, and the tests that pin the version number. Nothing but version numbers changes, so the v0.7.0 tag cut after this merges ships the reviewer-guidance fix plus the two changes already on main since v0.6.3.

**Acceptance criteria:**
- The marketplace manifest and both host plugin manifests state version 0.7.0, and every test that pins the version number pins 0.7.0.
- The change touches version numbers only - no behavior or prose changes ride along.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `medium` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — exit 0, all 23 packages ok including adapters/claude and adapters/codex, 3 [no test files], zero failures — commit `5e53da176677f622170d52e49c5fba1ece5e568c` (2026-08-15T18:56:52Z)
- **gofmt-check** — pass — `gofmt -l .` — exit 0, empty file list — commit `5e53da176677f622170d52e49c5fba1ece5e568c` (2026-08-15T18:56:52Z)
- **version-only-word-diff** — pass — `git diff --word-diff --ignore-all-space` — exactly 7 removal markers, each a 0.6.3 version literal paired with its 0.7.0 replacement (marketplace metadata.version, both plugin.json version fields, and both plugin_test.go pins covering the comparison and its error string); no other removal markers, so no prose or behavior rode along — commit `5e53da176677f622170d52e49c5fba1ece5e568c` (2026-08-15T18:56:52Z)
- **no-stale-version-pins** — pass — `git grep -n 0.6.3` — no matches remain in the worktree; a separate grep for version pins across adapters test files found only the json struct-tag fields and two unrelated comments about routed model versions — commit `5e53da176677f622170d52e49c5fba1ece5e568c` (2026-08-15T18:56:52Z)
- **branch-scope:files-changed** — pass — `git diff --stat origin/main...HEAD` — 5 files, +7/-7, same shape as the previous release bump f9e85b8: .claude-plugin/marketplace.json, adapters/claude/.claude-plugin/plugin.json, adapters/claude/plugin_test.go, adapters/codex/.codex-plugin/plugin.json, adapters/codex/plugin_test.go; single commit 5e53da176677f622170d52e49c5fba1ece5e568c, exactly one ahead of origin/main which already carries the merged #213 — commit `5e53da176677f622170d52e49c5fba1ece5e568c` (2026-08-15T18:56:52Z)
- **acceptance-criterion-1** — satisfied — git grep -F 0.7.0 at the reviewed OID returns exactly the seven expected lines across the marketplace manifest, both plugin manifests, and both plugin_test.go pins, while grep for 0.6.3 returns nothing; the same grep on origin/main returns exactly those seven pre-change lines, so no pin was missed, and the non-literal pins (marketplace consistency assertion, doctor's manifest-derived version) correctly needed no edit. — commit `5e53da176677f622170d52e49c5fba1ece5e568c` (2026-08-15T19:01:38Z)
- **acceptance-criterion-2** — satisfied — The full three-dot diff against origin/main is 5 files +7/-7 and every hunk is a single-token 0.6.3 to 0.7.0 swap on a version field or test pin - no JSON key, description, Go statement, or doc line changes - matching the previous release bump f9e85b8's identical five-file +7/-7 shape, which the reviewer diffed for comparison. — commit `5e53da176677f622170d52e49c5fba1ece5e568c` (2026-08-15T19:01:38Z)
- **review-cycle-1** — approve — Both acceptance criteria satisfied against the reviewer's own observations at the pinned head: git grep at the OID shows exactly seven 0.7.0 literals (marketplace metadata.version, both plugin manifests, both plugin_test.go pins covering comparison and error string) and zero remaining 0.6.3; the marketplace consistency test needed no edit because all three manifests moved together, and doctor derives its expected version from the embedded manifest rather than a constant. The three-dot diff against origin/main is 5 files +7/-7, every hunk a single version-literal swap, byte-for-byte parallel in shape to the previous bump f9e85b8. Both required tests re-run green including an uncached run of the touched packages; all six CI checks pass on the head and the PR is mergeable. Non-blocking findings: pre-existing README drift still advertising binary release v0.6.1 in several places (worth its own follow-up, widened by cutting v0.7.0); adapter version and binary release version are deliberately independent, so the v0.7.0 tag matching is convention, not enforcement. — commit `5e53da176677f622170d52e49c5fba1ece5e568c` (2026-08-15T19:01:38Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `5e53da176677f622170d52e49c5fba1ece5e568c` (2026-08-15T19:01:43Z)

<!-- orch:manifest:data
{
  "schema_version": 4,
  "objective": "Raise the released adapter and marketplace version from 0.6.3 to 0.7.0, in the same shape as the previous release bump: the marketplace manifest, both host plugin manifests, and the tests that pin the version number. Nothing but version numbers changes, so the v0.7.0 tag cut after this merges ships the reviewer-guidance fix plus the two changes already on main since v0.6.3.",
  "acceptance_criteria": [
    "The marketplace manifest and both host plugin manifests state version 0.7.0, and every test that pins the version number pins 0.7.0.",
    "The change touches version numbers only - no behavior or prose changes ride along."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "exit 0, all 23 packages ok including adapters/claude and adapters/codex, 3 [no test files], zero failures",
      "commit_oid": "5e53da176677f622170d52e49c5fba1ece5e568c",
      "at": "2026-08-15T18:56:52Z"
    },
    {
      "name": "gofmt-check",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "exit 0, empty file list",
      "commit_oid": "5e53da176677f622170d52e49c5fba1ece5e568c",
      "at": "2026-08-15T18:56:52Z"
    },
    {
      "name": "version-only-word-diff",
      "command": "git diff --word-diff --ignore-all-space",
      "result": "pass",
      "detail": "exactly 7 removal markers, each a 0.6.3 version literal paired with its 0.7.0 replacement (marketplace metadata.version, both plugin.json version fields, and both plugin_test.go pins covering the comparison and its error string); no other removal markers, so no prose or behavior rode along",
      "commit_oid": "5e53da176677f622170d52e49c5fba1ece5e568c",
      "at": "2026-08-15T18:56:52Z"
    },
    {
      "name": "no-stale-version-pins",
      "command": "git grep -n 0.6.3",
      "result": "pass",
      "detail": "no matches remain in the worktree; a separate grep for version pins across adapters test files found only the json struct-tag fields and two unrelated comments about routed model versions",
      "commit_oid": "5e53da176677f622170d52e49c5fba1ece5e568c",
      "at": "2026-08-15T18:56:52Z"
    },
    {
      "name": "branch-scope:files-changed",
      "command": "git diff --stat origin/main...HEAD",
      "result": "pass",
      "detail": "5 files, +7/-7, same shape as the previous release bump f9e85b8: .claude-plugin/marketplace.json, adapters/claude/.claude-plugin/plugin.json, adapters/claude/plugin_test.go, adapters/codex/.codex-plugin/plugin.json, adapters/codex/plugin_test.go; single commit 5e53da176677f622170d52e49c5fba1ece5e568c, exactly one ahead of origin/main which already carries the merged #213",
      "commit_oid": "5e53da176677f622170d52e49c5fba1ece5e568c",
      "at": "2026-08-15T18:56:52Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "git grep -F 0.7.0 at the reviewed OID returns exactly the seven expected lines across the marketplace manifest, both plugin manifests, and both plugin_test.go pins, while grep for 0.6.3 returns nothing; the same grep on origin/main returns exactly those seven pre-change lines, so no pin was missed, and the non-literal pins (marketplace consistency assertion, doctor's manifest-derived version) correctly needed no edit.",
      "commit_oid": "5e53da176677f622170d52e49c5fba1ece5e568c",
      "at": "2026-08-15T19:01:38Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "The full three-dot diff against origin/main is 5 files +7/-7 and every hunk is a single-token 0.6.3 to 0.7.0 swap on a version field or test pin - no JSON key, description, Go statement, or doc line changes - matching the previous release bump f9e85b8's identical five-file +7/-7 shape, which the reviewer diffed for comparison.",
      "commit_oid": "5e53da176677f622170d52e49c5fba1ece5e568c",
      "at": "2026-08-15T19:01:38Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Both acceptance criteria satisfied against the reviewer's own observations at the pinned head: git grep at the OID shows exactly seven 0.7.0 literals (marketplace metadata.version, both plugin manifests, both plugin_test.go pins covering comparison and error string) and zero remaining 0.6.3; the marketplace consistency test needed no edit because all three manifests moved together, and doctor derives its expected version from the embedded manifest rather than a constant. The three-dot diff against origin/main is 5 files +7/-7, every hunk a single version-literal swap, byte-for-byte parallel in shape to the previous bump f9e85b8. Both required tests re-run green including an uncached run of the touched packages; all six CI checks pass on the head and the PR is mergeable. Non-blocking findings: pre-existing README drift still advertising binary release v0.6.1 in several places (worth its own follow-up, widened by cutting v0.7.0); adapter version and binary release version are deliberately independent, so the v0.7.0 tag matching is convention, not enforcement.",
      "commit_oid": "5e53da176677f622170d52e49c5fba1ece5e568c",
      "at": "2026-08-15T19:01:38Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "5e53da176677f622170d52e49c5fba1ece5e568c",
      "at": "2026-08-15T19:01:43Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->