### PR TITLE
Correct merged OpenCode read-only-role documentation

### DIFF
--- a/ORCH-PRD.md
+++ b/ORCH-PRD.md
@@ -369,8 +369,10 @@ Orch fails closed.
   `orch-scout`, `orch-reviewer`, and `orch-reviewer-safe` definitions mechanically deny `edit`,
   `shell`, and `subagent`; the `edit` denial covers every built-in V2 mutation tool. OpenCode's
   read-only role enforcement therefore comes from those definitions, not the guard.
-- Neither closes the shell-write gap: the pre-write hook covers only the file-write tools, so a
-  shell-mediated write falls to the host's own approval prompts.
+- For Claude Code and Codex reviewers, the pre-write hook covers only file-write tools, so their
+  read-only discipline for shell-mediated writes rests on instructions plus host approval prompts.
+  OpenCode's native scout and reviewer definitions mechanically deny `shell`, so that gap does not
+  apply to OpenCode.
 - No agent may merge.
 - Hook, authentication, GitHub, or validation failures produce a blocked run.
 - Blocked worktrees and branches are preserved.

--- a/ORCH-PRD.md
+++ b/ORCH-PRD.md
@@ -364,9 +364,11 @@ Orch fails closed.
 - Completion requires a commit, pushed branch, PR, targeted-test evidence, and explicit CI state.
 - The guard does not attribute writes to roles. Claude Code's Scout has no shell tool, but its
   Reviewer and safe review downgrade do, so their read-only discipline for shell-mediated writes
-  rests on instructions. Codex has no per-agent tool whitelist. OpenCode's plugin guard is
-  host-global, so it likewise cannot prevent a scout or reviewer write inside a Delivery worktree
-  the guard otherwise permits.
+  rests on instructions. Codex has no per-agent tool whitelist. The OpenCode `orch.delivery`
+  guard is host-global and cannot attribute a write to a dispatched role. Its native
+  `orch-scout`, `orch-reviewer`, and `orch-reviewer-safe` definitions mechanically deny `edit`,
+  `shell`, and `subagent`; the `edit` denial covers every built-in V2 mutation tool. OpenCode's
+  read-only role enforcement therefore comes from those definitions, not the guard.
 - Neither closes the shell-write gap: the pre-write hook covers only the file-write tools, so a
   shell-mediated write falls to the host's own approval prompts.
 - No agent may merge.

--- a/README.md
+++ b/README.md
@@ -431,15 +431,19 @@ backstop; leave them on.
 **The guard cannot tell one role from another.** `orch guard` has a
 `--role` flag that would make a role mechanically read-only, but no
 adapter passes it. Claude Code and Codex CLI hook manifests run the
-bare command, and the OpenCode V2 plugin is host-global rather than
-attributed to a dispatched role. Inside a worktree the guard treats as
-writable, a scout or a reviewer is no more restricted than the
-implementer. On Claude Code the `orch-scout` subagent's tool whitelist
-does close its write surface — it carries no `Bash` — but
-`orch-reviewer` and `orch-reviewer-safe` both carry `Bash`, so their
-read-only discipline for shell-mediated writes rests on instructions
-there too. Codex agent definitions carry no tool whitelist; OpenCode's
-host-global guard likewise does not enforce read-only roles.
+bare command, and the OpenCode V2 `orch.delivery` guard is host-global
+rather than attributed to a dispatched role. In a worktree the guard
+treats as writable, a scout or reviewer is no more restricted by the
+guard than the implementer. On Claude Code the `orch-scout`
+subagent's tool whitelist does close its write surface — it carries no
+`Bash` — but `orch-reviewer` and `orch-reviewer-safe` both carry
+`Bash`, so their read-only discipline for shell-mediated writes rests
+on instructions there too. Codex agent definitions carry no tool
+whitelist. OpenCode's native `orch-scout`, `orch-reviewer`, and
+`orch-reviewer-safe` definitions mechanically deny `edit`, `shell`,
+and `subagent`; the `edit` denial covers every built-in V2 mutation
+tool. Its read-only role enforcement therefore comes from those
+definitions, not the host-global guard.
 
 **An `orch run` verb invoked from inside a Delivery worktree reports
 Assist and names the wrong fix.** Every `orch` command resolves


### PR DESCRIPTION
Delivers issue #232: Correct merged OpenCode read-only-role documentation

Closes #232

**Plan digest:** `sha256:d483cad7b992fc56cb8a93c1fc70c437807fdfc96cd974bc1d327495e0c9204f`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** README.md's known-limitations paragraph around lines 431-442 and ORCH-PRD.md section 15 bullet around lines 365-369 state that OpenCode cannot enforce scout/reviewer read-only discipline. That is false since fa864f5: the native adapters/opencode agent definitions for orch-scout, orch-reviewer, and orch-reviewer-safe carry frontmatter permissions mechanically denying edit, shell, and subagent actions (the edit denial covers every built-in mutation tool in V2). Rewrite both passages to state this truth while preserving the separate accurate claim that the orch.delivery guard itself is host-global and role-agnostic: it cannot attribute a write to a dispatched role, so the mechanical restriction comes from the agent definitions, not the guard. Sweep the remaining docs (rest of README.md, ORCH-PRD.md, adapters/*/README.md) for any other instance of the same false claim and correct those too. Documentation only: no Go or adapter behavior changes.

**Acceptance criteria:**
- README.md and ORCH-PRD.md no longer state that OpenCode cannot prevent or does not enforce scout/reviewer write restrictions; both state that the native agent definitions mechanically deny edit, shell, and subagent for orch-scout, orch-reviewer, and orch-reviewer-safe.
- Both files still document that the orch.delivery guard is host-global and cannot attribute a write to a role, so OpenCode's read-only enforcement comes from the definitions rather than write attribution.
- A search across README.md, ORCH-PRD.md, and adapters/*/README.md finds no remaining sentence claiming OpenCode lacks mechanical read-only role enforcement.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `gpt-5.6-terra` — effort `max` |
| Reviewer | `gpt-5.6-sol` — effort `medium` |
| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **go-test-all** — pass — `go test ./...` — passes at fix head 5d1d9a5 (executor cycle-1 run at ef313d9 superseded) — commit `5d1d9a565d0b652574b0aa92459cbaca65252d94` (2026-08-22T22:44:05Z)
- **gofmt-clean** — pass — `gofmt -l .` — no output at fix head 5d1d9a5 — commit `5d1d9a565d0b652574b0aa92459cbaca65252d94` (2026-08-22T22:44:05Z)
- **word-diff-removal-audit** — pass — `git diff origin/main..HEAD --word-diff=plain --ignore-all-space` — two-commit audit vs merge-base f1d4475: removals are only the superseded false claims and the stale Neither bullet; no unintended dropped words — commit `5d1d9a565d0b652574b0aa92459cbaca65252d94` (2026-08-22T22:44:05Z)
- **false-claim-sweep** — pass — `search README.md ORCH-PRD.md adapters/*/README.md for OpenCode-lacks-enforcement claims` — cycle-2 independent sweep by reviewer at head 5d1d9a5 finds no remaining instance; supersedes the inadequate cycle-1 entry — commit `5d1d9a565d0b652574b0aa92459cbaca65252d94` (2026-08-22T22:44:05Z)
- **reviewer-test-suite** — pass — `go test -count=1 ./...` — re-run by fresh reviewer at head 5d1d9a5 — commit `5d1d9a565d0b652574b0aa92459cbaca65252d94` (2026-08-22T22:44:05Z)
- **reviewer-gofmt** — pass — `gofmt -l .` — no output at head 5d1d9a5 — commit `5d1d9a565d0b652574b0aa92459cbaca65252d94` (2026-08-22T22:44:05Z)
- **acceptance-criterion-1** — satisfied — README.md 442-446 and ORCH-PRD.md 369-371 name all three agents and denied edit/shell/subagent actions, matching frontmatter at adapters/opencode/agents/{orch-scout,orch-reviewer,orch-reviewer-safe}.md lines 5-8. — commit `5d1d9a565d0b652574b0aa92459cbaca65252d94` (2026-08-22T22:44:06Z)
- **acceptance-criterion-2** — satisfied — Both files preserve the guard's host-global non-attribution and place OpenCode's read-only enforcement in the agent definitions. — commit `5d1d9a565d0b652574b0aa92459cbaca65252d94` (2026-08-22T22:44:06Z)
- **acceptance-criterion-3** — satisfied — Broad and focused searches across README.md, ORCH-PRD.md, and adapters/*/README.md find no remaining passage claiming OpenCode lacks mechanical role enforcement; the cycle-one 'Neither closes' defect is removed. — commit `5d1d9a565d0b652574b0aa92459cbaca65252d94` (2026-08-22T22:44:06Z)
- **review-cycle-1** — request-changes — Cycle 1: criteria 1 and 2 satisfied - both files name all three agents and all three denied actions, verified against actual frontmatter, and preserve the guard's host-global non-attribution. Criterion 3 unsatisfied: ORCH-PRD.md 369-373 retains 'Neither closes the shell-write gap' whose nearest antecedents are now the OpenCode definitions and guard, implying the definitions do not close shell writes for those roles - a directional/antecedent defect that contradicts the correction and makes the false-claim-sweep verification inaccurate. Everything else clean: docs-only scope, no word drops or moved blocks beyond this, six CI checks green at head ef313d9. — commit `ef313d96e6f6c030331dcb3a6fd3e5a3524cb442` (2026-08-22T22:34:36Z)
- **review-cycle-2** — approve — Cycle 2 approve. Fix commit 5d1d9a5 rewrote the shell-write-gap bullet with named Claude/Codex subjects, explicitly excluding OpenCode from the gap. All three criteria satisfied at the new head against actual frontmatter; two-commit word-stream audit clean; six CI checks green. Sole finding non-blocking: 'Its native definitions' at ORCH-PRD.md 368-369 could grammatically imply the guard owns the definitions, though line 371 states the distinction explicitly. — commit `5d1d9a565d0b652574b0aa92459cbaca65252d94` (2026-08-22T22:44:06Z)
- **required-ci** — passing — test (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `5d1d9a565d0b652574b0aa92459cbaca65252d94` (2026-08-22T22:44:15Z)

<!-- orch:manifest:data
{
  "schema_version": 4,
  "objective": "README.md's known-limitations paragraph around lines 431-442 and ORCH-PRD.md section 15 bullet around lines 365-369 state that OpenCode cannot enforce scout/reviewer read-only discipline. That is false since fa864f5: the native adapters/opencode agent definitions for orch-scout, orch-reviewer, and orch-reviewer-safe carry frontmatter permissions mechanically denying edit, shell, and subagent actions (the edit denial covers every built-in mutation tool in V2). Rewrite both passages to state this truth while preserving the separate accurate claim that the orch.delivery guard itself is host-global and role-agnostic: it cannot attribute a write to a dispatched role, so the mechanical restriction comes from the agent definitions, not the guard. Sweep the remaining docs (rest of README.md, ORCH-PRD.md, adapters/*/README.md) for any other instance of the same false claim and correct those too. Documentation only: no Go or adapter behavior changes.",
  "acceptance_criteria": [
    "README.md and ORCH-PRD.md no longer state that OpenCode cannot prevent or does not enforce scout/reviewer write restrictions; both state that the native agent definitions mechanically deny edit, shell, and subagent for orch-scout, orch-reviewer, and orch-reviewer-safe.",
    "Both files still document that the orch.delivery guard is host-global and cannot attribute a write to a role, so OpenCode's read-only enforcement comes from the definitions rather than write attribution.",
    "A search across README.md, ORCH-PRD.md, and adapters/*/README.md finds no remaining sentence claiming OpenCode lacks mechanical read-only role enforcement."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "gpt-5.6-terra",
    "effort": "max"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "gpt-5.6-sol",
    "effort": "medium"
  },
  "effort_delivery": "parameter",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "passes at fix head 5d1d9a5 (executor cycle-1 run at ef313d9 superseded)",
      "commit_oid": "5d1d9a565d0b652574b0aa92459cbaca65252d94",
      "at": "2026-08-22T22:44:05Z"
    },
    {
      "name": "gofmt-clean",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "no output at fix head 5d1d9a5",
      "commit_oid": "5d1d9a565d0b652574b0aa92459cbaca65252d94",
      "at": "2026-08-22T22:44:05Z"
    },
    {
      "name": "word-diff-removal-audit",
      "command": "git diff origin/main..HEAD --word-diff=plain --ignore-all-space",
      "result": "pass",
      "detail": "two-commit audit vs merge-base f1d4475: removals are only the superseded false claims and the stale Neither bullet; no unintended dropped words",
      "commit_oid": "5d1d9a565d0b652574b0aa92459cbaca65252d94",
      "at": "2026-08-22T22:44:05Z"
    },
    {
      "name": "false-claim-sweep",
      "command": "search README.md ORCH-PRD.md adapters/*/README.md for OpenCode-lacks-enforcement claims",
      "result": "pass",
      "detail": "cycle-2 independent sweep by reviewer at head 5d1d9a5 finds no remaining instance; supersedes the inadequate cycle-1 entry",
      "commit_oid": "5d1d9a565d0b652574b0aa92459cbaca65252d94",
      "at": "2026-08-22T22:44:05Z"
    },
    {
      "name": "reviewer-test-suite",
      "command": "go test -count=1 ./...",
      "result": "pass",
      "detail": "re-run by fresh reviewer at head 5d1d9a5",
      "commit_oid": "5d1d9a565d0b652574b0aa92459cbaca65252d94",
      "at": "2026-08-22T22:44:05Z"
    },
    {
      "name": "reviewer-gofmt",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "no output at head 5d1d9a5",
      "commit_oid": "5d1d9a565d0b652574b0aa92459cbaca65252d94",
      "at": "2026-08-22T22:44:05Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "README.md 442-446 and ORCH-PRD.md 369-371 name all three agents and denied edit/shell/subagent actions, matching frontmatter at adapters/opencode/agents/{orch-scout,orch-reviewer,orch-reviewer-safe}.md lines 5-8.",
      "commit_oid": "5d1d9a565d0b652574b0aa92459cbaca65252d94",
      "at": "2026-08-22T22:44:06Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "Both files preserve the guard's host-global non-attribution and place OpenCode's read-only enforcement in the agent definitions.",
      "commit_oid": "5d1d9a565d0b652574b0aa92459cbaca65252d94",
      "at": "2026-08-22T22:44:06Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "Broad and focused searches across README.md, ORCH-PRD.md, and adapters/*/README.md find no remaining passage claiming OpenCode lacks mechanical role enforcement; the cycle-one 'Neither closes' defect is removed.",
      "commit_oid": "5d1d9a565d0b652574b0aa92459cbaca65252d94",
      "at": "2026-08-22T22:44:06Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "Cycle 1: criteria 1 and 2 satisfied - both files name all three agents and all three denied actions, verified against actual frontmatter, and preserve the guard's host-global non-attribution. Criterion 3 unsatisfied: ORCH-PRD.md 369-373 retains 'Neither closes the shell-write gap' whose nearest antecedents are now the OpenCode definitions and guard, implying the definitions do not close shell writes for those roles - a directional/antecedent defect that contradicts the correction and makes the false-claim-sweep verification inaccurate. Everything else clean: docs-only scope, no word drops or moved blocks beyond this, six CI checks green at head ef313d9.",
      "commit_oid": "ef313d96e6f6c030331dcb3a6fd3e5a3524cb442",
      "at": "2026-08-22T22:34:36Z"
    },
    {
      "name": "review-cycle-2",
      "result": "approve",
      "detail": "Cycle 2 approve. Fix commit 5d1d9a5 rewrote the shell-write-gap bullet with named Claude/Codex subjects, explicitly excluding OpenCode from the gap. All three criteria satisfied at the new head against actual frontmatter; two-commit word-stream audit clean; six CI checks green. Sole finding non-blocking: 'Its native definitions' at ORCH-PRD.md 368-369 could grammatically imply the guard owns the definitions, though line 371 states the distinction explicitly.",
      "commit_oid": "5d1d9a565d0b652574b0aa92459cbaca65252d94",
      "at": "2026-08-22T22:44:06Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "5d1d9a565d0b652574b0aa92459cbaca65252d94",
      "at": "2026-08-22T22:44:15Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->