### PR TITLE
Add x-preview-f-free to the interview codex model list

### DIFF
--- a/internal/interview/sequence.go
+++ b/internal/interview/sequence.go
@@ -112,7 +112,7 @@ func defaultProfileFor(host string) func(string) profile {
 // third Claude model (claude-fable-5, PRD §10): the committed
 // configuration this interview writes never defaults to it.
 var hostModels = map[string][]string{
-	"codex":    {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"},
+	"codex":    {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "x-preview-f-free"},
 	"claude":   {"claude-opus-5", "claude-sonnet-5"},
 	"opencode": {"openai/gpt-5.6-sol", "openai/gpt-5.6-terra", "openai/gpt-5.6-luna", "opencode/x-preview-f-free"},
 }

--- a/internal/interview/testdata/transcript/step_08.json
+++ b/internal/interview/testdata/transcript/step_08.json
@@ -24,6 +24,10 @@
         {
           "value": "gpt-5.6-luna",
           "label": "gpt-5.6-luna"
+        },
+        {
+          "value": "x-preview-f-free",
+          "label": "x-preview-f-free"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript/step_09.json
+++ b/internal/interview/testdata/transcript/step_09.json
@@ -24,6 +24,10 @@
           "value": "gpt-5.6-luna",
           "label": "gpt-5.6-luna",
           "recommended": true
+        },
+        {
+          "value": "x-preview-f-free",
+          "label": "x-preview-f-free"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript/step_10.json
+++ b/internal/interview/testdata/transcript/step_10.json
@@ -24,6 +24,10 @@
         {
           "value": "gpt-5.6-luna",
           "label": "gpt-5.6-luna"
+        },
+        {
+          "value": "x-preview-f-free",
+          "label": "x-preview-f-free"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript/step_11.json
+++ b/internal/interview/testdata/transcript/step_11.json
@@ -24,6 +24,10 @@
         {
           "value": "gpt-5.6-luna",
           "label": "gpt-5.6-luna"
+        },
+        {
+          "value": "x-preview-f-free",
+          "label": "x-preview-f-free"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript/step_12.json
+++ b/internal/interview/testdata/transcript/step_12.json
@@ -24,6 +24,10 @@
         {
           "value": "gpt-5.6-luna",
           "label": "gpt-5.6-luna"
+        },
+        {
+          "value": "x-preview-f-free",
+          "label": "x-preview-f-free"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript/step_13.json
+++ b/internal/interview/testdata/transcript/step_13.json
@@ -24,6 +24,10 @@
         {
           "value": "gpt-5.6-luna",
           "label": "gpt-5.6-luna"
+        },
+        {
+          "value": "x-preview-f-free",
+          "label": "x-preview-f-free"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_03.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_03.json
@@ -24,6 +24,10 @@
         {
           "value": "gpt-5.6-luna",
           "label": "gpt-5.6-luna"
+        },
+        {
+          "value": "x-preview-f-free",
+          "label": "x-preview-f-free"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_04.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_04.json
@@ -24,6 +24,10 @@
           "value": "gpt-5.6-luna",
           "label": "gpt-5.6-luna",
           "recommended": true
+        },
+        {
+          "value": "x-preview-f-free",
+          "label": "x-preview-f-free"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_05.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_05.json
@@ -24,6 +24,10 @@
         {
           "value": "gpt-5.6-luna",
           "label": "gpt-5.6-luna"
+        },
+        {
+          "value": "x-preview-f-free",
+          "label": "x-preview-f-free"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_06.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_06.json
@@ -24,6 +24,10 @@
         {
           "value": "gpt-5.6-luna",
           "label": "gpt-5.6-luna"
+        },
+        {
+          "value": "x-preview-f-free",
+          "label": "x-preview-f-free"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_07.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_07.json
@@ -24,6 +24,10 @@
         {
           "value": "gpt-5.6-luna",
           "label": "gpt-5.6-luna"
+        },
+        {
+          "value": "x-preview-f-free",
+          "label": "x-preview-f-free"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_configure/enable_codex/step_08.json
+++ b/internal/interview/testdata/transcript_configure/enable_codex/step_08.json
@@ -24,6 +24,10 @@
         {
           "value": "gpt-5.6-luna",
           "label": "gpt-5.6-luna"
+        },
+        {
+          "value": "x-preview-f-free",
+          "label": "x-preview-f-free"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/flagship/step_08.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_08.json
@@ -24,6 +24,10 @@
         {
           "value": "gpt-5.6-luna",
           "label": "gpt-5.6-luna"
+        },
+        {
+          "value": "x-preview-f-free",
+          "label": "x-preview-f-free"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/flagship/step_09.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_09.json
@@ -24,6 +24,10 @@
         {
           "value": "gpt-5.6-luna",
           "label": "gpt-5.6-luna"
+        },
+        {
+          "value": "x-preview-f-free",
+          "label": "x-preview-f-free"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/flagship/step_10.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_10.json
@@ -24,6 +24,10 @@
         {
           "value": "gpt-5.6-luna",
           "label": "gpt-5.6-luna"
+        },
+        {
+          "value": "x-preview-f-free",
+          "label": "x-preview-f-free"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/flagship/step_11.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_11.json
@@ -24,6 +24,10 @@
         {
           "value": "gpt-5.6-luna",
           "label": "gpt-5.6-luna"
+        },
+        {
+          "value": "x-preview-f-free",
+          "label": "x-preview-f-free"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/flagship/step_12.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_12.json
@@ -24,6 +24,10 @@
         {
           "value": "gpt-5.6-luna",
           "label": "gpt-5.6-luna"
+        },
+        {
+          "value": "x-preview-f-free",
+          "label": "x-preview-f-free"
         }
       ],
       "free_text": true,

--- a/internal/interview/testdata/transcript_local/flagship/step_13.json
+++ b/internal/interview/testdata/transcript_local/flagship/step_13.json
@@ -24,6 +24,10 @@
         {
           "value": "gpt-5.6-luna",
           "label": "gpt-5.6-luna"
+        },
+        {
+          "value": "x-preview-f-free",
+          "label": "x-preview-f-free"
         }
       ],
       "free_text": true,


### PR DESCRIPTION
Delivers issue #236: Add x-preview-f-free to the interview codex model list

Closes #236

**Plan digest:** `sha256:b41c034678c2d502c449cd6547d849a09c25ec07b8adc9108c9736f07fd1e0ac`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** In internal/interview/sequence.go, append "x-preview-f-free" to hostModels["codex"] after the three existing entries (bare ID form, matching how codex roles store models). Do not touch hostLocalModels in configurelocal.go (it derives from hostModels via buildHostLocalModels) and do not modify defaultProfiles or any shipped agent definition under adapters/. Unlike the opencode-host change in f1d4475, the existing flagship golden transcripts exercise codex model questions, so regenerate them with go test ./internal/interview -update and keep every regenerated file that changed; add focused coverage only if a gap remains after regeneration.

**Acceptance criteria:**
- A codex-host role model question emitted by the init/configure interview lists x-preview-f-free among its select options alongside gpt-5.6-sol, gpt-5.6-terra, and gpt-5.6-luna, visible in the regenerated golden transcript steps.
- The configure-local interview's codex-host role model questions likewise list x-preview-f-free among their select options.
- No shipped default names the new model: a search across adapters/, ORCH-PRD.md, README.md, and the tests' default-profile pins finds no occurrence of x-preview-f-free outside internal/interview source and goldens.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `gpt-5.6-terra` — effort `max` |
| Reviewer | `gpt-5.6-sol` — effort `medium` |
| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
| Config revision | `sha256:9ab11562eb39` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **go-test-all** — pass — `go test -count=1 ./...` — re-run fresh by reviewer at head 736de82 — commit `736de829f04abb392392d7ce03fdd1c9309cd025` (2026-08-23T01:00:04Z)
- **gofmt-clean** — pass — `gofmt -l .` — no output at head 736de82 — commit `736de829f04abb392392d7ce03fdd1c9309cd025` (2026-08-23T01:00:04Z)
- **occurrence-confinement** — pass — `git grep x-preview-f-free across repo excluding internal/interview` — reviewer independently confirmed confinement — commit `736de829f04abb392392d7ce03fdd1c9309cd025` (2026-08-23T01:00:04Z)
- **golden-spread-check** — pass — `git diff --numstat origin/main..HEAD` — one source line plus 18 regenerated goldens (+4 lines each: transcript steps 08-13, enable_codex 03-08, transcript_local flagship 08-13); additions only — commit `736de829f04abb392392d7ce03fdd1c9309cd025` (2026-08-23T00:52:39Z)
- **acceptance-criterion-1** — satisfied — sequence.go:115 appends the bare ID after sol/terra/luna; init goldens transcript/step_08-13 and configure goldens enable_codex/step_03-08 show the exact option order with defaults unchanged. — commit `736de829f04abb392392d7ce03fdd1c9309cd025` (2026-08-23T01:00:06Z)
- **acceptance-criterion-2** — satisfied — hostLocalModels derives from hostModels (configurelocal.go:51-62) and modelOptionsLocal consumes it (:529-542); all six transcript_local/flagship step_08-13 goldens contain the fourth option. — commit `736de829f04abb392392d7ce03fdd1c9309cd025` (2026-08-23T01:00:06Z)
- **acceptance-criterion-3** — satisfied — defaultProfiles unchanged at sequence.go:68-96; git grep finds no occurrence in adapters/, ORCH-PRD.md, or README.md; confinement to interview source and goldens holds. — commit `736de829f04abb392392d7ce03fdd1c9309cd025` (2026-08-23T01:00:06Z)
- **review-cycle-1** — approve — First-pass approve, zero findings, high confidence. Exactly one hostModels[codex] list change plus 18 regenerated goldens (+4 lines each); all 18 questions carry sol, terra, luna, then x-preview-f-free in order. configurelocal.go derivation untouched and TestHostLocalModelsPinsFableFive still meaningful; defaultProfiles and its pin unchanged; occurrences confined to interview source and goldens. Reviewer independently ran go test -count=1 ./..., gofmt, go vet, go build - all green; six CI jobs passed at head 736de82. — commit `736de829f04abb392392d7ce03fdd1c9309cd025` (2026-08-23T01:00:06Z)
- **required-ci** — passing — lint=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass — commit `736de829f04abb392392d7ce03fdd1c9309cd025` (2026-08-23T01:00:11Z)

<!-- orch:manifest:data
{
  "schema_version": 4,
  "objective": "In internal/interview/sequence.go, append \"x-preview-f-free\" to hostModels[\"codex\"] after the three existing entries (bare ID form, matching how codex roles store models). Do not touch hostLocalModels in configurelocal.go (it derives from hostModels via buildHostLocalModels) and do not modify defaultProfiles or any shipped agent definition under adapters/. Unlike the opencode-host change in f1d4475, the existing flagship golden transcripts exercise codex model questions, so regenerate them with go test ./internal/interview -update and keep every regenerated file that changed; add focused coverage only if a gap remains after regeneration.",
  "acceptance_criteria": [
    "A codex-host role model question emitted by the init/configure interview lists x-preview-f-free among its select options alongside gpt-5.6-sol, gpt-5.6-terra, and gpt-5.6-luna, visible in the regenerated golden transcript steps.",
    "The configure-local interview's codex-host role model questions likewise list x-preview-f-free among their select options.",
    "No shipped default names the new model: a search across adapters/, ORCH-PRD.md, README.md, and the tests' default-profile pins finds no occurrence of x-preview-f-free outside internal/interview source and goldens."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "gpt-5.6-terra",
    "effort": "max"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "gpt-5.6-sol",
    "effort": "medium"
  },
  "effort_delivery": "parameter",
  "config_revision": "sha256:9ab11562eb39",
  "verifications": [
    {
      "name": "go-test-all",
      "command": "go test -count=1 ./...",
      "result": "pass",
      "detail": "re-run fresh by reviewer at head 736de82",
      "commit_oid": "736de829f04abb392392d7ce03fdd1c9309cd025",
      "at": "2026-08-23T01:00:04Z"
    },
    {
      "name": "gofmt-clean",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "no output at head 736de82",
      "commit_oid": "736de829f04abb392392d7ce03fdd1c9309cd025",
      "at": "2026-08-23T01:00:04Z"
    },
    {
      "name": "occurrence-confinement",
      "command": "git grep x-preview-f-free across repo excluding internal/interview",
      "result": "pass",
      "detail": "reviewer independently confirmed confinement",
      "commit_oid": "736de829f04abb392392d7ce03fdd1c9309cd025",
      "at": "2026-08-23T01:00:04Z"
    },
    {
      "name": "golden-spread-check",
      "command": "git diff --numstat origin/main..HEAD",
      "result": "pass",
      "detail": "one source line plus 18 regenerated goldens (+4 lines each: transcript steps 08-13, enable_codex 03-08, transcript_local flagship 08-13); additions only",
      "commit_oid": "736de829f04abb392392d7ce03fdd1c9309cd025",
      "at": "2026-08-23T00:52:39Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "sequence.go:115 appends the bare ID after sol/terra/luna; init goldens transcript/step_08-13 and configure goldens enable_codex/step_03-08 show the exact option order with defaults unchanged.",
      "commit_oid": "736de829f04abb392392d7ce03fdd1c9309cd025",
      "at": "2026-08-23T01:00:06Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "hostLocalModels derives from hostModels (configurelocal.go:51-62) and modelOptionsLocal consumes it (:529-542); all six transcript_local/flagship step_08-13 goldens contain the fourth option.",
      "commit_oid": "736de829f04abb392392d7ce03fdd1c9309cd025",
      "at": "2026-08-23T01:00:06Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "defaultProfiles unchanged at sequence.go:68-96; git grep finds no occurrence in adapters/, ORCH-PRD.md, or README.md; confinement to interview source and goldens holds.",
      "commit_oid": "736de829f04abb392392d7ce03fdd1c9309cd025",
      "at": "2026-08-23T01:00:06Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "First-pass approve, zero findings, high confidence. Exactly one hostModels[codex] list change plus 18 regenerated goldens (+4 lines each); all 18 questions carry sol, terra, luna, then x-preview-f-free in order. configurelocal.go derivation untouched and TestHostLocalModelsPinsFableFive still meaningful; defaultProfiles and its pin unchanged; occurrences confined to interview source and goldens. Reviewer independently ran go test -count=1 ./..., gofmt, go vet, go build - all green; six CI jobs passed at head 736de82.",
      "commit_oid": "736de829f04abb392392d7ce03fdd1c9309cd025",
      "at": "2026-08-23T01:00:06Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "lint=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "736de829f04abb392392d7ce03fdd1c9309cd025",
      "at": "2026-08-23T01:00:11Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->