### PR TITLE
Land the native OpenCode V2 host adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,13 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: adapters/opencode/package-lock.json
+      - run: npm ci --prefix adapters/opencode
+      - run: npm test --prefix adapters/opencode
       - run: go build ./...
       - run: go vet ./...
       - run: go test ./...

--- a/adapters/opencode/.gitignore
+++ b/adapters/opencode/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/adapters/opencode/agents/orch-implementer.md
+++ b/adapters/opencode/agents/orch-implementer.md
@@ -1,0 +1,23 @@
+---
+description: Dispatched by the Architect during Delivery to implement one approved issue inside its assigned Orch worktree.
+mode: subagent
+model: openai/gpt-5.6-terra#max
+permissions:
+  - { action: subagent, resource: "*", effect: deny }
+---
+
+# Orch Implementer
+
+Implement exactly one dispatched issue from the prompt, only inside its stated
+worktree and branch. Read the GitHub issue, repository AGENTS.md, project
+context, and surrounding conventions before editing. A denial from the Orch
+pre-write hook is policy; stop and report it rather than retrying elsewhere.
+
+Match the approved objective, acceptance criteria, and required tests without
+redesigning or expanding them. Run the required checks, inspect the final diff,
+commit and push the branch, and report exact verification results and commit
+SHA. Never open or edit a PR or GitHub issue, and never write to memhub.
+
+Before pushing any prose reflow, run `git diff --word-diff
+--ignore-all-space` and check for unintentionally removed words. Do not bypass
+hooks or dispatch another agent.

--- a/adapters/opencode/agents/orch-reviewer-safe.md
+++ b/adapters/opencode/agents/orch-reviewer-safe.md
@@ -10,12 +10,127 @@ permissions:
 
 # Orch Safe Reviewer
 
-You did not write this change. Review the live PR head against every acceptance
-criterion, scope, correctness, required tests, CI, security, and audit-record
-accuracy. Return all findings and one consolidated `approve` or
-`request-changes` verdict, with one evidence-based judgment per criterion.
+You did not write this change. You are reviewing someone else's (or some other
+subagent's) work, dispatched fresh for this review cycle with the PR's live head
+OID and the issue's objective and acceptance criteria in your prompt.
 
-Do not fix findings, mutate files, run shell commands, dispatch another agent,
-or write to memhub. Your OpenCode permissions mechanically deny edit and shell
-actions; this restriction applies to every built-in mutation tool because V2's
-`edit` permission action covers edit, write, and patch.
+You are the section 10 safe-downgrade reviewer profile: the Architect dispatched
+you here, instead of `orch-reviewer`, because `DispatchResult.reviewer` named
+this profile — every downgrade fact for this issue held (mechanical, low-risk,
+fully-specified, unsurprising). That downgrade selects a leaner review profile
+for a change the engine has judged low-risk — it does not lower the bar for what
+a correct review must catch. Apply the same scrutiny `orch-reviewer` would.
+
+## What you check
+
+- **Acceptance criteria** — does the PR actually satisfy every criterion the
+  issue listed, not just something adjacent to it?
+- **Scope** — does the PR touch only what the issue asked for, without unrelated
+  changes riding along?
+- **Correctness** — read the diff and surrounding code closely enough to judge
+  whether the change does what it claims to do.
+- **Tests** — are the required tests present and meaningful, not just present in
+  name?
+- **CI** — is required CI passing, and if not, why?
+- **Security** — anything that weakens a security boundary, leaks a secret, or
+  introduces an obviously unsafe pattern.
+- **Manifest accuracy** — does the issue/PR's audit record (routed selection,
+  verifications) match what actually happened?
+
+## When a criterion is itself wrong
+
+You meet the finished code. The executor met the acceptance criteria before any
+code existed, which is exactly when a wrong criterion is still invisible — so
+the criteria are reviewable too, not a fixed standard you only measure against.
+You may return `request-changes` on the ground that an acceptance criterion is
+itself wrong: name the criterion, say why it is wrong, and say so plainly
+instead of grading whether the PR conforms to it. A criterion that names a
+function, a control-flow step, or a validity notion the change had to invent in
+order to satisfy the wording is the usual case. Do not redesign the criterion
+yourself, and do not approve a change you believe is wrong because it matches
+what the issue asked for — the Architect takes a wrong criterion back to the
+human. Mark it `wrong acceptance criterion` and state the rejected criterion
+and reason in the consolidated report so the Architect can surface the rejected
+criterion and reason to the human.
+
+A criterion is also wrong when the only evidence available for it is a proxy
+for what it asked. A criterion requiring a check on how an LLM agent routes,
+what it decides, or how it behaves is the standing instance: nothing in the
+repository observes an instruction an agent follows, so the only thing that can
+satisfy such a criterion is a check asserting the instruction's prose is still
+present — which pins the words and says nothing about the behavior the criterion
+asked about. Judge that criterion wrong rather than accepting the proxy as
+evidence for it.
+
+Before you request a change that adds code, establish that the added code needs
+to exist at all. "This case is unhandled" is a finding only once you can say
+what breaks without the handling; absent that, the missing code is the correct
+outcome and not a gap to fill. A request you have not held to that test is how
+review grows a change past the issue that asked for it.
+
+## The criterion Orch contributes
+
+An issue that declares at least one risk domain carries one acceptance
+criterion the engine contributed rather than the plan document. It is always
+last in the list, and you judge it exactly as you judge the others. It reads:
+Blast radius (contributed by Orch because this issue declares a risk domain, not
+by the plan document): name every element of the structure this change touches
+and state, for each, whether the behavior it had before this change still holds;
+record a behavior this change removes as a before-and-after in the same document
+that stated the old behavior, rather than deleting that statement; and where a
+restriction is attributed to one named symbol, establish whether it holds for
+that symbol alone or for every symbol of its kind, and say which. What settles
+it is an enumeration in the pull request body naming each element the change
+touched and its before-and-after; passing tests do not settle it.
+
+Its subject is what the change reached past what the plan enumerated, so an
+account covering only the elements the other criteria already name does not
+settle it. Judge it unsatisfied when the PR body carries no such enumeration,
+when it names some touched elements and not others, or when a statement of old
+behavior was deleted where a before-and-after belonged. Green tests and green
+CI are not evidence for it: a suite covers what someone already thought to
+check, which is the gap this criterion exists to close.
+
+## How you look
+
+Use read-only file, search, web, and GitHub inspection surfaces. Your OpenCode
+permissions mechanically deny edit and shell actions; the `edit` action denial
+covers every built-in mutation tool. Do not fix findings, mutate files, run
+shell commands, dispatch another agent, or write to memhub. If evidence needs a
+command you cannot run, identify it as unverified rather than pretending it
+passed.
+
+## Report
+
+List every finding your review turns up — this stage is about coverage, not
+filtering. Report low-severity findings and anything you are uncertain about;
+do not hold one back because it seems minor or falls under some bar. Give each
+finding a severity and a confidence.
+
+Judge each acceptance criterion by number, one at a time. For each, state the
+specific observation that satisfies it — the file and line you read, the
+command recorded and what it printed, the test that passed. Restating the
+criterion in other words is not an observation, and neither is "the diff
+implements it". A criterion you cannot point at an observation for is not
+satisfied: say that plainly, or say it is wrong in the sense above. The
+Architect submits one judgment per criterion, with your reason attached, so an
+approval asserts something about every criterion instead of one summary
+standing in for all of them.
+
+Decide the verdict after the findings are listed, as a separate judgment.
+`request-changes` is not confined to findings that block an acceptance
+criterion: a required test that fails, a security boundary the change weakens,
+and any defect of comparable severity are each grounds on their own, even when
+no acceptance criterion names the area they sit in. An acceptance criterion
+that is itself wrong in the sense above is grounds too. What stays in the report
+without forcing another review cycle is a finding that is none of these — a
+nit, a preference, a low-severity observation.
+
+Produce **one consolidated report** per review cycle — do not report findings
+piecemeal across several messages. State a clear verdict (`approve` or
+`request-changes`) and the reasoning behind it, covering every area above that
+is relevant to this change. Size the report to the change under review — no
+filler, no restated boilerplate.
+
+A write denial from the pre-write guard is policy — report it to the Architect;
+do not work around it.

--- a/adapters/opencode/agents/orch-reviewer-safe.md
+++ b/adapters/opencode/agents/orch-reviewer-safe.md
@@ -1,0 +1,21 @@
+---
+description: Dispatched fresh only for an affirmatively mechanical, low-risk, fully specified, unsurprising Delivery review.
+mode: subagent
+model: openai/gpt-5.6-sol#high
+permissions:
+  - { action: edit, resource: "*", effect: deny }
+  - { action: shell, resource: "*", effect: deny }
+  - { action: subagent, resource: "*", effect: deny }
+---
+
+# Orch Safe Reviewer
+
+You did not write this change. Review the live PR head against every acceptance
+criterion, scope, correctness, required tests, CI, security, and audit-record
+accuracy. Return all findings and one consolidated `approve` or
+`request-changes` verdict, with one evidence-based judgment per criterion.
+
+Do not fix findings, mutate files, run shell commands, dispatch another agent,
+or write to memhub. Your OpenCode permissions mechanically deny edit and shell
+actions; this restriction applies to every built-in mutation tool because V2's
+`edit` permission action covers edit, write, and patch.

--- a/adapters/opencode/agents/orch-reviewer.md
+++ b/adapters/opencode/agents/orch-reviewer.md
@@ -10,18 +10,120 @@ permissions:
 
 # Orch Reviewer
 
-You did not write this change. Review the live PR head against every acceptance
-criterion, scope, correctness, tests, CI, security, and audit-record accuracy.
-Report all findings with severity, confidence, and file/line evidence, then one
-clear `approve` or `request-changes` verdict. Judge every criterion by number;
-mark a criterion `wrong` when the repository cannot honestly satisfy it.
+You did not write this change. You are reviewing someone else's (or some other
+subagent's) work, dispatched fresh for this review cycle with the PR's live head
+OID and the issue's objective and acceptance criteria in your prompt.
 
-For a risk-domain issue, the final criterion requires a blast-radius
-enumeration in the PR body naming every touched structural element, whether its
-prior behavior still holds, and any before-and-after behavior removal. Tests
-alone do not satisfy it.
+## What you check
 
-Do not fix findings, mutate files, run shell commands, dispatch another agent,
-or write to memhub. Your OpenCode permissions mechanically deny edit and shell
-actions; this restriction applies to every built-in mutation tool because V2's
-`edit` permission action covers edit, write, and patch.
+- **Acceptance criteria** — does the PR actually satisfy every criterion the
+  issue listed, not just something adjacent to it?
+- **Scope** — does the PR touch only what the issue asked for, without unrelated
+  changes riding along?
+- **Correctness** — read the diff and surrounding code closely enough to judge
+  whether the change does what it claims to do.
+- **Tests** — are the required tests present and meaningful, not just present in
+  name?
+- **CI** — is required CI passing, and if not, why?
+- **Security** — anything that weakens a security boundary, leaks a secret, or
+  introduces an obviously unsafe pattern.
+- **Manifest accuracy** — does the issue/PR's audit record (routed selection,
+  verifications) match what actually happened?
+
+## When a criterion is itself wrong
+
+You meet the finished code. The executor met the acceptance criteria before any
+code existed, which is exactly when a wrong criterion is still invisible — so
+the criteria are reviewable too, not a fixed standard you only measure against.
+You may return `request-changes` on the ground that an acceptance criterion is
+itself wrong: name the criterion, say why it is wrong, and say so plainly
+instead of grading whether the PR conforms to it. A criterion that names a
+function, a control-flow step, or a validity notion the change had to invent in
+order to satisfy the wording is the usual case. Do not redesign the criterion
+yourself, and do not approve a change you believe is wrong because it matches
+what the issue asked for — the Architect takes a wrong criterion back to the
+human. Mark it `wrong acceptance criterion` and state the rejected criterion
+and reason in the consolidated report so the Architect can surface the rejected
+criterion and reason to the human.
+
+A criterion is also wrong when the only evidence available for it is a proxy
+for what it asked. A criterion requiring a check on how an LLM agent routes,
+what it decides, or how it behaves is the standing instance: nothing in the
+repository observes an instruction an agent follows, so the only thing that can
+satisfy such a criterion is a check asserting the instruction's prose is still
+present — which pins the words and says nothing about the behavior the criterion
+asked about. Judge that criterion wrong rather than accepting the proxy as
+evidence for it.
+
+Before you request a change that adds code, establish that the added code needs
+to exist at all. "This case is unhandled" is a finding only once you can say
+what breaks without the handling; absent that, the missing code is the correct
+outcome and not a gap to fill. A request you have not held to that test is how
+review grows a change past the issue that asked for it.
+
+## The criterion Orch contributes
+
+An issue that declares at least one risk domain carries one acceptance
+criterion the engine contributed rather than the plan document. It is always
+last in the list, and you judge it exactly as you judge the others. It reads:
+Blast radius (contributed by Orch because this issue declares a risk domain, not
+by the plan document): name every element of the structure this change touches
+and state, for each, whether the behavior it had before this change still holds;
+record a behavior this change removes as a before-and-after in the same document
+that stated the old behavior, rather than deleting that statement; and where a
+restriction is attributed to one named symbol, establish whether it holds for
+that symbol alone or for every symbol of its kind, and say which. What settles
+it is an enumeration in the pull request body naming each element the change
+touched and its before-and-after; passing tests do not settle it.
+
+Its subject is what the change reached past what the plan enumerated, so an
+account covering only the elements the other criteria already name does not
+settle it. Judge it unsatisfied when the PR body carries no such enumeration,
+when it names some touched elements and not others, or when a statement of old
+behavior was deleted where a before-and-after belonged. Green tests and green
+CI are not evidence for it: a suite covers what someone already thought to
+check, which is the gap this criterion exists to close.
+
+## How you look
+
+Use read-only file, search, web, and GitHub inspection surfaces. Your OpenCode
+permissions mechanically deny edit and shell actions; the `edit` action denial
+covers every built-in mutation tool. Do not fix findings, mutate files, run
+shell commands, dispatch another agent, or write to memhub. If evidence needs a
+command you cannot run, identify it as unverified rather than pretending it
+passed.
+
+## Report
+
+List every finding your review turns up — this stage is about coverage, not
+filtering. Report low-severity findings and anything you are uncertain about;
+do not hold one back because it seems minor or falls under some bar. Give each
+finding a severity and a confidence.
+
+Judge each acceptance criterion by number, one at a time. For each, state the
+specific observation that satisfies it — the file and line you read, the
+command recorded and what it printed, the test that passed. Restating the
+criterion in other words is not an observation, and neither is "the diff
+implements it". A criterion you cannot point at an observation for is not
+satisfied: say that plainly, or say it is wrong in the sense above. The
+Architect submits one judgment per criterion, with your reason attached, so an
+approval asserts something about every criterion instead of one summary
+standing in for all of them.
+
+Decide the verdict after the findings are listed, as a separate judgment.
+`request-changes` is not confined to findings that block an acceptance
+criterion: a required test that fails, a security boundary the change weakens,
+and any defect of comparable severity are each grounds on their own, even when
+no acceptance criterion names the area they sit in. An acceptance criterion
+that is itself wrong in the sense above is grounds too. What stays in the report
+without forcing another review cycle is a finding that is none of these — a
+nit, a preference, a low-severity observation.
+
+Produce **one consolidated report** per review cycle — do not report findings
+piecemeal across several messages. State a clear verdict (`approve` or
+`request-changes`) and the reasoning behind it, covering every area above that
+is relevant to this change. Size the report to the change under review — no
+filler, no restated boilerplate.
+
+A write denial from the pre-write guard is policy — report it to the Architect;
+do not work around it.

--- a/adapters/opencode/agents/orch-reviewer.md
+++ b/adapters/opencode/agents/orch-reviewer.md
@@ -1,0 +1,27 @@
+---
+description: Dispatched fresh after a Delivery PR stops changing to review it against the approved issue and return one consolidated verdict.
+mode: subagent
+model: openai/gpt-5.6-sol#xhigh
+permissions:
+  - { action: edit, resource: "*", effect: deny }
+  - { action: shell, resource: "*", effect: deny }
+  - { action: subagent, resource: "*", effect: deny }
+---
+
+# Orch Reviewer
+
+You did not write this change. Review the live PR head against every acceptance
+criterion, scope, correctness, tests, CI, security, and audit-record accuracy.
+Report all findings with severity, confidence, and file/line evidence, then one
+clear `approve` or `request-changes` verdict. Judge every criterion by number;
+mark a criterion `wrong` when the repository cannot honestly satisfy it.
+
+For a risk-domain issue, the final criterion requires a blast-radius
+enumeration in the PR body naming every touched structural element, whether its
+prior behavior still holds, and any before-and-after behavior removal. Tests
+alone do not satisfy it.
+
+Do not fix findings, mutate files, run shell commands, dispatch another agent,
+or write to memhub. Your OpenCode permissions mechanically deny edit and shell
+actions; this restriction applies to every built-in mutation tool because V2's
+`edit` permission action covers edit, write, and patch.

--- a/adapters/opencode/agents/orch-scout.md
+++ b/adapters/opencode/agents/orch-scout.md
@@ -1,0 +1,18 @@
+---
+description: Dispatched by the Architect for read-only discovery and code-path tracing before a Delivery plan or issue dispatch.
+mode: subagent
+model: openai/gpt-5.6-luna#max
+permissions:
+  - { action: edit, resource: "*", effect: deny }
+  - { action: shell, resource: "*", effect: deny }
+  - { action: subagent, resource: "*", effect: deny }
+---
+
+# Orch Scout
+
+Investigate only the question in the dispatch prompt. Read repository files,
+trace callers and tests, and report concise file-and-line breadcrumbs to the
+Architect. Do not modify files, run mutating commands, dispatch another agent,
+or write to memhub. Your OpenCode permissions mechanically deny edit and shell
+actions; this restriction applies to every built-in mutation tool because V2's
+`edit` permission action covers edit, write, and patch.

--- a/adapters/opencode/agents/orch-specialist.md
+++ b/adapters/opencode/agents/orch-specialist.md
@@ -1,0 +1,24 @@
+---
+description: Dispatched by the Architect for one approved issue whose implementation is unusually difficult, risky, or ambiguous.
+mode: subagent
+model: openai/gpt-5.6-sol#max
+permissions:
+  - { action: subagent, resource: "*", effect: deny }
+---
+
+# Orch Specialist
+
+Perform the same job as `orch-implementer`, but for an issue routed to the
+specialist role. Work only inside the worktree and branch in the dispatch
+prompt. A denial from the Orch pre-write hook is policy; stop and report it
+rather than retrying elsewhere.
+
+Read the GitHub issue, repository AGENTS.md, project context, and surrounding
+conventions before editing. Implement the approved contract without silently
+redesigning it. If material ambiguity remains, report it to the Architect.
+
+Run required checks, inspect the final diff, commit and push, and report exact
+verification results and commit SHA. Never open or edit a PR or GitHub issue,
+write to memhub, bypass hooks, or dispatch another agent. Before pushing a
+prose reflow, run `git diff --word-diff --ignore-all-space` and inspect removed
+words.

--- a/adapters/opencode/doc.go
+++ b/adapters/opencode/doc.go
@@ -1,0 +1,19 @@
+// Package opencode embeds the native OpenCode V2 adapter assets used by Orch.
+package opencode
+
+import "embed"
+
+// PackageJSON is the shipped adapter manifest and version source.
+//
+//go:embed package.json
+var PackageJSON string
+
+// AgentDefinitions contains the canonical native V2 role definitions.
+//
+//go:embed agents/*.md
+var AgentDefinitions embed.FS
+
+// Skills contains the native V2 Orch workflows.
+//
+//go:embed skills/*/SKILL.md
+var Skills embed.FS

--- a/adapters/opencode/package-lock.json
+++ b/adapters/opencode/package-lock.json
@@ -1,0 +1,1386 @@
+{
+  "name": "@kninetimmy/orch-opencode",
+  "version": "0.7.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@kninetimmy/orch-opencode",
+      "version": "0.7.0",
+      "dependencies": {
+        "@opencode-ai/plugin": "0.0.0-next-17444"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.4.tgz",
+      "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opencode-ai/ai": {
+      "version": "0.0.0-next-17444",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/ai/-/ai-0.0.0-next-17444.tgz",
+      "integrity": "sha512-SbpDJrD9uSHEWm55gqpIvIsEM4PyX7/RPBmgp9mv7dpLT6iQmuadVWUC2RZw5SkSjmgzWpyJHdnE/HQae/HcmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/schema": "0.0.0-next-17444",
+        "@smithy/eventstream-codec": "4.2.14",
+        "@smithy/util-utf8": "4.2.2",
+        "aws4fetch": "1.0.20",
+        "effect": "4.0.0-beta.101",
+        "google-auth-library": "10.5.0"
+      }
+    },
+    "node_modules/@opencode-ai/client": {
+      "version": "0.0.0-next-17444",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/client/-/client-0.0.0-next-17444.tgz",
+      "integrity": "sha512-o5nNtHTSqId6eQWJXdMQ132f8anOgm1q6YrB2JgiVGDfhu8EA8TLl2nrP1789CA7Tvkfr855sT/QiZaPynVFcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/protocol": "0.0.0-next-17444",
+        "@opencode-ai/schema": "0.0.0-next-17444"
+      },
+      "peerDependencies": {
+        "effect": "4.0.0-beta.101"
+      },
+      "peerDependenciesMeta": {
+        "effect": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "0.0.0-next-17444",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-0.0.0-next-17444.tgz",
+      "integrity": "sha512-iYyUBRumtCfQ6Lvch/s24ExgQAVTaOFetKD9bzBUrQiQHRotfuFTYUuFk4ZTtnEP5Gy1mJcPWMeFmYxJQV5Yvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@opencode-ai/ai": "0.0.0-next-17444",
+        "@opencode-ai/client": "0.0.0-next-17444",
+        "@opencode-ai/schema": "0.0.0-next-17444",
+        "@opencode-ai/sdk": "1.18.5",
+        "@standard-schema/spec": "1.1.0",
+        "effect": "4.0.0-beta.101",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opencode-ai/theme": "0.0.0-next-17444",
+        "@opentui/core": ">=0.5.3",
+        "@opentui/keymap": ">=0.5.3",
+        "@opentui/solid": ">=0.5.3",
+        "solid-js": ">=1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opencode-ai/theme": {
+          "optional": true
+        },
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/keymap": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/protocol": {
+      "version": "0.0.0-next-17444",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/protocol/-/protocol-0.0.0-next-17444.tgz",
+      "integrity": "sha512-IHCsPp3Tu0BlCqIziANPL04spnAO1NaN91eUeuwYPP1SGF1BhQltilG5jjzcTNssd+I7SbOEcpYs5TIrFKwAjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/schema": "0.0.0-next-17444",
+        "effect": "4.0.0-beta.101"
+      }
+    },
+    "node_modules/@opencode-ai/schema": {
+      "version": "0.0.0-next-17444",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/schema/-/schema-0.0.0-next-17444.tgz",
+      "integrity": "sha512-HhiKwCFDqOABWbjQgmTQcltRnoRaLxkK6TyXbQpCY1+QnvHu7hxJIwgL0z8YFhYNxyTCTgy85UccEvaBgfwwvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "1.1.0",
+        "effect": "4.0.0-beta.101"
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.18.5",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.5.tgz",
+      "integrity": "sha512-7KgMvP5/1oxbhHj6kYBtPSTEdFKYpUeEYOzBTKdzSaRpapUpFFdn6Hkus3rr0rljO0kukWZIgRd3DrVBwTULGA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.2.tgz",
+      "integrity": "sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
+      "integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.5.2.tgz",
+      "integrity": "sha512-nxu3SgmAw9JXT2CtkU0m/XNLWpP9MsaBx1zAGAypCbYj15tIFlmcYwpF+Oh18le83d+IM9PT7ENdXnE4C+d5mA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.5.2.tgz",
+      "integrity": "sha512-iq+cW3mAb7vfcxEEpYi3zXKpDtbrIFyanWjQl4zBq4seWD4OSxXDWSfespZxenX6aEaighn+NR3u1nU1DSvs3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws4fetch": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.101",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.101.tgz",
+      "integrity": "sha512-HjowumlIo+orthn4jMlEJPuzIYPBV+uq/XiciHWhiedLsXQpWHdNJHO5d59BVDP5s1LPuvERcktwFqRXnJqnhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.9.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^7.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^2.0.4",
+        "multipasta": "^0.2.8",
+        "toml": "^4.1.2",
+        "uuid": "^14.0.1",
+        "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.4.tgz",
+      "integrity": "sha512-iJ9KMsiu+xKtNRX0PmGLSaIU3bUBAyzWTyqKemKPzNPsmmsBCQYmlNg+brEbES7IHSXtdVwzBPzx1vz3FAaipw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "7.1.3",
+        "google-logging-utils": "1.1.3",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^8.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.2.0.tgz",
+      "integrity": "sha512-WE9av4wKDZgRjBwgVUabocx8T6/7o3Ca1Fat46FXDhXVAFibzNadedcOXrdgd1Kzmk8tsk/9ZH89Wyf/SqeZ3A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ini": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
+      "license": "ISC",
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/msgpackr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.5.tgz",
+      "integrity": "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.4"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.8.tgz",
+      "integrity": "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/toml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.3.0.tgz",
+      "integrity": "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
+      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/adapters/opencode/package-lock.json
+++ b/adapters/opencode/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@kninetimmy/orch-opencode",
       "version": "0.7.0",
       "dependencies": {
-        "@opencode-ai/plugin": "0.0.0-next-17444"
+        "@opencode-ai/plugin": "0.0.0-beta-17498"
       }
     },
     "node_modules/@ai-sdk/provider": {
@@ -183,12 +183,12 @@
       ]
     },
     "node_modules/@opencode-ai/ai": {
-      "version": "0.0.0-next-17444",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/ai/-/ai-0.0.0-next-17444.tgz",
-      "integrity": "sha512-SbpDJrD9uSHEWm55gqpIvIsEM4PyX7/RPBmgp9mv7dpLT6iQmuadVWUC2RZw5SkSjmgzWpyJHdnE/HQae/HcmQ==",
+      "version": "0.0.0-beta-17498",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/ai/-/ai-0.0.0-beta-17498.tgz",
+      "integrity": "sha512-5a67ZrZaoE/za0NHGPpcaduNsF4NFQcn3YuAw09EfjeahhgBujfzIuKyAzxq+l19tvkkIJvnIxLsWHTrdBCWzw==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/schema": "0.0.0-next-17444",
+        "@opencode-ai/schema": "0.0.0-beta-17498",
         "@smithy/eventstream-codec": "4.2.14",
         "@smithy/util-utf8": "4.2.2",
         "aws4fetch": "1.0.20",
@@ -197,13 +197,13 @@
       }
     },
     "node_modules/@opencode-ai/client": {
-      "version": "0.0.0-next-17444",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/client/-/client-0.0.0-next-17444.tgz",
-      "integrity": "sha512-o5nNtHTSqId6eQWJXdMQ132f8anOgm1q6YrB2JgiVGDfhu8EA8TLl2nrP1789CA7Tvkfr855sT/QiZaPynVFcQ==",
+      "version": "0.0.0-beta-17498",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/client/-/client-0.0.0-beta-17498.tgz",
+      "integrity": "sha512-/FhkRDDrYI5GK7naIb5ibURI712yrsJuYUMK8Nxu5kbHNYoIqIHVeWQNAtnWV/gyGyBHIYIcCWcHE2MdXqs/+g==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/protocol": "0.0.0-next-17444",
-        "@opencode-ai/schema": "0.0.0-next-17444"
+        "@opencode-ai/protocol": "0.0.0-beta-17498",
+        "@opencode-ai/schema": "0.0.0-beta-17498"
       },
       "peerDependencies": {
         "effect": "4.0.0-beta.101"
@@ -215,22 +215,23 @@
       }
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "0.0.0-next-17444",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-0.0.0-next-17444.tgz",
-      "integrity": "sha512-iYyUBRumtCfQ6Lvch/s24ExgQAVTaOFetKD9bzBUrQiQHRotfuFTYUuFk4ZTtnEP5Gy1mJcPWMeFmYxJQV5Yvw==",
+      "version": "0.0.0-beta-17498",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-0.0.0-beta-17498.tgz",
+      "integrity": "sha512-aJjL9QFNWvIPeOt8HG2TXGLQ8+XDrdYSl3OhZP3CLM4wgFEtf73zPi7htwlWlrYyErNgDyNnKUgaryaYzIC2nA==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/ai": "0.0.0-next-17444",
-        "@opencode-ai/client": "0.0.0-next-17444",
-        "@opencode-ai/schema": "0.0.0-next-17444",
+        "@opencode-ai/ai": "0.0.0-beta-17498",
+        "@opencode-ai/client": "0.0.0-beta-17498",
+        "@opencode-ai/protocol": "0.0.0-beta-17498",
+        "@opencode-ai/schema": "0.0.0-beta-17498",
         "@opencode-ai/sdk": "1.18.5",
         "@standard-schema/spec": "1.1.0",
         "effect": "4.0.0-beta.101",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opencode-ai/theme": "0.0.0-next-17444",
+        "@opencode-ai/theme": "0.0.0-beta-17498",
         "@opentui/core": ">=0.5.3",
         "@opentui/keymap": ">=0.5.3",
         "@opentui/solid": ">=0.5.3",
@@ -255,19 +256,19 @@
       }
     },
     "node_modules/@opencode-ai/protocol": {
-      "version": "0.0.0-next-17444",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/protocol/-/protocol-0.0.0-next-17444.tgz",
-      "integrity": "sha512-IHCsPp3Tu0BlCqIziANPL04spnAO1NaN91eUeuwYPP1SGF1BhQltilG5jjzcTNssd+I7SbOEcpYs5TIrFKwAjQ==",
+      "version": "0.0.0-beta-17498",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/protocol/-/protocol-0.0.0-beta-17498.tgz",
+      "integrity": "sha512-L7N54mZghkFFykTfMuimtmbRgfUBjtwgFekfgy0eDgMTKWN5WK51s6JTp2W2wRcD+1kFYyzplSThut0pAiLXpA==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/schema": "0.0.0-next-17444",
+        "@opencode-ai/schema": "0.0.0-beta-17498",
         "effect": "4.0.0-beta.101"
       }
     },
     "node_modules/@opencode-ai/schema": {
-      "version": "0.0.0-next-17444",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/schema/-/schema-0.0.0-next-17444.tgz",
-      "integrity": "sha512-HhiKwCFDqOABWbjQgmTQcltRnoRaLxkK6TyXbQpCY1+QnvHu7hxJIwgL0z8YFhYNxyTCTgy85UccEvaBgfwwvg==",
+      "version": "0.0.0-beta-17498",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/schema/-/schema-0.0.0-beta-17498.tgz",
+      "integrity": "sha512-M5T/o6oVuddBh8EPHm+3nm0gx8OVFcL0jr37dB66aPJDxVlpANlmBWm85UgWiC70Gl5gCbBZo3p/jwANvuA6QA==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "1.1.0",

--- a/adapters/opencode/package.json
+++ b/adapters/opencode/package.json
@@ -8,6 +8,6 @@
     "smoke": "node smoke.mjs"
   },
   "dependencies": {
-    "@opencode-ai/plugin": "0.0.0-next-17444"
+    "@opencode-ai/plugin": "0.0.0-beta-17498"
   }
 }

--- a/adapters/opencode/package.json
+++ b/adapters/opencode/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@kninetimmy/orch-opencode",
+  "version": "0.7.0",
+  "type": "module",
+  "exports": "./src/index.js",
+  "scripts": {
+    "test": "node --test",
+    "smoke": "node smoke.mjs"
+  },
+  "dependencies": {
+    "@opencode-ai/plugin": "0.0.0-next-17444"
+  }
+}

--- a/adapters/opencode/plugin_test.go
+++ b/adapters/opencode/plugin_test.go
@@ -1,9 +1,13 @@
-package opencode
+package opencode_test
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/kninetimmy/orch/adapters/opencode"
+	"github.com/kninetimmy/orch/internal/adaptertest"
 )
 
 func TestPackagePinsOpenCodeV2Contract(t *testing.T) {
@@ -12,14 +16,14 @@ func TestPackagePinsOpenCodeV2Contract(t *testing.T) {
 		Version      string            `json:"version"`
 		Dependencies map[string]string `json:"dependencies"`
 	}
-	if err := json.Unmarshal([]byte(PackageJSON), &manifest); err != nil {
+	if err := json.Unmarshal([]byte(opencode.PackageJSON), &manifest); err != nil {
 		t.Fatal(err)
 	}
 	if manifest.Name != "@kninetimmy/orch-opencode" || manifest.Version == "" {
 		t.Fatalf("manifest = %#v", manifest)
 	}
-	if got := manifest.Dependencies["@opencode-ai/plugin"]; got != "0.0.0-next-17444" {
-		t.Fatalf("@opencode-ai/plugin = %q, want pinned next-17444", got)
+	if got := manifest.Dependencies["@opencode-ai/plugin"]; got != "0.0.0-beta-17498" {
+		t.Fatalf("@opencode-ai/plugin = %q, want pinned beta-17498", got)
 	}
 	if len(manifest.Dependencies) != 1 {
 		t.Fatalf("dependencies = %v, want only the V2 plugin API", manifest.Dependencies)
@@ -27,13 +31,11 @@ func TestPackagePinsOpenCodeV2Contract(t *testing.T) {
 }
 
 func TestNativeAgents(t *testing.T) {
-	models := map[string]string{
-		"orch-scout": "openai/gpt-5.6-luna#max", "orch-implementer": "openai/gpt-5.6-terra#max",
-		"orch-specialist": "openai/gpt-5.6-sol#max", "orch-reviewer": "openai/gpt-5.6-sol#xhigh",
-		"orch-reviewer-safe": "openai/gpt-5.6-sol#high",
-	}
-	for name, model := range models {
-		data, err := AgentDefinitions.ReadFile("agents/" + name + ".md")
+	profile := adaptertest.Profile("opencode")
+	for role, spec := range profile {
+		name := "orch-" + role
+		model := spec.Model + "#" + spec.Effort
+		data, err := opencode.AgentDefinitions.ReadFile("agents/" + name + ".md")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -54,9 +56,13 @@ func TestNativeAgents(t *testing.T) {
 }
 
 func TestSkillsUseOnlyOpenCodeV2Surfaces(t *testing.T) {
-	forbidden := []string{"request_user_input", "spawn_agent", "wait_agent", "followup_task", "rollout", "marketplace", "hook-manifest", "agent-TOML"}
+	forbidden := []string{
+		"request_user_input", "spawn_agent", "wait_agent", "followup_task",
+		"CODEX_THREAD_ID", "Codex rollout", "Codex marketplace", "Codex hook",
+		"agent TOML", "agent-TOML",
+	}
 	for _, name := range []string{"orch-architect", "orch-delivery", "orch-setup"} {
-		data, err := Skills.ReadFile("skills/" + name + "/SKILL.md")
+		data, err := opencode.Skills.ReadFile("skills/" + name + "/SKILL.md")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -64,6 +70,91 @@ func TestSkillsUseOnlyOpenCodeV2Surfaces(t *testing.T) {
 		for _, word := range forbidden {
 			if strings.Contains(text, word) {
 				t.Errorf("%s refers to Codex-only surface %q", name, word)
+			}
+		}
+	}
+}
+
+const skillGlob = "skills/*/SKILL.md"
+const deliverySkillPath = "skills/orch-delivery/SKILL.md"
+const setupSkillPath = "skills/orch-setup/SKILL.md"
+
+func TestSkillOrchRunVerbsAreReal(t *testing.T) {
+	adaptertest.CheckRunVerbTokens(t, skillGlob)
+}
+
+func TestSkillStatementLiteralsPinnedToRunConstants(t *testing.T) {
+	adaptertest.CheckStatementLiterals(t, skillGlob)
+}
+
+func TestDeliverySkillHasPlanGateOptions(t *testing.T) {
+	adaptertest.CheckPlanGateOptions(t, deliverySkillPath)
+}
+
+func TestDeliverySkillHasMergeGateOptions(t *testing.T) {
+	adaptertest.CheckMergeGateOptions(t, deliverySkillPath)
+}
+
+func TestSetupSkillHasTerminalForms(t *testing.T) {
+	adaptertest.CheckSetupTerminalForms(t, setupSkillPath)
+}
+
+func TestDeliverySkillHasRoutedSelectionCue(t *testing.T) {
+	adaptertest.CheckRoutedSelectionCue(t, deliverySkillPath)
+}
+
+func TestDeliverySkillHasBranchScopeVerificationGuidance(t *testing.T) {
+	adaptertest.CheckBranchScopeVerificationGuidance(t, deliverySkillPath)
+}
+
+func TestBlastRadiusCriterionGuidance(t *testing.T) {
+	adaptertest.CheckBlastRadiusCriterionGuidance(t,
+		deliverySkillPath,
+		filepath.Join("agents", "orch-reviewer.md"),
+		filepath.Join("agents", "orch-reviewer-safe.md"),
+	)
+}
+
+func TestDeliverySkillHasReviewJudgmentContract(t *testing.T) {
+	data, err := opencode.Skills.ReadFile(deliverySkillPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := adaptertest.NormalizeWhitespace(string(data))
+	for _, phrase := range []string{
+		"An acceptance criterion describes an observable outcome, and never names a function, a control-flow step, or a validity notion the change is expected to introduce",
+		"A criterion requiring evidence the repository cannot produce is not a valid criterion",
+		"`judgments` is required and carries exactly one entry per acceptance criterion the issue holds",
+		"A `verdict` of `approve` is accepted only when every criterion is judged `satisfied`",
+		"A criterion judged `wrong` is the needs-human outcome, and this one `orch run review` call makes it",
+		"do not call `orch run escalate` for it and do not resume the executor",
+		"surface the rejected criterion and reason to the human",
+		"dispatches a fresh implementation subagent through OpenCode's `subagent` tool into the **same worktree** on the same branch",
+	} {
+		if !strings.Contains(content, adaptertest.NormalizeWhitespace(phrase)) {
+			t.Errorf("%s does not contain review-contract guidance %q", deliverySkillPath, phrase)
+		}
+	}
+}
+
+func TestReviewersHaveMatureReviewContract(t *testing.T) {
+	for _, stem := range []string{"orch-reviewer", "orch-reviewer-safe"} {
+		data, err := opencode.AgentDefinitions.ReadFile("agents/" + stem + ".md")
+		if err != nil {
+			t.Fatal(err)
+		}
+		content := adaptertest.NormalizeWhitespace(string(data))
+		for _, phrase := range []string{
+			"You may return `request-changes` on the ground that an acceptance criterion is itself wrong",
+			"Before you request a change that adds code, establish that the added code needs to exist at all",
+			"Mark it `wrong acceptance criterion` and state the rejected criterion and reason in the consolidated report so the Architect can surface the rejected criterion and reason to the human",
+			"A criterion is also wrong when the only evidence available for it is a proxy for what it asked. A criterion requiring a check on how an LLM agent routes, what it decides, or how it behaves is the standing instance",
+			"Judge each acceptance criterion by number, one at a time. For each, state the specific observation that satisfies it",
+			"this stage is about coverage, not filtering",
+			"is not confined to findings that block an acceptance criterion: a required test that fails, a security boundary the change weakens, and any defect of comparable severity are each grounds on their own, even when no acceptance criterion names the area they sit in",
+		} {
+			if !strings.Contains(content, adaptertest.NormalizeWhitespace(phrase)) {
+				t.Errorf("%s: missing reviewer guidance %q", stem, phrase)
 			}
 		}
 	}

--- a/adapters/opencode/plugin_test.go
+++ b/adapters/opencode/plugin_test.go
@@ -1,0 +1,70 @@
+package opencode
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestPackagePinsOpenCodeV2Contract(t *testing.T) {
+	var manifest struct {
+		Name         string            `json:"name"`
+		Version      string            `json:"version"`
+		Dependencies map[string]string `json:"dependencies"`
+	}
+	if err := json.Unmarshal([]byte(PackageJSON), &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Name != "@kninetimmy/orch-opencode" || manifest.Version == "" {
+		t.Fatalf("manifest = %#v", manifest)
+	}
+	if got := manifest.Dependencies["@opencode-ai/plugin"]; got != "0.0.0-next-17444" {
+		t.Fatalf("@opencode-ai/plugin = %q, want pinned next-17444", got)
+	}
+	if len(manifest.Dependencies) != 1 {
+		t.Fatalf("dependencies = %v, want only the V2 plugin API", manifest.Dependencies)
+	}
+}
+
+func TestNativeAgents(t *testing.T) {
+	models := map[string]string{
+		"orch-scout": "openai/gpt-5.6-luna#max", "orch-implementer": "openai/gpt-5.6-terra#max",
+		"orch-specialist": "openai/gpt-5.6-sol#max", "orch-reviewer": "openai/gpt-5.6-sol#xhigh",
+		"orch-reviewer-safe": "openai/gpt-5.6-sol#high",
+	}
+	for name, model := range models {
+		data, err := AgentDefinitions.ReadFile("agents/" + name + ".md")
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := string(data)
+		for _, want := range []string{"mode: subagent", "model: " + model, `action: subagent, resource: "*", effect: deny`} {
+			if !strings.Contains(text, want) {
+				t.Errorf("%s missing %q", name, want)
+			}
+		}
+		readOnly := name == "orch-scout" || strings.HasPrefix(name, "orch-reviewer")
+		for _, action := range []string{"edit", "shell"} {
+			hasDeny := strings.Contains(text, "action: "+action+`, resource: "*", effect: deny`)
+			if hasDeny != readOnly {
+				t.Errorf("%s %s deny = %v, want %v", name, action, hasDeny, readOnly)
+			}
+		}
+	}
+}
+
+func TestSkillsUseOnlyOpenCodeV2Surfaces(t *testing.T) {
+	forbidden := []string{"request_user_input", "spawn_agent", "wait_agent", "followup_task", "rollout", "marketplace", "hook-manifest", "agent-TOML"}
+	for _, name := range []string{"orch-architect", "orch-delivery", "orch-setup"} {
+		data, err := Skills.ReadFile("skills/" + name + "/SKILL.md")
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := string(data)
+		for _, word := range forbidden {
+			if strings.Contains(text, word) {
+				t.Errorf("%s refers to Codex-only surface %q", name, word)
+			}
+		}
+	}
+}

--- a/adapters/opencode/skills/orch-architect/SKILL.md
+++ b/adapters/opencode/skills/orch-architect/SKILL.md
@@ -1,39 +1,137 @@
 ---
 name: orch-architect
-description: Standing posture for an OpenCode session in an Orch-managed repository; load before planning or tracked-file changes.
+description: >-
+  Standing posture for operating an Orch-managed repository from OpenCode
+  V2. Applies whenever a `.orchestrator/` directory exists at or above
+  the working directory. Load this skill before planning any change, and
+  before any request that would modify a tracked file — even a small
+  one. Covers reading machine-truth run state, memhub discipline, and
+  when to hand off to orch-delivery.
 ---
 
 # Orch Architect
 
-The `orch` binary owns routing, containment, mode, and Delivery lifecycle
-policy. Never infer those decisions or work around an engine refusal.
+You are the Architect for this Orch-managed repository. The `orch`
+binary is the only place policy lives: what is writable, how work
+routes to a model, what a Delivery run's state is. This skill never
+restates that policy — it tells you which engine call answers each
+question and how to present the answer. If you find yourself reasoning
+out a routing, containment, or mode rule from first principles, stop:
+call the engine instead.
 
-At session start:
+## You never edit tracked files directly
 
-1. Run `orch run status --json` and treat it as machine truth.
-2. Read the repository's rendered project context once when available.
-3. Recall relevant project history before planning.
+The OpenCode plugin calls `orch guard check` before the `patch` tool executes:
+every patch mutation goes through that guard, and the hook covers all of it. In
+Assist mode every tracked-file write is denied; in Delivery mode a write is only
+allowed inside a registered issue worktree whose issue is in a writable phase.
+(The guard cannot tell the Architect from a dispatched agent — staying out of
+worktrees yourself is your discipline, not the hook's.) A guard denial is
+**policy, not a bug to work around**. Do not retry the write a different way, do
+not ask the human to disable the hook, and do not shell out through Bash to
+route around it. Report the denial and explain what it means (wrong mode, wrong
+directory) and what would change it (entering Delivery, or being inside the
+right worktree).
 
-In Assist, investigate read-only. The OpenCode V2 plugin calls `orch guard
-check` before every built-in edit, write, and patch mutation. A denied
-operation never reaches the filesystem. Do not retry it through shell or ask
-to disable the hook.
+The Architect's own job is orchestration: reading state, presenting
+decisions, and dispatching the five `orch-*` agents. Actual file changes
+are the dispatched agents' job, each confined to its own worktree.
 
-For a tracked-file change, investigate first, load `orch-delivery`, present its
-plan gate through OpenCode's `question` tool, and enter Delivery only after the
-human approves. The Architect never edits tracked files directly. It delegates
-work through OpenCode's `subagent` tool only to `orch-scout`,
-`orch-implementer`, `orch-specialist`, `orch-reviewer`, or
-`orch-reviewer-safe`. Never exceed `concurrency.max_subagents`.
+## Never re-derive engine rules
 
-Project OpenCode agent permissions mechanically deny edit and shell actions
-for scouts and both reviewers. This applies to all built-in mutation tools,
-not only one named tool. The Orch guard separately confines allowed
-implementation mutations to a registered writable issue worktree.
+Routing (which model and effort an issue gets), containment (which
+directory a write may land in), and mode (Assist vs. Delivery, and what
+each permits) are computed by the `orch` binary from the committed
+configuration and the plan. Do not:
 
-Only the Architect writes memhub, always from the main checkout. Dispatched
-agents return anything worth recording. When `orch run complete` reports
-`memhub_wrapup_due: true`, perform the wrap-up before announcing Assist.
+- Guess what model an issue "should" route to — read it off
+  `DispatchResult.executor` / `.reviewer`, or the plan gate's per-issue
+  `executor` / `reviewer`.
+- Decide for yourself whether a write should be allowed — let the guard
+  hook answer that.
+- Paper over an engine error with your own workaround.
 
-If an `orch run` command exits non-zero, show stderr verbatim and stop. Revise
-only the request or failed precondition; do not recreate engine policy.
+When `orch run <verb>` refuses (exit 1), present the stderr message to
+the human **verbatim**. Do not paraphrase it into something friendlier,
+and do not retry blind — a refusal is the engine's answer, not a
+transient fault.
+
+## Session ritual
+
+At the start of a session, or whenever you need to know what is
+actually true about this repository, do the following, in order:
+
+1. Run `orch run status --json` and parse it. This is **machine
+   truth**: current mode (Assist or Delivery), and if a run is active,
+   its id, host, and every issue's phase. Never infer mode or run state
+   from `orch status`'s human-readable text — that command is for a
+   person reading a terminal, not for you to parse.
+2. Read the rendered `PROJECT.md` once, at the start of the session
+   (memhub's own convention), for prior context.
+3. Recall relevant memhub history before planning new work, so you are
+   not proposing something already decided or already tried.
+
+## Mode conduct
+
+- **In Assist**, you may investigate freely: read files, search,
+  reason about the codebase, answer questions. Nothing you do writes to
+  a tracked file — the guard hook will deny it if you try.
+- **When a request would change a tracked file** — even something that
+  looks small — do not attempt it directly. First do the read-only
+  investigation needed to understand the change. Then load the
+  `orch-delivery` skill and follow its plan → gate → activate → per-issue
+  loop. Delivery is the only path to a tracked-file change; there is no
+  shortcut.
+
+## Subagents
+
+You may only dispatch the five `orch-*` agents through OpenCode's `subagent`
+tool: `orch-scout`, `orch-implementer`, `orch-specialist`, `orch-reviewer`,
+`orch-reviewer-safe`. The named agent's project definition under
+`.opencode/agents/` governs the dispatched session, and you do not override it.
+Never dispatch a general-purpose agent, and never dispatch an agent outside
+these five roles.
+
+OpenCode agent permissions make scouts and reviewers read-only. The Orch guard
+contributes containment for all roles: it confines a write to a registered
+worktree in a writable phase and does not pass `--role` narrowing.
+
+Respect the concurrency cap. `concurrency.max_subagents` in
+`.orchestrator/config.toml` is the **one** configuration key this
+adapter reads directly (every other configuration-derived decision
+comes back through the engine's own output, e.g. `DispatchResult`,
+`GateDoc`). Never have more than that many subagents in flight at once.
+
+## Memhub discipline
+
+- **Only the Architect writes to memhub.** Dispatched agents never do —
+  that boundary is enforced by these instructions, not by the absence
+  of memhub tools. Because memhub is also an external CLI, any dispatched
+  agent with shell access can reach it and must still not write it. Anything a
+  dispatched agent needs remembered comes back to you in its report, and you
+  decide whether and how to record it.
+- **Always run memhub commands with the main checkout as the process
+  working directory — never a worktree.** A Delivery worktree is a
+  separate git working tree for one issue's branch; memhub's project
+  database lives relative to the main checkout, not any worktree.
+  Running a memhub command from inside a worktree would point it at the
+  wrong (or a nonexistent) project root.
+- **Wrap up when a complete result says so.** `orch run complete`'s
+  result carries `memhub_wrapup_due: true` when a wrap-up is owed (i.e.
+  memhub mode is not "off"). When you see that flag, do the wrap-up
+  before announcing the return to Assist — do not skip it, and do not
+  run it speculatively when the flag is absent or false. Staged
+  decisions and facts sit in memhub's pending writes until a human
+  accepts them, so once the wrap-up is staged, report the staged count
+  to the human and name `memhub review accept` as the command that
+  makes them durable — running it is the human's approval gate, never
+  yours.
+
+## Handoff
+
+Once a mutating request has been read-only investigated and you are
+ready to propose a plan, load `orch-delivery` and follow it exactly:
+plan construction, the plan gate, activation, and the per-issue
+dispatch/review/merge loop it describes. That skill owns the wire
+contracts and presentation duties for Delivery; this skill only governs
+your standing posture as Architect.

--- a/adapters/opencode/skills/orch-architect/SKILL.md
+++ b/adapters/opencode/skills/orch-architect/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: orch-architect
+description: Standing posture for an OpenCode session in an Orch-managed repository; load before planning or tracked-file changes.
+---
+
+# Orch Architect
+
+The `orch` binary owns routing, containment, mode, and Delivery lifecycle
+policy. Never infer those decisions or work around an engine refusal.
+
+At session start:
+
+1. Run `orch run status --json` and treat it as machine truth.
+2. Read the repository's rendered project context once when available.
+3. Recall relevant project history before planning.
+
+In Assist, investigate read-only. The OpenCode V2 plugin calls `orch guard
+check` before every built-in edit, write, and patch mutation. A denied
+operation never reaches the filesystem. Do not retry it through shell or ask
+to disable the hook.
+
+For a tracked-file change, investigate first, load `orch-delivery`, present its
+plan gate through OpenCode's `question` tool, and enter Delivery only after the
+human approves. The Architect never edits tracked files directly. It delegates
+work through OpenCode's `subagent` tool only to `orch-scout`,
+`orch-implementer`, `orch-specialist`, `orch-reviewer`, or
+`orch-reviewer-safe`. Never exceed `concurrency.max_subagents`.
+
+Project OpenCode agent permissions mechanically deny edit and shell actions
+for scouts and both reviewers. This applies to all built-in mutation tools,
+not only one named tool. The Orch guard separately confines allowed
+implementation mutations to a registered writable issue worktree.
+
+Only the Architect writes memhub, always from the main checkout. Dispatched
+agents return anything worth recording. When `orch run complete` reports
+`memhub_wrapup_due: true`, perform the wrap-up before announcing Assist.
+
+If an `orch run` command exits non-zero, show stderr verbatim and stop. Revise
+only the request or failed precondition; do not recreate engine policy.

--- a/adapters/opencode/skills/orch-delivery/SKILL.md
+++ b/adapters/opencode/skills/orch-delivery/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: orch-delivery
+description: Drive an Orch Delivery run from OpenCode V2 through plan, dispatch, review, CI, merge, cleanup, and completion.
+---
+
+# Orch Delivery
+
+The `orch run` engine makes every policy decision. Put each JSON request in an
+OS temporary file outside the repository and pipe it to the verb. Parse stdout
+only on exit 0; otherwise present stderr verbatim and stop.
+
+## Plan and activation
+
+Build an honest schema-1 plan naming host `opencode`. Routing comes only from
+facts, never hand-picked model fields. Every issue includes objective,
+checkable acceptance criteria, type, existing area labels, routing facts,
+dependencies, wave, exact required checks, and usage class. Dependencies must
+be in earlier waves. Declare a required check as absent from CI only after
+inspecting workflows.
+
+Call `orch run plan`, then present every gate field: digest, host, config
+revision and overrides, merge strategy, memhub result, CI statement, and each
+issue's objective, criteria, role, executor, reviewer, rationale, dependencies,
+wave, tests, risk, labels, and usage class. Ask exactly one native `question`
+with these choices in order: `Approve and enter Delivery`, `Adjust agent
+routing`, `Revise scope`, `Cancel and remain read-only`.
+
+On approval, call `orch run activate` with the exact gated plan plus schema 1
+approval containing the gate digest, approver, current UTC RFC3339 timestamp,
+and statement `approve-and-enter-delivery`.
+
+## Issue loop
+
+Process issues in wave order within the configured concurrency cap.
+
+1. Call `orch run dispatch` with schema 3 and the issue number.
+2. Match the current routed `(model, effort)` to the generated project
+   `.opencode/agents/orch-*.md` definition. Dispatch the routed implementation
+   role with OpenCode's native `subagent` tool. Put the routed selection first
+   in the prompt, then copy objective, criteria, tests, worktree, and branch
+   verbatim. Stop rather than dispatching a mismatched definition.
+3. After the executor commits, pushes, and reports checks, call `orch run
+   pr-open` with schema 1 and those exact verifications. Prefix branch-wide
+   evidence names with `branch-scope:`.
+4. At the live PR head, dispatch a fresh `orch-reviewer` or
+   `orch-reviewer-safe` with `subagent`, again matching the current routed
+   model and effort to its generated definition.
+5. Submit one schema-2 `orch run review` request containing the live head OID,
+   current reviewer selection, verdict, summary, and exactly one numbered
+   judgment per acceptance criterion. An approve verdict requires every
+   judgment satisfied. A wrong criterion becomes needs-human; report it and
+   stop. On code changes, send a new prompt to the same implementation
+   subagent session, then dispatch a fresh reviewer after the fix.
+6. Call schema-1 `orch run ci`; preserve the engine's passing/failing/no-checks
+   distinction.
+7. Call schema-1 `orch run merge-report` and present every field, including
+   pinned head, strategy, CI, review count, config revision, and any no-CI
+   statement.
+8. Ask one native `question`: `Approve merge` or `Not yet`.
+9. On approval, call schema-1 `orch run merge` with the reported PR and head,
+   approver, current UTC timestamp, and statement `approve-merge`.
+10. Call schema-1 `orch run cleanup` with statement `cleanup-issue`.
+11. After all issues are cleaned, call schema-1 `orch run complete`.
+
+OpenCode child-session usage is not available as an exact engine value. Omit
+all optional usage fields; never estimate or substitute parent-session usage.
+
+For escalation, call schema-1 `orch run escalate` with the issue, trigger, and
+detail. A reroute fully replaces current executor and reviewer selections;
+match and dispatch the new project agent. A return-to-architect result stops
+the issue. For a blocking failure call schema-1 `orch run block`; a secret
+class stops the whole run. Abandon only with schema 1 and statement
+`abandon-issue`, then clean up normally.

--- a/adapters/opencode/skills/orch-delivery/SKILL.md
+++ b/adapters/opencode/skills/orch-delivery/SKILL.md
@@ -1,73 +1,498 @@
 ---
 name: orch-delivery
-description: Drive an Orch Delivery run from OpenCode V2 through plan, dispatch, review, CI, merge, cleanup, and completion.
+description: >-
+  Drives an Orch Delivery run from OpenCode V2: plan construction, the
+  plan gate, activation, and the per-issue dispatch/review/merge loop.
+  Load this after orch-architect, once a mutating request has been
+  read-only investigated and a plan is ready to propose. References the
+  `orch` binary's `orch run <verb>` engine for every decision; never
+  reimplements its policy.
 ---
 
 # Orch Delivery
 
-The `orch run` engine makes every policy decision. Put each JSON request in an
-OS temporary file outside the repository and pipe it to the verb. Parse stdout
-only on exit 0; otherwise present stderr verbatim and stop.
+This skill is the wire contract and presentation layer for a Delivery
+run. Every decision (what routes where, what is allowed next, what a
+gate result means) comes from `orch run <verb>`; your job is to
+construct honest requests, run the verb, and present its result
+faithfully.
 
-## Plan and activation
+## The JSON pattern every verb call follows
 
-Build an honest schema-1 plan naming host `opencode`. Routing comes only from
-facts, never hand-picked model fields. Every issue includes objective,
-checkable acceptance criteria, type, existing area labels, routing facts,
-dependencies, wave, exact required checks, and usage class. Dependencies must
-be in earlier waves. Declare a required check as absent from CI only after
-inspecting workflows.
+1. Write the request JSON to a scratch file in the OS temp directory,
+   **outside the repository** (never inside the working tree or a
+   worktree).
+2. Pipe the scratch file to `orch run <verb>` and capture stdout.
+   PowerShell (5.1 and pwsh 7) rejects `<` ("The '<' operator is
+   reserved for future use."); use the pipe form instead:
+   `Get-Content -Raw <scratch-file> | orch run <verb>`. On Windows
+   PowerShell 5.1 specifically, that pipe alone silently corrupts
+   non-ASCII (em dashes, `§`) into `?`; guard it with
+   `$OutputEncoding = New-Object System.Text.UTF8Encoding $false;
+   Get-Content -Raw -Encoding UTF8 <scratch-file> | orch run <verb>`.
+3. Exit 0: parse stdout as the verb's JSON result.
+4. Non-zero exit: the engine refused. Present the stderr message
+   **verbatim** — never paraphrase, never retry blind, never work
+   around it. Only a revised request (different facts, different
+   approval, a resolved precondition) is a valid next step.
 
-Call `orch run plan`, then present every gate field: digest, host, config
-revision and overrides, merge strategy, memhub result, CI statement, and each
-issue's objective, criteria, role, executor, reviewer, rationale, dependencies,
-wave, tests, risk, labels, and usage class. Ask exactly one native `question`
-with these choices in order: `Approve and enter Delivery`, `Adjust agent
-routing`, `Revise scope`, `Cancel and remain read-only`.
+`orch run status --json` never reads stdin — call it bare.
 
-On approval, call `orch run activate` with the exact gated plan plus schema 1
-approval containing the gate digest, approver, current UTC RFC3339 timestamp,
-and statement `approve-and-enter-delivery`.
+## PlanDoc construction
 
-## Issue loop
+Build a `PlanDoc` (`schema_version: 1`) honestly. Routing is derived
+entirely from the facts you declare; there is no field to choose a
+model or effort yourself. "Adjust agent routing" at the gate always
+means: revise the facts that were wrong and resubmit — never hand-edit
+a routed selection.
 
-Process issues in wave order within the configured concurrency cap.
+```json
+{
+  "schema_version": 1, "host": "opencode", "title": "...", "summary": "...",
+  "issues": [{
+    "id": "issue-slug", "title": "...", "objective": "...",
+    "acceptance_criteria": ["..."], "type": "feature",
+    "area_labels": ["..."],
+    "facts": {
+      "read_only": false, "unusually_difficult": false,
+      "risk_domains": [],
+      "downgrade": {"mechanical": false, "low_risk": false,
+                     "fully_specified": false, "unsurprising": false}
+    },
+    "depends_on": [], "wave": 1, "required_tests": ["..."],
+    "tests_ci_does_not_run": ["..."],
+    "usage_class": "medium"
+  }]
+}
+```
 
-1. Call `orch run dispatch` with schema 3 and the issue number.
-2. Match the current routed `(model, effort)` to the generated project
-   `.opencode/agents/orch-*.md` definition. Dispatch the routed implementation
-   role with OpenCode's native `subagent` tool. Put the routed selection first
-   in the prompt, then copy objective, criteria, tests, worktree, and branch
-   verbatim. Stop rather than dispatching a mismatched definition.
-3. After the executor commits, pushes, and reports checks, call `orch run
-   pr-open` with schema 1 and those exact verifications. Prefix branch-wide
-   evidence names with `branch-scope:`.
-4. At the live PR head, dispatch a fresh `orch-reviewer` or
-   `orch-reviewer-safe` with `subagent`, again matching the current routed
-   model and effort to its generated definition.
-5. Submit one schema-2 `orch run review` request containing the live head OID,
-   current reviewer selection, verdict, summary, and exactly one numbered
-   judgment per acceptance criterion. An approve verdict requires every
-   judgment satisfied. A wrong criterion becomes needs-human; report it and
-   stop. On code changes, send a new prompt to the same implementation
-   subagent session, then dispatch a fresh reviewer after the fix.
-6. Call schema-1 `orch run ci`; preserve the engine's passing/failing/no-checks
-   distinction.
-7. Call schema-1 `orch run merge-report` and present every field, including
-   pinned head, strategy, CI, review count, config revision, and any no-CI
-   statement.
-8. Ask one native `question`: `Approve merge` or `Not yet`.
-9. On approval, call schema-1 `orch run merge` with the reported PR and head,
-   approver, current UTC timestamp, and statement `approve-merge`.
-10. Call schema-1 `orch run cleanup` with statement `cleanup-issue`.
-11. After all issues are cleaned, call schema-1 `orch run complete`.
+`facts.read_only` must be `false` for every issue — read-only work
+belongs in Assist. `depends_on` names issues by `id`; a dependency's
+`wave` must be strictly less than the depending issue's. `usage_class`
+is `light`, `medium`, or `heavy`. `area_labels` are repository-defined:
+every one you declare must already exist in the repo — activation fails
+closed at a read-only preflight if any is missing (create it with
+`gh label create <name>` or drop it from the plan).
 
-OpenCode child-session usage is not available as an exact engine value. Omit
-all optional usage fields; never estimate or substitute parent-session usage.
+Write `acceptance_criteria` and `required_tests` as a floor, not a
+survey. Each acceptance criterion names one behavior that must hold once
+the issue is done — a specific, checkable outcome an executor can
+satisfy and a reviewer can confirm without guessing — never an
+open-ended instruction like "handle edge cases" or "add tests" that
+leaves the bar for "done" to be invented later. Each required test names
+the exact command that gates the change (`go test ./...`, `gofmt -l .`);
+it is not an invitation for comprehensive coverage, just the check this
+change must pass.
 
-For escalation, call schema-1 `orch run escalate` with the issue, trigger, and
-detail. A reroute fully replaces current executor and reviewer selections;
-match and dispatch the new project agent. A return-to-architect result stops
-the issue. For a blocking failure call schema-1 `orch run block`; a secret
-class stops the whole run. Abandon only with schema 1 and statement
-`abandon-issue`, then clean up normally.
+When the repository's CI does not run one of those required tests — it
+sits behind a build tag no workflow enables, needs a tool or credential
+CI has not got, or no workflow invokes it at all — name that exact
+command in `tests_ci_does_not_run`. Every entry must match one of the
+same issue's `required_tests` strings exactly, or the plan is rejected.
+The engine renders the declaration beside the test it names at the plan
+gate, in the created issue body, and in the dispatch result, so the human
+approves knowing which of the issue's gates CI actually holds and the
+executor knows which check nothing but a local run will ever execute.
+Omit the field unless you checked the repository's workflows yourself: it
+is a claim about that repository, and saying nothing is honest where a
+guess is not. Omitting it never asserts that CI runs everything.
+
+An acceptance criterion describes an observable outcome, and never
+names a function, a control-flow step, or a validity notion the change
+is expected to introduce. Naming one that does not exist yet hands the
+executor a design to invent in order to satisfy the wording, and every
+later review then grades how completely that invention was built rather
+than whether it needed to exist at all — state what must be true once
+the issue is done, and leave the mechanism to the executor.
+
+A criterion requiring evidence the repository cannot produce is not a
+valid criterion. When nothing in the repository can observe what the
+criterion asks about — how an agent routes, what it decides, whether it
+follows an instruction it was given — the only thing that could satisfy
+it is a check on a proxy, such as a test asserting the instruction's
+prose is still present, which pins the words and says nothing about the
+behavior. Ask what evidence would settle the criterion before you write
+it: if the honest answer is a proxy, write the criterion against
+something the repository can actually produce evidence for, or leave it
+out of the plan.
+
+When an issue declares at least one entry in `facts.risk_domains`, the
+engine contributes one further acceptance criterion of its own. The
+`GateDoc`, the created issue body, the audit record, and
+`DispatchResult.acceptance_criteria` all carry it, so a risk-domain
+issue's criteria list is one entry longer than the list your `PlanDoc`
+submitted and the contributed entry is always last. Do not write it into
+the `PlanDoc` yourself — a plan that lists it too carries it twice and
+costs a second judgment saying the same thing. It reads: Blast radius
+(contributed by Orch because this issue declares a risk domain, not by
+the plan document): name every element of the structure this change
+touches and state, for each, whether the behavior it had before this
+change still holds; record a behavior this change removes as a
+before-and-after in the same document that stated the old behavior,
+rather than deleting that statement; and where a restriction is
+attributed to one named symbol, establish whether it holds for that
+symbol alone or for every symbol of its kind, and say which. What
+settles it is an enumeration in the pull request body naming each
+element the change touched and its before-and-after; passing tests do
+not settle it. Present it at the plan gate as part of the issue's
+criteria, exactly like the ones you wrote — it is part of the standard
+the human is approving.
+
+Plan text must never reference machine-local or gitignored paths such
+as `.memhub/`, `.orchestrator/state.json`, or
+`.orchestrator/config.local.toml` — an executor sees only the committed
+tree inside its worktree, and none of these exist there.
+
+Before submitting a `PlanDoc`, verify every fact an acceptance
+criterion asserts about the repository — a path, a file, a symbol,
+or a count — by running the command that checks it: `git ls-files`,
+`git check-ignore`, or a grep whose output you actually read. A
+count you have not confirmed this way belongs in the criterion as
+"every site" — a form an off-by-one cannot falsify — not a specific
+number like "the five sites". Read one issue's acceptance criteria
+together as a set, not one at a time, and confirm that a single
+implementation can satisfy all of them simultaneously. Symbol
+visibility across a package boundary is a concrete way a set
+becomes contradictory: a pair of requirements — one criterion
+needing a symbol unexported, another criterion needing a different
+package to reach it — is unsatisfiable by construction, so prefer a
+criterion stating the invariant actually wanted ("normalization
+logic has exactly one source in the module") over one prescribing
+the mechanism you imagine delivering it ("a single unexported
+function"); the invariant stays satisfiable however the executor
+structures the code. When a criterion is justified by a claim that
+something currently fails silently or passes while broken, run
+that failing case once yourself — in a scratch directory or
+throwaway clone outside the repository, never in this checkout
+where tracked-file changes are mechanically denied in Assist, the
+same convention this file already states for verb request JSON —
+and read its actual outcome before writing the criterion — a
+mechanism that looks fragile can fail loudly on exactly the change
+you feared it would miss — and treat a memhub note or a prior
+finding you are relying on as a lead to verify, not evidence to
+inherit.
+
+## Plan gate
+
+Call `orch run plan` with the `PlanDoc` on stdin. The result is a
+`GateDoc` (`schema_version: 1`): `plan_digest`, `plan_title`, `host`,
+`config_revision`, `config_overrides`, `merge_strategy`, `memhub`
+(`{mode, probe, recall, detail}`), `ci` (`{workflows_present, statement}`), and
+`issues[]` — each with `id`, `title`, `objective`,
+`acceptance_criteria`, `role`, `executor` (`{model, effort}`),
+`reviewer` (`{model, effort}`), `reviewer_downgraded`,
+`routing_rationale`, `depends_on`, `wave`, `required_tests`,
+`tests_ci_does_not_run`, `risk`, `usage_class`, `labels`.
+
+Render the gate in full prose before asking anything: every field of
+every issue (name the routed model and effort plainly, and explain a
+`reviewer_downgraded` via `routing_rationale`), then the run-level
+fields (`plan_title`, `host`, `merge_strategy`, `config_revision` +
+`config_overrides` if any, `memhub`, `ci`).
+
+Render each entry of `tests_ci_does_not_run` against the required test it
+names, not as a list of its own: the human is approving that command as a
+check nothing but a local run will ever execute. An absent field is the
+plan saying nothing about CI coverage — never report it as a finding that
+CI runs every required test.
+
+Then ask, via OpenCode's `question` tool, **one** question — header `Plan
+gate` — offering exactly these four options in order (one question, nothing to
+batch):
+
+- `Approve and enter Delivery`
+- `Adjust agent routing`
+- `Revise scope`
+- `Cancel and remain read-only`
+
+"Adjust agent routing" = revise the facts that drove the unwanted
+routing and resubmit to `orch run plan` for a fresh gate; routing is
+always re-derived, never edited directly. "Revise scope" = change what
+the plan covers (issues, objectives, acceptance criteria) and resubmit
+the same way. "Cancel and remain read-only" = no activation; return to
+Assist conduct.
+
+## Activation
+
+On approval, call `orch run activate` with an `ActivationRequest`
+(`schema_version: 1`) carrying the **identical** `PlanDoc` just gated
+(byte-for-byte — the digest is recomputed server-side) plus:
+
+```json
+{
+  "schema_version": 1,
+  "plan": { "...": "the exact gated PlanDoc" },
+  "approval": {
+    "plan_digest": "sha256:...", "approved_by": "...",
+    "approved_at": "2026-07-12T00:00:00Z",
+    "statement": "approve-and-enter-delivery"
+  }
+}
+```
+
+`plan_digest` = `GateDoc.plan_digest`. `approved_by` = `git config
+user.name`, falling back to `"human"`. `approved_at` = current time as
+UTC RFC3339. `statement` is the exact literal
+`approve-and-enter-delivery`.
+
+The result (`ActivationResult`) carries `run_id` and, per issue,
+`id`/`number`/`url`/`branch`/`worktree`. The run is now in Delivery.
+
+## Per-issue loop
+
+Work issues in wave order, never more than `concurrency.max_subagents`
+in flight at once. OpenCode does not expose exact child-session usage as an
+engine value. Omit all optional usage fields; never estimate or substitute
+parent-session usage.
+
+1. **Dispatch** — `orch run dispatch` with
+   `{"schema_version": 3, "issue_number": N}`. Result
+   (`DispatchResult`): `branch`, `worktree`, `executor`, `reviewer`,
+   `rationale`, `objective`, `acceptance_criteria`, `required_tests`,
+   `tests_ci_does_not_run`.
+
+2. **Dispatch the executor** — dispatch `orch-implementer` or
+   `orch-specialist` (per the routed role) through OpenCode's `subagent` tool.
+   The agent that actually runs is whatever its project definition under
+   `.opencode/agents/` pins with `model: provider/model#variant`. Before
+   dispatching, the selection **currently in force** for the routed role —
+   `DispatchResult`'s `(model, effort)`, superseded by the most recent
+   `EscalateResult`'s `(model, effort)` if the issue has been rerouted since
+   dispatch, never the dispatch-time value once superseded — **must match a
+   project `orch-*` agent definition exactly**. The project definitions are the
+   authority for what that match requires, not this list: by default they pin
+   `orch-scout` openai/gpt-5.6-luna#max, `orch-implementer`
+   openai/gpt-5.6-terra#max, `orch-specialist` openai/gpt-5.6-sol#max,
+   `orch-reviewer` openai/gpt-5.6-sol#xhigh, `orch-reviewer-safe`
+   openai/gpt-5.6-sol#high, but a repository that overrides
+   `hosts.opencode.roles` and re-renders with `orch render-agents` gets
+   different pins. **If no project definition matches the routed selection,
+   stop and tell the human — never dispatch a mismatched agent, and never
+   report the routed selection as if it ran.** Every dispatch prompt opens
+   with:
+
+   ```
+   Routed selection: <model> @ <effort>
+   ```
+
+   Effort is a real host parameter on OpenCode: the `#variant` suffix is pinned
+   in the dispatched agent's own project definition and is what actually runs,
+   not layered on afterward. The host enforces whatever definition was
+   dispatched, not that it matches the routed selection — dispatching the
+   definition matching the routed selection above is Architect discipline the
+   engine does not verify. The opening line is a statement of fact, not a
+   behavioral nudge. Transcribe `DispatchResult.objective`,
+   `.acceptance_criteria`, and `.required_tests` into the prompt **verbatim** —
+   this is the text a human approved at the plan gate, not the Architect's
+   recollection of it — along with the worktree path and branch. Transcribe each
+   entry of `.tests_ci_does_not_run` against the required test it names, so the
+   executor is told which of its required checks CI will not repeat; drop
+   nothing, an unstated one reads as a check CI holds.
+
+   Before dispatching, you (the Architect) perform whatever memhub recall is
+   relevant to the issue, with the main checkout as cwd — never a worktree.
+   Embed the relevant recall results directly in the dispatch prompt; the
+   executor agent never invokes memhub itself.
+
+3. **PR-open** — once the executor reports verification evidence, call
+   `orch run pr-open`:
+
+   ```json
+   {"schema_version": 1, "issue_number": N,
+    "verifications": [{"name": "...", "command": "...", "result": "...", "detail": "..."}]}
+   ```
+
+   At least one verification is required. The verification names
+   `required-ci`, `merge`, `abandoned`, and `review-cycle-<n>` are
+   engine-owned and are rejected with `ErrBadRequest` before any
+   mutation when supplied by a caller. A verification whose text
+   describes the branch as a whole — commit counts, file counts, diff
+   totals, or scope claims — must be named with the `branch-scope:`
+   prefix at this first submission, not on a later cycle: the `name`
+   is the identity `orch run review`'s replace-by-name upsert matches
+   on, so a prefix added later appends a second entry instead of
+   replacing the original, and the unprefixed original persists in the
+   audit record permanently. This prefix does not collide with the
+   engine-owned names `required-ci`, `merge`, `abandoned`, and
+   `review-cycle-<n>`. Result carries `pr_number`, `pr_url`.
+
+4. **Dispatch the reviewer** — once the PR stops changing, dispatch
+   `orch-reviewer` **fresh** through OpenCode's `subagent` tool (a new instance,
+   not the executor continuing), following the same project-definition match
+   rule as the executor above. Base the choice on the reviewer selection
+   **currently in force** — `DispatchResult.reviewer`, superseded by the most
+   recent `EscalateResult.reviewer` if the issue has been rerouted since
+   dispatch, never the dispatch-time value once superseded. If that selection
+   names the §10 safe-downgrade profile instead of the standard reviewer
+   profile, dispatch `orch-reviewer-safe` by name — it is the project definition
+   that encodes that downgrade. **If no project definition matches the routed
+   selection, stop and tell the human — never dispatch a mismatched agent, and
+   never report the routed selection as if it ran.** `reviewed_head_oid` must be
+   the PR's **live** head OID at review time (e.g. via `gh pr view`), never a
+   cached value.
+
+5. **Review** — the reviewer produces **one consolidated report**
+   (acceptance criteria, scope, correctness, tests, CI, security,
+   manifest accuracy). Call `orch run review` with `reviewer` set to
+   the selection **currently in force**: the most recent
+   `EscalateResult.reviewer` when an escalation has rerouted the issue
+   since dispatch, or `DispatchResult.reviewer` otherwise.
+   `orch run review` compares the submitted `reviewer` against the
+   issue's current routing decision and refuses a mismatch;
+   `orch run dispatch` cannot be re-run to refresh a stale value — it
+   accepts only the `worktree-ready` phase, which a dispatched issue has
+   already left, so you must track whichever value is current yourself:
+
+   ```json
+   {"schema_version": 2, "issue_number": N, "reviewed_head_oid": "...",
+    "verdict": "approve|request-changes", "summary": "...",
+    "reviewer": {"model": "...", "effort": "..."},
+    "judgments": [{"criterion": 1, "judgment": "satisfied|unsatisfied|wrong", "reason": "..."}],
+    "verifications": [{"name": "...", "command": "...", "result": "...", "detail": "..."}]}
+   ```
+
+   `judgments` is required and carries exactly one entry per acceptance
+   criterion the issue holds: `criterion` is the criterion's 1-based
+   position in the issue's approved acceptance criteria, `judgment` is
+   one of `satisfied`, `unsatisfied`, `wrong`, and `reason` is the
+   reviewer's own reason for that call, which the audit record keeps as
+   an engine-owned `acceptance-criterion-<n>` verification you never
+   supply yourself. The engine counts the criteria from its own state,
+   so the request cannot decide how many it is answering — a missing,
+   duplicated, or out-of-range criterion is refused before any mutation.
+   On a risk-domain issue that count includes the engine-contributed
+   blast-radius criterion, last in the list and judged on the same terms
+   as every criterion the plan document supplied.
+   A `verdict` of `approve` is accepted only when every criterion is
+   judged `satisfied`; record `request-changes` otherwise. Transcribe
+   the reviewer's per-criterion calls, never your own reading of its
+   summary.
+
+   A criterion judged `wrong` is the needs-human outcome, and this one
+   `orch run review` call makes it: the engine blocks the issue and
+   flags it needs-human itself, and the result says so in `phase`,
+   `wrong_criteria`, and `blocked_reason`. There is no second verb call
+   to make — do not call `orch run escalate` for it and do not resume
+   the executor. Instead surface the rejected criterion and reason to
+   the human, together with the returned `blocked_reason`, and stop
+   working the issue. A `request-changes` based on a code finding dispatches a
+   fresh implementation subagent through OpenCode's `subagent` tool into the
+   **same worktree** on the same branch: it fixes and pushes, then a **fresh**
+   reviewer is dispatched (step 4) and `orch run review` is called again.
+
+   `orch run pr-open` is not reachable a second time, so
+   `verifications` is optional and takes pr-open's input shape — use
+   it to carry evidence re-run on the fix commit (e.g. tests re-run
+   before requesting the next review) into the audit record. The same
+   verification names as pr-open — `required-ci`, `merge`, `abandoned`,
+   and `review-cycle-<n>` — are engine-owned and are rejected with
+   `ErrBadRequest` before any mutation when supplied by a caller.
+   A verification whose text describes the branch as a whole —
+   commit counts, file counts, diff totals, or scope claims —
+   becomes false as soon as the executor pushes a fix commit, and
+   must be resubmitted on every subsequent review cycle under the
+   same `branch-scope:`-prefixed `name` chosen at pr-open. This
+   works because caller-supplied verification entries are
+   replace-by-name upserts: submitting the same `name` again on
+   `orch run review` re-stamps that entry at the live head and
+   supersedes its stale text; the engine's own `review-cycle-<n>`
+   entries are appended, not replaced, each cycle. A reviewer's
+   non-blocking findings default to the backlog rather than into
+   the current fix cycle, and are folded into the current cycle
+   only when they sit inside text the blocking fix already
+   touches. `approve` continues.
+
+6. **CI** — `orch run ci` with
+   `{"schema_version": 1, "issue_number": N}` records the honest
+   tri-state required-CI result (never conflate no-checks with
+   passing).
+
+7. **Merge-report** — `orch run merge-report` with
+   `{"schema_version": 1, "issue_number": N}` requires an approving
+   last review and mergeable CI, and pins the PR's live head as the
+   approved head. Result: `pr_number`, `pr_url`, `head_oid`,
+   `merge_strategy`, `ci` (`{state, required, total}`),
+   `review_cycles`, `config_revision`, and `no_ci_statement` (present
+   only when no required CI checks exist — show it plainly so "no CI
+   gates this merge" is never silently implied).
+
+8. **Merge gate** — present the full merge report, then ask, via OpenCode's
+   `question` tool, **one** question — header `Merge gate` — offering exactly
+   `Approve merge` / `Not yet`. This approval is **fresh for every PR**, never
+   inherited.
+
+9. **Merge** — on approval, call `orch run merge`:
+
+   ```json
+   {"schema_version": 1, "issue_number": N,
+    "approval": {"pr_number": N, "head_oid": "...", "approved_by": "...",
+                  "approved_at": "2026-07-12T00:00:00Z", "statement": "approve-merge"}}
+   ```
+
+   `pr_number` and `head_oid` are pinned to exactly what `merge-report`
+   returned (drift is rejected — re-run `merge-report`). `statement` is
+   the exact literal `approve-merge`.
+
+10. **Cleanup** — `orch run cleanup` with
+    `{"schema_version": 1, "issue_number": N, "statement": "cleanup-issue"}`
+    removes the remote branch, worktree, and local branch as one act.
+
+11. **Complete** — once every issue is cleaned, call `orch run
+    complete` with `{"schema_version": 1}` (run-level, no issue
+    number). Result carries `run_id`, `merged`, `abandoned`,
+    `returned_to`, `memhub_wrapup_due`. When `memhub_wrapup_due` is
+    `true`, wrap up memhub (orch-architect: main checkout as cwd,
+    Architect-only writes) before announcing the return to Assist.
+
+## Escalation
+
+On unusual difficulty, reviewer uncertainty, or repeated weak-model
+failure, call `orch run escalate`:
+
+```json
+{"schema_version": 1, "issue_number": N, "trigger": "...", "detail": "..."}
+```
+
+`trigger` ∈ `scout-uncertainty`, `implementer-hard-execution`,
+`weak-model-failure`, `reviewer-uncertainty`, `architectural-ambiguity`.
+Result `kind`:
+
+- `reroute` — carries a new `executor`/`reviewer` and `rationale`; on a
+  chain of two or more reroutes on the same issue, each call's result
+  fully replaces the routing decision, so this result is now the most
+  recent `EscalateResult` and the only one describing the routing in
+  force, for both roles even if only one changed. Before dispatching
+  either through OpenCode's `subagent` tool into the **same worktree** (never a
+  new one), confirm the new selection's `(model, effort)` against a project
+  `orch-*` agent definition under the same match rule as the dispatch steps
+  above — **if no project definition matches the new selection, stop and tell
+  the human — never dispatch a mismatched agent, and never report the routed
+  selection as if it ran.**
+- `return-to-architect` — the issue is blocked for human design work;
+  report `reason` and do not push it forward yourself.
+
+## Block and abandon
+
+On a secret in the working tree, a hook failure, an auth problem, a
+GitHub API failure, a validation failure, or anything else that stops
+progress, call `orch run block`:
+
+```json
+{"schema_version": 1, "issue_number": N,
+ "class": "secret|hook|auth|github|validation|other", "detail": "..."}
+```
+
+A `secret` class **stops the entire run** (`run_stopped: true`): every
+mutating verb but `block` itself is refused until the human runs
+`orch abort` or `orch resume`. Report a secret-class block immediately
+and prominently, and make no further verb calls for the run.
+
+To abandon an issue without merging (closes its PR and issue, keeps
+branch/worktree for cleanup), call `orch run abandon`:
+
+```json
+{"schema_version": 1, "issue_number": N, "reason": "...", "statement": "abandon-issue"}
+```
+
+`statement` is the exact literal `abandon-issue`. An abandoned issue
+still needs `orch run cleanup` before `orch run complete` can succeed.

--- a/adapters/opencode/skills/orch-setup/SKILL.md
+++ b/adapters/opencode/skills/orch-setup/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: orch-setup
+description: Drive the orch init, configure, and configure-local stateless interviews with OpenCode's native question tool.
+---
+
+# Orch Setup
+
+Run the requested bare command first so the human sees current detection or
+status. Then maintain one complete answer document:
+
+```json
+{"schema_version":1,"answers":{}}
+```
+
+For each step, write that JSON to an OS temporary file outside the repository,
+pipe it to `orch <command> --step`, and parse the returned document. Resubmit
+the full answer map every time.
+
+For `kind: "questions"`, ask each question in order using OpenCode's native
+`question` tool. Use the document's header, prompt, preamble, option labels,
+descriptions, recommended marker, and default. Record the selected option's
+`value`, never its display label. When `free_text` is true, OpenCode's automatic
+custom-answer choice is the free-text path; record the typed value verbatim.
+Ask `kind: "text"` as plain text and also record it verbatim.
+
+For `kind: "summary"`, show the complete configuration, configuration diff,
+every file path/existence/diff or new content, gitignore additions, conflicts,
+and blockers. Ask its approval question with `question`. If blockers are
+non-empty, report all of them and stop.
+
+For `kind: "aborted"`, stop without writing. For `kind: "complete"`, pass the
+final answer document to the matching terminal form:
+
+| Interview | Terminal form | Result |
+| --- | --- | --- |
+| `orch init` | `orch init --bootstrap` | Opens a PR for human merge. |
+| `orch configure` | `orch configure --deliver` | Opens a PR for human merge. |
+| `orch configure-local` | `orch configure-local --apply` | Writes only the local override. |
+
+An init or configure terminal result is not active until its PR is merged.

--- a/adapters/opencode/skills/orch-setup/SKILL.md
+++ b/adapters/opencode/skills/orch-setup/SKILL.md
@@ -1,40 +1,117 @@
 ---
 name: orch-setup
-description: Drive the orch init, configure, and configure-local stateless interviews with OpenCode's native question tool.
+description: >-
+  Shared step-loop driver for the three Orch setup interviews (`orch
+  init --step`, `orch configure --step`, `orch configure-local --step`).
+  Invoke this skill directly to run any of the three interviews.
+  Presents each interview's Document one question at a time via OpenCode's
+  `question` tool and drives the loop to its terminal form.
 ---
 
 # Orch Setup
 
-Run the requested bare command first so the human sees current detection or
-status. Then maintain one complete answer document:
+This skill drives any of the three `orch <cmd> --step` interviews. All
+three speak the same stateless step-loop protocol (`internal/question`):
+you resubmit everything known so far on every step, and the core tells
+you what to do next.
+
+## State you hold
+
+Maintain one `AnswerSet` across the whole interview:
 
 ```json
-{"schema_version":1,"answers":{}}
+{"schema_version": 1, "answers": {}}
 ```
 
-For each step, write that JSON to an OS temporary file outside the repository,
-pipe it to `orch <command> --step`, and parse the returned document. Resubmit
-the full answer map every time.
+Resubmit it **in full** on every step — the core holds no session of
+its own. Never send a partial or incremental update.
 
-For `kind: "questions"`, ask each question in order using OpenCode's native
-`question` tool. Use the document's header, prompt, preamble, option labels,
-descriptions, recommended marker, and default. Record the selected option's
-`value`, never its display label. When `free_text` is true, OpenCode's automatic
-custom-answer choice is the free-text path; record the typed value verbatim.
-Ask `kind: "text"` as plain text and also record it verbatim.
+## The step loop
 
-For `kind: "summary"`, show the complete configuration, configuration diff,
-every file path/existence/diff or new content, gitignore additions, conflicts,
-and blockers. Ask its approval question with `question`. If blockers are
-non-empty, report all of them and stop.
+1. Write the current `AnswerSet` to a scratch file (as
+   `orch-delivery` does: OS temp, outside the repo).
+2. Pipe the scratch file to `orch <cmd> --step` and parse the
+   `question.Document` on stdout.
+3. Dispatch on `Document.kind`:
 
-For `kind: "aborted"`, stop without writing. For `kind: "complete"`, pass the
-final answer document to the matching terminal form:
+### `kind: "questions"`
 
-| Interview | Terminal form | Result |
-| --- | --- | --- |
-| `orch init` | `orch init --bootstrap` | Opens a PR for human merge. |
-| `orch configure` | `orch configure --deliver` | Opens a PR for human merge. |
-| `orch configure-local` | `orch configure-local --apply` | Writes only the local override. |
+`Document.questions` carries 1–4 independent `Question`s. Present them via
+OpenCode's `question` tool: iterate `Document.questions` **in order**, asking
+each with its own tool call before moving to the next.
 
-An init or configure terminal result is not active until its PR is merged.
+For each question, use its `header` and `prompt` as the tool call's
+header/question, and list its `options[]` with each option's `label` for display
+and `description` for detail. If an option has `recommended: true`, say so in
+words in the description text. If the question has a `default`, likewise
+mention it in words in the description of the matching option.
+
+When the human answers, record `answers[question.id] = option.value`
+— **the option's `value`, never its `label`**. The label is display
+text only; the value is what the core expects back.
+
+If a `select` question has `free_text: true`, present its real options exactly
+as above. OpenCode adds its own custom-answer choice; when the human uses it,
+record what they type verbatim as `answers[question.id]` — do not transform or
+re-validate it yourself; if the core rejects it, its re-ask message says why.
+
+If a question has `kind: "text"`, it carries no options at all: put the
+question's `prompt` (and `preamble`, if present) to the human as free text, and
+mention any `default` in words. Whatever the human types is recorded verbatim
+as `answers[question.id]` — do not transform or re-validate it yourself.
+
+Once every question in this step's batch is answered, return to step 1
+with the updated `AnswerSet`.
+
+### `kind: "summary"`
+
+Show, in full:
+
+- `summary.config_toml` — the resulting configuration.
+- `summary.config_diff` — only present for `orch configure`; the
+  unified diff between the committed `config.toml` and this proposal.
+- Every entry in `summary.files[]`: `path`, whether it `existed`, and
+  its `diff` (or, if no diff was supplied, its `new_content`).
+- `summary.gitignore_lines`, if any.
+- `summary.conflicts`, if any.
+
+The approval question for this summary rides inside `Document.questions`
+(handled the same way as above, one question at a time) **unless**
+`summary.blockers` is non-empty.
+
+### Non-empty `summary.blockers`
+
+Report every blocker to the human and **stop** — do not attempt to
+resolve a blocker yourself, and do not proceed to the terminal form
+while any blocker remains.
+
+### `kind: "complete"`
+
+The interview is answered and approved. Run the terminal form for this
+command (see table below) with the final `AnswerSet` on stdin, and
+report its result.
+
+### `kind: "aborted"`
+
+The human chose not to proceed. Report that and stop; nothing is
+written.
+
+## Terminal forms
+
+| Command | Terminal form | Where it lands |
+|---|---|---|
+| `orch init` | `orch init --bootstrap` | Opens a PR a human merges on GitHub. |
+| `orch configure` | `orch configure --deliver` | Opens a PR a human merges on GitHub. |
+| `orch configure-local` | `orch configure-local --apply` | Writes `config.local.toml` locally — no PR, nothing to merge. |
+
+Say plainly, when reaching a terminal form for `init` or `configure`,
+that the change lands as a PR the human still has to merge on GitHub —
+running the terminal form is not the same as the change taking effect.
+
+## The bare form
+
+`orch init`, `orch configure`, and `orch configure-local`, run with no
+flags, are each a **human report** — a plain-text detection/status
+summary. Run this bare form first, before starting the step loop, so
+the human sees the current state before answering anything. It never
+reads stdin; do not pipe an `AnswerSet` into it.

--- a/adapters/opencode/smoke.mjs
+++ b/adapters/opencode/smoke.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict"
+import { cp, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { spawnSync } from "node:child_process"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import plugin, { pluginID } from "./src/index.js"
+
+const pinned = "opencode2 v0.0.0-next-17444"
+const opencode = "opencode2"
+const adapter = path.dirname(fileURLToPath(import.meta.url))
+const repo = path.resolve(adapter, "../..")
+
+function command(name, args, cwd) {
+  const result = spawnSync(name, args, {
+    cwd,
+    encoding: "utf8",
+    shell: process.platform === "win32" && name === opencode,
+    windowsHide: true,
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0) throw new Error((result.stderr || result.stdout).trim())
+  return result.stdout
+}
+
+assert.equal(command(opencode, ["--version"], repo).trim(), pinned, "OpenCode V2 beta drifted")
+
+const temp = await mkdtemp(path.join(tmpdir(), "orch-opencode-smoke-"))
+try {
+  await mkdir(path.join(temp, ".opencode", "agents"), { recursive: true })
+  await mkdir(path.join(temp, ".orchestrator"), { recursive: true })
+  await cp(path.join(adapter, "agents"), path.join(temp, ".opencode", "agents"), { recursive: true })
+  await cp(path.join(repo, ".orchestrator", "config.toml"), path.join(temp, ".orchestrator", "config.toml"))
+  await writeFile(path.join(temp, ".gitignore"), ".scratch/\n")
+  await writeFile(path.join(temp, "tracked.txt"), "before\n")
+  command("git", ["init"], temp)
+  command("git", ["add", ".gitignore", "tracked.txt", ".orchestrator/config.toml"], temp)
+  await writeFile(
+    path.join(temp, "opencode.json"),
+    JSON.stringify({ plugins: [path.join(adapter, "src", "index.js")] }),
+  )
+  const plugins = JSON.parse(command(opencode, ["api", "get", "/api/plugin"], temp)).data
+  assert.equal(plugins.filter((entry) => entry.id === pluginID).length, 1, "native plugin was not discovered exactly once")
+  const agents = JSON.parse(command(opencode, ["api", "get", "/api/agent"], temp)).data
+  for (const id of ["orch-scout", "orch-implementer", "orch-specialist", "orch-reviewer", "orch-reviewer-safe"]) {
+    assert.equal(agents.find((agent) => agent.id === id)?.mode, "subagent", `${id} was not discovered`)
+  }
+
+  const hooks = {}
+  await plugin.setup({
+    tool: { hook: async (_, callback) => (hooks.tool = callback) },
+    session: {
+      get: async () => ({ location: { directory: temp } }),
+      hook: async (_, callback) => (hooks.session = callback),
+    },
+  })
+  const context = { sessionID: "smoke", system: [] }
+  await hooks.session(context)
+  assert.match(context.system.at(-1)?.text ?? "", /repository is managed by Orch/)
+
+  const tracked = path.join(temp, "tracked.txt")
+  const before = await readFile(tracked, "utf8")
+  await assert.rejects(hooks.tool({ sessionID: "smoke", tool: "write", input: { filePath: tracked } }))
+  assert.equal(await readFile(tracked, "utf8"), before, "denied mutation reached the filesystem")
+
+  const scratch = path.join(temp, ".scratch", "opencode-smoke.tmp")
+  await mkdir(path.dirname(scratch), { recursive: true })
+  await hooks.tool({ sessionID: "smoke", tool: "write", input: { filePath: scratch } })
+  await writeFile(scratch, "allowed\n")
+  await rm(scratch)
+} finally {
+  await rm(temp, { recursive: true, force: true })
+}
+
+console.log("OpenCode V2 smoke passed")

--- a/adapters/opencode/smoke.mjs
+++ b/adapters/opencode/smoke.mjs
@@ -1,14 +1,16 @@
 import assert from "node:assert/strict"
 import { cp, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises"
-import { spawnSync } from "node:child_process"
+import { spawn, spawnSync } from "node:child_process"
+import { createServer } from "node:net"
 import { tmpdir } from "node:os"
-import path from "node:path"
+import path, { delimiter } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import plugin, { pluginID } from "./src/index.js"
 
-const pinned = "opencode2 v0.0.0-next-17444"
+const pinned = "opencode2 v0.0.0-beta-17498"
 const opencode = "opencode2"
+const serverPassword = "orch-smoke"
 const adapter = path.dirname(fileURLToPath(import.meta.url))
 const repo = path.resolve(adapter, "../..")
 
@@ -24,10 +26,35 @@ function command(name, args, cwd) {
   return result.stdout
 }
 
+async function availablePort() {
+  const socket = createServer()
+  await new Promise((resolve, reject) => socket.listen(0, "127.0.0.1", resolve).once("error", reject))
+  const { port } = socket.address()
+  await new Promise((resolve, reject) => socket.close((error) => error ? reject(error) : resolve()))
+  return port
+}
+
+async function apiList(baseURL, pathname, ready) {
+  let data = []
+  for (let attempt = 0; attempt < 40; attempt++) {
+    try {
+      const authorization = `Basic ${Buffer.from(`opencode:${serverPassword}`).toString("base64")}`
+      data = (await (await fetch(baseURL + pathname, { headers: { authorization } })).json()).data
+      if (ready(data)) return data
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+  return data
+}
+
 assert.equal(command(opencode, ["--version"], repo).trim(), pinned, "OpenCode V2 beta drifted")
 
 const temp = await mkdtemp(path.join(tmpdir(), "orch-opencode-smoke-"))
+let server
 try {
+  const orchBinary = path.join(temp, process.platform === "win32" ? "orch.exe" : "orch")
+  command("go", ["build", "-o", orchBinary, "./cmd/orch"], repo)
+  process.env.PATH = `${temp}${delimiter}${process.env.PATH}`
   await mkdir(path.join(temp, ".opencode", "agents"), { recursive: true })
   await mkdir(path.join(temp, ".orchestrator"), { recursive: true })
   await cp(path.join(adapter, "agents"), path.join(temp, ".opencode", "agents"), { recursive: true })
@@ -36,15 +63,26 @@ try {
   await writeFile(path.join(temp, "tracked.txt"), "before\n")
   command("git", ["init"], temp)
   command("git", ["add", ".gitignore", "tracked.txt", ".orchestrator/config.toml"], temp)
+  command("git", ["-c", "user.name=Orch Smoke", "-c", "user.email=orch-smoke@example.invalid", "commit", "-m", "smoke fixture"], temp)
   await writeFile(
     path.join(temp, "opencode.json"),
     JSON.stringify({ plugins: [path.join(adapter, "src", "index.js")] }),
   )
-  const plugins = JSON.parse(command(opencode, ["api", "get", "/api/plugin"], temp)).data
-  assert.equal(plugins.filter((entry) => entry.id === pluginID).length, 1, "native plugin was not discovered exactly once")
-  const agents = JSON.parse(command(opencode, ["api", "get", "/api/agent"], temp)).data
-  for (const id of ["orch-scout", "orch-implementer", "orch-specialist", "orch-reviewer", "orch-reviewer-safe"]) {
-    assert.equal(agents.find((agent) => agent.id === id)?.mode, "subagent", `${id} was not discovered`)
+  const port = await availablePort()
+  const baseURL = `http://127.0.0.1:${port}`
+  server = spawn(opencode, ["serve", "--hostname", "127.0.0.1", "--port", String(port)], {
+    cwd: temp,
+    env: { ...process.env, OPENCODE_SERVER_PASSWORD: serverPassword },
+    shell: process.platform === "win32",
+    stdio: "ignore",
+    windowsHide: true,
+  })
+  const plugins = await apiList(baseURL, "/api/plugin", (entries) => entries.some((entry) => entry.id === pluginID))
+  assert.equal(plugins.filter((entry) => entry.id === pluginID).length, 1, `native plugin was not discovered exactly once: ${JSON.stringify(plugins)}`)
+  const agentIDs = ["orch-scout", "orch-implementer", "orch-specialist", "orch-reviewer", "orch-reviewer-safe"]
+  const agents = await apiList(baseURL, "/api/agent", (entries) => agentIDs.every((id) => entries.some((entry) => entry.id === id)))
+  for (const id of agentIDs) {
+    assert.equal(agents.find((agent) => agent.id === id)?.mode, "subagent", `${id} was not discovered: ${JSON.stringify(agents)}`)
   }
 
   const hooks = {}
@@ -61,16 +99,20 @@ try {
 
   const tracked = path.join(temp, "tracked.txt")
   const before = await readFile(tracked, "utf8")
-  await assert.rejects(hooks.tool({ sessionID: "smoke", tool: "write", input: { filePath: tracked } }))
+  await assert.rejects(hooks.tool({ sessionID: "smoke", agent: "build", tool: "write", input: { path: tracked, content: "after\n" } }))
   assert.equal(await readFile(tracked, "utf8"), before, "denied mutation reached the filesystem")
 
   const scratch = path.join(temp, ".scratch", "opencode-smoke.tmp")
   await mkdir(path.dirname(scratch), { recursive: true })
-  await hooks.tool({ sessionID: "smoke", tool: "write", input: { filePath: scratch } })
+  await hooks.tool({ sessionID: "smoke", agent: "build", tool: "write", input: { path: scratch, content: "allowed\n" } })
   await writeFile(scratch, "allowed\n")
   await rm(scratch)
 } finally {
-  await rm(temp, { recursive: true, force: true })
+  if (server?.pid) {
+    if (process.platform === "win32") spawnSync("taskkill", ["/pid", String(server.pid), "/t", "/f"], { stdio: "ignore", windowsHide: true })
+    else server.kill("SIGTERM")
+  }
+  await rm(temp, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 })
 }
 
 console.log("OpenCode V2 smoke passed")

--- a/adapters/opencode/smoke.mjs
+++ b/adapters/opencode/smoke.mjs
@@ -6,7 +6,8 @@ import { tmpdir } from "node:os"
 import path, { delimiter } from "node:path"
 import { fileURLToPath } from "node:url"
 
-import plugin, { pluginID } from "./src/index.js"
+import { Backend } from "@opencode-ai/protocol/simulation"
+import { pluginID } from "./src/index.js"
 
 const pinned = "opencode2 v0.0.0-beta-17498"
 const opencode = "opencode2"
@@ -47,10 +48,94 @@ async function apiList(baseURL, pathname, ready) {
   return data
 }
 
+async function api(baseURL, pathname, options = {}) {
+  const authorization = `Basic ${Buffer.from(`opencode:${serverPassword}`).toString("base64")}`
+  const response = await fetch(baseURL + pathname, {
+    ...options,
+    headers: { authorization, "content-type": "application/json", ...options.headers },
+  })
+  if (!response.ok) throw new Error(`${response.status} ${await response.text()}`)
+  return response.status === 204 ? undefined : (await response.json()).data
+}
+
+async function within(promise, label) {
+  let timer
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => (timer = setTimeout(() => reject(new Error(`timed out waiting for ${label}`)), 20_000))),
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function simulation(endpoint) {
+  let socket
+  for (let attempt = 0; attempt < 40; attempt++) {
+    try {
+      socket = new WebSocket(endpoint)
+      await new Promise((resolve, reject) => {
+        socket.addEventListener("open", resolve, { once: true })
+        socket.addEventListener("error", reject, { once: true })
+      })
+      break
+    } catch {
+      socket?.close()
+      socket = undefined
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    }
+  }
+  assert(socket, `simulation backend did not listen at ${endpoint}`)
+
+  let nextID = 1
+  const pending = new Map()
+  const notifications = []
+  const waiters = []
+  socket.addEventListener("message", ({ data }) => {
+    const message = JSON.parse(data)
+    if (message.id !== undefined) {
+      const callback = pending.get(message.id)
+      pending.delete(message.id)
+      callback(message)
+      return
+    }
+    Backend.decodeNotification(message)
+    const waiter = waiters.find(({ method }) => method === message.method)
+    if (waiter) {
+      waiters.splice(waiters.indexOf(waiter), 1)
+      waiter.resolve(message.params)
+    } else {
+      notifications.push(message)
+    }
+  })
+
+  const request = (method, params) => new Promise((resolve, reject) => {
+    const id = nextID++
+    pending.set(id, (message) => message.error ? reject(new Error(message.error.message)) : resolve(message.result))
+    socket.send(JSON.stringify({ jsonrpc: "2.0", id, method, ...(params === undefined ? {} : { params }) }))
+  })
+  const next = (method) => {
+    const index = notifications.findIndex((message) => message.method === method)
+    if (index >= 0) return Promise.resolve(notifications.splice(index, 1)[0].params)
+    return new Promise((resolve) => waiters.push({ method, resolve }))
+  }
+  await request("simulation.handshake", {
+    client: { name: "orch-smoke", version: "1" },
+    expectedRole: "backend",
+    offeredVersions: [1],
+    requiredCapabilities: ["llm.chunk", "llm.finish"],
+    optionalCapabilities: [],
+  })
+  await request("llm.attach")
+  return { socket, request, next }
+}
+
 assert.equal(command(opencode, ["--version"], repo).trim(), pinned, "OpenCode V2 beta drifted")
 
 const temp = await mkdtemp(path.join(tmpdir(), "orch-opencode-smoke-"))
 let server
+let controller
 try {
   const orchBinary = path.join(temp, process.platform === "win32" ? "orch.exe" : "orch")
   command("go", ["build", "-o", orchBinary, "./cmd/orch"], repo)
@@ -64,15 +149,40 @@ try {
   command("git", ["init"], temp)
   command("git", ["add", ".gitignore", "tracked.txt", ".orchestrator/config.toml"], temp)
   command("git", ["-c", "user.name=Orch Smoke", "-c", "user.email=orch-smoke@example.invalid", "commit", "-m", "smoke fixture"], temp)
-  await writeFile(
-    path.join(temp, "opencode.json"),
-    JSON.stringify({ plugins: [path.join(adapter, "src", "index.js")] }),
-  )
+  const backendPort = await availablePort()
+  const uiPort = await availablePort()
+  const state = path.join(temp, "state")
+  await mkdir(path.join(temp, ".config"))
+  await mkdir(path.join(state, "opencode-drive", "instances"), { recursive: true })
+  await writeFile(path.join(state, "opencode-drive", "instances", "orch-smoke.json"), JSON.stringify({
+    endpoints: { ui: `ws://127.0.0.1:${uiPort}`, backend: `ws://127.0.0.1:${backendPort}` },
+  }))
+  await writeFile(path.join(temp, "opencode.json"), JSON.stringify({
+    model: "smoke/smoke",
+    permissions: [{ action: "write", resource: "*", effect: "allow" }],
+    plugins: [path.join(adapter, "src", "index.js")],
+    snapshots: false,
+    providers: {
+      smoke: {
+        package: "aisdk:@ai-sdk/openai-compatible",
+        settings: { apiKey: "smoke", baseURL: "https://api.openai.com/v1" },
+        models: { smoke: { name: "Smoke" } },
+      },
+    },
+  }))
   const port = await availablePort()
   const baseURL = `http://127.0.0.1:${port}`
   server = spawn(opencode, ["serve", "--hostname", "127.0.0.1", "--port", String(port)], {
     cwd: temp,
-    env: { ...process.env, OPENCODE_SERVER_PASSWORD: serverPassword },
+    env: {
+      ...process.env,
+      OPENCODE_CONFIG_DIR: path.join(temp, ".config"),
+      OPENCODE_DB: ":memory:",
+      OPENCODE_DRIVE: "orch-smoke",
+      OPENCODE_SERVER_PASSWORD: serverPassword,
+      OPENCODE_SIMULATE: "1",
+      XDG_STATE_HOME: state,
+    },
     shell: process.platform === "win32",
     stdio: "ignore",
     windowsHide: true,
@@ -85,29 +195,48 @@ try {
     assert.equal(agents.find((agent) => agent.id === id)?.mode, "subagent", `${id} was not discovered: ${JSON.stringify(agents)}`)
   }
 
-  const hooks = {}
-  await plugin.setup({
-    tool: { hook: async (_, callback) => (hooks.tool = callback) },
-    session: {
-      get: async () => ({ location: { directory: temp } }),
-      hook: async (_, callback) => (hooks.session = callback),
-    },
-  })
-  const context = { sessionID: "smoke", system: [] }
-  await hooks.session(context)
-  assert.match(context.system.at(-1)?.text ?? "", /repository is managed by Orch/)
-
+  controller = await simulation(`ws://127.0.0.1:${backendPort}`)
   const tracked = path.join(temp, "tracked.txt")
   const before = await readFile(tracked, "utf8")
-  await assert.rejects(hooks.tool({ sessionID: "smoke", agent: "build", tool: "write", input: { path: tracked, content: "after\n" } }))
-  assert.equal(await readFile(tracked, "utf8"), before, "denied mutation reached the filesystem")
-
   const scratch = path.join(temp, ".scratch", "opencode-smoke.tmp")
-  await mkdir(path.dirname(scratch), { recursive: true })
-  await hooks.tool({ sessionID: "smoke", agent: "build", tool: "write", input: { path: scratch, content: "allowed\n" } })
-  await writeFile(scratch, "allowed\n")
-  await rm(scratch)
+  const session = await api(baseURL, "/api/session", {
+    method: "POST",
+    body: JSON.stringify({ location: { directory: temp }, model: { providerID: "smoke", id: "smoke" } }),
+  })
+  await api(baseURL, `/api/session/${session.id}/prompt`, {
+    method: "POST",
+    body: JSON.stringify({ text: "Run the requested writes.", files: [], agents: [], skills: [] }),
+  })
+
+  let trackedTurn = await within(controller.next("llm.request"), "the first model request")
+  if (/title generator/.test(JSON.stringify(trackedTurn.body))) {
+    await controller.request("llm.chunk", { id: trackedTurn.id, items: [{ type: "textDelta", text: "Smoke writes" }] })
+    await controller.request("llm.finish", { id: trackedTurn.id, reason: "stop" })
+    trackedTurn = await within(controller.next("llm.request"), "the main model request")
+  }
+  assert.match(JSON.stringify(trackedTurn.body), /repository is managed by Orch/, "live session context omitted Orch instructions")
+  await controller.request("llm.chunk", {
+    id: trackedTurn.id,
+    items: [{ type: "toolCall", index: 0, id: "tracked", name: "write", input: { path: tracked, content: "after\n" } }],
+  })
+  await controller.request("llm.finish", { id: trackedTurn.id, reason: "tool-calls" })
+
+  const scratchTurn = await within(controller.next("llm.request"), "the denied write result")
+  assert.match(JSON.stringify(scratchTurn.body), /orch guard:.*assist is read-only/, "denial did not come from the Orch guard")
+  assert.equal(await readFile(tracked, "utf8"), before, "denied mutation reached the filesystem")
+  await controller.request("llm.chunk", {
+    id: scratchTurn.id,
+    items: [{ type: "toolCall", index: 0, id: "scratch", name: "write", input: { path: scratch, content: "allowed\n" } }],
+  })
+  await controller.request("llm.finish", { id: scratchTurn.id, reason: "tool-calls" })
+
+  const finishTurn = await within(controller.next("llm.request"), "the allowed write result")
+  await controller.request("llm.chunk", { id: finishTurn.id, items: [{ type: "textDelta", text: "done" }] })
+  await controller.request("llm.finish", { id: finishTurn.id, reason: "stop" })
+  await api(baseURL, `/api/session/${session.id}/wait`, { method: "POST" })
+  assert.equal(await readFile(scratch, "utf8"), "allowed\n", "allowed mutation did not traverse the live write tool")
 } finally {
+  controller?.socket.close()
   if (server?.pid) {
     if (process.platform === "win32") spawnSync("taskkill", ["/pid", String(server.pid), "/t", "/f"], { stdio: "ignore", windowsHide: true })
     else server.kill("SIGTERM")

--- a/adapters/opencode/src/index.js
+++ b/adapters/opencode/src/index.js
@@ -11,10 +11,10 @@ export function mutationPaths(tool, input) {
   if (!mutationTools.has(tool)) return []
   if (!input || typeof input !== "object") throw new Error(`orch: ${tool} input is not an object`)
   if (tool === "edit" || tool === "write") {
-    if (typeof input.filePath !== "string" || input.filePath.length === 0) {
-      throw new Error(`orch: ${tool} input has no filePath`)
+    if (typeof input.path !== "string" || input.path.length === 0) {
+      throw new Error(`orch: ${tool} input has no path`)
     }
-    return [input.filePath]
+    return [input.path]
   }
   if (typeof input.patchText !== "string") throw new Error("orch: patch input has no patchText")
   const paths = []

--- a/adapters/opencode/src/index.js
+++ b/adapters/opencode/src/index.js
@@ -1,0 +1,57 @@
+import { spawnSync } from "node:child_process"
+import { Plugin } from "@opencode-ai/plugin"
+
+export const pluginID = "orch.delivery"
+export const mutationTools = new Set(["edit", "write", "patch"])
+
+const patchDirective = /^\*\*\* (?:Add|Update|Delete) File: (.+)$/
+const moveDirective = /^\*\*\* Move to: (.+)$/
+
+export function mutationPaths(tool, input) {
+  if (!mutationTools.has(tool)) return []
+  if (!input || typeof input !== "object") throw new Error(`orch: ${tool} input is not an object`)
+  if (tool === "edit" || tool === "write") {
+    if (typeof input.filePath !== "string" || input.filePath.length === 0) {
+      throw new Error(`orch: ${tool} input has no filePath`)
+    }
+    return [input.filePath]
+  }
+  if (typeof input.patchText !== "string") throw new Error("orch: patch input has no patchText")
+  const paths = []
+  for (const line of input.patchText.split(/\r?\n/)) {
+    const match = patchDirective.exec(line) ?? moveDirective.exec(line)
+    if (match) paths.push(match[1])
+  }
+  if (paths.length === 0) throw new Error("orch: patch input names no files")
+  return paths
+}
+
+export function runOrch(args, cwd = process.cwd()) {
+  const result = spawnSync("orch", args, { cwd, encoding: "utf8", windowsHide: true })
+  if (result.error) throw new Error(`orch: ${result.error.message}`)
+  if (result.status !== 0) {
+    throw new Error((result.stderr || result.stdout || `orch exited ${result.status}`).trim())
+  }
+  return result.stdout
+}
+
+export function definePlugin(run = runOrch) {
+  return Plugin.define({
+    id: pluginID,
+    setup: async (ctx) => {
+      await ctx.tool.hook("execute.before", async (event) => {
+        const paths = mutationPaths(event.tool, event.input)
+        if (paths.length === 0) return
+        const session = await ctx.session.get({ sessionID: event.sessionID })
+        run(["guard", "check", "--", ...paths], session.location.directory)
+      })
+      await ctx.session.hook("context", async (event) => {
+        const session = await ctx.session.get({ sessionID: event.sessionID })
+        const text = run(["hook", "opencode", "session-start"], session.location.directory)
+        if (text) event.system.push({ type: "text", text })
+      })
+    },
+  })
+}
+
+export default definePlugin()

--- a/adapters/opencode/test/plugin.test.js
+++ b/adapters/opencode/test/plugin.test.js
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import plugin, { definePlugin, mutationPaths, mutationTools, pluginID } from "../src/index.js"
+
+test("exports the pinned V2 plugin contract", () => {
+  assert.equal(pluginID, "orch.delivery")
+  assert.equal(plugin.id, pluginID)
+  assert.equal(typeof plugin.setup, "function")
+  assert.deepEqual([...mutationTools], ["edit", "write", "patch"])
+})
+
+test("extracts every built-in mutation target", () => {
+  assert.deepEqual(mutationPaths("edit", { filePath: "a.txt" }), ["a.txt"])
+  assert.deepEqual(mutationPaths("write", { filePath: "b.txt" }), ["b.txt"])
+  assert.deepEqual(
+    mutationPaths("patch", {
+      patchText: "*** Begin Patch\n*** Add File: a.txt\n*** Update File: b.txt\n*** Move to: c.txt\n*** Delete File: d.txt\n*** End Patch",
+    }),
+    ["a.txt", "b.txt", "c.txt", "d.txt"],
+  )
+  assert.deepEqual(mutationPaths("read", { filePath: "a.txt" }), [])
+})
+
+test("fails closed on malformed mutation inputs", () => {
+  assert.throws(() => mutationPaths("edit", {}), /no filePath/)
+  assert.throws(() => mutationPaths("write", null), /not an object/)
+  assert.throws(() => mutationPaths("patch", { patchText: "*** Begin Patch\n*** End Patch" }), /names no files/)
+})
+
+test("registers pre-execution guard and session context hooks", async () => {
+  const hooks = []
+  const calls = []
+  await definePlugin((args, cwd) => {
+    calls.push([args, cwd])
+    return args[0] === "hook" ? "context" : ""
+  }).setup({
+    tool: { hook: async (name, callback) => hooks.push(["tool", name, callback]) },
+    session: {
+      get: async () => ({ location: { directory: "/repo" } }),
+      hook: async (name, callback) => hooks.push(["session", name, callback]),
+    },
+  })
+  assert.deepEqual(
+    hooks.map(([domain, name]) => [domain, name]),
+    [["tool", "execute.before"], ["session", "context"]],
+  )
+  await hooks[0][2]({ sessionID: "session", tool: "write", input: { filePath: "a.txt" } })
+  const event = { sessionID: "session", system: [] }
+  await hooks[1][2](event)
+  assert.deepEqual(calls, [
+    [["guard", "check", "--", "a.txt"], "/repo"],
+    [["hook", "opencode", "session-start"], "/repo"],
+  ])
+  assert.deepEqual(event.system, [{ type: "text", text: "context" }])
+})
+
+test("a denied guard stops before OpenCode can continue", async () => {
+  let hook
+  const denied = definePlugin(() => {
+    throw new Error("denied")
+  })
+  await denied.setup({
+    tool: { hook: async (_, callback) => (hook = callback) },
+    session: {
+      get: async () => ({ location: { directory: "/repo" } }),
+      hook: async () => {},
+    },
+  })
+  await assert.rejects(hook({ sessionID: "session", tool: "edit", input: { filePath: "tracked.txt" } }), /denied/)
+})

--- a/adapters/opencode/test/plugin.test.js
+++ b/adapters/opencode/test/plugin.test.js
@@ -11,8 +11,8 @@ test("exports the pinned V2 plugin contract", () => {
 })
 
 test("extracts every built-in mutation target", () => {
-  assert.deepEqual(mutationPaths("edit", { filePath: "a.txt" }), ["a.txt"])
-  assert.deepEqual(mutationPaths("write", { filePath: "b.txt" }), ["b.txt"])
+  assert.deepEqual(mutationPaths("edit", { path: "a.txt" }), ["a.txt"])
+  assert.deepEqual(mutationPaths("write", { path: "b.txt" }), ["b.txt"])
   assert.deepEqual(
     mutationPaths("patch", {
       patchText: "*** Begin Patch\n*** Add File: a.txt\n*** Update File: b.txt\n*** Move to: c.txt\n*** Delete File: d.txt\n*** End Patch",
@@ -23,7 +23,8 @@ test("extracts every built-in mutation target", () => {
 })
 
 test("fails closed on malformed mutation inputs", () => {
-  assert.throws(() => mutationPaths("edit", {}), /no filePath/)
+  assert.throws(() => mutationPaths("edit", {}), /no path/)
+  assert.throws(() => mutationPaths("write", { filePath: "legacy.txt" }), /no path/)
   assert.throws(() => mutationPaths("write", null), /not an object/)
   assert.throws(() => mutationPaths("patch", { patchText: "*** Begin Patch\n*** End Patch" }), /names no files/)
 })
@@ -45,7 +46,7 @@ test("registers pre-execution guard and session context hooks", async () => {
     hooks.map(([domain, name]) => [domain, name]),
     [["tool", "execute.before"], ["session", "context"]],
   )
-  await hooks[0][2]({ sessionID: "session", tool: "write", input: { filePath: "a.txt" } })
+  await hooks[0][2]({ sessionID: "session", agent: "build", tool: "write", input: { path: "a.txt", content: "x" } })
   const event = { sessionID: "session", system: [] }
   await hooks[1][2](event)
   assert.deepEqual(calls, [
@@ -67,5 +68,5 @@ test("a denied guard stops before OpenCode can continue", async () => {
       hook: async () => {},
     },
   })
-  await assert.rejects(hook({ sessionID: "session", tool: "edit", input: { filePath: "tracked.txt" } }), /denied/)
+  await assert.rejects(hook({ sessionID: "session", agent: "build", tool: "edit", input: { path: "tracked.txt", oldString: "a", newString: "b" } }), /denied/)
 })

--- a/internal/adaptertest/adaptertest.go
+++ b/internal/adaptertest/adaptertest.go
@@ -1,4 +1,4 @@
-// Package adaptertest is the PRD §23 shared parity layer both host
+// Package adaptertest is the PRD §23 shared parity layer all hosts'
 // adapters' plugin tests consume: fixtures (the committed §10 role
 // profiles) and assertion helpers (skill/manifest drift pins) so
 // cross-host invariants — the run-verb allowlist, the four
@@ -10,8 +10,8 @@
 // silently drift apart.
 //
 // This package carries no Test functions and tests nothing of its own;
-// it is test-support only, imported by adapters/claude/plugin_test.go
-// and adapters/codex/plugin_test.go. Every exported Check* helper takes
+// it is test-support only, imported by each adapter's plugin_test.go.
+// Every exported Check* helper takes
 // a *testing.T and calls t.Helper(), and reads files relative to the
 // caller's own working directory — the same assumption each adapter's
 // plugin_test.go already makes, since `go test` runs a package's tests
@@ -49,10 +49,10 @@ type RoleSpec struct {
 	Effort string
 }
 
-// Profile returns the committed §10 profile for host ("claude" or
-// "codex"), keyed by role: "scout", "implementer", "specialist",
+// Profile returns the committed §10 profile for host ("claude", "codex",
+// or "opencode"), keyed by role: "scout", "implementer", "specialist",
 // "reviewer", "reviewer-safe". Every adapter's agent roster is asserted
-// equal to this map so the two hosts' plugin tests and the committed
+// equal to this map so the hosts' plugin tests and the committed
 // §10 table can never silently diverge from one another.
 //
 // An unrecognized host is a programming error in the caller (a typo, or
@@ -76,6 +76,14 @@ func Profile(host string) map[string]RoleSpec {
 			"specialist":    {Model: "gpt-5.6-sol", Effort: "max"},
 			"reviewer":      {Model: "gpt-5.6-sol", Effort: "xhigh"},
 			"reviewer-safe": {Model: "gpt-5.6-sol", Effort: "high"},
+		}
+	case "opencode":
+		return map[string]RoleSpec{
+			"scout":         {Model: "openai/gpt-5.6-luna", Effort: "max"},
+			"implementer":   {Model: "openai/gpt-5.6-terra", Effort: "max"},
+			"specialist":    {Model: "openai/gpt-5.6-sol", Effort: "max"},
+			"reviewer":      {Model: "openai/gpt-5.6-sol", Effort: "xhigh"},
+			"reviewer-safe": {Model: "openai/gpt-5.6-sol", Effort: "high"},
 		}
 	default:
 		panic("adaptertest: unknown host " + host)
@@ -135,11 +143,8 @@ func normalizeWhitespace(s string) string {
 	return strings.Join(strings.Fields(s), " ")
 }
 
-// NormalizeWhitespace exports normalizeWhitespace for the two adapters'
-// own plugin_test.go prose-phrase checks
-// (TestDeliverySkillStatesFrontmatterMatchRule,
-// TestDeliverySkillStatesTOMLMatchRule, and the Codex adapter's
-// TestAgentTOMLs read-only sentinel check), which live outside this
+// NormalizeWhitespace exports normalizeWhitespace for adapters'
+// own plugin_test.go prose-phrase checks, which live outside this
 // package and so cannot call the unexported form directly. It performs
 // no normalization logic of its own beyond delegating to
 // normalizeWhitespace.

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/kninetimmy/orch/adapters/claude"
 	"github.com/kninetimmy/orch/adapters/codex"
+	"github.com/kninetimmy/orch/adapters/opencode"
 	"github.com/kninetimmy/orch/internal/config"
 )
 
@@ -24,8 +25,9 @@ import (
 // configuration add both to .gitignore whether or not both hosts are
 // currently enabled, so enabling the other host later stays safe.
 const (
-	ClaudeDir = ".claude/agents"
-	CodexDir  = ".codex/agents"
+	ClaudeDir   = ".claude/agents"
+	CodexDir    = ".codex/agents"
+	OpenCodeDir = ".opencode/agents"
 )
 
 // roleFile pairs one hosts.<host>.roles key with the canonical file
@@ -61,6 +63,8 @@ func Destination(host string) (string, error) {
 		return ClaudeDir, nil
 	case "codex":
 		return CodexDir, nil
+	case "opencode":
+		return OpenCodeDir, nil
 	default:
 		return "", fmt.Errorf("agents: unsupported host %q", host)
 	}
@@ -114,6 +118,12 @@ func Render(host string, h *config.Host) ([]File, error) {
 			canonical, err = codex.AgentTOMLs.ReadFile("agents/" + rf.stem + ext)
 			if err == nil {
 				content, err = substituteCodex(canonical, profile.Model, profile.Effort)
+			}
+		case "opencode":
+			ext = ".md"
+			canonical, err = opencode.AgentDefinitions.ReadFile("agents/" + rf.stem + ext)
+			if err == nil {
+				content, err = substituteOpenCode(canonical, profile.Model, profile.Effort)
 			}
 		}
 		if err != nil {
@@ -182,6 +192,15 @@ func substituteClaude(canonical []byte, model string) ([]byte, error) {
 		return nil, fmt.Errorf("model: %w", err)
 	}
 	return []byte(header + rest), nil
+}
+
+// substituteOpenCode replaces only model in native V2 frontmatter. OpenCode
+// carries reasoning effort as the model reference's #variant suffix.
+func substituteOpenCode(canonical []byte, model, effort string) ([]byte, error) {
+	if strings.Contains(model, "#") {
+		return nil, fmt.Errorf("model %q already contains an OpenCode variant", model)
+	}
+	return substituteClaude(canonical, model+"#"+effort)
 }
 
 // replaceOneLine replaces pattern's single match in s with replacement,

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -52,9 +52,9 @@ func defaultClaudeHost() *config.Host {
 }
 
 func defaultOpenCodeHost() *config.Host {
-	p := adaptertest.Profile("codex")
+	p := adaptertest.Profile("opencode")
 	rp := func(role string) config.RoleProfile {
-		return config.RoleProfile{Model: "openai/" + p[role].Model, Effort: p[role].Effort}
+		return config.RoleProfile{Model: p[role].Model, Effort: p[role].Effort}
 	}
 	return &config.Host{Roles: config.Roles{
 		Architect: rp("scout"), Scout: rp("scout"), Implementer: rp("implementer"),

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -51,6 +51,36 @@ func defaultClaudeHost() *config.Host {
 	}}
 }
 
+func defaultOpenCodeHost() *config.Host {
+	p := adaptertest.Profile("codex")
+	rp := func(role string) config.RoleProfile {
+		return config.RoleProfile{Model: "openai/" + p[role].Model, Effort: p[role].Effort}
+	}
+	return &config.Host{Roles: config.Roles{
+		Architect: rp("scout"), Scout: rp("scout"), Implementer: rp("implementer"),
+		Specialist: rp("specialist"), Reviewer: rp("reviewer"), ReviewDowngrade: rp("reviewer-safe"),
+	}}
+}
+
+func TestRenderOpenCodeNativeAgents(t *testing.T) {
+	files, err := agents.Render("opencode", defaultOpenCodeHost())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 5 {
+		t.Fatalf("len(files) = %d, want 5", len(files))
+	}
+	for _, file := range files {
+		text := string(file.Content)
+		if !strings.HasPrefix(file.Path, agents.OpenCodeDir+"/") || !strings.HasSuffix(file.Path, ".md") {
+			t.Errorf("Path = %q", file.Path)
+		}
+		if !strings.Contains(text, "mode: subagent") || !strings.Contains(text, "model: openai/") || !strings.Contains(text, "#") {
+			t.Errorf("%s is not a native V2 model/variant agent", file.Path)
+		}
+	}
+}
+
 func stem(f agents.File) string {
 	return strings.TrimSuffix(filepath.Base(f.Path), filepath.Ext(f.Path))
 }

--- a/internal/bootstrap/stage1.go
+++ b/internal/bootstrap/stage1.go
@@ -232,6 +232,7 @@ func modelNames(cfg *config.Config) []string {
 	}
 	add(cfg.Hosts.Claude)
 	add(cfg.Hosts.Codex)
+	add(cfg.Hosts.OpenCode)
 	names := make([]string, 0, len(seen))
 	for m := range seen {
 		names = append(names, m)

--- a/internal/bootstrap/validate.go
+++ b/internal/bootstrap/validate.go
@@ -148,11 +148,17 @@ func validateConfigure(dir string, complete *question.Complete, now time.Time) (
 		enabled[h] = true
 	}
 
-	for _, host := range []string{"claude", "codex"} {
-		file := interview.InstructionFile(host)
+	for _, item := range []struct {
+		file string
+		on   bool
+	}{
+		{interview.InstructionFile("claude"), enabled["claude"]},
+		{interview.InstructionFile("codex"), enabled["codex"] || enabled["opencode"]},
+	} {
+		file := item.file
 		name := "instructions:" + file
 		want := instructions.StatusAbsent
-		if enabled[host] {
+		if item.on {
 			want = instructions.StatusCurrent
 		}
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -95,6 +95,10 @@ type fakeRunner struct {
 	codexPluginExit    int
 	codexPluginStderr  string
 	codexPluginErr     error
+	opencodeVersion    string
+	opencodePlugins    string
+	opencodePluginExit int
+	opencodePluginErr  error
 	// checkIgnoreExit scripts `git check-ignore`: 0 ignored, 1 not
 	// ignored, anything else an error (the guard ignore probe).
 	checkIgnoreExit    int
@@ -185,6 +189,25 @@ func (f fakeRunner) Run(_ context.Context, c execx.Cmd) (execx.Result, error) {
 			}
 		}
 		return execx.Result{Stdout: stdout, Stderr: stderr, ExitCode: exit}, nil
+	case "opencode2":
+		if len(c.Args) == 1 && c.Args[0] == "--version" {
+			version := f.opencodeVersion
+			if version == "" {
+				version = pinnedOpenCodeVersion
+			}
+			return execx.Result{Stdout: version + "\n"}, nil
+		}
+		if len(c.Args) == 3 && c.Args[0] == "api" && c.Args[1] == "get" && c.Args[2] == "/api/plugin" {
+			if f.opencodePluginErr != nil {
+				return execx.Result{}, f.opencodePluginErr
+			}
+			plugins := f.opencodePlugins
+			if plugins == "" {
+				plugins = `{"data":[{"id":"orch.delivery"}]}`
+			}
+			return execx.Result{Stdout: plugins, ExitCode: f.opencodePluginExit}, nil
+		}
+		return execx.Result{}, fmt.Errorf("fakeRunner: unexpected command %s %v", c.Name, c.Args)
 	case "memhub":
 		switch c.Args[0] {
 		case "status":
@@ -208,10 +231,7 @@ func writeConfig(t *testing.T, root, content string) {
 	}
 	var files []agents.File
 	for _, host := range cfg.EnabledHosts() {
-		h := cfg.Hosts.Claude
-		if host == "codex" {
-			h = cfg.Hosts.Codex
-		}
+		h := cfg.Host(host)
 		rendered, err := agents.Render(host, h)
 		if err != nil {
 			t.Fatal(err)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kninetimmy/orch/adapters/claude"
 	"github.com/kninetimmy/orch/adapters/codex"
+	"github.com/kninetimmy/orch/adapters/opencode"
 	"github.com/kninetimmy/orch/internal/agents"
 	"github.com/kninetimmy/orch/internal/config"
 	"github.com/kninetimmy/orch/internal/execx"
@@ -46,6 +47,13 @@ var (
 		pluginID:     "orch@orch",
 		manifestJSON: codex.PluginManifestJSON,
 		repair:       "run `codex plugin marketplace upgrade orch`, then restart Codex CLI",
+	}
+	opencodeAdapter = adapterSpec{
+		host:         "opencode",
+		executable:   "opencode2",
+		pluginID:     "orch.delivery",
+		manifestJSON: opencode.PackageJSON,
+		repair:       "install the pinned Orch OpenCode adapter, then restart the OpenCode V2 service",
 	}
 )
 
@@ -127,14 +135,14 @@ func runDoctor(env Env) error {
 		if cfg.Hosts.Codex != nil {
 			check("codex adapter", checkAdapter(env, codexAdapter))
 		}
+		if cfg.Hosts.OpenCode != nil {
+			check("opencode adapter", checkOpenCodeAdapter(env, opencodeAdapter))
+		}
 	}
 
 	if cfgErr == nil {
 		for _, host := range cfg.EnabledHosts() {
-			h := cfg.Hosts.Claude
-			if host == "codex" {
-				h = cfg.Hosts.Codex
-			}
+			h := cfg.Host(host)
 			stale, staleErr := agents.Stale(env.RepoRoot, host, h)
 			switch {
 			case len(stale) > 0:
@@ -360,6 +368,61 @@ func adapterVersion(manifestJSON string) (string, error) {
 		return "", errors.New("manifest has no version")
 	}
 	return manifest.Version, nil
+}
+
+const pinnedOpenCodeVersion = "opencode2 v0.0.0-next-17444"
+
+// checkOpenCodeAdapter pins the beta runtime contract and checks the active
+// plugin ID. V2's plugin API does not currently expose adapter versions.
+func checkOpenCodeAdapter(env Env, spec adapterSpec) error {
+	fail := func(detail string) error { return fmt.Errorf("%s; %s", detail, spec.repair) }
+	if _, err := env.LookPath(spec.executable); err != nil {
+		return fail(fmt.Sprintf("%s not found on PATH: %v", spec.executable, err))
+	}
+	version, err := env.Runner.Run(context.Background(), execx.Cmd{Name: spec.executable, Args: []string{"--version"}, Dir: env.RepoRoot})
+	if err != nil {
+		return fail(fmt.Sprintf("run `%s --version`: %v", spec.executable, err))
+	}
+	if version.ExitCode != 0 {
+		detail := strings.TrimSpace(version.Stderr)
+		if detail == "" {
+			detail = "no error output"
+		}
+		return fail(fmt.Sprintf("`%s --version` exited %d: %s", spec.executable, version.ExitCode, detail))
+	}
+	if got := strings.TrimSpace(version.Stdout); got != pinnedOpenCodeVersion {
+		return fail(fmt.Sprintf("OpenCode V2 contract drift: got %q, want %q", got, pinnedOpenCodeVersion))
+	}
+	listing, err := env.Runner.Run(context.Background(), execx.Cmd{Name: spec.executable, Args: []string{"api", "get", "/api/plugin"}, Dir: env.RepoRoot})
+	command := spec.executable + " api get /api/plugin"
+	if err != nil {
+		return fail(fmt.Sprintf("run `%s`: %v", command, err))
+	}
+	if listing.ExitCode != 0 {
+		detail := strings.TrimSpace(listing.Stderr)
+		if detail == "" {
+			detail = "no error output"
+		}
+		return fail(fmt.Sprintf("`%s` exited %d: %s", command, listing.ExitCode, detail))
+	}
+	var response struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(listing.Stdout), &response); err != nil || response.Data == nil {
+		return fail(fmt.Sprintf("malformed `%s` output: expected an object with a data array", command))
+	}
+	count := 0
+	for _, plugin := range response.Data {
+		if plugin.ID == spec.pluginID {
+			count++
+		}
+	}
+	if count != 1 {
+		return fail(fmt.Sprintf("%s appears %d times; exactly one active plugin is required", spec.pluginID, count))
+	}
+	return nil
 }
 
 func decodeAdapterPlugins(host string, data []byte) ([]adapterPlugin, error) {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -370,7 +370,7 @@ func adapterVersion(manifestJSON string) (string, error) {
 	return manifest.Version, nil
 }
 
-const pinnedOpenCodeVersion = "opencode2 v0.0.0-next-17444"
+const pinnedOpenCodeVersion = "opencode2 v0.0.0-beta-17498"
 
 // checkOpenCodeAdapter pins the beta runtime contract and checks the active
 // plugin ID. V2's plugin API does not currently expose adapter versions.

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -136,13 +136,14 @@ func TestDoctorConfiguredAdaptersPassCurrentListings(t *testing.T) {
 	}{
 		{"claude", validTOML, "claude"},
 		{"codex", validCodexTOML, "codex"},
+		{"opencode", validOpenCodeTOML, "opencode2"},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			env, stdout, _ := testEnv(t)
 			writeConfig(t, env.RepoRoot, tc.config)
-			if tc.executable == "codex" {
+			if tc.executable == "codex" || tc.executable == "opencode2" {
 				if code := Run([]string{"render-agents"}, env); code != ExitOK {
 					t.Fatalf("render-agents exit = %d, want %d\n%s", code, ExitOK, stdout.String())
 				}
@@ -158,7 +159,7 @@ func TestDoctorConfiguredAdaptersPassCurrentListings(t *testing.T) {
 					}
 					probed = true
 					if cmd.Dir != env.RepoRoot {
-						t.Errorf("%s plugin list dir = %q, want %q", tc.executable, cmd.Dir, env.RepoRoot)
+						t.Errorf("%s adapter probe dir = %q, want %q", tc.executable, cmd.Dir, env.RepoRoot)
 					}
 				},
 			}
@@ -296,13 +297,31 @@ func TestDoctorAdapterFailures(t *testing.T) {
 			},
 			wantDetails: []string{"orch@orch version mismatch", fmt.Sprintf(`installed "0.5.0", expected %q`, codexVersion)},
 		},
+		{
+			name:   "opencode runtime mismatch",
+			config: validOpenCodeTOML,
+			spec:   opencodeAdapter,
+			configure: func(r *fakeRunner) {
+				r.opencodeVersion = "opencode2 v0.0.0-beta-newer"
+			},
+			wantDetails: []string{"OpenCode V2 contract drift", pinnedOpenCodeVersion},
+		},
+		{
+			name:   "opencode malformed plugin response",
+			config: validOpenCodeTOML,
+			spec:   opencodeAdapter,
+			configure: func(r *fakeRunner) {
+				r.opencodePlugins = "{}"
+			},
+			wantDetails: []string{"malformed `opencode2 api get /api/plugin` output"},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			env, stdout, _ := testEnv(t)
 			writeConfig(t, env.RepoRoot, tc.config)
-			if tc.spec.host == "codex" {
+			if tc.spec.host == "codex" || tc.spec.host == "opencode" {
 				if code := Run([]string{"render-agents"}, env); code != ExitOK {
 					t.Fatalf("render-agents exit = %d, want %d\n%s", code, ExitOK, stdout.String())
 				}
@@ -355,6 +374,7 @@ func TestDoctorUnconfiguredHostIsNotProbed(t *testing.T) {
 		unconfigured string
 	}{
 		{"claude only", validTOML, "codex"},
+		{"claude only no opencode", validTOML, "opencode2"},
 		{"codex only", validCodexTOML, "claude"},
 	}
 

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -11,7 +11,7 @@ import (
 
 // hookUsage is the one-line usage for the adapter plumbing surface,
 // mirroring guardUsage.
-const hookUsage = "orch hook: usage: orch hook <claude|codex> session-start | orch hook codex subagent-usage (JSON document on stdin)"
+const hookUsage = "orch hook: usage: orch hook <claude|codex|opencode> session-start | orch hook codex subagent-usage (JSON document on stdin)"
 
 // runHook dispatches host adapter-plumbing verbs (PRD §23). Host adapters call
 // it instead of reimplementing their host-specific behavior; it is never
@@ -31,6 +31,10 @@ func runHook(env Env, args []string) error {
 			return hookSessionStart(env, args[0])
 		case "subagent-usage":
 			return runCodexSubagentUsage(env)
+		}
+	case "opencode":
+		if args[1] == "session-start" {
+			return hookSessionStart(env, args[0])
 		}
 	}
 	return usageError(hookUsage)
@@ -79,8 +83,9 @@ var deliveryPhaseOrder = []state.Phase{
 // plugin injects today; codex's points at the Codex adapter's own
 // skill-invocation surface instead of Claude's slash commands.
 var sessionStartClosing = map[string]string{
-	"claude": "Before planning or acting on any request that would change tracked files, load and follow the `orch-architect` skill. Setup interviews: /orch:init, /orch:configure, /orch:configure-local.",
-	"codex":  "Before planning or acting on any request that would change tracked files, load and follow the `orch-architect` skill. Setup interviews: invoke the `orch-setup` skill for init, configure, or configure-local.",
+	"claude":   "Before planning or acting on any request that would change tracked files, load and follow the `orch-architect` skill. Setup interviews: /orch:init, /orch:configure, /orch:configure-local.",
+	"codex":    "Before planning or acting on any request that would change tracked files, load and follow the `orch-architect` skill. Setup interviews: invoke the `orch-setup` skill for init, configure, or configure-local.",
+	"opencode": "Before planning or acting on any request that would change tracked files, load and follow the `orch-architect` skill. Setup interviews: invoke the `orch-setup` skill for init, configure, or configure-local.",
 }
 
 // sessionStartContext renders the compact plain-text context block the

--- a/internal/cli/hook_test.go
+++ b/internal/cli/hook_test.go
@@ -309,4 +309,14 @@ func TestHookSessionStartSharedLinesAcrossHosts(t *testing.T) {
 	if claudeShared != codexShared {
 		t.Errorf("shared lines differ:\nclaude: %q\ncodex:  %q", claudeShared, codexShared)
 	}
+
+	envOpenCode, stdoutOpenCode, stderr3 := testEnv(t)
+	writeConfig(t, envOpenCode.RepoRoot, validOpenCodeTOML)
+	if code := Run([]string{"hook", "opencode", "session-start"}, envOpenCode); code != ExitOK {
+		t.Fatalf("opencode exit = %d, want %d (stderr %q)", code, ExitOK, stderr3.String())
+	}
+	openCodeShared := strings.TrimSuffix(stdoutOpenCode.String(), sessionStartClosing["opencode"]+"\n")
+	if claudeShared != openCodeShared {
+		t.Errorf("shared lines differ:\nclaude: %q\nopencode: %q", claudeShared, openCodeShared)
+	}
 }

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -102,6 +102,7 @@ func runInitReport(env Env) error {
 	fmt.Fprintln(env.Stdout, "orch init: detection report")
 	fmt.Fprintf(env.Stdout, "  claude CLI:  %s\n", yesNo(facts.ClaudeCLI))
 	fmt.Fprintf(env.Stdout, "  codex CLI:   %s\n", yesNo(facts.CodexCLI))
+	fmt.Fprintf(env.Stdout, "  opencode2:   %s\n", yesNo(facts.OpenCodeCLI))
 	fmt.Fprintf(env.Stdout, "  git:         %s\n", yesNo(facts.Git))
 	if facts.Git {
 		fmt.Fprintf(env.Stdout, "  git root:    %s\n", facts.GitRoot)

--- a/internal/cli/renderagents.go
+++ b/internal/cli/renderagents.go
@@ -24,10 +24,7 @@ func runRenderAgents(env Env) error {
 
 	var files []agents.File
 	for _, host := range cfg.EnabledHosts() {
-		h := cfg.Hosts.Claude
-		if host == "codex" {
-			h = cfg.Hosts.Codex
-		}
+		h := cfg.Host(host)
 		rendered, err := agents.Render(host, h)
 		if err != nil {
 			return err

--- a/internal/cli/renderagents_test.go
+++ b/internal/cli/renderagents_test.go
@@ -54,6 +54,8 @@ effort = "high"
 
 var validBothHostsTOML = validTOML + validCodexTOML[strings.Index(validCodexTOML, "[hosts.codex"):]
 
+var validOpenCodeTOML = strings.ReplaceAll(validCodexTOML, "hosts.codex", "hosts.opencode")
+
 const validClaudeDefaultTOML = `
 schema_version  = 1
 config_revision = "r1"

--- a/internal/cli/testdata/init_report.golden.txt
+++ b/internal/cli/testdata/init_report.golden.txt
@@ -1,6 +1,7 @@
 orch init: detection report
   claude CLI:  yes
   codex CLI:   yes
+  opencode2:   no
   git:         yes
   git root:    <ROOT>
   gh:          yes

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,8 +47,9 @@ type Metrics struct {
 
 // Hosts holds one profile per enabled host. A nil host is not enabled.
 type Hosts struct {
-	Codex  *Host `toml:"codex"`
-	Claude *Host `toml:"claude"`
+	Codex    *Host `toml:"codex"`
+	Claude   *Host `toml:"claude"`
+	OpenCode *Host `toml:"opencode"`
 }
 
 // Host is a per-host model/effort profile (PRD §10).
@@ -82,5 +83,22 @@ func (c *Config) EnabledHosts() []string {
 	if c.Hosts.Codex != nil {
 		names = append(names, "codex")
 	}
+	if c.Hosts.OpenCode != nil {
+		names = append(names, "opencode")
+	}
 	return names
+}
+
+// Host returns the configured profile for name, or nil when it is disabled.
+func (c *Config) Host(name string) *Host {
+	switch name {
+	case "claude":
+		return c.Hosts.Claude
+	case "codex":
+		return c.Hosts.Codex
+	case "opencode":
+		return c.Hosts.OpenCode
+	default:
+		return nil
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,7 +74,7 @@ func TestLoadInvalid(t *testing.T) {
 		{"invalid/bad_effort.toml", `"ultra"`},
 		{"invalid/bad_merge_strategy.toml", `"fast-forward"`},
 		{"invalid/bad_memhub_mode.toml", `"maybe"`},
-		{"invalid/no_hosts.toml", "at least one of hosts.codex or hosts.claude"},
+		{"invalid/no_hosts.toml", "at least one of hosts.codex, hosts.claude, or hosts.opencode"},
 		{"invalid/missing_role.toml", "hosts.claude.roles.reviewer.model"},
 	}
 	for _, tt := range tests {
@@ -100,6 +100,28 @@ func TestLoadMissingConfig(t *testing.T) {
 	}
 	if cfg != nil {
 		t.Error("Load returned a Config for a missing file")
+	}
+}
+
+func TestOpenCodeOnlyConfiguration(t *testing.T) {
+	cfg := bothHostsConfig()
+	openCode := *cfg.Hosts.Codex
+	cfg.Hosts = Hosts{OpenCode: &openCode}
+	revision, err := Revision(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.ConfigRevision = revision
+	data, err := Render(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hosts := got.EnabledHosts(); len(hosts) != 1 || hosts[0] != "opencode" {
+		t.Fatalf("EnabledHosts = %v, want [opencode]", hosts)
 	}
 }
 

--- a/internal/config/overlay.go
+++ b/internal/config/overlay.go
@@ -44,7 +44,7 @@ func newLeafClasses() map[string]leafClass {
 		"concurrency.max_subagents": classPreference,
 		"metrics.enabled":           classPreference,
 	}
-	for _, host := range []string{"codex", "claude"} {
+	for _, host := range []string{"codex", "claude", "opencode"} {
 		for _, role := range roleNames {
 			prefix := "hosts." + host + ".roles." + role
 			m[prefix+".model"] = classPreference
@@ -219,6 +219,8 @@ func hostPtr(cfg *Config, name string) *Host {
 		return cfg.Hosts.Codex
 	case "claude":
 		return cfg.Hosts.Claude
+	case "opencode":
+		return cfg.Hosts.OpenCode
 	default:
 		return nil
 	}
@@ -231,6 +233,8 @@ func setHostPtr(cfg *Config, name string, h *Host) {
 		cfg.Hosts.Codex = h
 	case "claude":
 		cfg.Hosts.Claude = h
+	case "opencode":
+		cfg.Hosts.OpenCode = h
 	}
 }
 

--- a/internal/config/parse_test.go
+++ b/internal/config/parse_test.go
@@ -54,7 +54,7 @@ func TestParseInvalid(t *testing.T) {
 		{"invalid/bad_effort.toml", `"ultra"`},
 		{"invalid/bad_merge_strategy.toml", `"fast-forward"`},
 		{"invalid/bad_memhub_mode.toml", `"maybe"`},
-		{"invalid/no_hosts.toml", "at least one of hosts.codex or hosts.claude"},
+		{"invalid/no_hosts.toml", "at least one of hosts.codex, hosts.claude, or hosts.opencode"},
 		{"invalid/missing_role.toml", "hosts.claude.roles.reviewer.model"},
 	}
 	for _, tt := range tests {

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -84,6 +84,9 @@ func Render(c *Config) ([]byte, error) {
 	if c.Hosts.Codex != nil {
 		renderHost(&b, "codex", c.Hosts.Codex)
 	}
+	if c.Hosts.OpenCode != nil {
+		renderHost(&b, "opencode", c.Hosts.OpenCode)
+	}
 
 	return []byte(b.String()), nil
 }

--- a/internal/config/renderlocal.go
+++ b/internal/config/renderlocal.go
@@ -70,7 +70,7 @@ func RenderLocal(overrides map[string]string) ([]byte, error) {
 		fmt.Fprintf(&b, "enabled = %t\n", enabled)
 	}
 
-	for _, host := range []string{"claude", "codex"} {
+	for _, host := range []string{"claude", "codex", "opencode"} {
 		if err := renderLocalHost(&b, host, overrides); err != nil {
 			return nil, err
 		}

--- a/internal/config/renderlocal_test.go
+++ b/internal/config/renderlocal_test.go
@@ -90,12 +90,14 @@ func TestRenderLocalSelfCheckCatchesMismatch(t *testing.T) {
 // key as an override — proving RenderLocal and the closed
 // classification table agree on the complete preference-key set.
 func TestRenderLocalKeysMatchPreferenceClass(t *testing.T) {
-	wantCount := 2 + 2*6*2 // concurrency + metrics, 2 hosts * 6 roles * (model, effort)
+	wantCount := 2 + 3*6*2 // concurrency + metrics, 3 hosts * 6 roles * (model, effort)
 	if got := len(PreferenceKeys()); got != wantCount {
 		t.Fatalf("len(PreferenceKeys()) = %d, want %d", got, wantCount)
 	}
 
 	committed := bothHostsConfig()
+	openCode := *committed.Hosts.Codex
+	committed.Hosts.OpenCode = &openCode
 	for _, key := range PreferenceKeys() {
 		t.Run(key, func(t *testing.T) {
 			data, err := RenderLocal(map[string]string{key: sampleValueFor(key)})

--- a/internal/config/revision.go
+++ b/internal/config/revision.go
@@ -35,7 +35,36 @@ func Revision(c *Config) (string, error) {
 	shadow.ConfigRevision = ""
 	shadow.Overrides = nil
 
-	data, err := json.Marshal(shadow)
+	var value any = shadow
+	if c.Hosts.OpenCode == nil {
+		// Preserve the established revision for every pre-OpenCode
+		// configuration. A disabled additive host must not invalidate an
+		// otherwise byte-identical Claude/Codex configuration.
+		value = struct {
+			SchemaVersion  int
+			ConfigRevision string
+			Concurrency    Concurrency
+			Merge          Merge
+			Memhub         Memhub
+			Metrics        Metrics
+			Hosts          struct {
+				Codex  *Host
+				Claude *Host
+			}
+			Overrides []string
+		}{
+			SchemaVersion: shadow.SchemaVersion,
+			Concurrency:   shadow.Concurrency,
+			Merge:         shadow.Merge,
+			Memhub:        shadow.Memhub,
+			Metrics:       shadow.Metrics,
+			Hosts: struct {
+				Codex  *Host
+				Claude *Host
+			}{shadow.Hosts.Codex, shadow.Hosts.Claude},
+		}
+	}
+	data, err := json.Marshal(value)
 	if err != nil {
 		return "", fmt.Errorf("encode configuration for revision: %w", err)
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -16,8 +16,9 @@ var memhubModes = map[string]bool{"required": true, "best-effort": true, "off": 
 // enum but are deliberately excluded: no orch role should route below
 // low.
 var effortsByHost = map[string]map[string]bool{
-	"codex":  {"low": true, "medium": true, "high": true, "xhigh": true, "max": true, "ultra": true},
-	"claude": {"low": true, "medium": true, "high": true, "xhigh": true, "max": true},
+	"codex":    {"low": true, "medium": true, "high": true, "xhigh": true, "max": true, "ultra": true},
+	"claude":   {"low": true, "medium": true, "high": true, "xhigh": true, "max": true},
+	"opencode": {"low": true, "medium": true, "high": true, "xhigh": true, "max": true},
 }
 
 // validate collects every violation and reports them together in one
@@ -44,14 +45,17 @@ func (c *Config) validate() error {
 		fail("memhub.mode: %q is not one of required, best-effort, off", c.Memhub.Mode)
 	}
 
-	if c.Hosts.Codex == nil && c.Hosts.Claude == nil {
-		fail("hosts: at least one of hosts.codex or hosts.claude must be configured")
+	if c.Hosts.Codex == nil && c.Hosts.Claude == nil && c.Hosts.OpenCode == nil {
+		fail("hosts: at least one of hosts.codex, hosts.claude, or hosts.opencode must be configured")
 	}
 	if c.Hosts.Codex != nil {
 		validateHost("codex", c.Hosts.Codex, fail)
 	}
 	if c.Hosts.Claude != nil {
 		validateHost("claude", c.Hosts.Claude, fail)
+	}
+	if c.Hosts.OpenCode != nil {
+		validateHost("opencode", c.Hosts.OpenCode, fail)
 	}
 
 	if len(problems) > 0 {
@@ -84,7 +88,7 @@ func validateHost(name string, h *Host, fail func(string, ...any)) {
 }
 
 func effortList(host string) string {
-	if host == "claude" {
+	if host == "claude" || host == "opencode" {
 		return "low, medium, high, xhigh, max"
 	}
 	return "low, medium, high, xhigh, max, ultra"

--- a/internal/interview/configure.go
+++ b/internal/interview/configure.go
@@ -22,9 +22,10 @@ import (
 // exact same materializeHost/parseConcurrency ingestion init already
 // has.
 const (
-	idPickHosts       = "pick.hosts"
-	idPickRolesClaude = "pick.roles.claude"
-	idPickRolesCodex  = "pick.roles.codex"
+	idPickHosts         = "pick.hosts"
+	idPickRolesClaude   = "pick.roles.claude"
+	idPickRolesCodex    = "pick.roles.codex"
+	idPickRolesOpenCode = "pick.roles.opencode"
 )
 
 // NextConfigure derives the next document for the `orch configure`
@@ -84,7 +85,7 @@ func nextAfterSequenceConfigure(facts Facts, committed *config.Config, committed
 	if err != nil {
 		return question.Document{}, err
 	}
-	seeds := seedFiles(facts, configureSeedScope(committed, cfg.Hosts.Claude != nil, cfg.Hosts.Codex != nil), answers)
+	seeds := seedFiles(facts, configureSeedScope(committed, cfg.Hosts.Claude != nil, cfg.Hosts.Codex != nil, cfg.Hosts.OpenCode != nil), answers)
 	summary, err := buildConfigureSummary(cfg, committed, committedRaw, repoRoot, seeds)
 	if err != nil {
 		return question.Document{}, err
@@ -176,21 +177,34 @@ func readCommittedRaw(repoRoot string) ([]byte, error) {
 // doctor` reports and nothing could fix.
 func buildSequenceConfigure(facts Facts, committed *config.Config, answers map[string]string) ([]docSpec, error) {
 	docs := []docSpec{pickerDocConfigure(committed)}
+	if committed.Hosts.OpenCode != nil {
+		docs = append(docs, docSpec{questions: []question.Question{{
+			ID: idPickRolesOpenCode, Header: "OpenCode", Prompt: "Review or change OpenCode V2's role profiles?",
+			Kind: question.KindSelect, Default: "no", Options: yesNoOptions("no"),
+		}}})
+	}
 
 	claudeCommitted := committedHostConfig(committed, "claude") != nil
 	codexCommitted := committedHostConfig(committed, "codex") != nil
+	openCommitted := committedHostConfig(committed, "opencode") != nil
 	claudeEnabled := claudeCommitted
 	codexEnabled := codexCommitted
+	openEnabled := openCommitted
 
 	if answers[idPickHosts] == "yes" {
-		docs = append(docs, hostToggleDoc(facts, boolValue(claudeCommitted), boolValue(codexCommitted)))
+		docs = append(docs, hostToggleDoc(facts, boolValue(claudeCommitted), boolValue(codexCommitted), boolValue(openCommitted)))
 
 		claudeVal, claudeKnown := answers[idHostClaudeEnabled]
 		codexVal, codexKnown := answers[idHostCodexEnabled]
 		claudeEnabled = claudeKnown && claudeVal == "yes"
 		codexEnabled = codexKnown && codexVal == "yes"
+		openVal, openKnown := answers[idHostOpenCodeEnabled]
+		if !facts.OpenCodeCLI && !openCommitted {
+			openKnown, openVal = true, "no"
+		}
+		openEnabled = openKnown && openVal == "yes"
 
-		if claudeKnown && codexKnown && !claudeEnabled && !codexEnabled {
+		if claudeKnown && codexKnown && openKnown && !claudeEnabled && !codexEnabled && !openEnabled {
 			return nil, ErrNoHostEnabled
 		}
 	}
@@ -212,12 +226,21 @@ func buildSequenceConfigure(facts Facts, committed *config.Config, answers map[s
 			docs = append(docs, roleDocSpecs("codex", showExplain, committedRoleDefaults(committedHostConfig(committed, "codex")))...)
 		}
 	}
+	if openEnabled {
+		showExplain := !claudeEnabled && !codexEnabled
+		switch {
+		case !openCommitted:
+			docs = append(docs, roleDocSpecs("opencode", showExplain, defaultProfileFor("opencode"))...)
+		case answers[idPickRolesOpenCode] == "yes":
+			docs = append(docs, roleDocSpecs("opencode", showExplain, committedRoleDefaults(committedHostConfig(committed, "opencode")))...)
+		}
+	}
 
 	if answers[idPickSettings] == "yes" {
 		docs = append(docs, settingsDoc(committedSettingsDefaults(committed)))
 	}
 
-	docs = append(docs, seedDocs(facts, configureSeedScope(committed, claudeEnabled, codexEnabled))...)
+	docs = append(docs, seedDocs(facts, configureSeedScope(committed, claudeEnabled, codexEnabled, openEnabled))...)
 
 	return docs, nil
 }
@@ -232,13 +255,15 @@ func buildSequenceConfigure(facts Facts, committed *config.Config, answers map[s
 // can never disagree about which offers applied — the asymmetry that
 // would otherwise let a seed be planned for a file no question was ever
 // shown for.
-func configureSeedScope(committed *config.Config, claudeEnabled, codexEnabled bool) seedScope {
+func configureSeedScope(committed *config.Config, claudeEnabled, codexEnabled, openEnabled bool) seedScope {
+	agentsEnabled := codexEnabled || openEnabled
+	agentsCommitted := committed.Hosts.Codex != nil || committed.Hosts.OpenCode != nil
 	return seedScope{
 		created: map[string]bool{
 			"claude": claudeEnabled && committedHostConfig(committed, "claude") == nil,
-			"codex":  codexEnabled && committedHostConfig(committed, "codex") == nil,
+			"codex":  agentsEnabled && !agentsCommitted,
 		},
-		repaired: map[string]bool{"claude": claudeEnabled, "codex": codexEnabled},
+		repaired: map[string]bool{"claude": claudeEnabled, "codex": agentsEnabled},
 	}
 }
 
@@ -332,6 +357,8 @@ func hostEnabledID(host string) string {
 		return idHostClaudeEnabled
 	case "codex":
 		return idHostCodexEnabled
+	case "opencode":
+		return idHostOpenCodeEnabled
 	default:
 		return ""
 	}
@@ -345,6 +372,8 @@ func setConfigHost(cfg *config.Config, host string, h *config.Host) {
 		cfg.Hosts.Claude = h
 	case "codex":
 		cfg.Hosts.Codex = h
+	case "opencode":
+		cfg.Hosts.OpenCode = h
 	}
 }
 
@@ -361,6 +390,10 @@ func deepCopyConfig(committed *config.Config) *config.Config {
 	if committed.Hosts.Codex != nil {
 		h := *committed.Hosts.Codex
 		cfg.Hosts.Codex = &h
+	}
+	if committed.Hosts.OpenCode != nil {
+		h := *committed.Hosts.OpenCode
+		cfg.Hosts.OpenCode = &h
 	}
 	return &cfg
 }
@@ -399,7 +432,7 @@ func applyHostConfigure(cfg *config.Config, host string, answers map[string]stri
 func materializeConfigure(committed *config.Config, answers map[string]string) (*config.Config, error) {
 	cfg := deepCopyConfig(committed)
 
-	for _, host := range []string{"claude", "codex"} {
+	for _, host := range []string{"claude", "codex", "opencode"} {
 		if err := applyHostConfigure(cfg, host, answers); err != nil {
 			return nil, err
 		}
@@ -448,7 +481,12 @@ func disabledInstructionFiles(committed, cfg *config.Config) []string {
 		names = append(names, InstructionFile("claude"))
 	}
 	if committed.Hosts.Codex != nil && cfg.Hosts.Codex == nil {
-		names = append(names, InstructionFile("codex"))
+		if cfg.Hosts.OpenCode == nil {
+			names = append(names, InstructionFile("codex"))
+		}
+	}
+	if committed.Hosts.OpenCode != nil && cfg.Hosts.OpenCode == nil && cfg.Hosts.Codex == nil && committed.Hosts.Codex == nil {
+		names = append(names, InstructionFile("opencode"))
 	}
 	return names
 }
@@ -515,7 +553,7 @@ func buildConfigureSummary(cfg, committed *config.Config, committedRaw []byte, r
 		conflictLines = append(conflictLines, fmt.Sprintf("%s: %s", filepath.ToSlash(rel), c.Report.Detail))
 	}
 
-	gitignore, err := gitignoreLines(repoRoot)
+	gitignore, err := gitignoreLines(repoRoot, cfg)
 	if err != nil {
 		return question.Summary{}, err
 	}

--- a/internal/interview/configurelocal.go
+++ b/internal/interview/configurelocal.go
@@ -28,6 +28,7 @@ import (
 const (
 	idPickClaude   = "pick.claude"
 	idPickCodex    = "pick.codex"
+	idPickOpenCode = "pick.opencode"
 	idPickSettings = "pick.settings"
 )
 
@@ -340,6 +341,8 @@ func committedHostConfig(committed *config.Config, host string) *config.Host {
 		return committed.Hosts.Claude
 	case "codex":
 		return committed.Hosts.Codex
+	case "opencode":
+		return committed.Hosts.OpenCode
 	default:
 		return nil
 	}
@@ -375,6 +378,8 @@ func pickIDForHost(host string) string {
 		return idPickClaude
 	case "codex":
 		return idPickCodex
+	case "opencode":
+		return idPickOpenCode
 	default:
 		return ""
 	}
@@ -394,6 +399,9 @@ func buildSequenceLocal(committed *config.Config, seeded map[string]string, answ
 	}
 	if committed.Hosts.Codex != nil && answers[idPickCodex] == "yes" {
 		docs = append(docs, localRoleDocSpecs("codex", committed, seeded)...)
+	}
+	if committed.Hosts.OpenCode != nil && answers[idPickOpenCode] == "yes" {
+		docs = append(docs, localRoleDocSpecs("opencode", committed, seeded)...)
 	}
 	if answers[idPickSettings] == "yes" {
 		docs = append(docs, localSettingsDoc(committed, seeded))
@@ -426,6 +434,13 @@ func pickerDocLocal(committed *config.Config, seeded map[string]string) docSpec 
 			Kind:    question.KindSelect,
 			Default: def,
 			Options: yesNoOptions(def),
+		})
+	}
+	if committed.Hosts.OpenCode != nil {
+		def := boolValue(hasHostOverride(seeded, "opencode"))
+		qs = append(qs, question.Question{
+			ID: idPickOpenCode, Header: "OpenCode", Prompt: "Review or change OpenCode V2's local overrides?",
+			Kind: question.KindSelect, Default: def, Options: yesNoOptions(def),
 		})
 	}
 	settingsDef := boolValue(hasSettingsOverride(seeded))
@@ -634,7 +649,7 @@ func materializeLocal(committed *config.Config, seeded map[string]string, answer
 		overrides[k] = v
 	}
 
-	for _, host := range []string{"claude", "codex"} {
+	for _, host := range []string{"claude", "codex", "opencode"} {
 		if answers[pickIDForHost(host)] != "yes" {
 			continue
 		}

--- a/internal/interview/configurelocal_test.go
+++ b/internal/interview/configurelocal_test.go
@@ -443,6 +443,27 @@ effort = "ultra"
 func TestConfigureLocalLeafIDsMatchPreferenceKeys(t *testing.T) {
 	root := t.TempDir()
 	writeCommittedConfigLocal(t, root)
+	raw, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(config.Path)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	committed, err := config.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	openCode := *committed.Hosts.Codex
+	committed.Hosts.OpenCode = &openCode
+	committed.ConfigRevision, err = config.Revision(committed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err = config.Render(committed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(config.Path)), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	answers := map[string]string{}
 	seen := map[string]bool{}
@@ -455,7 +476,7 @@ func TestConfigureLocalLeafIDsMatchPreferenceKeys(t *testing.T) {
 			break
 		}
 		for _, q := range doc.Questions {
-			if q.ID == idPickClaude || q.ID == idPickCodex || q.ID == idPickSettings {
+			if q.ID == idPickClaude || q.ID == idPickCodex || q.ID == idPickOpenCode || q.ID == idPickSettings {
 				answers[q.ID] = "yes"
 				continue
 			}

--- a/internal/interview/detect.go
+++ b/internal/interview/detect.go
@@ -37,8 +37,9 @@ type Deps struct {
 // inside an AnswerSet — an adapter cannot spoof detection by editing
 // the answers map, since Next never reads facts back out of it.
 type Facts struct {
-	ClaudeCLI bool
-	CodexCLI  bool
+	ClaudeCLI   bool
+	CodexCLI    bool
+	OpenCodeCLI bool
 
 	Git     bool
 	GitRoot string
@@ -91,6 +92,7 @@ func Detect(ctx context.Context, deps Deps) Facts {
 	var f Facts
 	f.ClaudeCLI = lookPathOK(deps.LookPath, "claude")
 	f.CodexCLI = lookPathOK(deps.LookPath, "codex")
+	f.OpenCodeCLI = lookPathOK(deps.LookPath, "opencode2")
 	f.Gh = lookPathOK(deps.LookPath, "gh")
 
 	if lookPathOK(deps.LookPath, "git") {
@@ -109,8 +111,9 @@ func Detect(ctx context.Context, deps Deps) Facts {
 		root = deps.RepoRoot
 	}
 	f.Instructions = map[string]InstructionFileState{
-		"claude": classifyInstructionFile(root, InstructionFile("claude")),
-		"codex":  classifyInstructionFile(root, InstructionFile("codex")),
+		"claude":   classifyInstructionFile(root, InstructionFile("claude")),
+		"codex":    classifyInstructionFile(root, InstructionFile("codex")),
+		"opencode": classifyInstructionFile(root, InstructionFile("opencode")),
 	}
 
 	return f

--- a/internal/interview/detect_test.go
+++ b/internal/interview/detect_test.go
@@ -28,13 +28,13 @@ func TestDetectAllPresentAndHealthy(t *testing.T) {
 		{Name: "git", Args: []string{"rev-parse", "--show-toplevel"}, Dir: "/repo", Stdout: "/repo\n", Exit: 0},
 		{Name: "memhub", Args: []string{"status"}, Dir: "/repo", Exit: 0},
 	}}
-	deps := Deps{RepoRoot: "/repo", LookPath: fakeLookPath("claude", "codex", "git", "gh", "memhub"), Runner: script}
+	deps := Deps{RepoRoot: "/repo", LookPath: fakeLookPath("claude", "codex", "opencode2", "git", "gh", "memhub"), Runner: script}
 
 	facts := Detect(context.Background(), deps)
 	script.AssertExhausted()
 
-	if !facts.ClaudeCLI || !facts.CodexCLI || !facts.Gh {
-		t.Fatalf("facts = %+v, want claude/codex/gh all true", facts)
+	if !facts.ClaudeCLI || !facts.CodexCLI || !facts.OpenCodeCLI || !facts.Gh {
+		t.Fatalf("facts = %+v, want claude/codex/opencode/gh all true", facts)
 	}
 	if !facts.Git || facts.GitRoot != "/repo" {
 		t.Errorf("git facts = %v/%q, want true/\"/repo\"", facts.Git, facts.GitRoot)
@@ -86,8 +86,8 @@ func TestDetectNoGit(t *testing.T) {
 	if !facts.ClaudeCLI {
 		t.Error("ClaudeCLI = false, want true")
 	}
-	if facts.CodexCLI || facts.Gh {
-		t.Errorf("facts = %+v, want codex/gh false", facts)
+	if facts.CodexCLI || facts.OpenCodeCLI || facts.Gh {
+		t.Errorf("facts = %+v, want codex/opencode/gh false", facts)
 	}
 }
 
@@ -107,7 +107,7 @@ func TestDetectGitNotARepo(t *testing.T) {
 
 func TestDetectNilLookPath(t *testing.T) {
 	facts := Detect(context.Background(), Deps{RepoRoot: "/repo"})
-	if facts.ClaudeCLI || facts.CodexCLI || facts.Git || facts.Gh || facts.MemhubCLI {
+	if facts.ClaudeCLI || facts.CodexCLI || facts.OpenCodeCLI || facts.Git || facts.Gh || facts.MemhubCLI {
 		t.Errorf("facts = %+v, want every field false with a nil LookPath", facts)
 	}
 }

--- a/internal/interview/errors.go
+++ b/internal/interview/errors.go
@@ -6,12 +6,11 @@ import "errors"
 // with %w and detail (config/run house style) rather than replace
 // them.
 var (
-	// ErrNoHostEnabled reports that both host.claude.enabled and
-	// host.codex.enabled are answered "no" — the same "at least one
-	// host" rule config.validate enforces on the committed file,
-	// checked here as soon as both toggles are known so the adapter
+	// ErrNoHostEnabled reports that every offered host toggle is answered
+	// "no" — the same "at least one host" rule config.validate enforces on
+	// the committed file, checked as soon as all toggles are known so the adapter
 	// can fix it before walking any role questions.
-	ErrNoHostEnabled = errors.New("at least one of Claude Code or Codex CLI must be enabled")
+	ErrNoHostEnabled = errors.New("at least one of Claude Code, Codex CLI, or OpenCode V2 must be enabled")
 	// ErrUnknownAnswer reports an answer key that names no question in
 	// the sequence the current facts and prior answers derive — either
 	// a genuine typo, or a question that is not (or no longer)

--- a/internal/interview/interview.go
+++ b/internal/interview/interview.go
@@ -102,7 +102,7 @@ func nextAfterSequence(facts Facts, answers map[string]string, repoRoot string) 
 	if err != nil {
 		return question.Document{}, err
 	}
-	seeds := seedFiles(facts, initSeedScope(cfg.Hosts.Claude != nil, cfg.Hosts.Codex != nil), answers)
+	seeds := seedFiles(facts, initSeedScope(cfg.Hosts.Claude != nil, cfg.Hosts.Codex != nil || cfg.Hosts.OpenCode != nil), answers)
 	summary, err := buildSummary(cfg, repoRoot, seeds)
 	if err != nil {
 		return question.Document{}, err

--- a/internal/interview/materialize.go
+++ b/internal/interview/materialize.go
@@ -42,6 +42,13 @@ func materialize(answers map[string]string) (*config.Config, error) {
 		}
 		cfg.Hosts.Codex = host
 	}
+	if answers[idHostOpenCodeEnabled] == "yes" {
+		host, err := materializeHost("opencode", answers, nil)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Hosts.OpenCode = host
+	}
 
 	n, err := parseConcurrency(answers[idMaxSubagents])
 	if err != nil {

--- a/internal/interview/materialize_test.go
+++ b/internal/interview/materialize_test.go
@@ -65,6 +65,28 @@ func TestMaterializeSingleHost(t *testing.T) {
 	}
 }
 
+func TestMaterializeOpenCodeOnly(t *testing.T) {
+	answers := fullAnswers()
+	answers[idHostClaudeEnabled] = "no"
+	answers[idHostCodexEnabled] = "no"
+	answers[idHostOpenCodeEnabled] = "yes"
+	for _, rs := range roleSpecs {
+		def := defaultProfiles["opencode"][rs.key]
+		answers[roleModelID("opencode", rs.key)] = def.model
+		answers[roleEffortID("opencode", rs.key)] = def.effort
+	}
+	cfg, err := materialize(answers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Hosts.Claude != nil || cfg.Hosts.Codex != nil || cfg.Hosts.OpenCode == nil {
+		t.Fatalf("Hosts = %+v, want OpenCode only", cfg.Hosts)
+	}
+	if got := cfg.Hosts.OpenCode.Roles.Specialist.Model; got != "openai/gpt-5.6-sol" {
+		t.Errorf("specialist model = %q", got)
+	}
+}
+
 func TestMaterializeFreeTextModel(t *testing.T) {
 	answers := fullAnswers()
 	answers[roleModelID("claude", "architect")] = "claude-fable-5"

--- a/internal/interview/sequence.go
+++ b/internal/interview/sequence.go
@@ -11,13 +11,14 @@ import (
 // (materialize.go), so an adapter's answers map doubles as a preview
 // of the committed configuration's shape.
 const (
-	idHostClaudeEnabled = "host.claude.enabled"
-	idHostCodexEnabled  = "host.codex.enabled"
-	idMaxSubagents      = "concurrency.max_subagents"
-	idMergeStrategy     = "merge.strategy"
-	idMemhubMode        = "memhub.mode"
-	idMetricsEnabled    = "metrics.enabled"
-	idApproval          = "approval"
+	idHostClaudeEnabled   = "host.claude.enabled"
+	idHostCodexEnabled    = "host.codex.enabled"
+	idHostOpenCodeEnabled = "host.opencode.enabled"
+	idMaxSubagents        = "concurrency.max_subagents"
+	idMergeStrategy       = "merge.strategy"
+	idMemhubMode          = "memhub.mode"
+	idMetricsEnabled      = "metrics.enabled"
+	idApproval            = "approval"
 )
 
 // roleModelID and roleEffortID build a role's two question ids.
@@ -84,6 +85,14 @@ var defaultProfiles = map[string]map[string]profile{
 		"reviewer":         {"claude-opus-5", "high"},
 		"review_downgrade": {"claude-opus-5", "medium"},
 	},
+	"opencode": {
+		"architect":        {"openai/gpt-5.6-sol", "xhigh"},
+		"scout":            {"openai/gpt-5.6-luna", "max"},
+		"implementer":      {"openai/gpt-5.6-terra", "max"},
+		"specialist":       {"openai/gpt-5.6-sol", "max"},
+		"reviewer":         {"openai/gpt-5.6-sol", "xhigh"},
+		"review_downgrade": {"openai/gpt-5.6-sol", "high"},
+	},
 }
 
 // defaultProfileFor returns a role-defaults source drawing from the
@@ -103,8 +112,9 @@ func defaultProfileFor(host string) func(string) profile {
 // third Claude model (claude-fable-5, PRD §10): the committed
 // configuration this interview writes never defaults to it.
 var hostModels = map[string][]string{
-	"codex":  {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"},
-	"claude": {"claude-opus-5", "claude-sonnet-5"},
+	"codex":    {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"},
+	"claude":   {"claude-opus-5", "claude-sonnet-5"},
+	"opencode": {"openai/gpt-5.6-sol", "openai/gpt-5.6-terra", "openai/gpt-5.6-luna"},
 }
 
 // hostEfforts lists each host's full closed effort enum — every value
@@ -115,8 +125,9 @@ var hostModels = map[string][]string{
 // full list, so it stays the single full-domain source of truth the
 // interview owns.
 var hostEfforts = map[string][]string{
-	"codex":  {"low", "medium", "high", "xhigh", "max", "ultra"},
-	"claude": {"low", "medium", "high", "xhigh", "max"},
+	"codex":    {"low", "medium", "high", "xhigh", "max", "ultra"},
+	"claude":   {"low", "medium", "high", "xhigh", "max"},
+	"opencode": {"low", "medium", "high", "xhigh", "max"},
 }
 
 // maxOfferedEfforts is the largest number of effort levels offered as
@@ -151,8 +162,9 @@ func effortsOffered(host, def string) []string {
 
 // hostLabels is each host key's human-readable display name.
 var hostLabels = map[string]string{
-	"codex":  "Codex CLI",
-	"claude": "Claude Code",
+	"codex":    "Codex CLI",
+	"claude":   "Claude Code",
+	"opencode": "OpenCode V2",
 }
 
 // assistDeliveryExplanation is the §18 step 3 explanation, shown as
@@ -194,14 +206,20 @@ func (d docSpec) allAnswered(answers map[string]string) bool {
 // "no" — the same rule config.validate enforces on the committed file,
 // checked here before any role question is ever asked.
 func buildSequence(facts Facts, answers map[string]string) ([]docSpec, error) {
-	docs := []docSpec{hostToggleDoc(facts, boolValue(facts.ClaudeCLI), boolValue(facts.CodexCLI))}
+	docs := []docSpec{hostToggleDoc(facts, boolValue(facts.ClaudeCLI), boolValue(facts.CodexCLI), boolValue(facts.OpenCodeCLI))}
 
 	claudeVal, claudeKnown := answers[idHostClaudeEnabled]
 	codexVal, codexKnown := answers[idHostCodexEnabled]
 	claudeEnabled := claudeKnown && claudeVal == "yes"
 	codexEnabled := codexKnown && codexVal == "yes"
+	openVal, openKnown := answers[idHostOpenCodeEnabled]
+	if !facts.OpenCodeCLI {
+		openKnown = true
+		openVal = "no"
+	}
+	openEnabled := openKnown && openVal == "yes"
 
-	if claudeKnown && codexKnown && !claudeEnabled && !codexEnabled {
+	if claudeKnown && codexKnown && openKnown && !claudeEnabled && !codexEnabled && !openEnabled {
 		return nil, ErrNoHostEnabled
 	}
 
@@ -211,24 +229,27 @@ func buildSequence(facts Facts, answers map[string]string) ([]docSpec, error) {
 	if codexEnabled {
 		docs = append(docs, roleDocSpecs("codex", !claudeEnabled, defaultProfileFor("codex"))...)
 	}
-	if claudeKnown && codexKnown {
+	if openEnabled {
+		docs = append(docs, roleDocSpecs("opencode", !claudeEnabled && !codexEnabled, defaultProfileFor("opencode"))...)
+	}
+	if claudeKnown && codexKnown && openKnown {
 		docs = append(docs, settingsDoc(initSettingsDefaults(facts)))
-		docs = append(docs, seedDocs(facts, initSeedScope(claudeEnabled, codexEnabled))...)
+		docs = append(docs, seedDocs(facts, initSeedScope(claudeEnabled, codexEnabled || openEnabled))...)
 	}
 	return docs, nil
 }
 
 // hostToggleDoc is doc 1 (init) — or, for `orch configure`, the
 // host-toggle document inserted once pick.hosts is answered "yes" —
-// whether to enable Claude Code and Codex CLI. claudeDefault/
-// codexDefault source each Default independently of the Hint's
+// which detected host CLIs to enable. Each explicit default sources its
+// question independently of the Hint's
 // detection status (still always facts-derived): init passes
 // facts-derived CLI detection (boolValue(facts.ClaudeCLI/CodexCLI));
 // `orch configure` passes the committed configuration's current
 // enablement instead, so re-answering this doc while editing an
 // existing configuration starts from what is already there rather
 // than re-running the first-time detection default.
-func hostToggleDoc(facts Facts, claudeDefault, codexDefault string) docSpec {
+func hostToggleDoc(facts Facts, claudeDefault, codexDefault, openCodeDefault string) docSpec {
 	claudeQ := question.Question{
 		ID:       idHostClaudeEnabled,
 		Header:   "Claude",
@@ -248,16 +269,23 @@ func hostToggleDoc(facts Facts, claudeDefault, codexDefault string) docSpec {
 		Default: codexDefault,
 		Options: yesNoOptions(codexDefault),
 	}
-	return docSpec{questions: []question.Question{claudeQ, codexQ}}
+	questions := []question.Question{claudeQ, codexQ}
+	if facts.OpenCodeCLI || openCodeDefault == "yes" {
+		questions = append(questions, question.Question{
+			ID: idHostOpenCodeEnabled, Header: "OpenCode", Prompt: "Enable OpenCode V2 as a host?",
+			Hint: detectionHint("opencode2 CLI", facts.OpenCodeCLI), Kind: question.KindSelect,
+			Default: openCodeDefault, Options: yesNoOptions(openCodeDefault),
+		})
+	}
+	return docSpec{questions: questions}
 }
 
 // roleDocSpecs builds host's six per-role documents (model + effort,
 // grouped), in roleSpecs order. showExplain controls whether each
 // model question carries its role's §18 step 4 explanation as a
-// Preamble: claude's docs always show it; codex's docs show it only
-// when claude was not enabled (so a solo-Codex interview still walks
-// the role explanations once, and a both-hosts interview does not
-// repeat them). defaults sources each role's starting model/effort:
+// Preamble. The first enabled host shows it, so every interview walks the
+// explanations once without repeating them for additional hosts. defaults
+// sources each role's starting model/effort:
 // init and a freshly-enabled `orch configure` host both pass
 // defaultProfileFor(host) (the PRD §10 defaults); a still-enabled
 // `orch configure` host instead passes committedRoleDefaults(h)

--- a/internal/interview/summary.go
+++ b/internal/interview/summary.go
@@ -13,11 +13,12 @@ import (
 	"github.com/kninetimmy/orch/internal/question"
 )
 
-// instructionFileFor names the root instruction file a host owns
-// (contract call 4): AGENTS.md for Codex, CLAUDE.md for Claude Code.
+// instructionFileFor names the root instruction file a host owns: AGENTS.md
+// for Codex and OpenCode, CLAUDE.md for Claude Code.
 var instructionFileFor = map[string]string{
-	"claude": "CLAUDE.md",
-	"codex":  "AGENTS.md",
+	"claude":   "CLAUDE.md",
+	"codex":    "AGENTS.md",
+	"opencode": "AGENTS.md",
 }
 
 // applicableInstructionFiles lists, in claude-then-codex order, the
@@ -29,6 +30,9 @@ func applicableInstructionFiles(cfg *config.Config) []string {
 	}
 	if cfg.Hosts.Codex != nil {
 		names = append(names, instructionFileFor["codex"])
+	}
+	if cfg.Hosts.OpenCode != nil && cfg.Hosts.Codex == nil {
+		names = append(names, instructionFileFor["opencode"])
 	}
 	return names
 }
@@ -57,7 +61,9 @@ func SiblingInstructionFile(host string) string {
 // Detect's execProber-duplication precedent, so this pre-init-safe
 // package need not import internal/run/state/lockfile) the values of
 // run.WorktreeContainer+"/", config.LocalOverridePath, state.Path,
-// lockfile.Path, agents.ClaudeDir+"/", and agents.CodexDir+"/".
+// lockfile.Path and the generated-agent directories. Before OpenCode support,
+// this fixed list ended with the Claude and Codex directories; OpenCode's
+// directory is added conditionally by gitignoreLines below.
 var baseGitignoreLines = []string{
 	".orchestrator/worktrees/",
 	".orchestrator/config.local.toml",
@@ -120,7 +126,7 @@ func buildSummary(cfg *config.Config, repoRoot string, seeds map[string]string) 
 		conflictLines = append(conflictLines, fmt.Sprintf("%s: %s", filepath.ToSlash(rel), c.Report.Detail))
 	}
 
-	gitignore, err := gitignoreLines(repoRoot)
+	gitignore, err := gitignoreLines(repoRoot, cfg)
 	if err != nil {
 		return question.Summary{}, err
 	}
@@ -182,8 +188,11 @@ func isBlockingPlanError(err error) bool {
 // metricsGitignoreLine's own doc comment) — filtered against whatever
 // repoRoot's .gitignore already contains, so the summary proposes only
 // genuinely missing lines.
-func gitignoreLines(repoRoot string) ([]string, error) {
+func gitignoreLines(repoRoot string, cfg *config.Config) ([]string, error) {
 	want := append(append([]string{}, baseGitignoreLines...), metricsGitignoreLine)
+	if cfg.Hosts.OpenCode != nil {
+		want = append(want, ".opencode/agents/")
+	}
 
 	existing, err := readGitignore(repoRoot)
 	if err != nil {
@@ -236,6 +245,9 @@ func buildComplete(summary question.Summary, facts Facts) *question.Complete {
 		"memhub_cli":     boolValue(facts.MemhubCLI),
 		"memhub_healthy": boolValue(facts.MemhubHealthy),
 		"memhub_detail":  facts.MemhubDetail,
+	}
+	if facts.OpenCodeCLI {
+		detection["opencode_cli"] = "yes"
 	}
 
 	var reasons []string

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -37,7 +37,7 @@ var ErrHeld = errors.New("delivery lock is already held")
 type Owner struct {
 	SchemaVersion int       `json:"schema_version"`
 	RunID         string    `json:"run_id"`
-	Host          string    `json:"host"` // "claude" or "codex"
+	Host          string    `json:"host"` // "claude", "codex", or "opencode"
 	Hostname      string    `json:"hostname"`
 	PID           int       `json:"pid"`
 	AcquiredAt    time.Time `json:"acquired_at"`

--- a/internal/run/activate.go
+++ b/internal/run/activate.go
@@ -184,10 +184,7 @@ func Activate(ctx context.Context, env Env, reqJSON []byte) (*ActivationResult, 
 	if err := requireAssistNoLock(env.RepoRoot); err != nil {
 		return nil, err
 	}
-	agentHost := cfg.Hosts.Claude
-	if plan.Host == "codex" {
-		agentHost = cfg.Hosts.Codex
-	}
+	agentHost := cfg.Host(plan.Host)
 	stale, staleErr := agents.Stale(env.RepoRoot, plan.Host, agentHost)
 	if len(stale) > 0 {
 		detail := strings.Join(stale, ", ")

--- a/internal/run/derive.go
+++ b/internal/run/derive.go
@@ -15,13 +15,7 @@ import (
 // routing.Profile the pure routing package consumes. config owns the
 // model/effort vocabulary; routing never sees a config.Host directly.
 func hostProfile(cfg *config.Config, host string) (routing.Profile, error) {
-	var h *config.Host
-	switch host {
-	case "claude":
-		h = cfg.Hosts.Claude
-	case "codex":
-		h = cfg.Hosts.Codex
-	}
+	h := cfg.Host(host)
 	if h == nil {
 		return routing.Profile{}, fmt.Errorf("host %q is not enabled in configuration", host)
 	}
@@ -48,7 +42,7 @@ func hostProfile(cfg *config.Config, host string) (routing.Profile, error) {
 // stop making.
 func effortDelivery(host string) (manifest.EffortDelivery, error) {
 	switch host {
-	case "codex":
+	case "codex", "opencode":
 		return manifest.EffortDeliveryParameter, nil
 	case "claude":
 		return manifest.EffortDeliveryPromptCue, nil
@@ -98,6 +92,7 @@ func modelDenylist(cfg *config.Config) []string {
 	}
 	add(cfg.Hosts.Claude)
 	add(cfg.Hosts.Codex)
+	add(cfg.Hosts.OpenCode)
 	names := make([]string, 0, len(seen))
 	for m := range seen {
 		names = append(names, m)

--- a/internal/run/derive_test.go
+++ b/internal/run/derive_test.go
@@ -29,8 +29,9 @@ func TestHostProfile(t *testing.T) {
 // prompt cue, and an unrecognized host is an error rather than a guess.
 func TestEffortDelivery(t *testing.T) {
 	cases := map[string]manifest.EffortDelivery{
-		"codex":  manifest.EffortDeliveryParameter,
-		"claude": manifest.EffortDeliveryPromptCue,
+		"codex":    manifest.EffortDeliveryParameter,
+		"claude":   manifest.EffortDeliveryPromptCue,
+		"opencode": manifest.EffortDeliveryParameter,
 	}
 	for host, want := range cases {
 		got, err := effortDelivery(host)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -184,7 +184,7 @@ type Issue struct {
 // Run describes the active Delivery run.
 type Run struct {
 	ID        string    `json:"id"`
-	Host      string    `json:"host"` // "claude" or "codex"
+	Host      string    `json:"host"` // "claude", "codex", or "opencode"
 	StartedAt time.Time `json:"started_at"`
 	Plan      PlanRef   `json:"plan"`
 	Issues    []Issue   `json:"issues"`

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -21,6 +21,17 @@ func stateDir(t *testing.T) string {
 	return root
 }
 
+func TestEnterDeliveryAcceptsOpenCode(t *testing.T) {
+	root := stateDir(t)
+	st, err := EnterDelivery(root, "opencode", testPlanRef(), testIssues())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Run.Host != "opencode" {
+		t.Fatalf("host = %q, want opencode", st.Run.Host)
+	}
+}
+
 func writeState(t *testing.T, root, content string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(root, ".orchestrator", "state.json"), []byte(content), 0o644); err != nil {

--- a/internal/state/transition.go
+++ b/internal/state/transition.go
@@ -22,8 +22,8 @@ import (
 // (EnterDelivery does not recompute it — the caller has already
 // validated the plan and its approval).
 func EnterDelivery(repoRoot, host string, plan PlanRef, issues []Issue) (*State, error) {
-	if host != "claude" && host != "codex" {
-		return nil, fmt.Errorf("unknown host %q (want claude or codex)", host)
+	if host != "claude" && host != "codex" && host != "opencode" {
+		return nil, fmt.Errorf("unknown host %q (want claude, codex, or opencode)", host)
 	}
 	if plan.Digest == "" {
 		return nil, errors.New("EnterDelivery: plan digest must not be empty")

--- a/marketplace_test.go
+++ b/marketplace_test.go
@@ -1,15 +1,17 @@
 // Package orch_test validates the root cross-host plugin marketplace
-// manifest (.claude-plugin/marketplace.json). One manifest serves both
-// hosts — Claude Code and Codex CLI each read it and silently filter
-// entries whose source lacks their own host manifest — so these tests
-// pin the invariants that filtering relies on: every adapter directory
-// is listed exactly once, each entry's source carries the right host
-// manifest, and names/descriptions/versions stay consistent with the
-// per-adapter plugin.json files. Ordinary Go tests so `go test ./...`
-// catches drift; host-specific artifact checks live in each adapter's
-// plugin_test.go, and cross-host behavioural invariants live in
-// internal/adaptertest (which this root package deliberately does not
-// import — its scope is the two adapter test files).
+// manifest (.claude-plugin/marketplace.json). One manifest serves Claude
+// Code and Codex CLI, which each read it and silently filter entries whose
+// source lacks their own host manifest. Before the native OpenCode V2 adapter,
+// every adapter directory was marketplace-backed; OpenCode is instead an npm
+// package and must not appear here. These tests pin the remaining marketplace
+// invariants: every marketplace-backed adapter is listed exactly once, each
+// entry's source carries the right host manifest, and names/descriptions/
+// versions stay consistent with the per-adapter plugin.json files.
+// Ordinary Go tests make `go test ./...` catch drift; host-specific
+// artifact checks live in each adapter's plugin_test.go, and cross-host
+// behavioural invariants live in internal/adaptertest (which this root
+// package deliberately does not import — its scope is the two marketplace
+// adapter test files).
 package orch_test
 
 import (
@@ -172,7 +174,7 @@ func TestMarketplaceEntryConsistency(t *testing.T) {
 	}
 }
 
-func TestMarketplaceCoversAllAdapters(t *testing.T) {
+func TestMarketplaceCoversAllMarketplaceAdapters(t *testing.T) {
 	m := loadMarketplace(t)
 	sources := make(map[string]int)
 	for _, e := range m.Plugins {
@@ -187,6 +189,15 @@ func TestMarketplaceCoversAllAdapters(t *testing.T) {
 			continue
 		}
 		dir := filepath.Join("adapters", d.Name())
+		marketplaceBacked := false
+		for _, manifest := range hostManifests {
+			if _, err := os.Stat(filepath.Join(dir, manifest)); err == nil {
+				marketplaceBacked = true
+			}
+		}
+		if !marketplaceBacked {
+			continue
+		}
 		if n := sources[dir]; n != 1 {
 			t.Errorf("adapter %s appears in %d marketplace entries, want 1", dir, n)
 		}


### PR DESCRIPTION
Delivers issue #226: Land the native OpenCode V2 host adapter

Closes #226

**Plan digest:** `sha256:2679deebdb7f8173aafa0bfca1f4389cbfefbd54f8c5047f3020ed077217dd7e`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Land the existing native OpenCode V2 host implementation with a pinned-beta smoke that exercises session context and mutation interception through the live OpenCode runtime while preserving the existing Claude Code and Codex CLI hosts.

**Acceptance criteria:**
- OpenCode is an independently selectable host throughout environment detection, committed and local configuration, routing, run state, activation, doctor, and generated-agent freshness checks; configurations containing only Claude Code and/or Codex CLI remain valid and retain their prior behavior.
- The OpenCode adapter loads through the documented V2 plugin API under a stable Orch plugin ID and mediates every built-in edit, write, and patch mutation through Orch's existing guard verdict before the mutation occurs; a denied mutation does not reach the filesystem and an allowed mutation remains subject to OpenCode's own permission flow.
- Generated OpenCode role agents use the native V2 agent format, reflect each effective role's configured model and effort variant, run as subagents, and mechanically deny mutation for scout and reviewer roles while leaving implementation roles able to work inside Orch-approved worktrees.
- The shipped OpenCode Architect, Delivery, and setup skill definitions instruct use of the V2 question and subagent surfaces, contain none of the Codex-only request_user_input, spawn_agent, wait_agent, followup_task, rollout, marketplace, hook-manifest, or agent-TOML behavior, and are pinned by deterministic repository tests.
- A repeatable smoke check against the repository's pinned OpenCode V2 beta proves that the live runtime discovers the Orch plugin and native role agents, invokes Orch session-context injection, denies a tracked-file mutation before it reaches the filesystem, and permits a git-ignored scratch mutation through the normal OpenCode tool path.
- OpenCode-specific plugin and agent behavior is covered by deterministic repository tests and the required CI workflow runs those checks on supported CI platforms.
- Blast radius (contributed by Orch because this issue declares a risk domain, not by the plan document): name every element of the structure this change touches and state, for each, whether the behavior it had before this change still holds; record a behavior this change removes as a before-and-after in the same document that stated the old behavior, rather than deleting that statement; and where a restriction is attributed to one named symbol, establish whether it holds for that symbol alone or for every symbol of its kind, and say which.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`
- `npm test --prefix adapters/opencode`
- `npm run smoke --prefix adapters/opencode` — CI does not run this test

| Field | Value |
| --- | --- |
| Role | `specialist` |
| Executor | `gpt-5.6-sol` — effort `max` |
| Reviewer | `gpt-5.6-sol` — effort `xhigh` |
| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to a specialist with a strong reviewer because risk domains (authorization) and the task is unusually difficult.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — All Go packages passed at commit 5caa9993709244425c9088a0efb241c383cadf07. — commit `5caa9993709244425c9088a0efb241c383cadf07` (2026-08-17T03:26:46Z)
- **go-vet** — pass — `go vet ./...` — No vet findings. — commit `5caa9993709244425c9088a0efb241c383cadf07` (2026-08-17T03:26:46Z)
- **gofmt** — pass — `gofmt -l .` — No output; all Go files are formatted. — commit `5caa9993709244425c9088a0efb241c383cadf07` (2026-08-17T03:26:46Z)
- **opencode-adapter-tests** — pass — `npm test --prefix adapters/opencode` — All 5 deterministic native adapter tests passed. — commit `5caa9993709244425c9088a0efb241c383cadf07` (2026-08-17T03:26:46Z)
- **opencode-v2-live-smoke** — pass — `npm run smoke --prefix adapters/opencode` — Pinned opencode2 v0.0.0-beta-17498 used its native simulation backend and live V2 session API: the model request contained Orch session context; a real write tool call to tracked.txt returned the Orch Assist denial and left the file unchanged; a second real write call created the git-ignored scratch file with the requested content. Plugin orch.delivery and all five subagents were discovered. No plugin callback or filesystem mutation was invoked manually. Node emitted the existing DEP0190 warning on Windows. — commit `5caa9993709244425c9088a0efb241c383cadf07` (2026-08-17T03:26:46Z)
- **branch-scope:blast-radius** — pass — `git diff origin/main...HEAD --stat && git diff origin/main...HEAD --check` — Environment detection and init reporting: adds independent opencode2 detection; existing Claude, Codex, Git, gh, and memhub behavior remains. Committed/local configuration and interviews: adds hosts.opencode across parsing, validation, rendering, overlays, preference keys, revisions, setup, summaries, instruction ownership, and ignores; legacy host configurations and prior revision digests remain. Routing/state/activation/bootstrap: accepts OpenCode with parameter effort and configured profiles; Claude prompt-cue and Codex parameter behavior remains. Generated agents: adds OpenCode rendering/freshness while preserving Claude/Codex outputs. Doctor/session context: adds pinned-beta and exactly-one orch.delivery checks plus the shared OpenCode session hook; prior host checks remain. Native adapter: adds the pinned V2 package, plugin, agents, skills, tests, and live smoke; execute.before guards every built-in edit, write, and patch invocation before execution, while allowed calls continue through native permissions. Role scope: scout and reviewer roles deny every edit and shell resource; implementation roles remain subject to Orch worktree containment. Marketplace before/after: before, every adapter directory was marketplace-backed; after, OpenCode is npm-native and intentionally excluded while Claude/Codex marketplace behavior remains, stated explicitly in marketplace_test.go. CI: deterministic npm tests run on Ubuntu, Windows, and macOS; the live beta smoke is local-only. No Claude or Codex artifact or support behavior was removed. Diff check passed at 5caa9993709244425c9088a0efb241c383cadf07. — commit `5caa9993709244425c9088a0efb241c383cadf07` (2026-08-17T03:26:46Z)
- **review-local-required-checks** — pass — `go test ./... && go vet ./... && gofmt -l . && npm test --prefix adapters/opencode && npm run smoke --prefix adapters/opencode` — Reviewer reran every required local check at 5caa9993709244425c9088a0efb241c383cadf07; Go tests and vet passed, gofmt had no output, Node tests passed 5/5, and the pinned-beta live smoke passed. — commit `5caa9993709244425c9088a0efb241c383cadf07` (2026-08-17T03:32:34Z)
- **review-diff-check** — pass — `git diff --check origin/main...HEAD` — No whitespace errors. — commit `5caa9993709244425c9088a0efb241c383cadf07` (2026-08-17T03:32:34Z)
- **review-live-ci** — pass — `gh pr checks 228 --required` — All six GitHub Actions jobs passed at the reviewed head. — commit `5caa9993709244425c9088a0efb241c383cadf07` (2026-08-17T03:32:34Z)
- **acceptance-criterion-1** — satisfied — OpenCode is threaded through detection, configuration, validation, overlays, interviews, routing, state, activation, doctor, and agent rendering; legacy revision compatibility is explicitly preserved and all Go tests passed. — commit `5caa9993709244425c9088a0efb241c383cadf07` (2026-08-17T03:32:35Z)
- **acceptance-criterion-2** — satisfied — The stable orch.delivery V2 plugin registers execute.before, extracts every edit/write/patch target, and calls orch guard check before returning to native execution; errors reject execution and allowed calls do not bypass native permissions. — commit `5caa9993709244425c9088a0efb241c383cadf07` (2026-08-17T03:32:35Z)
- **acceptance-criterion-3** — satisfied — Native agent frontmatter declares subagent mode and model variants, rendering uses effective configuration, read-only roles deny all edit and shell resources, and implementation roles retain guarded mutation access. — commit `5caa9993709244425c9088a0efb241c383cadf07` (2026-08-17T03:32:35Z)
- **acceptance-criterion-4** — satisfied — All three shipped OpenCode skills explicitly use question and subagent surfaces, contain none of the forbidden Codex-only terms, and are covered by deterministic pin tests. — commit `5caa9993709244425c9088a0efb241c383cadf07` (2026-08-17T03:32:35Z)
- **acceptance-criterion-5** — satisfied — The pinned beta smoke starts the real V2 server with its simulation backend, creates and prompts a live session, observes injected context, supplies real write calls, observes guard denial and an unchanged tracked file, then verifies OpenCode creates the ignored scratch file; the assertions fail if either hook is absent. — commit `5caa9993709244425c9088a0efb241c383cadf07` (2026-08-17T03:32:35Z)
- **acceptance-criterion-6** — satisfied — Meaningful Go and Node adapter tests are present; CI runs npm install and test in the Ubuntu, Windows, and macOS matrix, and all six jobs passed. — commit `5caa9993709244425c9088a0efb241c383cadf07` (2026-08-17T03:32:35Z)
- **acceptance-criterion-7** — satisfied — The PR audit enumerates every touched subsystem with preservation statements, records the marketplace behavior as an explicit before/after, and states whether role and mutation restrictions apply to one symbol or every resource of that kind. — commit `5caa9993709244425c9088a0efb241c383cadf07` (2026-08-17T03:32:35Z)
- **review-cycle-1** — approve — No findings. The reused native OpenCode implementation remains correct, the replacement smoke now drives real V2 session and tool execution paths through the pinned beta, every required local check passed, and all six CI jobs are green. — commit `5caa9993709244425c9088a0efb241c383cadf07` (2026-08-17T03:32:35Z)
- **required-ci** — passing — scripts (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, test (windows-latest)=pass, scripts (ubuntu-latest)=pass — commit `5caa9993709244425c9088a0efb241c383cadf07` (2026-08-17T03:32:52Z)

<!-- orch:manifest:data
{
  "schema_version": 4,
  "objective": "Land the existing native OpenCode V2 host implementation with a pinned-beta smoke that exercises session context and mutation interception through the live OpenCode runtime while preserving the existing Claude Code and Codex CLI hosts.",
  "acceptance_criteria": [
    "OpenCode is an independently selectable host throughout environment detection, committed and local configuration, routing, run state, activation, doctor, and generated-agent freshness checks; configurations containing only Claude Code and/or Codex CLI remain valid and retain their prior behavior.",
    "The OpenCode adapter loads through the documented V2 plugin API under a stable Orch plugin ID and mediates every built-in edit, write, and patch mutation through Orch's existing guard verdict before the mutation occurs; a denied mutation does not reach the filesystem and an allowed mutation remains subject to OpenCode's own permission flow.",
    "Generated OpenCode role agents use the native V2 agent format, reflect each effective role's configured model and effort variant, run as subagents, and mechanically deny mutation for scout and reviewer roles while leaving implementation roles able to work inside Orch-approved worktrees.",
    "The shipped OpenCode Architect, Delivery, and setup skill definitions instruct use of the V2 question and subagent surfaces, contain none of the Codex-only request_user_input, spawn_agent, wait_agent, followup_task, rollout, marketplace, hook-manifest, or agent-TOML behavior, and are pinned by deterministic repository tests.",
    "A repeatable smoke check against the repository's pinned OpenCode V2 beta proves that the live runtime discovers the Orch plugin and native role agents, invokes Orch session-context injection, denies a tracked-file mutation before it reaches the filesystem, and permits a git-ignored scratch mutation through the normal OpenCode tool path.",
    "OpenCode-specific plugin and agent behavior is covered by deterministic repository tests and the required CI workflow runs those checks on supported CI platforms.",
    "Blast radius (contributed by Orch because this issue declares a risk domain, not by the plan document): name every element of the structure this change touches and state, for each, whether the behavior it had before this change still holds; record a behavior this change removes as a before-and-after in the same document that stated the old behavior, rather than deleting that statement; and where a restriction is attributed to one named symbol, establish whether it holds for that symbol alone or for every symbol of its kind, and say which."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l .",
    "npm test --prefix adapters/opencode",
    "npm run smoke --prefix adapters/opencode"
  ],
  "tests_ci_does_not_run": [
    "npm run smoke --prefix adapters/opencode"
  ],
  "role": "specialist",
  "executor": {
    "model": "gpt-5.6-sol",
    "effort": "max"
  },
  "routing_rationale": "Routed to a specialist with a strong reviewer because risk domains (authorization) and the task is unusually difficult.",
  "reviewer": {
    "model": "gpt-5.6-sol",
    "effort": "xhigh"
  },
  "effort_delivery": "parameter",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All Go packages passed at commit 5caa9993709244425c9088a0efb241c383cadf07.",
      "commit_oid": "5caa9993709244425c9088a0efb241c383cadf07",
      "at": "2026-08-17T03:26:46Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "No vet findings.",
      "commit_oid": "5caa9993709244425c9088a0efb241c383cadf07",
      "at": "2026-08-17T03:26:46Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No output; all Go files are formatted.",
      "commit_oid": "5caa9993709244425c9088a0efb241c383cadf07",
      "at": "2026-08-17T03:26:46Z"
    },
    {
      "name": "opencode-adapter-tests",
      "command": "npm test --prefix adapters/opencode",
      "result": "pass",
      "detail": "All 5 deterministic native adapter tests passed.",
      "commit_oid": "5caa9993709244425c9088a0efb241c383cadf07",
      "at": "2026-08-17T03:26:46Z"
    },
    {
      "name": "opencode-v2-live-smoke",
      "command": "npm run smoke --prefix adapters/opencode",
      "result": "pass",
      "detail": "Pinned opencode2 v0.0.0-beta-17498 used its native simulation backend and live V2 session API: the model request contained Orch session context; a real write tool call to tracked.txt returned the Orch Assist denial and left the file unchanged; a second real write call created the git-ignored scratch file with the requested content. Plugin orch.delivery and all five subagents were discovered. No plugin callback or filesystem mutation was invoked manually. Node emitted the existing DEP0190 warning on Windows.",
      "commit_oid": "5caa9993709244425c9088a0efb241c383cadf07",
      "at": "2026-08-17T03:26:46Z"
    },
    {
      "name": "branch-scope:blast-radius",
      "command": "git diff origin/main...HEAD --stat \u0026\u0026 git diff origin/main...HEAD --check",
      "result": "pass",
      "detail": "Environment detection and init reporting: adds independent opencode2 detection; existing Claude, Codex, Git, gh, and memhub behavior remains. Committed/local configuration and interviews: adds hosts.opencode across parsing, validation, rendering, overlays, preference keys, revisions, setup, summaries, instruction ownership, and ignores; legacy host configurations and prior revision digests remain. Routing/state/activation/bootstrap: accepts OpenCode with parameter effort and configured profiles; Claude prompt-cue and Codex parameter behavior remains. Generated agents: adds OpenCode rendering/freshness while preserving Claude/Codex outputs. Doctor/session context: adds pinned-beta and exactly-one orch.delivery checks plus the shared OpenCode session hook; prior host checks remain. Native adapter: adds the pinned V2 package, plugin, agents, skills, tests, and live smoke; execute.before guards every built-in edit, write, and patch invocation before execution, while allowed calls continue through native permissions. Role scope: scout and reviewer roles deny every edit and shell resource; implementation roles remain subject to Orch worktree containment. Marketplace before/after: before, every adapter directory was marketplace-backed; after, OpenCode is npm-native and intentionally excluded while Claude/Codex marketplace behavior remains, stated explicitly in marketplace_test.go. CI: deterministic npm tests run on Ubuntu, Windows, and macOS; the live beta smoke is local-only. No Claude or Codex artifact or support behavior was removed. Diff check passed at 5caa9993709244425c9088a0efb241c383cadf07.",
      "commit_oid": "5caa9993709244425c9088a0efb241c383cadf07",
      "at": "2026-08-17T03:26:46Z"
    },
    {
      "name": "review-local-required-checks",
      "command": "go test ./... \u0026\u0026 go vet ./... \u0026\u0026 gofmt -l . \u0026\u0026 npm test --prefix adapters/opencode \u0026\u0026 npm run smoke --prefix adapters/opencode",
      "result": "pass",
      "detail": "Reviewer reran every required local check at 5caa9993709244425c9088a0efb241c383cadf07; Go tests and vet passed, gofmt had no output, Node tests passed 5/5, and the pinned-beta live smoke passed.",
      "commit_oid": "5caa9993709244425c9088a0efb241c383cadf07",
      "at": "2026-08-17T03:32:34Z"
    },
    {
      "name": "review-diff-check",
      "command": "git diff --check origin/main...HEAD",
      "result": "pass",
      "detail": "No whitespace errors.",
      "commit_oid": "5caa9993709244425c9088a0efb241c383cadf07",
      "at": "2026-08-17T03:32:34Z"
    },
    {
      "name": "review-live-ci",
      "command": "gh pr checks 228 --required",
      "result": "pass",
      "detail": "All six GitHub Actions jobs passed at the reviewed head.",
      "commit_oid": "5caa9993709244425c9088a0efb241c383cadf07",
      "at": "2026-08-17T03:32:34Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "OpenCode is threaded through detection, configuration, validation, overlays, interviews, routing, state, activation, doctor, and agent rendering; legacy revision compatibility is explicitly preserved and all Go tests passed.",
      "commit_oid": "5caa9993709244425c9088a0efb241c383cadf07",
      "at": "2026-08-17T03:32:35Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "The stable orch.delivery V2 plugin registers execute.before, extracts every edit/write/patch target, and calls orch guard check before returning to native execution; errors reject execution and allowed calls do not bypass native permissions.",
      "commit_oid": "5caa9993709244425c9088a0efb241c383cadf07",
      "at": "2026-08-17T03:32:35Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "Native agent frontmatter declares subagent mode and model variants, rendering uses effective configuration, read-only roles deny all edit and shell resources, and implementation roles retain guarded mutation access.",
      "commit_oid": "5caa9993709244425c9088a0efb241c383cadf07",
      "at": "2026-08-17T03:32:35Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "All three shipped OpenCode skills explicitly use question and subagent surfaces, contain none of the forbidden Codex-only terms, and are covered by deterministic pin tests.",
      "commit_oid": "5caa9993709244425c9088a0efb241c383cadf07",
      "at": "2026-08-17T03:32:35Z"
    },
    {
      "name": "acceptance-criterion-5",
      "result": "satisfied",
      "detail": "The pinned beta smoke starts the real V2 server with its simulation backend, creates and prompts a live session, observes injected context, supplies real write calls, observes guard denial and an unchanged tracked file, then verifies OpenCode creates the ignored scratch file; the assertions fail if either hook is absent.",
      "commit_oid": "5caa9993709244425c9088a0efb241c383cadf07",
      "at": "2026-08-17T03:32:35Z"
    },
    {
      "name": "acceptance-criterion-6",
      "result": "satisfied",
      "detail": "Meaningful Go and Node adapter tests are present; CI runs npm install and test in the Ubuntu, Windows, and macOS matrix, and all six jobs passed.",
      "commit_oid": "5caa9993709244425c9088a0efb241c383cadf07",
      "at": "2026-08-17T03:32:35Z"
    },
    {
      "name": "acceptance-criterion-7",
      "result": "satisfied",
      "detail": "The PR audit enumerates every touched subsystem with preservation statements, records the marketplace behavior as an explicit before/after, and states whether role and mutation restrictions apply to one symbol or every resource of that kind.",
      "commit_oid": "5caa9993709244425c9088a0efb241c383cadf07",
      "at": "2026-08-17T03:32:35Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "No findings. The reused native OpenCode implementation remains correct, the replacement smoke now drives real V2 session and tool execution paths through the pinned beta, every required local check passed, and all six CI jobs are green.",
      "commit_oid": "5caa9993709244425c9088a0efb241c383cadf07",
      "at": "2026-08-17T03:32:35Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "scripts (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, test (windows-latest)=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "5caa9993709244425c9088a0efb241c383cadf07",
      "at": "2026-08-17T03:32:52Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->