### PR TITLE
Restructure README into a new-user flow with both animations before Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,23 +19,13 @@ Orch sits underneath the CLI you already use (Claude Code or Codex CLI) and take
 
 The payoff: cheap, fast models handle read-only exploration and mechanical work, a frontier model gets spent only where the plan calls for it, and every change that lands is auditable and gated by a human at the one step that matters — the merge.
 
+**[Jump to Quickstart →](#quickstart)** · **[See how it works →](#how-it-works)**
+
 <br>
 
 <p align="center">
   <img src="docs/images/orch-overview.gif" alt="Animated overview of how Orch works: in Assist the guard denies a tracked-file write with its verbatim reason and allows git-ignored scratch; approving a plan enters Delivery, routing pins the exact model, and writes land only inside the registered issue worktree before the run auto-returns to Assist" width="920"/>
 </p>
-
----
-
-## What you actually get
-
-- **Read-only by default.** Assist mode mechanically denies every write to a file git does not ignore — not a convention the agent is asked to honor, but a decision `orch guard` makes before the write happens.
-- **You route the model, not the agent.** Six roles — architect, scout, implementer, specialist, reviewer, and a cheaper review downgrade — each pin an exact model version and effort level you choose, so a cheap model handles read-only work and a frontier model is spent only where the plan calls for it.
-- **Every issue gets its own worktree.** Delivery work happens on its own branch, in its own isolated git worktree, never in your primary checkout.
-- **A separate dispatch reviews the work.** The pull request is reviewed in a dispatch separate from the one that wrote it — never the same run marking its own homework.
-- **You hold the merge gate.** Nothing lands on your default branch until you approve it, and the merge fails closed if the pull request moved after your approval.
-- **Every issue and PR carries an audit record.** The exact model, the effort, how the host actually delivered that effort, and the routing rationale are recorded on the issue and mirrored onto its pull request.
-- **Works with the CLI you already use.** Orch works with both [Claude Code](adapters/claude/README.md) and [Codex CLI](adapters/codex/README.md), so you keep working in the agent you already have.
 
 ---
 
@@ -66,17 +56,18 @@ Concretely, asking for a change goes like this:
 4. A reviewer reviews the pull request. CI runs.
 5. You approve the merge, and it runs against GitHub pinned to the commit that approval names — it fails closed if the pull request moved after that.
 
+Each issue then walks the engine's Delivery pipeline, phase by phase:
+
+<p align="center">
+  <img src="docs/images/delivery-pipeline.gif" alt="Animated Delivery pipeline: one issue walks the engine's closed phase lifecycle from plan approval through activation, dispatch, pull request, review cycles, the OID-pinned human merge gate, cleanup, and completion back to Assist, with failure routes and engine guarantees alongside" width="920"/>
+</p>
+
 The full product definition lives in [ORCH-PRD.md](ORCH-PRD.md).
 
-## Status
+## Quickstart
 
-Early software. What can be stated as fact: 19 tagged releases, v0.1.0 through v0.7.0, and every pull request merged since PR #40 carries an Orch audit record in its body — apart from the configuration deliveries, which `orch configure` writes in its own body format. Since PR #40, this repository has been built through the pipeline described above: a plan gate, an isolated worktree per issue, a review dispatched separately from the work, CI, and a merge that fails closed unless it carries an approval pinned to the commit `merge-report` recorded.
-
-All of that evidence comes from one repository: this one.
-
-## Install
-
-### Have your agent do it
+<details>
+<summary><b>Have your agent do it</b> — recommended: one prompt, pasted into Claude Code or Codex CLI</summary>
 
 Paste this into a Claude Code or Codex CLI session, started anywhere.
 It does not assume you have cloned this repository.
@@ -147,11 +138,11 @@ on this machine. Work in a scratch directory, not in one of my projects.
    carrying .orchestrator/config.toml for me to review and merge. After
    that PR is merged, `orch render-agents` must be run in the repository;
    it generates project definitions for every enabled host and must be
-   rerun after role configuration or Orch changes. Before this change,
-   the Codex instructions also allowed manually copying five TOMLs and
-   Claude had no project-render step; after it, this command is the one
-   per-repository workflow for both hosts.
+   rerun after role configuration or Orch changes. This command is the
+   one per-repository workflow for both hosts.
 ```
+
+</details>
 
 ### Then initialize each repository you want orchestrated
 
@@ -277,6 +268,20 @@ go install github.com/kninetimmy/orch/cmd/orch@latest
 
 </details>
 
+---
+
+## What you actually get
+
+- **Read-only by default.** Assist mode mechanically denies every write to a file git does not ignore — not a convention the agent is asked to honor, but a decision `orch guard` makes before the write happens.
+- **You route the model, not the agent.** Six roles — architect, scout, implementer, specialist, reviewer, and a cheaper review downgrade — each pin an exact model version and effort level you choose, so a cheap model handles read-only work and a frontier model is spent only where the plan calls for it.
+- **Every issue gets its own worktree.** Delivery work happens on its own branch, in its own isolated git worktree, never in your primary checkout.
+- **A separate dispatch reviews the work.** The pull request is reviewed in a dispatch separate from the one that wrote it — never the same run marking its own homework.
+- **You hold the merge gate.** Nothing lands on your default branch until you approve it, and the merge fails closed if the pull request moved after your approval.
+- **Every issue and PR carries an audit record.** The exact model, the effort, how the host actually delivered that effort, and the routing rationale are recorded on the issue and mirrored onto its pull request.
+- **Works with the CLI you already use.** Orch works with both [Claude Code](adapters/claude/README.md) and [Codex CLI](adapters/codex/README.md), so you keep working in the agent you already have.
+
+---
+
 ## Day to day
 
 `orch help` lists every command, human and plumbing, in one place:
@@ -387,6 +392,12 @@ Every memhub command runs with the primary checkout as its working
 directory, never inside a per-issue worktree, because worktrees never
 receive a copy of the memhub database.
 
+## Status
+
+Early software. What can be stated as fact: 19 tagged releases, v0.1.0 through v0.7.0, and every pull request merged since PR #40 carries an Orch audit record in its body — apart from the configuration deliveries, which `orch configure` writes in its own body format. Since PR #40, this repository has been built through the pipeline described above: a plan gate, an isolated worktree per issue, a review dispatched separately from the work, CI, and a merge that fails closed unless it carries an approval pinned to the commit `merge-report` recorded.
+
+All of that evidence comes from one repository: this one.
+
 ## Known issues and limitations
 
 <details>
@@ -486,13 +497,10 @@ TOML and the host enforces it.
 **A model override does not reach a dispatched agent by itself, on
 either host.** Neither host can override a model per spawn, so the
 routed selection has to match the active project agent definition.
-Before, only Codex had generated project files: Claude doctor compared
-the configured model to the installed plugin copy, repaired nothing,
-and Claude activation did not gate on the mismatch. After, `orch
-render-agents` writes all five dispatched roles for every enabled host
-under `.claude/agents/` or `.codex/agents/`, using the shipped plugin
-definition as the canonical body and changing only that host's routing
-fields. Claude Code's [scope priority
+`orch render-agents` writes all five dispatched roles for every
+enabled host under `.claude/agents/` or `.codex/agents/`, using the
+shipped plugin definition as the canonical body and changing only
+that host's routing fields. Claude Code's [scope priority
 table](https://code.claude.com/docs/en/sub-agents#choose-the-subagent-scope)
 places project definitions above plugin definitions, so a generated
 same-named `.claude/agents/` file is what runs while retaining the
@@ -802,11 +810,8 @@ point is recoverable.
 
 ### The Delivery pipeline
 
-<br>
-
-<p align="center">
-  <img src="docs/images/delivery-pipeline.gif" alt="Animated Delivery pipeline: one issue walks the engine's closed phase lifecycle from plan approval through activation, dispatch, pull request, review cycles, the OID-pinned human merge gate, cleanup, and completion back to Assist, with failure routes and engine guarantees alongside" width="920"/>
-</p>
+The animation in [How it works](#how-it-works) walks this lifecycle end
+to end; what follows is the same pipeline in detail.
 
 A run starts at the **plan gate**: a schema-versioned plan document
 (issues, dependency waves, risk facts) is validated fail-closed, and a


### PR DESCRIPTION
Delivers issue #221: Restructure README into a new-user flow with both animations before Quickstart

Closes #221

**Plan digest:** `sha256:1126dfe2fc9f5811466afbfa51b10e503b88752db49b1fcf7713f1b66f8624bd`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** README.md (the only file in scope) is factually accurate but ordered for contributors, not new users. Restructure it into this reading order, preserving all existing content: (1) title, tagline, badges as they are; (2) the existing intro paragraphs, ending with bold jump links in the pattern '**[Jump to Quickstart →](#quickstart)** · **[See how it works →](#how-it-works)**'; (3) the overview animation (docs/images/orch-overview.gif) with its existing alt text; (4) the 'How it works' section — the existing two-modes / six-roles / guard / five-step-walkthrough prose — which now also hosts the Delivery-pipeline animation (docs/images/delivery-pipeline.gif) with a one-line lead-in; the deeper pipeline prose stays in Under the hood, which should refer back to the animation above rather than embed it a second time; (5) a section named 'Quickstart' holding the current agent install prompt inside a collapsible details block with a summary line marking it as the recommended agent-driven path, followed by the existing 'Then initialize each repository' prose and the existing 'Install it yourself' details block; (6) 'What you actually get' after the Quickstart/How-it-works head of the document; (7) the remaining sections in this order: Day to day, Settings, Memhub integration, Status, Known issues, Fixed, Under the hood, License. Nothing is deleted: every bullet, table, known issue, fixed entry, and paragraph of the current README survives the restructure (retitling, reordering, and moving prose between sections is allowed). Two passages additionally get rewritten in present tense because they narrate a change as a PR-diff before/after: the final sentence of step 7 of the agent install prompt (beginning 'Before this change, the Codex instructions also allowed manually copying five TOMLs') and the before/after narration inside the Known-issues entry titled 'A model override does not reach a dispatched agent by itself'; each rewrite states only current behavior and neither adds nor removes a factual claim. Do not alter verified factual content: the orch help block, the settings table, the default-model table, the Fixed list entries, and the Known-issues facts are all correct as they stand.

**Acceptance criteria:**
- Reading the restructured README top to bottom, the overview animation (docs/images/orch-overview.gif) appears after the opening intro and before any install or quickstart content, and the Delivery-pipeline animation (docs/images/delivery-pipeline.gif) appears inside the 'How it works' section, which itself precedes the Quickstart section; neither animation is embedded more than once in the document.
- The document's section order for a new user is: intro ending in jump links to Quickstart and How it works, the overview animation, How it works, Quickstart, then the remaining sections; the Quickstart section contains the agent install prompt inside a collapsible details block and the existing manual-install details block, and the 'Then initialize each repository' guidance sits between them.
- Every section of the pre-change README — What you actually get, How it works, Status, the install content, Day to day, Settings, Memhub integration, Known issues, Fixed, Under the hood, License — is still present in the restructured document with its content preserved: no bullet, table row, known-issues entry, fixed entry, or factual statement from the current README is deleted (retitling, reordering, and moving prose between sections is allowed).
- The final sentence of step 7 of the agent install prompt (currently beginning 'Before this change, the Codex instructions also allowed') and the before/after narration in the Known-issues entry 'A model override does not reach a dispatched agent by itself' are each rewritten to state only current behavior in present tense, with no factual claim added or removed anywhere in either passage.
- Every intra-document anchor link in the restructured README resolves to a heading present in the document, and every relative link and image path names a file tracked in the repository.

**Required tests:**
- `go test ./...`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `claude-opus-5` — effort `medium` |
| Reviewer | `claude-opus-5` — effort `high` |
| Effort delivery | `prompt-cue` — this host has no effort parameter; the routed effort reached the executor as a prompt cue only |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — Run inside the issue worktree: all 23 packages ok, 4 report no test files, zero failures. — commit `1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c` (2026-08-16T15:49:04Z)
- **branch-scope:content-preservation** — pass — `git show HEAD:README.md | grep -v blank | sort, compared with comm against the new file; git diff --word-diff --ignore-all-space -- README.md; git diff --stat` — Single commit touching README.md only (40 insertions, 35 deletions). Line-set comparison shows the only removed lines are the two passages the issue requires rewritten, the two retitled headings (## Install -&gt; ## Quickstart, ### Have your agent do it -&gt; details summary), and one &lt;br&gt;; added lines are the jump links, the Quickstart details wrapper, two horizontal rules, the animation lead-in and Under-the-hood refer-back, and the rewritten sentences. No content deleted. — commit `1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c` (2026-08-16T15:49:04Z)
- **anchors-and-links** — pass — `grep for intra-doc anchors vs headings; git ls-files on every relative link/image target` — Anchors #how-it-works, #quickstart, #known-issues-and-limitations each resolve to a present heading. docs/images/orch-overview.gif, docs/images/delivery-pipeline.gif, ORCH-PRD.md, LICENSE, and both adapter READMEs are tracked; both adapter READMEs carry the '## Install order' heading behind the #install-order fragments. Each animation is embedded exactly once. — commit `1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c` (2026-08-16T15:49:04Z)
- **acceptance-criterion-1** — satisfied — The orch-overview.gif img is at line 27, after the intro (16-20) and jump links (22), and the first install/quickstart content is ## Quickstart at line 67; delivery-pipeline.gif is at line 62 inside ## How it works (32-66), which precedes Quickstart. grep -c on each path returns exactly one occurrence, and the old embed at the former Delivery-pipeline subsection is replaced by a refer-back at lines 813-814. — commit `1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c` (2026-08-16T15:55:10Z)
- **acceptance-criterion-2** — satisfied — Line 22 ends the intro with the exact jump-links pattern; order top-to-bottom is intro, overview gif (27), How it works (32), Quickstart (67), then the remaining sections. Inside Quickstart the agent prompt sits in a details block (69-145) with a summary marking it recommended, 'Then initialize each repository you want orchestrated' follows at 147-167, and the 'Install it yourself' details block sits at 169-269 — the initialize guidance between the two blocks as required, with the tail order matching the objective heading for heading. — commit `1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c` (2026-08-16T15:55:10Z)
- **acceptance-criterion-3** — satisfied — A blank-stripped sorted line-set comparison (comm) shows the complete only-in-old set is the reflowed lines of the two mandated rewrites, the retitled '## Install' and '### Have your agent do it' headings, and one &lt;br&gt;; nothing else was removed. The word-diff shows the moved Status paragraphs and all seven 'What you actually get' bullets byte-identical after the move, and every directional cross-reference (Settings table below/above, upgrade commands above, pipeline described above) still resolves in the right direction. — commit `1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c` (2026-08-16T15:55:10Z)
- **acceptance-criterion-4** — satisfied — Step 7 (lines 139-142) now ends 'This command is the one per-repository workflow for both hosts' with the current-behavior clause surviving verbatim; in the Known-issues entry (497-512) the word-diff shows the deletion is exactly the 'Before, only Codex had... After,' framing and nothing more, the surviving text character-identical to the old post-'After' text. No current-behavior claim added or removed in either passage; the criterion's 'no factual claim removed' is read against current-behavior claims per the objective's own wording, since past-state claims necessarily go. — commit `1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c` (2026-08-16T15:55:10Z)
- **acceptance-criterion-5** — satisfied — The three intra-document anchors used (#quickstart, #how-it-works, #known-issues-and-limitations) each resolve to a present heading; git ls-files --error-unmatch confirms all six relative link/image targets tracked (LICENSE, ORCH-PRD.md, both adapter READMEs, both gifs), and both #install-order fragments resolve to a real '## Install order' heading in the adapter READMEs. — commit `1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c` (2026-08-16T15:55:10Z)
- **review-cycle-1** — approve — Approve. Scope is one commit touching README.md only (40 insertions, 35 deletions); go test ./... passes in the review worktree (23 packages ok) and all six required CI checks are green. All five acceptance criteria judged satisfied against direct observations: both animations sit before Quickstart and are embedded exactly once (overview at line 27 after the intro and jump links, pipeline gif at line 62 inside How it works, old Under-the-hood embed replaced by a refer-back); the section order matches the approved flow with the agent prompt and manual-install content in collapsible blocks bracketing the initialize guidance; a line-set comparison proves nothing was deleted beyond the two mandated rewrites, two retitled headings, and one &lt;br&gt;, with moved Status paragraphs and all seven What-you-actually-get bullets byte-identical, and every above/below cross-reference still pointing the right direction; the two before/after passages now state only current behavior with the surviving text character-identical to the old post-'After' text; all three intra-document anchors resolve to present headings and all six relative link/image targets are tracked, including the #install-order fragments in both adapter READMEs. Four non-blocking findings, none warranting a cycle: a missing &lt;br&gt; above the relocated pipeline animation (nit), the lead-in's 'then' connective reading slightly sequential after the five-step walkthrough (nit), Status's 'pipeline described above' now pointing back ~340 lines (low, position mandated by the objective), and both Quickstart paths collapsed by default (low, exactly the approved design). Manifest verifications were each re-run and reproduced. No security surface touched. — commit `1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c` (2026-08-16T15:55:10Z)
- **required-ci** — passing — lint=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass — commit `1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c` (2026-08-16T15:55:14Z)

<!-- orch:manifest:data
{
  "schema_version": 4,
  "objective": "README.md (the only file in scope) is factually accurate but ordered for contributors, not new users. Restructure it into this reading order, preserving all existing content: (1) title, tagline, badges as they are; (2) the existing intro paragraphs, ending with bold jump links in the pattern '**[Jump to Quickstart →](#quickstart)** · **[See how it works →](#how-it-works)**'; (3) the overview animation (docs/images/orch-overview.gif) with its existing alt text; (4) the 'How it works' section — the existing two-modes / six-roles / guard / five-step-walkthrough prose — which now also hosts the Delivery-pipeline animation (docs/images/delivery-pipeline.gif) with a one-line lead-in; the deeper pipeline prose stays in Under the hood, which should refer back to the animation above rather than embed it a second time; (5) a section named 'Quickstart' holding the current agent install prompt inside a collapsible details block with a summary line marking it as the recommended agent-driven path, followed by the existing 'Then initialize each repository' prose and the existing 'Install it yourself' details block; (6) 'What you actually get' after the Quickstart/How-it-works head of the document; (7) the remaining sections in this order: Day to day, Settings, Memhub integration, Status, Known issues, Fixed, Under the hood, License. Nothing is deleted: every bullet, table, known issue, fixed entry, and paragraph of the current README survives the restructure (retitling, reordering, and moving prose between sections is allowed). Two passages additionally get rewritten in present tense because they narrate a change as a PR-diff before/after: the final sentence of step 7 of the agent install prompt (beginning 'Before this change, the Codex instructions also allowed manually copying five TOMLs') and the before/after narration inside the Known-issues entry titled 'A model override does not reach a dispatched agent by itself'; each rewrite states only current behavior and neither adds nor removes a factual claim. Do not alter verified factual content: the orch help block, the settings table, the default-model table, the Fixed list entries, and the Known-issues facts are all correct as they stand.",
  "acceptance_criteria": [
    "Reading the restructured README top to bottom, the overview animation (docs/images/orch-overview.gif) appears after the opening intro and before any install or quickstart content, and the Delivery-pipeline animation (docs/images/delivery-pipeline.gif) appears inside the 'How it works' section, which itself precedes the Quickstart section; neither animation is embedded more than once in the document.",
    "The document's section order for a new user is: intro ending in jump links to Quickstart and How it works, the overview animation, How it works, Quickstart, then the remaining sections; the Quickstart section contains the agent install prompt inside a collapsible details block and the existing manual-install details block, and the 'Then initialize each repository' guidance sits between them.",
    "Every section of the pre-change README — What you actually get, How it works, Status, the install content, Day to day, Settings, Memhub integration, Known issues, Fixed, Under the hood, License — is still present in the restructured document with its content preserved: no bullet, table row, known-issues entry, fixed entry, or factual statement from the current README is deleted (retitling, reordering, and moving prose between sections is allowed).",
    "The final sentence of step 7 of the agent install prompt (currently beginning 'Before this change, the Codex instructions also allowed') and the before/after narration in the Known-issues entry 'A model override does not reach a dispatched agent by itself' are each rewritten to state only current behavior in present tense, with no factual claim added or removed anywhere in either passage.",
    "Every intra-document anchor link in the restructured README resolves to a heading present in the document, and every relative link and image path names a file tracked in the repository."
  ],
  "required_tests": [
    "go test ./..."
  ],
  "role": "implementer",
  "executor": {
    "model": "claude-opus-5",
    "effort": "medium"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "claude-opus-5",
    "effort": "high"
  },
  "effort_delivery": "prompt-cue",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "Run inside the issue worktree: all 23 packages ok, 4 report no test files, zero failures.",
      "commit_oid": "1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c",
      "at": "2026-08-16T15:49:04Z"
    },
    {
      "name": "branch-scope:content-preservation",
      "command": "git show HEAD:README.md | grep -v blank | sort, compared with comm against the new file; git diff --word-diff --ignore-all-space -- README.md; git diff --stat",
      "result": "pass",
      "detail": "Single commit touching README.md only (40 insertions, 35 deletions). Line-set comparison shows the only removed lines are the two passages the issue requires rewritten, the two retitled headings (## Install -\u003e ## Quickstart, ### Have your agent do it -\u003e details summary), and one \u003cbr\u003e; added lines are the jump links, the Quickstart details wrapper, two horizontal rules, the animation lead-in and Under-the-hood refer-back, and the rewritten sentences. No content deleted.",
      "commit_oid": "1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c",
      "at": "2026-08-16T15:49:04Z"
    },
    {
      "name": "anchors-and-links",
      "command": "grep for intra-doc anchors vs headings; git ls-files on every relative link/image target",
      "result": "pass",
      "detail": "Anchors #how-it-works, #quickstart, #known-issues-and-limitations each resolve to a present heading. docs/images/orch-overview.gif, docs/images/delivery-pipeline.gif, ORCH-PRD.md, LICENSE, and both adapter READMEs are tracked; both adapter READMEs carry the '## Install order' heading behind the #install-order fragments. Each animation is embedded exactly once.",
      "commit_oid": "1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c",
      "at": "2026-08-16T15:49:04Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "The orch-overview.gif img is at line 27, after the intro (16-20) and jump links (22), and the first install/quickstart content is ## Quickstart at line 67; delivery-pipeline.gif is at line 62 inside ## How it works (32-66), which precedes Quickstart. grep -c on each path returns exactly one occurrence, and the old embed at the former Delivery-pipeline subsection is replaced by a refer-back at lines 813-814.",
      "commit_oid": "1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c",
      "at": "2026-08-16T15:55:10Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "Line 22 ends the intro with the exact jump-links pattern; order top-to-bottom is intro, overview gif (27), How it works (32), Quickstart (67), then the remaining sections. Inside Quickstart the agent prompt sits in a details block (69-145) with a summary marking it recommended, 'Then initialize each repository you want orchestrated' follows at 147-167, and the 'Install it yourself' details block sits at 169-269 — the initialize guidance between the two blocks as required, with the tail order matching the objective heading for heading.",
      "commit_oid": "1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c",
      "at": "2026-08-16T15:55:10Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "A blank-stripped sorted line-set comparison (comm) shows the complete only-in-old set is the reflowed lines of the two mandated rewrites, the retitled '## Install' and '### Have your agent do it' headings, and one \u003cbr\u003e; nothing else was removed. The word-diff shows the moved Status paragraphs and all seven 'What you actually get' bullets byte-identical after the move, and every directional cross-reference (Settings table below/above, upgrade commands above, pipeline described above) still resolves in the right direction.",
      "commit_oid": "1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c",
      "at": "2026-08-16T15:55:10Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "Step 7 (lines 139-142) now ends 'This command is the one per-repository workflow for both hosts' with the current-behavior clause surviving verbatim; in the Known-issues entry (497-512) the word-diff shows the deletion is exactly the 'Before, only Codex had... After,' framing and nothing more, the surviving text character-identical to the old post-'After' text. No current-behavior claim added or removed in either passage; the criterion's 'no factual claim removed' is read against current-behavior claims per the objective's own wording, since past-state claims necessarily go.",
      "commit_oid": "1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c",
      "at": "2026-08-16T15:55:10Z"
    },
    {
      "name": "acceptance-criterion-5",
      "result": "satisfied",
      "detail": "The three intra-document anchors used (#quickstart, #how-it-works, #known-issues-and-limitations) each resolve to a present heading; git ls-files --error-unmatch confirms all six relative link/image targets tracked (LICENSE, ORCH-PRD.md, both adapter READMEs, both gifs), and both #install-order fragments resolve to a real '## Install order' heading in the adapter READMEs.",
      "commit_oid": "1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c",
      "at": "2026-08-16T15:55:10Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approve. Scope is one commit touching README.md only (40 insertions, 35 deletions); go test ./... passes in the review worktree (23 packages ok) and all six required CI checks are green. All five acceptance criteria judged satisfied against direct observations: both animations sit before Quickstart and are embedded exactly once (overview at line 27 after the intro and jump links, pipeline gif at line 62 inside How it works, old Under-the-hood embed replaced by a refer-back); the section order matches the approved flow with the agent prompt and manual-install content in collapsible blocks bracketing the initialize guidance; a line-set comparison proves nothing was deleted beyond the two mandated rewrites, two retitled headings, and one \u003cbr\u003e, with moved Status paragraphs and all seven What-you-actually-get bullets byte-identical, and every above/below cross-reference still pointing the right direction; the two before/after passages now state only current behavior with the surviving text character-identical to the old post-'After' text; all three intra-document anchors resolve to present headings and all six relative link/image targets are tracked, including the #install-order fragments in both adapter READMEs. Four non-blocking findings, none warranting a cycle: a missing \u003cbr\u003e above the relocated pipeline animation (nit), the lead-in's 'then' connective reading slightly sequential after the five-step walkthrough (nit), Status's 'pipeline described above' now pointing back ~340 lines (low, position mandated by the objective), and both Quickstart paths collapsed by default (low, exactly the approved design). Manifest verifications were each re-run and reproduced. No security surface touched.",
      "commit_oid": "1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c",
      "at": "2026-08-16T15:55:10Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "lint=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "1b7b6e662b60b6036707ccb2a4a2254c3db2fb7c",
      "at": "2026-08-16T15:55:14Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->