### PR TITLE
Document and package OpenCode V2 support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Orch
 
-A cross-host development orchestrator for the Codex CLI and Claude Code CLI.
+A cross-host development orchestrator for Claude Code, Codex CLI, and OpenCode V2.
 
 ## Session Continuity
 
@@ -19,7 +19,9 @@ Shared core is Go (module `github.com/kninetimmy/orch`, Go 1.26+).
 - Format: `gofmt -w .` (CI fails on unformatted files)
 - Run:    `go run ./cmd/orch status` (or `doctor`, `help`)
 
-Host adapters under `adapters/` are non-Go artifacts (not implemented yet).
+Host adapters under `adapters/` are non-Go artifacts. Claude Code and Codex
+CLI share the root marketplace manifest; OpenCode V2 uses the local npm package
+at `adapters/opencode/` and the beta `opencode2` runtime.
 
 <!-- orchestrator:managed:start version=1 -->
 This file is partially managed by Orch (see `.orchestrator/config.toml`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Orch
 
-A cross-host development orchestrator for the Codex CLI and Claude Code CLI.
+A cross-host development orchestrator for Claude Code, Codex CLI, and OpenCode V2.
 
 ## Session Continuity
 
@@ -19,7 +19,9 @@ Shared core is Go (module `github.com/kninetimmy/orch`, Go 1.26+).
 - Format: `gofmt -w .` (CI fails on unformatted files)
 - Run:    `go run ./cmd/orch status` (or `doctor`, `help`)
 
-Host adapters under `adapters/` are non-Go artifacts (not implemented yet).
+Host adapters under `adapters/` are non-Go artifacts. Claude Code and Codex
+CLI share the root marketplace manifest; OpenCode V2 uses the local npm package
+at `adapters/opencode/` and the beta `opencode2` runtime.
 
 <!-- orchestrator:managed:start version=1 -->
 This file is partially managed by Orch (see `.orchestrator/config.toml`).

--- a/ORCH-PRD.md
+++ b/ORCH-PRD.md
@@ -37,7 +37,7 @@ Orch must:
 - Delegate read-only exploration without polluting the Architect context.
 - Delegate implementation according to difficulty and risk.
 - Support exact model-version and reasoning-effort selection per role.
-- Provide native configuration dialogs inside all supported hosts.
+- Provide native arrow-key configuration dialogs inside Claude Code and Codex CLI, and native configuration dialogs inside OpenCode V2.
 - Require the complete Delivery workflow for every tracked-file mutation.
 - Enforce Assist mode as read-only.
 - Work independently with Claude Code, Codex CLI, OpenCode V2, or any combination.
@@ -351,10 +351,11 @@ Orch fails closed.
 - Writes must remain inside the registered worktree.
 - The active branch must not be `main`.
 - Completion requires a commit, pushed branch, PR, targeted-test evidence, and explicit CI state.
-- Read-only roles are held read-only by per-agent tool whitelists on Claude Code and OpenCode, and by agent
-  instructions on Codex, not by the guard. The Claude whitelist accounts fully only for the Scout,
-  which is granted no shell tool; the Reviewer and its safe review downgrade are granted one, so
-  their read-only discipline for shell-mediated writes rests on instructions there too.
+- The guard does not attribute writes to roles. Claude Code's Scout has no shell tool, but its
+  Reviewer and safe review downgrade do, so their read-only discipline for shell-mediated writes
+  rests on instructions. Codex has no per-agent tool whitelist. OpenCode's plugin guard is
+  host-global, so it likewise cannot prevent a scout or reviewer write inside a Delivery worktree
+  the guard otherwise permits.
 - Neither closes the shell-write gap: the pre-write hook covers only the file-write tools, so a
   shell-mediated write falls to the host's own approval prompts.
 - No agent may merge.

--- a/ORCH-PRD.md
+++ b/ORCH-PRD.md
@@ -6,7 +6,7 @@
 
 ## 1. Product summary
 
-Orch is a cross-host development orchestrator for Codex CLI and Claude Code CLI. It keeps a
+Orch is a cross-host development orchestrator for Claude Code, Codex CLI, and OpenCode V2. It keeps a
 frontier model in the Architect role while routing exploration, implementation, specialist work,
 and review to explicitly configured models with appropriate reasoning levels.
 
@@ -23,7 +23,7 @@ is wasteful. Existing orchestration approaches, including the first
 - Models and effort levels are hard-coded.
 - Provider model names are conflated with task roles.
 - Exploration remains in the expensive main context.
-- Codex and Claude implementations duplicate workflow logic.
+- Codex, Claude, and OpenCode implementations must not duplicate workflow logic.
 - GitHub and worktree enforcement is shell- and hook-heavy.
 - Configuration lacks a native per-repository interview.
 - Workflow failure is sometimes fail-open.
@@ -37,10 +37,10 @@ Orch must:
 - Delegate read-only exploration without polluting the Architect context.
 - Delegate implementation according to difficulty and risk.
 - Support exact model-version and reasoning-effort selection per role.
-- Provide native arrow-key configuration dialogs inside both supported hosts.
+- Provide native configuration dialogs inside all supported hosts.
 - Require the complete Delivery workflow for every tracked-file mutation.
 - Enforce Assist mode as read-only.
-- Work independently with Codex CLI, Claude Code CLI, or both.
+- Work independently with Claude Code, Codex CLI, OpenCode V2, or any combination.
 - Maintain behavioral parity through a shared cross-platform core.
 - Integrate with memhub when present.
 - Recover safely from interrupted sessions without losing work.
@@ -56,7 +56,7 @@ Orch must:
 - Moving model aliases as canonical configuration.
 - Outbound telemetry.
 - Recursive worker delegation.
-- Transfer of an active Delivery run between Codex and Claude.
+- Transfer of an active Delivery run between hosts.
 - Automated A/B evaluation of write-producing agents.
 - Choosing the shared core's implementation language in this PRD.
 
@@ -64,6 +64,7 @@ Orch must:
 
 - Codex CLI.
 - Claude Code CLI.
+- OpenCode V2 (beta API, pinned to `opencode2 v0.0.0-beta-17498`).
 - Windows, macOS, and Linux.
 - GitHub through authenticated `gh`.
 - Git repositories with isolated worktree support.
@@ -73,7 +74,7 @@ authentication, repository state, and worktree prerequisites pass validation.
 
 ## 6. Architecture
 
-Orch consists of a shared cross-platform core and two thin host adapters.
+Orch consists of a shared cross-platform core and three thin host adapters.
 
 ### Shared core
 
@@ -93,7 +94,7 @@ The shared core owns:
 
 ### Host adapters
 
-Codex and Claude adapters own:
+Codex, Claude, and OpenCode adapters own:
 
 - Native structured-question dialogs.
 - Session lifecycle integration.
@@ -331,7 +332,7 @@ Models do not become GitHub labels.
 
 ## 14. Concurrency
 
-- One active Delivery coordinator per repository across both hosts.
+- One active Delivery coordinator per repository across all hosts.
 - The active run may contain multiple issues.
 - Default maximum: three concurrent subagents.
 - Initialization may configure another cap.
@@ -350,7 +351,7 @@ Orch fails closed.
 - Writes must remain inside the registered worktree.
 - The active branch must not be `main`.
 - Completion requires a commit, pushed branch, PR, targeted-test evidence, and explicit CI state.
-- Read-only roles are held read-only by per-agent tool whitelists on Claude Code and by agent
+- Read-only roles are held read-only by per-agent tool whitelists on Claude Code and OpenCode, and by agent
   instructions on Codex, not by the guard. The Claude whitelist accounts fully only for the Scout,
   which is granted no shell tool; the Reviewer and its safe review downgrade are granted one, so
   their read-only discipline for shell-mediated writes rests on instructions there too.
@@ -426,7 +427,7 @@ Global host plugins are installed before repository initialization.
 14. Opens and reviews a bootstrap PR.
 15. Waits for human merge approval.
 
-Codex and Claude Code may be enabled independently. Adding another host later uses Delivery.
+Claude Code, Codex CLI, and OpenCode V2 may be enabled independently. Adding another host later uses Delivery.
 
 ## 19. Managed instruction blocks
 
@@ -517,8 +518,9 @@ Assist.
 
 `orch render-agents` generates all five dispatched role definitions for every enabled host from
 the effective `hosts.<host>.roles` configuration. It writes Claude Markdown under
-`.claude/agents/` and Codex TOML under `.codex/agents/`, using each shipped plugin definition as
-the canonical body and changing only routing fields the host supports. Both destinations are
+`.claude/agents/`, Codex TOML under `.codex/agents/`, and OpenCode Markdown under
+`.opencode/agents/`, using each shipped plugin definition as
+the canonical body and changing only routing fields the host supports. All destinations are
 gitignored machine-local output. Doctor checks every enabled host and activation checks the
 selected host; missing, unreadable, or stale definitions fail closed with the affected paths and
 the render command as remediation. Installed-adapter health is checked separately.
@@ -527,7 +529,7 @@ the render command as remediation. Installed-adapter health is checked separatel
 
 V1 is acceptable when:
 
-- Both CLIs can initialize independently using native question dialogs.
+- All three hosts can initialize independently using native question dialogs.
 - Initialization creates a reviewed bootstrap PR without editing the primary checkout.
 - Assist reliably blocks tracked-file changes.
 - Delivery cannot write outside registered worktrees.
@@ -543,7 +545,7 @@ V1 is acceptable when:
 - Disabled metrics create no metrics storage.
 - Successful merge leaves the primary checkout current and no stale worktree behind.
 - Behavior is validated on Windows, macOS, and Linux.
-- Codex and Claude adapters pass shared parity tests.
+- Codex and Claude adapters retain their shared parity tests; OpenCode passes its native adapter tests and pinned-beta smoke check.
 
 ## 24. Deferred implementation decisions
 

--- a/ORCH-PRD.md
+++ b/ORCH-PRD.md
@@ -1,7 +1,7 @@
 # Orch Product Requirements Document
 
 - Status: Draft for future implementation
-- Last updated: 2026-07-10
+- Last updated: 2026-08-17
 - Intended implementation context: A new memhub-enabled repository
 
 ## 1. Product summary
@@ -239,6 +239,17 @@ All entries use exact model versions.
 | Specialist | `gpt-5.6-sol` | `max` |
 | Reviewer | `gpt-5.6-sol` | `xhigh` |
 | Safe review downgrade | `gpt-5.6-sol` | `high` |
+
+### OpenCode V2
+
+| Role | Model | Effort |
+|---|---|---|
+| Architect | `openai/gpt-5.6-sol` | `xhigh` |
+| Scout | `openai/gpt-5.6-luna` | `max` |
+| Implementer | `openai/gpt-5.6-terra` | `max` |
+| Specialist | `openai/gpt-5.6-sol` | `max` |
+| Reviewer | `openai/gpt-5.6-sol` | `xhigh` |
+| Safe review downgrade | `openai/gpt-5.6-sol` | `high` |
 
 ### Claude Code
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
   <img src="https://img.shields.io/badge/Release-v0.7.0-24292F?style=flat&logo=github&logoColor=white" alt="Release: v0.7.0"/>
   <br/>
   <img src="https://img.shields.io/badge/Platform-Linux%20%C2%B7%20macOS%20%C2%B7%20Windows-607D8B?style=flat" alt="Platform: Linux, macOS, Windows"/>
-  <img src="https://img.shields.io/badge/Hosts-Claude%20Code%20%C2%B7%20Codex%20CLI-6E56CF?style=flat" alt="Hosts: Claude Code and Codex CLI"/>
+  <img src="https://img.shields.io/badge/Hosts-Claude%20Code%20%C2%B7%20Codex%20CLI%20%C2%B7%20OpenCode%20V2-6E56CF?style=flat" alt="Hosts: Claude Code, Codex CLI, and OpenCode V2"/>
 </p>
 
 ---
 
 Left to itself, a coding agent picks its own model for every task, and it can write to any file it can reach. That's fine until the model is wrong for the job — too expensive for something trivial, or too weak for something that actually matters — or until a change lands somewhere you didn't intend it to.
 
-Orch sits underneath the CLI you already use (Claude Code or Codex CLI) and takes over those two decisions. By default it puts the repository in **Assist**: a mechanical, read-only mode where the agent can look around, search, explain and plan, but a write to a file git does not ignore is refused before it happens. When you approve a plan, Orch enters **Delivery**: each task becomes a GitHub issue with its own isolated git worktree, gets implemented there, is reviewed by a separate agent dispatch, runs CI, and is merged only after you approve it. Which model handles which job is not the agent's call either — you route it, per role, to an exact model version and effort level.
+Orch sits underneath the CLI you already use (Claude Code, Codex CLI, or OpenCode V2) and takes over those two decisions. By default it puts the repository in **Assist**: a mechanical, read-only mode where the agent can look around, search, explain and plan, but a write to a file git does not ignore is refused before it happens. When you approve a plan, Orch enters **Delivery**: each task becomes a GitHub issue with its own isolated git worktree, gets implemented there, is reviewed by a separate agent dispatch, runs CI, and is merged only after you approve it. Which model handles which job is not the agent's call either — you route it, per role, to an exact model version and effort level.
 
 The payoff: cheap, fast models handle read-only exploration and mechanical work, a frontier model gets spent only where the plan calls for it, and every change that lands is auditable and gated by a human at the one step that matters — the merge.
 
@@ -24,7 +24,7 @@ The payoff: cheap, fast models handle read-only exploration and mechanical work,
 <br>
 
 <p align="center">
-  <img src="docs/images/orch-overview.gif" alt="Animated overview of how Orch works: in Assist the guard denies a tracked-file write with its verbatim reason and allows git-ignored scratch; approving a plan enters Delivery, routing pins the exact model, and writes land only inside the registered issue worktree before the run auto-returns to Assist" width="920"/>
+  <img src="docs/images/orch-overview.svg" alt="Animated overview of how Orch works: in Assist the guard denies a tracked-file write with its verbatim reason and allows git-ignored scratch; approving a plan enters Delivery, routing pins the exact model, and writes land only inside the registered issue worktree before the run auto-returns to Assist" width="920"/>
 </p>
 
 ---
@@ -67,9 +67,9 @@ The full product definition lives in [ORCH-PRD.md](ORCH-PRD.md).
 ## Quickstart
 
 <details>
-<summary><b>Have your agent do it</b> — recommended: one prompt, pasted into Claude Code or Codex CLI</summary>
+<summary><b>Have your agent do it</b> — recommended: one prompt, pasted into Claude Code, Codex CLI, or OpenCode V2</summary>
 
-Paste this into a Claude Code or Codex CLI session, started anywhere.
+Paste this into a Claude Code, Codex CLI, or OpenCode V2 session, started anywhere.
 It does not assume you have cloned this repository.
 
 ```text
@@ -105,11 +105,13 @@ on this machine. Work in a scratch directory, not in one of my projects.
      - Claude Code:
          claude plugin marketplace add kninetimmy/orch
          claude plugin install orch-claude@orch
-     - Codex CLI:
-         codex plugin marketplace add kninetimmy/orch
-         codex plugin add orch@orch
+      - Codex CLI:
+          codex plugin marketplace add kninetimmy/orch
+          codex plugin add orch@orch
+      - OpenCode V2: follow the local npm package install in
+        `adapters/opencode/README.md`; it is not a Codex marketplace plugin.
 
-4. Codex CLI only. Skip this entire step on Claude Code:
+4. Codex CLI only. Skip this entire step on Claude Code and OpenCode V2:
    a. Add both of these stanzas to ~/.codex/config.toml, leaving any
       existing content in place:
         [tools.experimental_request_user_input]
@@ -139,7 +141,7 @@ on this machine. Work in a scratch directory, not in one of my projects.
    that PR is merged, `orch render-agents` must be run in the repository;
    it generates project definitions for every enabled host and must be
    rerun after role configuration or Orch changes. This command is the
-   one per-repository workflow for both hosts.
+   one per-repository workflow for all enabled hosts.
 ```
 
 </details>
@@ -164,7 +166,8 @@ repository's remote. Assist works without a remote.
 Each adapter's README carries its host's exact install order and its
 own known limitations, worth reading once for the host you use:
 [Claude Code](adapters/claude/README.md#install-order),
-[Codex CLI](adapters/codex/README.md#install-order).
+[Codex CLI](adapters/codex/README.md#install-order), and
+[OpenCode V2](adapters/opencode/README.md#install-order).
 
 <details>
 <summary><b>Install it yourself</b> — scripts, plugins, manual download, source builds</summary>
@@ -192,8 +195,8 @@ iwr https://raw.githubusercontent.com/kninetimmy/orch/main/install.ps1 -OutFile 
 powershell -ExecutionPolicy Bypass -File .\install.ps1
 ```
 
-**Plugin install (two commands per host).** With the binary on `PATH`,
-each host installs its adapter from this repository's marketplace
+**Adapter install.** With the binary on `PATH`, Claude Code and Codex
+CLI install their adapters from this repository's shared marketplace
 manifest:
 
 ```sh
@@ -206,19 +209,22 @@ codex plugin marketplace add kninetimmy/orch
 codex plugin add orch@orch
 ```
 
-One manifest (`.claude-plugin/marketplace.json`) serves both hosts, and
-the other host's entry may show up in your listing too — install yours
-by its exact name: `orch-claude` on Claude Code, `orch` on Codex CLI.
-Then follow the host-specific steps in the adapter
+One manifest (`.claude-plugin/marketplace.json`) serves those two hosts,
+and the other host's entry may show up in your listing too — install
+yours by its exact name: `orch-claude` on Claude Code, `orch` on Codex
+CLI. OpenCode V2 is npm-native, not a marketplace adapter: install the
+local `adapters/opencode/` package and configure its plugin module as
+documented in its README. Then follow the host-specific steps in the adapter
 READMEs — [Claude Code](adapters/claude/README.md#install-order),
-[Codex CLI](adapters/codex/README.md#install-order). Codex CLI needs
+[Codex CLI](adapters/codex/README.md#install-order),
+[OpenCode V2](adapters/opencode/README.md#install-order). Codex CLI needs
 two more things the plugin install cannot do for you: the one-time hook
 trust approval and the two `request_user_input` stanzas in
-`~/.codex/config.toml`. Every initialized repository, on either host,
+`~/.codex/config.toml`. Every initialized repository, on every enabled host,
 also needs `orch render-agents` after initialization, role-configuration
 changes, and upgrades.
 
-**Plugin upgrade (existing installs).** Do not repeat the first-install
+**Adapter upgrade (existing installs).** Do not repeat the first-install
 commands above. Upgrade the configured host's marketplace and adapter:
 
 ```sh
@@ -230,8 +236,10 @@ claude plugin update orch-claude@orch
 codex plugin marketplace upgrade orch
 ```
 
-Restart Claude Code or Codex CLI after upgrading its adapter so the new
-hooks and skills are loaded.
+For OpenCode V2, update the local checkout and run `npm ci --prefix
+adapters/opencode` again; see its README for the exact commands and
+plugin-ID check. Restart Claude Code, Codex CLI, or the OpenCode V2
+service after upgrading its adapter so the new hooks and skills are loaded.
 
 **Manual download.** Take the static binary for your OS and
 architecture from
@@ -278,7 +286,7 @@ go install github.com/kninetimmy/orch/cmd/orch@latest
 - **A separate dispatch reviews the work.** The pull request is reviewed in a dispatch separate from the one that wrote it — never the same run marking its own homework.
 - **You hold the merge gate.** Nothing lands on your default branch until you approve it, and the merge fails closed if the pull request moved after your approval.
 - **Every issue and PR carries an audit record.** The exact model, the effort, how the host actually delivered that effort, and the routing rationale are recorded on the issue and mirrored onto its pull request.
-- **Works with the CLI you already use.** Orch works with both [Claude Code](adapters/claude/README.md) and [Codex CLI](adapters/codex/README.md), so you keep working in the agent you already have.
+- **Works with the CLI you already use.** Orch works with [Claude Code](adapters/claude/README.md), [Codex CLI](adapters/codex/README.md), and [OpenCode V2](adapters/opencode/README.md), so you keep working in the agent you already have.
 
 ---
 
@@ -326,7 +334,7 @@ local override can never weaken a shared workflow rule.
 
 | Setting | Values (default) | Local override? |
 |---|---|---|
-| `hosts.claude` / `hosts.codex` | enable a host by giving it a role table | no (committed) |
+| `hosts.claude` / `hosts.codex` / `hosts.opencode` | enable a host by giving it a role table | no (committed) |
 | `hosts.<host>.roles.<role>.model` | exact model version string | yes |
 | `hosts.<host>.roles.<role>.effort` | `low` `medium` `high` `xhigh` `max` (+ `ultra` on codex) | yes |
 | `concurrency.max_subagents` | integer ≥ 1 (`3`) | yes |
@@ -344,14 +352,14 @@ than tier aliases, and whatever string is configured is the one that
 lands in the audit record, so the record says what ran instead of what
 tier it belonged to. The defaults `orch init` offers:
 
-| Role | Claude Code | Codex |
-|---|---|---|
-| Architect | `claude-opus-5` / high | `gpt-5.6-sol` / xhigh |
-| Scout | `claude-opus-5` / low | `gpt-5.6-luna` / max |
-| Implementer | `claude-opus-5` / medium | `gpt-5.6-terra` / max |
-| Specialist | `claude-opus-5` / high | `gpt-5.6-sol` / max |
-| Reviewer | `claude-opus-5` / high | `gpt-5.6-sol` / xhigh |
-| Review downgrade | `claude-opus-5` / medium | `gpt-5.6-sol` / high |
+| Role | Claude Code | Codex CLI | OpenCode V2 |
+|---|---|---|---|
+| Architect | `claude-opus-5` / high | `gpt-5.6-sol` / xhigh | `openai/gpt-5.6-sol` / xhigh |
+| Scout | `claude-opus-5` / low | `gpt-5.6-luna` / max | `openai/gpt-5.6-luna` / max |
+| Implementer | `claude-opus-5` / medium | `gpt-5.6-terra` / max | `openai/gpt-5.6-terra` / max |
+| Specialist | `claude-opus-5` / high | `gpt-5.6-sol` / max | `openai/gpt-5.6-sol` / max |
+| Reviewer | `claude-opus-5` / high | `gpt-5.6-sol` / xhigh | `openai/gpt-5.6-sol` / xhigh |
+| Review downgrade | `claude-opus-5` / medium | `gpt-5.6-sol` / high | `openai/gpt-5.6-sol` / high |
 
 Typical tuning: point a role at a bigger or smaller model on one
 machine with `configure-local` (run the Architect on a frontier model
@@ -404,8 +412,9 @@ All of that evidence comes from one repository: this one.
 <summary>What will bite you today — symptom, cause, workaround</summary>
 
 **Writes made through the shell are not guarded.** The pre-write hook
-covers Claude Code's `Write`, `Edit`, `MultiEdit` and `NotebookEdit`
-and Codex CLI's `apply_patch`. A file written by a shell command —
+covers Claude Code's `Write`, `Edit`, `MultiEdit` and `NotebookEdit`,
+Codex CLI's `apply_patch`, and OpenCode V2's `edit`, `write`, and
+`patch`. A file written by a shell command —
 `echo > file`, a script, a `git checkout` — never reaches `orch
 guard`, so neither Assist's read-only rule nor Delivery's worktree
 containment applies to it. Symptom: an agent modifies your working
@@ -436,11 +445,11 @@ activate` to enter Delivery first``. Activating a second run is exactly
 the wrong move. Workaround: run every `orch run` verb with the primary
 checkout as the working directory.
 
-**A missing binary fails open, not closed.** Both adapters' hooks are
-bare `orch guard <host>` commands. If `orch` does not resolve on
-`PATH`, the hook exits with a shell "command not found", which both
-hook protocols treat as non-blocking: the guard silently stops
-enforcing and the session-start context stops being injected. No
+**A missing binary fails open, not closed.** The Claude Code and Codex
+CLI adapters invoke bare `orch guard <host>` commands; the OpenCode V2
+plugin invokes `orch guard check`. If `orch` does not resolve on
+`PATH`, the host does not receive an Orch denial, so the guard silently
+stops enforcing and the session-start context stops being injected. No
 error, no denial. On Codex CLI the same is true while the plugin's
 one-time hook trust approval is outstanding — until you approve it,
 the bundled hooks do not run at all. Symptom: no denial where you
@@ -466,13 +475,15 @@ expected adapter version when they diverge.
 **`orch doctor` fails on a machine that lacks a configured host's
 command-line tool.** Doctor checks every host the committed
 configuration names, and fails when that host's CLI is missing from
-`PATH`, when its plugin listing cannot be read, or when its adapter is
-in any of six states — absent, listed more than once, disabled,
-reporting no version at all, reporting a different version, or, on
-Codex, marked not installed. Host enablement is a committed-only key
-— the Settings table above marks `hosts.claude` / `hosts.codex` as
+`PATH` or its adapter check fails. Claude and Codex adapter checks also
+report absent, duplicate, disabled, missing-version, and version-
+mismatch states (plus Codex's not-installed state). OpenCode instead
+checks its exact beta runtime and active plugin ID because its beta API
+does not expose adapter versions. Host enablement is a committed-only key
+— the Settings table above marks `hosts.claude` / `hosts.codex` /
+`hosts.opencode` as
 `no (committed)` — so machine-local configuration cannot switch a
-host off for one machine. Symptom: a repository configured for both
+host off for one machine. Symptom: a repository configured for multiple
 hosts reports a failing doctor on every machine that has only one of
 them installed. Workaround: enable only the hosts every machine
 working on the repository will have, or install the missing CLI on
@@ -491,14 +502,15 @@ confirm the sandbox actually works on that machine before setting
 effort reaches a Claude subagent as a cue in its prompt, not as a host
 parameter, so the effort in the audit record is what was routed rather
 than something the host applied. The record says so outright, as
-`Effort delivery: prompt-cue`. Codex pins effort in the project agent
-TOML and the host enforces it.
+`Effort delivery: prompt-cue`. Codex and OpenCode pin effort in their
+project agent definitions and the host enforces it.
 
 **A model override does not reach a dispatched agent by itself, on
-either host.** Neither host can override a model per spawn, so the
+either host.** No host can override a model per spawn, so the
 routed selection has to match the active project agent definition.
 `orch render-agents` writes all five dispatched roles for every
-enabled host under `.claude/agents/` or `.codex/agents/`, using the
+enabled host under `.claude/agents/`, `.codex/agents/`, or
+`.opencode/agents/`, using the
 shipped plugin definition as the canonical body and changing only
 that host's routing fields. Claude Code's [scope priority
 table](https://code.claude.com/docs/en/sub-agents#choose-the-subagent-scope)
@@ -517,6 +529,15 @@ any `*** ` directive line it does not recognize as a malformed
 envelope and denies the write. That is deliberate — an unparsed write
 must never be allowed — but it means a host upgrade can produce
 spurious denials. Workaround: update `orch`.
+
+**OpenCode V2 support is pinned to a beta API.** The live smoke check
+exercises exactly `opencode2 v0.0.0-beta-17498` and
+`@opencode-ai/plugin` `0.0.0-beta-17498`; no other V2 build is a
+supported compatibility floor yet. `orch doctor` checks that exact
+runtime version and that the running service lists plugin ID
+`orch.delivery`, but the V2 API does not expose an adapter version.
+After an OpenCode upgrade, restart the service and rerun that plugin-ID
+check before relying on enforcement.
 
 **The merge gate cannot tell a human's approval from an agent's.** The
 engine requires an approval carrying the exact literal `approve-merge`,
@@ -549,7 +570,7 @@ Everything here is merged on `main` and shipped in v0.7.0, the latest
 tagged release.
 
 - The wrong-criterion guidance in all four reviewer agent definitions —
-  both hosts, standard reviewer and safe downgrade alike — now names a
+  all hosts, standard reviewer and safe downgrade alike — now names a
   criterion about "how an LLM agent routes, decides, or behaves" as the
   standing instance of proxy-only evidence, instead of stating it of
   any agent; before, a reviewer applying the sentence literally could
@@ -592,7 +613,7 @@ tagged release.
   gate document, the run state, the audit record and the created issue
   body all carry it, so the human approves it and the existing
   one-judgment-per-criterion rule holds the reviewer to it like any
-  other criterion; both hosts' Delivery skills and every shipped
+  other criterion; all hosts' Delivery skills and every shipped
   reviewer definition — the standard reviewer and the safe review
   downgrade alike — now quote it and say what settles it: an
   enumeration in the pull request body of each element touched with
@@ -653,7 +674,7 @@ tagged release.
   [#166](https://github.com/kninetimmy/orch/pull/166). That Codex-only
   coverage was the before state; after this change the same generated-file
   check covers every enabled host.
-- Every reviewer agent definition on both hosts — the standard
+- Every reviewer agent definition on all hosts — the standard
   reviewer and the safe review downgrade alike — now states that a
   `request-changes` verdict is not confined to findings that block an
   acceptance criterion: a required test that fails, a security boundary
@@ -899,8 +920,9 @@ its own.
 | `internal/question/` | Host-neutral native question contract (documents out, answer sets back) |
 | `internal/interview/` | Pure question engines for `init`, `configure` and `configure-local` |
 | `internal/bootstrap/` | Mechanical PR-flow executors behind `init --bootstrap` and `configure --deliver` |
-| `internal/adaptertest/` | Shared cross-host parity-test layer consumed by both adapters' plugin tests |
-| `adapters/claude/`, `adapters/codex/` | Host-adapter artifacts: plugin manifest, hooks, skills, agent definitions, plus Claude Code's slash commands — cross-host parity-tested |
+| `internal/adaptertest/` | Shared cross-host parity-test layer consumed by the host adapters' tests |
+| `adapters/claude/`, `adapters/codex/` | Marketplace host-adapter artifacts: plugin manifests, hooks, skills, agent definitions, plus Claude Code's slash commands |
+| `adapters/opencode/` | npm-native OpenCode V2 adapter package (`@kninetimmy/orch-opencode`): plugin module, native agents, skills, tests, and pinned-beta smoke check; not a Codex marketplace artifact |
 | `ORCH-PRD.md` | Product requirements — source of truth for v1 |
 
 ### Design principles

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The payoff: cheap, fast models handle read-only exploration and mechanical work,
 
 Which role gets an issue is derived from the issue's own facts by a deterministic table, not chosen by the model that will run it. The reviewer is always a separate dispatch — never the session that wrote the code — though under the shipped defaults it is often the same model on both sides. What Orch guarantees is the independent dispatch and the recorded routing, not model diversity; pin different models per role (the Settings table below) if you want that too.
 
-**The guard.** None of the above is an instruction the agent is asked to honor. Both host adapters wire the CLI's pre-write hook to `orch guard`, a subcommand of the same binary, which is consulted before the agent writes a file and answers allow or deny. In Assist it denies every write to a file git does not ignore. In Delivery it allows a write only inside a worktree registered to the running plan, on that worktree's registered branch, in a phase where writing is allowed. Git internals are never writable, and neither is the orchestrator state your session is running against. It fails closed: anything it cannot establish is a denial. What it enforces is containment — it cannot tell which role is writing, and a file written by a shell command never reaches it at all (see [Known issues](#known-issues-and-limitations)).
+**The guard.** None of the above is an instruction the agent is asked to honor. Claude Code and Codex CLI wire their pre-write hooks to `orch guard`; the OpenCode V2 plugin calls the same guard before its `edit`, `write`, and `patch` tools. In Assist it denies every write to a file git does not ignore. In Delivery it allows a write only inside a worktree registered to the running plan, on that worktree's registered branch, in a phase where writing is allowed. Git internals are never writable, and neither is the orchestrator state your session is running against. It fails closed: anything it cannot establish is a denial. What it enforces is containment — it cannot tell which role is writing, and a file written by a shell command never reaches it at all (see [Known issues](#known-issues-and-limitations)).
 
 Concretely, asking for a change goes like this:
 
@@ -108,8 +108,14 @@ on this machine. Work in a scratch directory, not in one of my projects.
       - Codex CLI:
           codex plugin marketplace add kninetimmy/orch
           codex plugin add orch@orch
-      - OpenCode V2: follow the local npm package install in
-        `adapters/opencode/README.md`; it is not a Codex marketplace plugin.
+      - OpenCode V2: it is not a Codex marketplace plugin. Run
+        `git clone https://github.com/kninetimmy/orch.git "$HOME/orch"`
+        and `npm ci --prefix "$HOME/orch/adapters/opencode"`, then add
+        the absolute path to `$HOME/orch/adapters/opencode/src/index.js`
+        to the `plugins` array in `opencode.json`. Restart OpenCode V2,
+        then run `opencode2 --version` and
+        `opencode2 api get /api/plugin`; require exactly one
+        `orch.delivery` plugin entry before relying on enforcement.
 
 4. Codex CLI only. Skip this entire step on Claude Code and OpenCode V2:
    a. Add both of these stanzas to ~/.codex/config.toml, leaving any
@@ -423,16 +429,17 @@ permission and approval prompts on shell commands are the only
 backstop; leave them on.
 
 **The guard cannot tell one role from another.** `orch guard` has a
-`--role` flag that would make a role mechanically read-only. Neither
-adapter passes it: host hooks are plugin-global rather than scoped per
-dispatched agent, so both `hooks.json` files run the bare command.
-Inside a worktree the guard treats as writable, a scout or a
-reviewer is no more restricted than the implementer. On Claude Code
-the `orch-scout` subagent's tool whitelist does close its write
-surface — it carries no `Bash` — but `orch-reviewer` and
-`orch-reviewer-safe` both carry `Bash`, so their read-only discipline
-rests on their instructions. Codex agent definitions carry no tool
-whitelist at all.
+`--role` flag that would make a role mechanically read-only, but no
+adapter passes it. Claude Code and Codex CLI hook manifests run the
+bare command, and the OpenCode V2 plugin is host-global rather than
+attributed to a dispatched role. Inside a worktree the guard treats as
+writable, a scout or a reviewer is no more restricted than the
+implementer. On Claude Code the `orch-scout` subagent's tool whitelist
+does close its write surface — it carries no `Bash` — but
+`orch-reviewer` and `orch-reviewer-safe` both carry `Bash`, so their
+read-only discipline for shell-mediated writes rests on instructions
+there too. Codex agent definitions carry no tool whitelist; OpenCode's
+host-global guard likewise does not enforce read-only roles.
 
 **An `orch run` verb invoked from inside a Delivery worktree reports
 Assist and names the wrong fix.** Every `orch` command resolves
@@ -505,8 +512,8 @@ than something the host applied. The record says so outright, as
 `Effort delivery: prompt-cue`. Codex and OpenCode pin effort in their
 project agent definitions and the host enforces it.
 
-**A model override does not reach a dispatched agent by itself, on
-either host.** No host can override a model per spawn, so the
+**A model override does not reach a dispatched agent by itself.** No
+host can override a model per spawn, so the
 routed selection has to match the active project agent definition.
 `orch render-agents` writes all five dispatched roles for every
 enabled host under `.claude/agents/`, `.codex/agents/`, or
@@ -569,8 +576,8 @@ continue, or `orch abort` to end it.
 Everything here is merged on `main` and shipped in v0.7.0, the latest
 tagged release.
 
-- The wrong-criterion guidance in all four reviewer agent definitions —
-  all hosts, standard reviewer and safe downgrade alike — now names a
+- The wrong-criterion guidance in the standard and safe reviewer
+  definitions for each host now names a
   criterion about "how an LLM agent routes, decides, or behaves" as the
   standing instance of proxy-only evidence, instead of stating it of
   any agent; before, a reviewer applying the sentence literally could
@@ -815,11 +822,13 @@ never the worktree's copy.
 
 What the table decides is containment. The guard is given the write's
 target paths, not the identity of the agent making the write, so it
-cannot make one role read-only and another writable; the `--role`
-narrowing that exists for that purpose is passed by neither adapter.
-Nor does it see writes the host does not route through a guarded tool,
-which is why shell-mediated writes escape it entirely. Both gaps are
-in [Known issues](#known-issues-and-limitations).
+cannot make one role read-only and another writable; no host adapter
+passes the `--role` narrowing that exists for that purpose. Claude
+Code and Codex CLI hook manifests invoke the bare guard command, while
+the OpenCode V2 plugin invokes its host-global guard call. Nor does the
+guard see writes the host does not route through a guarded tool, which
+is why shell-mediated writes escape it entirely. Both gaps are in
+[Known issues](#known-issues-and-limitations).
 
 Delivery is exclusive across hosts and machines: a lock file
 (`.orchestrator/delivery.lock`, created with `O_EXCL`) is the lock,

--- a/adapters/opencode/README.md
+++ b/adapters/opencode/README.md
@@ -1,0 +1,91 @@
+# OpenCode V2 adapter
+
+This directory is Orch's npm-native OpenCode V2 adapter. Its package ID
+is `@kninetimmy/orch-opencode` (version `0.7.0`) and its running plugin
+ID is `orch.delivery`. It is not the Codex marketplace adapter: that is
+`adapters/codex/`, installed as `orch@orch` from the shared marketplace.
+
+## Compatibility
+
+The OpenCode V2 plugin API is beta. The live smoke check exercises
+exactly `opencode2 v0.0.0-beta-17498` with
+`@opencode-ai/plugin` `0.0.0-beta-17498`; that exact beta is the
+current compatibility floor, not a claim of compatibility with other
+V2 builds.
+
+## Install order
+
+The adapter is not published to npm and releases do not publish an npm
+artifact. Install the checked-out `adapters/opencode/` package — the
+same directory CI installs with `npm ci --prefix adapters/opencode` —
+then load its plugin module from an absolute path.
+
+1. Install the `orch` binary first, then clone the repository somewhere
+   persistent (not into a project it will orchestrate):
+
+   ```sh
+   git clone https://github.com/kninetimmy/orch.git ~/src/orch
+   cd ~/src/orch
+   npm ci --prefix adapters/opencode
+   ```
+
+2. Add the absolute plugin module path to OpenCode V2's `opencode.json`.
+   Keep any existing configuration and plugins:
+
+   ```json
+   {
+     "plugins": ["/absolute/path/to/orch/adapters/opencode/src/index.js"]
+   }
+   ```
+
+   The module is supplied by the local
+   `@kninetimmy/orch-opencode` package; `npm install
+   @kninetimmy/orch-opencode` is not an installation path because that
+   package is not published.
+
+3. Restart the OpenCode V2 service, then verify both the pinned runtime
+   and the active plugin ID before relying on enforcement:
+
+   ```sh
+   opencode2 --version
+   opencode2 api get /api/plugin
+   opencode2 api get /api/plugin | node -e 'let s=""; process.stdin.on("data", d => s += d).on("end", () => { if (JSON.parse(s).data.filter(p => p.id === "orch.delivery").length !== 1) throw new Error("orch.delivery is not active exactly once") })'
+   ```
+
+   The first command must print `opencode2 v0.0.0-beta-17498`. The JSON
+   from the second must contain exactly one `data` entry whose `id` is
+   `orch.delivery`; the third command fails otherwise. `orch doctor`
+   performs the same runtime and plugin-ID checks for a repository with
+   `hosts.opencode` enabled; it cannot check an OpenCode adapter version
+   because the beta API does not expose one.
+
+4. In each repository, run `orch init`, review and merge its bootstrap
+   PR, then run `orch render-agents`. It writes the five OpenCode role
+   definitions under `.opencode/agents/`; run it again after changing
+   `hosts.opencode.roles` or upgrading Orch.
+
+## Upgrade
+
+Do not reinstall as though this were a first install. In the existing
+checkout, update the same local adapter package CI exercises, then
+restart OpenCode V2 and repeat the plugin-ID verification:
+
+```sh
+git -C ~/src/orch pull --ff-only
+npm ci --prefix ~/src/orch/adapters/opencode
+opencode2 api get /api/plugin
+opencode2 api get /api/plugin | node -e 'let s=""; process.stdin.on("data", d => s += d).on("end", () => { if (JSON.parse(s).data.filter(p => p.id === "orch.delivery").length !== 1) throw new Error("orch.delivery is not active exactly once") })'
+```
+
+The configured absolute module path stays the same. If the checkout
+path changes, update `opencode.json` to the new absolute
+`adapters/opencode/src/index.js` path before restarting.
+
+## Limitations
+
+- The beta API only proves the active plugin ID, not its adapter version.
+- The plugin guards OpenCode's `edit`, `write`, and `patch` tools. Shell
+  writes bypass Orch's guard and remain subject to OpenCode's own
+  permissions.
+- The plugin needs `orch` on `PATH`. If it is absent, OpenCode cannot
+  receive an Orch guard verdict.

--- a/docs/images/orch-overview.svg
+++ b/docs/images/orch-overview.svg
@@ -55,7 +55,7 @@
   <text x="78" y="198" class="sm">describe the change &#183; approve gates</text>
 
   <rect x="64" y="250" width="202" height="70" rx="6" fill="#111111" stroke="#a78bfa" stroke-width="1.5"/>
-  <text x="78" y="274" class="nm" fill="#a78bfa">Claude Code &#183; Codex CLI</text>
+  <text x="78" y="274" class="nm" fill="#a78bfa">Claude &#183; Codex &#183; OpenCode V2</text>
   <text x="78" y="292" class="sm">the CLI you already use;</text>
   <text x="78" y="306" class="sm">its pre-write hook calls orch guard</text>
 


### PR DESCRIPTION
Delivers issue #227: Document and package OpenCode V2 support

Closes #227

**Plan digest:** `sha256:2679deebdb7f8173aafa0bfca1f4389cbfefbd54f8c5047f3020ed077217dd7e`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Make every public support statement and installation path accurately describe the new OpenCode V2 host, its beta compatibility floor, its adapter lifecycle, and its limitations.

**Acceptance criteria:**
- The root README names OpenCode V2 alongside Claude Code and Codex CLI in its host badge, introduction, quickstart, manual installation and upgrade instructions, settings, operational guidance, known limitations, and package layout without implying that the Codex adapter is the OpenCode adapter.
- The OpenCode adapter documentation gives exact first-install, upgrade, verification, initialization, and render-agents steps using the opencode2 executable and the adapter's actual package and plugin IDs, and clearly labels the V2 plugin API as beta with the exact build or version range exercised by the smoke check.
- Repository-level product, contributor, release, and support documentation consistently describes three hosts and retains the existing Claude Code and Codex CLI compatibility statements rather than replacing them.
- The documented distribution path installs the same adapter artifact exercised by CI and gives users a deterministic way to verify that its plugin ID is active before relying on Orch enforcement.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`
- `git diff --check` — CI does not run this test

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `gpt-5.6-terra` — effort `max` |
| Reviewer | `gpt-5.6-sol` — effort `xhigh` |
| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a strong reviewer with no reviewer downgrade requested.

**Escalations:** _none_

**Verification:**
- **go-test** — pass — `go test ./...` — All Go packages passed at commit e5c1e338e0d106809bd30961f5073e4f07e52932. — commit `e5c1e338e0d106809bd30961f5073e4f07e52932` (2026-08-17T06:55:26Z)
- **go-vet** — pass — `go vet ./...` — No vet findings. — commit `e5c1e338e0d106809bd30961f5073e4f07e52932` (2026-08-17T06:55:26Z)
- **gofmt** — pass — `gofmt -l .` — No output; all Go files are formatted. — commit `e5c1e338e0d106809bd30961f5073e4f07e52932` (2026-08-17T06:55:26Z)
- **diff-check** — pass — `git diff --check` — No whitespace errors; this local-only required check passed. — commit `e5c1e338e0d106809bd30961f5073e4f07e52932` (2026-08-17T06:55:26Z)
- **documentation-contract** — pass — `git diff --word-diff --ignore-all-space origin/main...HEAD -- README.md ORCH-PRD.md AGENTS.md CLAUDE.md adapters/opencode/README.md docs/images/orch-overview.svg` — Reviewed the complete six-path documentation diff at 9011f9a746d2c60483d8ddbf03813eaf9dba8c34. OpenCode's npm-native package, role-agnostic host guard, executable quickstart, verified package/plugin IDs, exact beta floor, limitations, and six-role defaults are accurate; Claude/Codex hook, upgrade, arrow-key, marketplace, and profile statements remain intact; no unintended prose was dropped. — commit `9011f9a746d2c60483d8ddbf03813eaf9dba8c34` (2026-08-17T07:21:45Z)
- **review-local-required-checks** — pass — `go test ./... && go vet ./... && gofmt -l . && git diff --check` — Reviewer reran all required checks at e5c1e338e0d106809bd30961f5073e4f07e52932; tests and vet passed, gofmt listed no files, and diff check found no whitespace errors. — commit `e5c1e338e0d106809bd30961f5073e4f07e52932` (2026-08-17T07:04:17Z)
- **review-opencode-doc-commands** — pass — `opencode2 --version; opencode2 api --help; opencode2 api --standalone get /api/plugin; npm view @kninetimmy/orch-opencode version` — The CLI reported v0.0.0-beta-17498, confirmed the documented API syntax and plugin-list JSON shape, and npm returned E404 as documented because the package is unpublished. — commit `e5c1e338e0d106809bd30961f5073e4f07e52932` (2026-08-17T07:04:17Z)
- **review-live-ci** — pass — `gh pr checks 229 --required` — All six CI jobs passed at the reviewed head; each OS test job installed and tested adapters/opencode. — commit `e5c1e338e0d106809bd30961f5073e4f07e52932` (2026-08-17T07:04:17Z)
- **acceptance-criterion-1** — satisfied — The README covers OpenCode V2 in every named badge, introduction, quickstart, install/upgrade, settings, operations, limitations, and package-layout surface and explicitly distinguishes it from the Codex marketplace adapter. — commit `9011f9a746d2c60483d8ddbf03813eaf9dba8c34` (2026-08-17T07:21:46Z)
- **acceptance-criterion-2** — satisfied — The adapter README names the exact package, plugin, runtime beta, and plugin API versions and provides verified first-install, restart, exactly-once plugin verification, initialization, render-agents, and upgrade commands. — commit `9011f9a746d2c60483d8ddbf03813eaf9dba8c34` (2026-08-17T07:21:46Z)
- **acceptance-criterion-3** — satisfied — Repository-level product and contributor documentation consistently describes three hosts; OpenCode's six-role profile matches implementation and README exactly, while base-versus-head comparison confirms existing Claude and Codex profile tables are unchanged. — commit `9011f9a746d2c60483d8ddbf03813eaf9dba8c34` (2026-08-17T07:21:46Z)
- **acceptance-criterion-4** — satisfied — The documented path installs and upgrades the checked-out adapters/opencode artifact that CI installs and tests, accurately states the package is unpublished, and deterministically verifies exactly one orch.delivery plugin. — commit `9011f9a746d2c60483d8ddbf03813eaf9dba8c34` (2026-08-17T07:21:46Z)
- **review-cycle-1** — request-changes — Six documentation defects remain. The PR overstates OpenCode read-only-role enforcement, leaves the from-anywhere quickstart unusable for OpenCode, retains current two-adapter wording in operational sections, weakens an existing Claude/Codex arrow-key compatibility statement, miscounts reviewer definitions, and consequently overstates its documentation verification. Criteria 2 and 4 are satisfied; criteria 1 and 3 are not. — commit `e5c1e338e0d106809bd30961f5073e4f07e52932` (2026-08-17T07:04:18Z)
- **review-local-required-checks-cycle-2** — pass — `go test ./... && go vet ./... && gofmt -l . && git diff --check` — All required checks passed at baaffb417a5d921fd6e04bd3db69cbc896a35aeb; gofmt listed no files and diff check found no whitespace errors. — commit `baaffb417a5d921fd6e04bd3db69cbc896a35aeb` (2026-08-17T07:14:02Z)
- **review-live-ci-cycle-2** — pass — `gh pr checks 229 --required` — All six CI jobs passed at the reviewed head; each OS test job installed and tested adapters/opencode. — commit `baaffb417a5d921fd6e04bd3db69cbc896a35aeb` (2026-08-17T07:14:02Z)
- **review-cycle-2** — request-changes — All six cycle-1 findings are closed. Two PRD consistency defects remain: the default-model-profile section still omits OpenCode's implemented six-role profile, and the PRD retains a stale last-updated date. Criteria 1, 2, and 4 are satisfied; criterion 3 remains unsatisfied. — commit `baaffb417a5d921fd6e04bd3db69cbc896a35aeb` (2026-08-17T07:14:03Z)
- **review-local-required-checks-cycle-3** — pass — `go test ./... && go vet ./... && gofmt -l . && git diff --check` — All required checks passed at 9011f9a746d2c60483d8ddbf03813eaf9dba8c34; gofmt and diff check produced no output. — commit `9011f9a746d2c60483d8ddbf03813eaf9dba8c34` (2026-08-17T07:21:45Z)
- **review-profile-parity** — pass — `compare OpenCode role profiles across internal/interview/sequence.go, README.md, and ORCH-PRD.md` — All six OpenCode roles matched code, README, and PRD; existing Claude and Codex PRD profile tables were unchanged from the base. — commit `9011f9a746d2c60483d8ddbf03813eaf9dba8c34` (2026-08-17T07:21:45Z)
- **review-live-ci-cycle-3** — pass — `gh pr checks 229 --required` — All six CI jobs passed at the reviewed head. — commit `9011f9a746d2c60483d8ddbf03813eaf9dba8c34` (2026-08-17T07:21:45Z)
- **review-cycle-3** — approve — No findings. All prior documentation defects remain closed; OpenCode is accurately distinguished as the npm-native third host, its package and pinned beta commands are verified, its PRD profile matches code and README, legacy host profiles remain unchanged, all required checks pass, and all six CI jobs are green. — commit `9011f9a746d2c60483d8ddbf03813eaf9dba8c34` (2026-08-17T07:21:46Z)
- **required-ci** — passing — test (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `9011f9a746d2c60483d8ddbf03813eaf9dba8c34` (2026-08-17T07:22:05Z)

<!-- orch:manifest:data
{
  "schema_version": 4,
  "objective": "Make every public support statement and installation path accurately describe the new OpenCode V2 host, its beta compatibility floor, its adapter lifecycle, and its limitations.",
  "acceptance_criteria": [
    "The root README names OpenCode V2 alongside Claude Code and Codex CLI in its host badge, introduction, quickstart, manual installation and upgrade instructions, settings, operational guidance, known limitations, and package layout without implying that the Codex adapter is the OpenCode adapter.",
    "The OpenCode adapter documentation gives exact first-install, upgrade, verification, initialization, and render-agents steps using the opencode2 executable and the adapter's actual package and plugin IDs, and clearly labels the V2 plugin API as beta with the exact build or version range exercised by the smoke check.",
    "Repository-level product, contributor, release, and support documentation consistently describes three hosts and retains the existing Claude Code and Codex CLI compatibility statements rather than replacing them.",
    "The documented distribution path installs the same adapter artifact exercised by CI and gives users a deterministic way to verify that its plugin ID is active before relying on Orch enforcement."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l .",
    "git diff --check"
  ],
  "tests_ci_does_not_run": [
    "git diff --check"
  ],
  "role": "implementer",
  "executor": {
    "model": "gpt-5.6-terra",
    "effort": "max"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer with no reviewer downgrade requested.",
  "reviewer": {
    "model": "gpt-5.6-sol",
    "effort": "xhigh"
  },
  "effort_delivery": "parameter",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All Go packages passed at commit e5c1e338e0d106809bd30961f5073e4f07e52932.",
      "commit_oid": "e5c1e338e0d106809bd30961f5073e4f07e52932",
      "at": "2026-08-17T06:55:26Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "No vet findings.",
      "commit_oid": "e5c1e338e0d106809bd30961f5073e4f07e52932",
      "at": "2026-08-17T06:55:26Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No output; all Go files are formatted.",
      "commit_oid": "e5c1e338e0d106809bd30961f5073e4f07e52932",
      "at": "2026-08-17T06:55:26Z"
    },
    {
      "name": "diff-check",
      "command": "git diff --check",
      "result": "pass",
      "detail": "No whitespace errors; this local-only required check passed.",
      "commit_oid": "e5c1e338e0d106809bd30961f5073e4f07e52932",
      "at": "2026-08-17T06:55:26Z"
    },
    {
      "name": "documentation-contract",
      "command": "git diff --word-diff --ignore-all-space origin/main...HEAD -- README.md ORCH-PRD.md AGENTS.md CLAUDE.md adapters/opencode/README.md docs/images/orch-overview.svg",
      "result": "pass",
      "detail": "Reviewed the complete six-path documentation diff at 9011f9a746d2c60483d8ddbf03813eaf9dba8c34. OpenCode's npm-native package, role-agnostic host guard, executable quickstart, verified package/plugin IDs, exact beta floor, limitations, and six-role defaults are accurate; Claude/Codex hook, upgrade, arrow-key, marketplace, and profile statements remain intact; no unintended prose was dropped.",
      "commit_oid": "9011f9a746d2c60483d8ddbf03813eaf9dba8c34",
      "at": "2026-08-17T07:21:45Z"
    },
    {
      "name": "review-local-required-checks",
      "command": "go test ./... \u0026\u0026 go vet ./... \u0026\u0026 gofmt -l . \u0026\u0026 git diff --check",
      "result": "pass",
      "detail": "Reviewer reran all required checks at e5c1e338e0d106809bd30961f5073e4f07e52932; tests and vet passed, gofmt listed no files, and diff check found no whitespace errors.",
      "commit_oid": "e5c1e338e0d106809bd30961f5073e4f07e52932",
      "at": "2026-08-17T07:04:17Z"
    },
    {
      "name": "review-opencode-doc-commands",
      "command": "opencode2 --version; opencode2 api --help; opencode2 api --standalone get /api/plugin; npm view @kninetimmy/orch-opencode version",
      "result": "pass",
      "detail": "The CLI reported v0.0.0-beta-17498, confirmed the documented API syntax and plugin-list JSON shape, and npm returned E404 as documented because the package is unpublished.",
      "commit_oid": "e5c1e338e0d106809bd30961f5073e4f07e52932",
      "at": "2026-08-17T07:04:17Z"
    },
    {
      "name": "review-live-ci",
      "command": "gh pr checks 229 --required",
      "result": "pass",
      "detail": "All six CI jobs passed at the reviewed head; each OS test job installed and tested adapters/opencode.",
      "commit_oid": "e5c1e338e0d106809bd30961f5073e4f07e52932",
      "at": "2026-08-17T07:04:17Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "The README covers OpenCode V2 in every named badge, introduction, quickstart, install/upgrade, settings, operations, limitations, and package-layout surface and explicitly distinguishes it from the Codex marketplace adapter.",
      "commit_oid": "9011f9a746d2c60483d8ddbf03813eaf9dba8c34",
      "at": "2026-08-17T07:21:46Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "The adapter README names the exact package, plugin, runtime beta, and plugin API versions and provides verified first-install, restart, exactly-once plugin verification, initialization, render-agents, and upgrade commands.",
      "commit_oid": "9011f9a746d2c60483d8ddbf03813eaf9dba8c34",
      "at": "2026-08-17T07:21:46Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "Repository-level product and contributor documentation consistently describes three hosts; OpenCode's six-role profile matches implementation and README exactly, while base-versus-head comparison confirms existing Claude and Codex profile tables are unchanged.",
      "commit_oid": "9011f9a746d2c60483d8ddbf03813eaf9dba8c34",
      "at": "2026-08-17T07:21:46Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "The documented path installs and upgrades the checked-out adapters/opencode artifact that CI installs and tests, accurately states the package is unpublished, and deterministically verifies exactly one orch.delivery plugin.",
      "commit_oid": "9011f9a746d2c60483d8ddbf03813eaf9dba8c34",
      "at": "2026-08-17T07:21:46Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "Six documentation defects remain. The PR overstates OpenCode read-only-role enforcement, leaves the from-anywhere quickstart unusable for OpenCode, retains current two-adapter wording in operational sections, weakens an existing Claude/Codex arrow-key compatibility statement, miscounts reviewer definitions, and consequently overstates its documentation verification. Criteria 2 and 4 are satisfied; criteria 1 and 3 are not.",
      "commit_oid": "e5c1e338e0d106809bd30961f5073e4f07e52932",
      "at": "2026-08-17T07:04:18Z"
    },
    {
      "name": "review-local-required-checks-cycle-2",
      "command": "go test ./... \u0026\u0026 go vet ./... \u0026\u0026 gofmt -l . \u0026\u0026 git diff --check",
      "result": "pass",
      "detail": "All required checks passed at baaffb417a5d921fd6e04bd3db69cbc896a35aeb; gofmt listed no files and diff check found no whitespace errors.",
      "commit_oid": "baaffb417a5d921fd6e04bd3db69cbc896a35aeb",
      "at": "2026-08-17T07:14:02Z"
    },
    {
      "name": "review-live-ci-cycle-2",
      "command": "gh pr checks 229 --required",
      "result": "pass",
      "detail": "All six CI jobs passed at the reviewed head; each OS test job installed and tested adapters/opencode.",
      "commit_oid": "baaffb417a5d921fd6e04bd3db69cbc896a35aeb",
      "at": "2026-08-17T07:14:02Z"
    },
    {
      "name": "review-cycle-2",
      "result": "request-changes",
      "detail": "All six cycle-1 findings are closed. Two PRD consistency defects remain: the default-model-profile section still omits OpenCode's implemented six-role profile, and the PRD retains a stale last-updated date. Criteria 1, 2, and 4 are satisfied; criterion 3 remains unsatisfied.",
      "commit_oid": "baaffb417a5d921fd6e04bd3db69cbc896a35aeb",
      "at": "2026-08-17T07:14:03Z"
    },
    {
      "name": "review-local-required-checks-cycle-3",
      "command": "go test ./... \u0026\u0026 go vet ./... \u0026\u0026 gofmt -l . \u0026\u0026 git diff --check",
      "result": "pass",
      "detail": "All required checks passed at 9011f9a746d2c60483d8ddbf03813eaf9dba8c34; gofmt and diff check produced no output.",
      "commit_oid": "9011f9a746d2c60483d8ddbf03813eaf9dba8c34",
      "at": "2026-08-17T07:21:45Z"
    },
    {
      "name": "review-profile-parity",
      "command": "compare OpenCode role profiles across internal/interview/sequence.go, README.md, and ORCH-PRD.md",
      "result": "pass",
      "detail": "All six OpenCode roles matched code, README, and PRD; existing Claude and Codex PRD profile tables were unchanged from the base.",
      "commit_oid": "9011f9a746d2c60483d8ddbf03813eaf9dba8c34",
      "at": "2026-08-17T07:21:45Z"
    },
    {
      "name": "review-live-ci-cycle-3",
      "command": "gh pr checks 229 --required",
      "result": "pass",
      "detail": "All six CI jobs passed at the reviewed head.",
      "commit_oid": "9011f9a746d2c60483d8ddbf03813eaf9dba8c34",
      "at": "2026-08-17T07:21:45Z"
    },
    {
      "name": "review-cycle-3",
      "result": "approve",
      "detail": "No findings. All prior documentation defects remain closed; OpenCode is accurately distinguished as the npm-native third host, its package and pinned beta commands are verified, its PRD profile matches code and README, legacy host profiles remain unchanged, all required checks pass, and all six CI jobs are green.",
      "commit_oid": "9011f9a746d2c60483d8ddbf03813eaf9dba8c34",
      "at": "2026-08-17T07:21:46Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "9011f9a746d2c60483d8ddbf03813eaf9dba8c34",
      "at": "2026-08-17T07:22:05Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->