### PR TITLE
Add opencode/x-preview-f-free to the interview opencode model list

### DIFF
--- a/internal/interview/configure_test.go
+++ b/internal/interview/configure_test.go
@@ -219,6 +219,20 @@ func TestGoldenTranscriptConfigureMergeAndModel(t *testing.T) {
 	}
 }
 
+func TestGoldenTranscriptConfigureOpenCodeRoleModels(t *testing.T) {
+	root := t.TempDir()
+	writeCommittedConfigOpenCodeOnly(t, root)
+	doc, err := NextConfigure(configureFacts(), map[string]string{
+		idPickHosts:         "no",
+		idPickRolesOpenCode: "yes",
+		idPickSettings:      "no",
+	}, root)
+	if err != nil {
+		t.Fatalf("NextConfigure: %v", err)
+	}
+	checkGoldenDocument(t, filepath.Join("testdata", "transcript_configure", "opencode_role", "step_01.json"), doc)
+}
+
 // TestGoldenTranscriptConfigureDisableCodex disables codex from a
 // both-hosts committed configuration and expects AGENTS.md's managed
 // block to be proposed for block-only removal (ActionRemove), never a

--- a/internal/interview/configurelocal_test.go
+++ b/internal/interview/configurelocal_test.go
@@ -49,6 +49,25 @@ func writeCommittedConfigLocal(t *testing.T, root string) *config.Config {
 	return cfg
 }
 
+func writeCommittedConfigOpenCodeOnly(t *testing.T, root string) *config.Config {
+	t.Helper()
+	answers := fullAnswers()
+	answers[idHostClaudeEnabled] = "no"
+	answers[idHostCodexEnabled] = "no"
+	answers[idHostOpenCodeEnabled] = "yes"
+	for _, rs := range roleSpecs {
+		def := defaultProfiles["opencode"][rs.key]
+		answers[roleModelID("opencode", rs.key)] = def.model
+		answers[roleEffortID("opencode", rs.key)] = def.effort
+	}
+	cfg, err := materialize(answers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeCommittedConfig(t, root, cfg)
+	return cfg
+}
+
 // writeCommittedConfig revisions, renders, and writes cfg to root's
 // committed configuration path — the tail writeCommittedConfigLocal
 // shares with any test that needs the same fixture carrying one edited
@@ -189,6 +208,19 @@ func TestGoldenTranscriptLocalFlagship(t *testing.T) {
 	if change.Diff == "" {
 		t.Error("Diff is empty, want a diff showing the new override")
 	}
+}
+
+func TestGoldenTranscriptLocalOpenCodeRoleModels(t *testing.T) {
+	root := t.TempDir()
+	writeCommittedConfigOpenCodeOnly(t, root)
+	doc, err := NextConfigureLocal(map[string]string{
+		idPickOpenCode: "yes",
+		idPickSettings: "no",
+	}, root)
+	if err != nil {
+		t.Fatalf("NextConfigureLocal: %v", err)
+	}
+	checkGoldenDocument(t, filepath.Join("testdata", "transcript_local", "opencode_role", "step_01.json"), doc)
 }
 
 // TestGoldenTranscriptLocalClearAll answers the only existing override

--- a/internal/interview/interview_test.go
+++ b/internal/interview/interview_test.go
@@ -96,6 +96,18 @@ func TestGoldenTranscriptBothHosts(t *testing.T) {
 	t.Fatal("transcript did not reach a complete document within 100 steps")
 }
 
+func TestGoldenTranscriptOpenCodeRoleModels(t *testing.T) {
+	doc, err := Next(Facts{OpenCodeCLI: true}, map[string]string{
+		idHostClaudeEnabled:   "no",
+		idHostCodexEnabled:    "no",
+		idHostOpenCodeEnabled: "yes",
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	checkGoldenDocument(t, filepath.Join("testdata", "transcript", "opencode_role", "step_01.json"), doc)
+}
+
 // TestGoldenTranscriptAbort re-walks the same both-hosts transcript up
 // to the summary document, then aborts instead of approving.
 func TestGoldenTranscriptAbort(t *testing.T) {

--- a/internal/interview/sequence.go
+++ b/internal/interview/sequence.go
@@ -114,7 +114,7 @@ func defaultProfileFor(host string) func(string) profile {
 var hostModels = map[string][]string{
 	"codex":    {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"},
 	"claude":   {"claude-opus-5", "claude-sonnet-5"},
-	"opencode": {"openai/gpt-5.6-sol", "openai/gpt-5.6-terra", "openai/gpt-5.6-luna"},
+	"opencode": {"openai/gpt-5.6-sol", "openai/gpt-5.6-terra", "openai/gpt-5.6-luna", "opencode/x-preview-f-free"},
 }
 
 // hostEfforts lists each host's full closed effort enum — every value

--- a/internal/interview/testdata/transcript/opencode_role/step_01.json
+++ b/internal/interview/testdata/transcript/opencode_role/step_01.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "kind": "questions",
+  "progress": {
+    "index": 2,
+    "total": 8
+  },
+  "questions": [
+    {
+      "id": "host.opencode.role.architect.model",
+      "header": "Architect",
+      "prompt": "Architect model (OpenCode V2)",
+      "preamble": "Architect: requirements discovery, architecture and design, issue decomposition, routing and escalation, the plan gate, and final review judgment. Never edits tracked files directly.",
+      "kind": "select",
+      "options": [
+        {
+          "value": "openai/gpt-5.6-sol",
+          "label": "openai/gpt-5.6-sol",
+          "recommended": true
+        },
+        {
+          "value": "openai/gpt-5.6-terra",
+          "label": "openai/gpt-5.6-terra"
+        },
+        {
+          "value": "openai/gpt-5.6-luna",
+          "label": "openai/gpt-5.6-luna"
+        },
+        {
+          "value": "opencode/x-preview-f-free",
+          "label": "opencode/x-preview-f-free"
+        }
+      ],
+      "free_text": true,
+      "default": "openai/gpt-5.6-sol"
+    },
+    {
+      "id": "host.opencode.role.architect.effort",
+      "header": "Architect",
+      "prompt": "Architect reasoning effort (OpenCode V2)",
+      "kind": "select",
+      "options": [
+        {
+          "value": "low",
+          "label": "low"
+        },
+        {
+          "value": "medium",
+          "label": "medium"
+        },
+        {
+          "value": "high",
+          "label": "high"
+        },
+        {
+          "value": "xhigh",
+          "label": "xhigh",
+          "recommended": true
+        }
+      ],
+      "free_text": true,
+      "default": "xhigh"
+    }
+  ]
+}

--- a/internal/interview/testdata/transcript_configure/opencode_role/step_01.json
+++ b/internal/interview/testdata/transcript_configure/opencode_role/step_01.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "kind": "questions",
+  "progress": {
+    "index": 3,
+    "total": 8
+  },
+  "questions": [
+    {
+      "id": "host.opencode.role.architect.model",
+      "header": "Architect",
+      "prompt": "Architect model (OpenCode V2)",
+      "preamble": "Architect: requirements discovery, architecture and design, issue decomposition, routing and escalation, the plan gate, and final review judgment. Never edits tracked files directly.",
+      "kind": "select",
+      "options": [
+        {
+          "value": "openai/gpt-5.6-sol",
+          "label": "openai/gpt-5.6-sol",
+          "recommended": true
+        },
+        {
+          "value": "openai/gpt-5.6-terra",
+          "label": "openai/gpt-5.6-terra"
+        },
+        {
+          "value": "openai/gpt-5.6-luna",
+          "label": "openai/gpt-5.6-luna"
+        },
+        {
+          "value": "opencode/x-preview-f-free",
+          "label": "opencode/x-preview-f-free"
+        }
+      ],
+      "free_text": true,
+      "default": "openai/gpt-5.6-sol"
+    },
+    {
+      "id": "host.opencode.role.architect.effort",
+      "header": "Architect",
+      "prompt": "Architect reasoning effort (OpenCode V2)",
+      "kind": "select",
+      "options": [
+        {
+          "value": "low",
+          "label": "low"
+        },
+        {
+          "value": "medium",
+          "label": "medium"
+        },
+        {
+          "value": "high",
+          "label": "high"
+        },
+        {
+          "value": "xhigh",
+          "label": "xhigh",
+          "recommended": true
+        }
+      ],
+      "free_text": true,
+      "default": "xhigh"
+    }
+  ]
+}

--- a/internal/interview/testdata/transcript_local/opencode_role/step_01.json
+++ b/internal/interview/testdata/transcript_local/opencode_role/step_01.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": 1,
+  "kind": "questions",
+  "progress": {
+    "index": 2,
+    "total": 7
+  },
+  "questions": [
+    {
+      "id": "hosts.opencode.roles.architect.model",
+      "header": "Architect",
+      "prompt": "Architect model (OpenCode V2)",
+      "kind": "select",
+      "options": [
+        {
+          "value": "openai/gpt-5.6-sol",
+          "label": "openai/gpt-5.6-sol (committed)",
+          "recommended": true
+        },
+        {
+          "value": "openai/gpt-5.6-terra",
+          "label": "openai/gpt-5.6-terra"
+        },
+        {
+          "value": "openai/gpt-5.6-luna",
+          "label": "openai/gpt-5.6-luna"
+        },
+        {
+          "value": "opencode/x-preview-f-free",
+          "label": "opencode/x-preview-f-free"
+        }
+      ],
+      "free_text": true,
+      "default": "openai/gpt-5.6-sol"
+    },
+    {
+      "id": "hosts.opencode.roles.architect.effort",
+      "header": "Architect",
+      "prompt": "Architect reasoning effort (OpenCode V2)",
+      "kind": "select",
+      "options": [
+        {
+          "value": "low",
+          "label": "low"
+        },
+        {
+          "value": "medium",
+          "label": "medium"
+        },
+        {
+          "value": "high",
+          "label": "high"
+        },
+        {
+          "value": "xhigh",
+          "label": "xhigh (committed)",
+          "recommended": true
+        }
+      ],
+      "free_text": true,
+      "default": "xhigh"
+    }
+  ]
+}


### PR DESCRIPTION
Delivers issue #230: Add opencode/x-preview-f-free to the interview opencode model list

Closes #230

**Plan digest:** `sha256:3c14bee0b4904ed5ae564a86d4b0b5a3877692b72effeeb4f6edbb420208b1e3`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** In internal/interview/sequence.go, append "opencode/x-preview-f-free" to hostModels["opencode"] after the three existing openai/ entries. Do not touch hostLocalModels in configurelocal.go (it derives from hostModels via buildHostLocalModels) and do not modify defaultProfiles or any shipped agent definition under adapters/. Regenerate the golden transcripts with go test ./internal/interview -update and keep only the regenerated files whose opencode model options changed.

**Acceptance criteria:**
- An opencode-host role model question emitted by the init/configure interview lists opencode/x-preview-f-free among its select options alongside the three existing openai/ options, visible in the regenerated golden transcript steps.
- The configure-local interview's opencode-host role model questions likewise list opencode/x-preview-f-free among their select options.
- No shipped default names the new model: a search across adapters/, ORCH-PRD.md, README.md, and the tests' default-profile pins finds no occurrence of x-preview-f-free.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `gpt-5.6-terra` — effort `max` |
| Reviewer | `gpt-5.6-sol` — effort `medium` |
| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **go-test-all** — pass — `go test ./...` — full module test suite passes on commit d6732af — commit `d6732afb851a324cdcc9d91941515a33b798b0b5` (2026-08-22T21:43:55Z)
- **interview-package-tests** — pass — `go test ./internal/interview` — includes new opencode_role golden transcript walks for init/configure/configure-local — commit `d6732afb851a324cdcc9d91941515a33b798b0b5` (2026-08-22T21:43:55Z)
- **gofmt-clean** — pass — `gofmt -l .` — no output; tree formatted — commit `d6732afb851a324cdcc9d91941515a33b798b0b5` (2026-08-22T21:43:55Z)
- **no-shipped-default-mention** — pass — `grep x-preview-f-free across adapters/, ORCH-PRD.md, README.md, default-profile test pins` — no occurrence outside internal/interview source and its goldens — commit `d6732afb851a324cdcc9d91941515a33b798b0b5` (2026-08-22T21:43:55Z)
- **reviewer-test-suite** — pass — `go test -count=1 ./...` — re-run by reviewer at head d6732af — commit `d6732afb851a324cdcc9d91941515a33b798b0b5` (2026-08-22T21:48:28Z)
- **reviewer-gofmt** — pass — `gofmt -l .` — no output at head d6732af — commit `d6732afb851a324cdcc9d91941515a33b798b0b5` (2026-08-22T21:48:28Z)
- **acceptance-criterion-1** — satisfied — sequence.go:117 appends the new model after the three existing options; roleDocSpecs sources every init/configure role's options through that list; init and configure goldens show all four options. — commit `d6732afb851a324cdcc9d91941515a33b798b0b5` (2026-08-22T21:48:29Z)
- **acceptance-criterion-2** — satisfied — hostLocalModels remains derived from hostModels; all configure-local role documents use it through modelOptionsLocal; local golden contains all four options. — commit `d6732afb851a324cdcc9d91941515a33b798b0b5` (2026-08-22T21:48:29Z)
- **acceptance-criterion-3** — satisfied — Repository-wide search found occurrences only in sequence.go and the three new interview goldens; none in adapters/, ORCH-PRD.md, README.md, or default-profile pin tests; defaultProfiles unchanged. — commit `d6732afb851a324cdcc9d91941515a33b798b0b5` (2026-08-22T21:48:29Z)
- **review-cycle-1** — approve — Approved first cycle. Production diff is exactly the requested one-list change in internal/interview/sequence.go; configurelocal.go, shipped agents, docs, and defaultProfiles untouched. Added focused one-step golden coverage (init/configure/configure-local opencode_role transcripts) supplies the acceptance evidence existing flagships lacked. All six CI checks green at reviewed head d6732af. Sole finding is non-blocking P3 audit wording ('golden transcript walks' overstates one-step golden checks). — commit `d6732afb851a324cdcc9d91941515a33b798b0b5` (2026-08-22T21:48:29Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, test (windows-latest)=pass, scripts (windows-latest)=pass — commit `d6732afb851a324cdcc9d91941515a33b798b0b5` (2026-08-22T21:48:40Z)

<!-- orch:manifest:data
{
  "schema_version": 4,
  "objective": "In internal/interview/sequence.go, append \"opencode/x-preview-f-free\" to hostModels[\"opencode\"] after the three existing openai/ entries. Do not touch hostLocalModels in configurelocal.go (it derives from hostModels via buildHostLocalModels) and do not modify defaultProfiles or any shipped agent definition under adapters/. Regenerate the golden transcripts with go test ./internal/interview -update and keep only the regenerated files whose opencode model options changed.",
  "acceptance_criteria": [
    "An opencode-host role model question emitted by the init/configure interview lists opencode/x-preview-f-free among its select options alongside the three existing openai/ options, visible in the regenerated golden transcript steps.",
    "The configure-local interview's opencode-host role model questions likewise list opencode/x-preview-f-free among their select options.",
    "No shipped default names the new model: a search across adapters/, ORCH-PRD.md, README.md, and the tests' default-profile pins finds no occurrence of x-preview-f-free."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "gpt-5.6-terra",
    "effort": "max"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "gpt-5.6-sol",
    "effort": "medium"
  },
  "effort_delivery": "parameter",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "full module test suite passes on commit d6732af",
      "commit_oid": "d6732afb851a324cdcc9d91941515a33b798b0b5",
      "at": "2026-08-22T21:43:55Z"
    },
    {
      "name": "interview-package-tests",
      "command": "go test ./internal/interview",
      "result": "pass",
      "detail": "includes new opencode_role golden transcript walks for init/configure/configure-local",
      "commit_oid": "d6732afb851a324cdcc9d91941515a33b798b0b5",
      "at": "2026-08-22T21:43:55Z"
    },
    {
      "name": "gofmt-clean",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "no output; tree formatted",
      "commit_oid": "d6732afb851a324cdcc9d91941515a33b798b0b5",
      "at": "2026-08-22T21:43:55Z"
    },
    {
      "name": "no-shipped-default-mention",
      "command": "grep x-preview-f-free across adapters/, ORCH-PRD.md, README.md, default-profile test pins",
      "result": "pass",
      "detail": "no occurrence outside internal/interview source and its goldens",
      "commit_oid": "d6732afb851a324cdcc9d91941515a33b798b0b5",
      "at": "2026-08-22T21:43:55Z"
    },
    {
      "name": "reviewer-test-suite",
      "command": "go test -count=1 ./...",
      "result": "pass",
      "detail": "re-run by reviewer at head d6732af",
      "commit_oid": "d6732afb851a324cdcc9d91941515a33b798b0b5",
      "at": "2026-08-22T21:48:28Z"
    },
    {
      "name": "reviewer-gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "no output at head d6732af",
      "commit_oid": "d6732afb851a324cdcc9d91941515a33b798b0b5",
      "at": "2026-08-22T21:48:28Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "sequence.go:117 appends the new model after the three existing options; roleDocSpecs sources every init/configure role's options through that list; init and configure goldens show all four options.",
      "commit_oid": "d6732afb851a324cdcc9d91941515a33b798b0b5",
      "at": "2026-08-22T21:48:29Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "hostLocalModels remains derived from hostModels; all configure-local role documents use it through modelOptionsLocal; local golden contains all four options.",
      "commit_oid": "d6732afb851a324cdcc9d91941515a33b798b0b5",
      "at": "2026-08-22T21:48:29Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "Repository-wide search found occurrences only in sequence.go and the three new interview goldens; none in adapters/, ORCH-PRD.md, README.md, or default-profile pin tests; defaultProfiles unchanged.",
      "commit_oid": "d6732afb851a324cdcc9d91941515a33b798b0b5",
      "at": "2026-08-22T21:48:29Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approved first cycle. Production diff is exactly the requested one-list change in internal/interview/sequence.go; configurelocal.go, shipped agents, docs, and defaultProfiles untouched. Added focused one-step golden coverage (init/configure/configure-local opencode_role transcripts) supplies the acceptance evidence existing flagships lacked. All six CI checks green at reviewed head d6732af. Sole finding is non-blocking P3 audit wording ('golden transcript walks' overstates one-step golden checks).",
      "commit_oid": "d6732afb851a324cdcc9d91941515a33b798b0b5",
      "at": "2026-08-22T21:48:29Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, test (windows-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "d6732afb851a324cdcc9d91941515a33b798b0b5",
      "at": "2026-08-22T21:48:40Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->