### PR TITLE
Bump release identities for v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/License-MIT-2E7D32?style=flat&logo=opensourceinitiative&logoColor=white" alt="License: MIT"/>
   <img src="https://img.shields.io/badge/Go-1.26%2B-00ADD8?style=flat&logo=go&logoColor=white" alt="Go 1.26+"/>
-  <img src="https://img.shields.io/badge/Release-v0.7.0-24292F?style=flat&logo=github&logoColor=white" alt="Release: v0.7.0"/>
+  <img src="https://img.shields.io/badge/Release-v0.8.0-24292F?style=flat&logo=github&logoColor=white" alt="Release: v0.8.0"/>
   <br/>
   <img src="https://img.shields.io/badge/Platform-Linux%20%C2%B7%20macOS%20%C2%B7%20Windows-607D8B?style=flat" alt="Platform: Linux, macOS, Windows"/>
   <img src="https://img.shields.io/badge/Hosts-Claude%20Code%20%C2%B7%20Codex%20CLI%20%C2%B7%20OpenCode%20V2-6E56CF?style=flat" alt="Hosts: Claude Code, Codex CLI, and OpenCode V2"/>
@@ -408,7 +408,7 @@ receive a copy of the memhub database.
 
 ## Status
 
-Early software. What can be stated as fact: 19 tagged releases, v0.1.0 through v0.7.0, and every pull request merged since PR #40 carries an Orch audit record in its body — apart from the configuration deliveries, which `orch configure` writes in its own body format. Since PR #40, this repository has been built through the pipeline described above: a plan gate, an isolated worktree per issue, a review dispatched separately from the work, CI, and a merge that fails closed unless it carries an approval pinned to the commit `merge-report` recorded.
+Early software. What can be stated as fact: 20 tagged releases, v0.1.0 through v0.8.0, and every pull request merged since PR #40 carries an Orch audit record in its body — apart from the configuration deliveries, which `orch configure` writes in its own body format. Since PR #40, this repository has been built through the pipeline described above: a plan gate, an isolated worktree per issue, a review dispatched separately from the work, CI, and a merge that fails closed unless it carries an approval pinned to the commit `merge-report` recorded.
 
 All of that evidence comes from one repository: this one.
 
@@ -577,7 +577,7 @@ continue, or `orch abort` to end it.
 <details>
 <summary>Defects already corrected, newest first</summary>
 
-Everything here is merged on `main` and shipped in v0.7.0, the latest
+Everything here is merged on `main` and shipped in v0.8.0, the latest
 tagged release.
 
 - The wrong-criterion guidance in the standard and safe reviewer

--- a/adapters/opencode/README.md
+++ b/adapters/opencode/README.md
@@ -1,7 +1,7 @@
 # OpenCode V2 adapter
 
 This directory is Orch's npm-native OpenCode V2 adapter. Its package ID
-is `@kninetimmy/orch-opencode` (version `0.7.0`) and its running plugin
+is `@kninetimmy/orch-opencode` (version `0.8.0`) and its running plugin
 ID is `orch.delivery`. It is not the Codex marketplace adapter: that is
 `adapters/codex/`, installed as `orch@orch` from the shared marketplace.
 

--- a/adapters/opencode/package-lock.json
+++ b/adapters/opencode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kninetimmy/orch-opencode",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kninetimmy/orch-opencode",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@opencode-ai/plugin": "0.0.0-beta-17498"
       }

--- a/adapters/opencode/package.json
+++ b/adapters/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kninetimmy/orch-opencode",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "exports": "./src/index.js",
   "scripts": {


### PR DESCRIPTION
Delivers issue #233: Bump release identities for v0.8.0

Closes #233

**Plan digest:** `sha256:d483cad7b992fc56cb8a93c1fc70c437807fdfc96cd974bc1d327495e0c9204f`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Prepare identity bumps for the v0.8.0 release (tagging itself happens after this merges). Bump to 0.8.0: adapters/opencode/package.json, both version fields in adapters/opencode/package-lock.json, and the version mention in adapters/opencode/README.md. Update README.md's Release badge to v0.8.0 and its latest-release prose: the Status-section claim of what is shipped in the latest release (~line 576) and the tagged-releases count sentence (~line 411, becomes 20 tagged releases through v0.8.0). Do NOT touch .claude-plugin/marketplace.json or adapters/claude and adapters/codex plugin manifests and their test literals: those adapters have zero content change since v0.7.0 and stay at 0.7.0 per the binary-only-release precedent. Leave the install-command example pins in README (ORCH_VERSION / -Version examples) untouched. The internal binary version needs no file change (ldflags-injected at tag time).

**Acceptance criteria:**
- Every file naming the opencode adapter package version reads 0.8.0: package.json, both lockfile version fields, and the adapter README mention.
- The marketplace manifest and claude/codex plugin manifests still read 0.7.0, and their pinning tests pass unchanged.
- README.md's Release badge reads v0.8.0, and the latest-release and tagged-release-count prose reference v0.8.0 and the updated count.
- go test ./... passes and gofmt -l . is clean.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `gpt-5.6-terra` — effort `max` |
| Reviewer | `gpt-5.6-sol` — effort `medium` |
| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **go-test-all** — pass — `go test ./...` — passes at head 44274ac — commit `44274acb70cacbee44f061aee1b90b94b70b1dee` (2026-08-22T23:03:26Z)
- **gofmt-clean** — pass — `gofmt -l .` — no output at head 44274ac — commit `44274acb70cacbee44f061aee1b90b94b70b1dee` (2026-08-22T23:03:26Z)
- **identity-spread-check** — pass — `git grep 0.8.0 across README.md and adapters/opencode; git grep -c 0.7.0 across .claude-plugin and adapters/{claude,codex}/.claude-plugin` — reviewer independently confirmed the same spread: seven required 0.8.0 sites, three retained 0.7.0 manifests, installer example pins untouched — commit `44274acb70cacbee44f061aee1b90b94b70b1dee` (2026-08-22T23:03:26Z)
- **acceptance-criterion-1** — satisfied — package.json:3, package-lock.json:3 and :9, adapters/opencode/README.md:4 all read 0.8.0; JSON parse confirmed consistency. — commit `44274acb70cacbee44f061aee1b90b94b70b1dee` (2026-08-22T23:03:27Z)
- **acceptance-criterion-2** — satisfied — Marketplace and both host manifests remain 0.7.0; their tests unchanged and passing under go test ./... — commit `44274acb70cacbee44f061aee1b90b94b70b1dee` (2026-08-22T23:03:27Z)
- **acceptance-criterion-3** — satisfied — Badge v0.8.0 at README.md:8; 20-tagged-releases-through-v0.8.0 at :411; v0.8.0-latest claim at :580-581. — commit `44274acb70cacbee44f061aee1b90b94b70b1dee` (2026-08-22T23:03:27Z)
- **acceptance-criterion-4** — satisfied — Reviewer independently re-ran go test ./... (pass) and gofmt -l . (no output). — commit `44274acb70cacbee44f061aee1b90b94b70b1dee` (2026-08-22T23:03:27Z)
- **review-cycle-1** — approve — First-pass approve with zero findings. Exactly four files changed (7+/7-): opencode package.json, both lockfile fields, adapter README to 0.8.0; README badge L8, count sentence L411 (20 releases through v0.8.0), latest-release prose L580-581 to v0.8.0. Marketplace and claude/codex manifests untouched at 0.7.0 with pinning tests green; all ten remaining 0.7.0 occurrences classified intentional (installer examples plus retained manifests). Six CI checks green at head 44274ac. — commit `44274acb70cacbee44f061aee1b90b94b70b1dee` (2026-08-22T23:03:27Z)
- **required-ci** — passing — test (windows-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass — commit `44274acb70cacbee44f061aee1b90b94b70b1dee` (2026-08-22T23:03:31Z)

<!-- orch:manifest:data
{
  "schema_version": 4,
  "objective": "Prepare identity bumps for the v0.8.0 release (tagging itself happens after this merges). Bump to 0.8.0: adapters/opencode/package.json, both version fields in adapters/opencode/package-lock.json, and the version mention in adapters/opencode/README.md. Update README.md's Release badge to v0.8.0 and its latest-release prose: the Status-section claim of what is shipped in the latest release (~line 576) and the tagged-releases count sentence (~line 411, becomes 20 tagged releases through v0.8.0). Do NOT touch .claude-plugin/marketplace.json or adapters/claude and adapters/codex plugin manifests and their test literals: those adapters have zero content change since v0.7.0 and stay at 0.7.0 per the binary-only-release precedent. Leave the install-command example pins in README (ORCH_VERSION / -Version examples) untouched. The internal binary version needs no file change (ldflags-injected at tag time).",
  "acceptance_criteria": [
    "Every file naming the opencode adapter package version reads 0.8.0: package.json, both lockfile version fields, and the adapter README mention.",
    "The marketplace manifest and claude/codex plugin manifests still read 0.7.0, and their pinning tests pass unchanged.",
    "README.md's Release badge reads v0.8.0, and the latest-release and tagged-release-count prose reference v0.8.0 and the updated count.",
    "go test ./... passes and gofmt -l . is clean."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "gpt-5.6-terra",
    "effort": "max"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "gpt-5.6-sol",
    "effort": "medium"
  },
  "effort_delivery": "parameter",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test-all",
      "command": "go test ./...",
      "result": "pass",
      "detail": "passes at head 44274ac",
      "commit_oid": "44274acb70cacbee44f061aee1b90b94b70b1dee",
      "at": "2026-08-22T23:03:26Z"
    },
    {
      "name": "gofmt-clean",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "no output at head 44274ac",
      "commit_oid": "44274acb70cacbee44f061aee1b90b94b70b1dee",
      "at": "2026-08-22T23:03:26Z"
    },
    {
      "name": "identity-spread-check",
      "command": "git grep 0.8.0 across README.md and adapters/opencode; git grep -c 0.7.0 across .claude-plugin and adapters/{claude,codex}/.claude-plugin",
      "result": "pass",
      "detail": "reviewer independently confirmed the same spread: seven required 0.8.0 sites, three retained 0.7.0 manifests, installer example pins untouched",
      "commit_oid": "44274acb70cacbee44f061aee1b90b94b70b1dee",
      "at": "2026-08-22T23:03:26Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "package.json:3, package-lock.json:3 and :9, adapters/opencode/README.md:4 all read 0.8.0; JSON parse confirmed consistency.",
      "commit_oid": "44274acb70cacbee44f061aee1b90b94b70b1dee",
      "at": "2026-08-22T23:03:27Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "Marketplace and both host manifests remain 0.7.0; their tests unchanged and passing under go test ./...",
      "commit_oid": "44274acb70cacbee44f061aee1b90b94b70b1dee",
      "at": "2026-08-22T23:03:27Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "Badge v0.8.0 at README.md:8; 20-tagged-releases-through-v0.8.0 at :411; v0.8.0-latest claim at :580-581.",
      "commit_oid": "44274acb70cacbee44f061aee1b90b94b70b1dee",
      "at": "2026-08-22T23:03:27Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "Reviewer independently re-ran go test ./... (pass) and gofmt -l . (no output).",
      "commit_oid": "44274acb70cacbee44f061aee1b90b94b70b1dee",
      "at": "2026-08-22T23:03:27Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "First-pass approve with zero findings. Exactly four files changed (7+/7-): opencode package.json, both lockfile fields, adapter README to 0.8.0; README badge L8, count sentence L411 (20 releases through v0.8.0), latest-release prose L580-581 to v0.8.0. Marketplace and claude/codex manifests untouched at 0.7.0 with pinning tests green; all ten remaining 0.7.0 occurrences classified intentional (installer examples plus retained manifests). Six CI checks green at head 44274ac.",
      "commit_oid": "44274acb70cacbee44f061aee1b90b94b70b1dee",
      "at": "2026-08-22T23:03:27Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass",
      "commit_oid": "44274acb70cacbee44f061aee1b90b94b70b1dee",
      "at": "2026-08-22T23:03:31Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->