### PR TITLE
Add safe project-scoped OpenCode catalog discovery

### DIFF
--- a/ORCH-PRD.md
+++ b/ORCH-PRD.md
@@ -64,7 +64,10 @@ Orch must:
 
 - Codex CLI.
 - Claude Code CLI.
-- OpenCode V2 (beta API, pinned to `opencode2 v0.0.0-beta-17498`).
+- OpenCode V2 beta API. Before project-scoped catalog discovery it was pinned to
+  `opencode2 v0.0.0-beta-17498` without a model/location contract; that behavior no longer
+  holds. It is now pinned to `opencode2 v0.0.0-beta-18314`, with project-scoped model and
+  returned-location validation.
 - Windows, macOS, and Linux.
 - GitHub through authenticated `gh`.
 - Git repositories with isolated worktree support.

--- a/README.md
+++ b/README.md
@@ -541,14 +541,22 @@ envelope and denies the write. That is deliberate — an unparsed write
 must never be allowed — but it means a host upgrade can produce
 spurious denials. Workaround: update `orch`.
 
-**OpenCode V2 support is pinned to a beta API.** The live smoke check
-exercises exactly `opencode2 v0.0.0-beta-17498` and
-`@opencode-ai/plugin` `0.0.0-beta-17498`; no other V2 build is a
-supported compatibility floor yet. `orch doctor` checks that exact
-runtime version and that the running service lists plugin ID
-`orch.delivery`, but the V2 API does not expose an adapter version.
-After an OpenCode upgrade, restart the service and rerun that plugin-ID
-check before relying on enforcement.
+**OpenCode V2 support is pinned to a beta API.** Before project-scoped
+catalog discovery, the live smoke check exercised exactly `opencode2
+v0.0.0-beta-17498` and `@opencode-ai/plugin`
+`0.0.0-beta-17498`, while doctor checked only that runtime and the active
+plugin ID. That old compatibility behavior no longer holds. The current
+package and live smoke instead exercise exactly `opencode2
+v0.0.0-beta-18314` and `@opencode-ai/plugin`
+`0.0.0-beta-18314`; no other V2 build is a supported compatibility floor.
+`orch doctor` checks that exact runtime, plugin ID `orch.delivery`, and a
+URL-location-scoped model catalog response for the repository. It retains
+only enabled text-input/text-output tool-capable `provider/model` IDs and
+their variant IDs; provider settings, headers, credentials, account IDs,
+and raw API payloads never enter the returned catalog or its diagnostics.
+The V2 API still does not expose an adapter version. After an OpenCode
+upgrade, restart the service and rerun doctor before relying on
+enforcement.
 
 **The merge gate cannot tell a human's approval from an agent's.** The
 engine requires an approval carrying the exact literal `approve-merge`,

--- a/adapters/opencode/README.md
+++ b/adapters/opencode/README.md
@@ -7,11 +7,40 @@ ID is `orch.delivery`. It is not the Codex marketplace adapter: that is
 
 ## Compatibility
 
-The OpenCode V2 plugin API is beta. The live smoke check exercises
-exactly `opencode2 v0.0.0-beta-17498` with
-`@opencode-ai/plugin` `0.0.0-beta-17498`; that exact beta is the
-current compatibility floor, not a claim of compatibility with other
-V2 builds.
+The OpenCode V2 plugin API is beta. Before the project-scoped catalog
+contract landed, the live smoke check exercised exactly `opencode2
+v0.0.0-beta-17498` with `@opencode-ai/plugin`
+`0.0.0-beta-17498` and did not check the model or returned-location
+APIs. That old compatibility behavior no longer holds. After the
+catalog change, the package, doctor, documentation, and live smoke pin
+exactly `opencode2 v0.0.0-beta-18314` with `@opencode-ai/plugin`
+`0.0.0-beta-18314`; that exact beta is the current compatibility floor,
+not a claim of compatibility with other V2 builds.
+
+## Catalog safety and blast radius
+
+Orch queries `/api/model` with the repository in the URL-encoded
+`location[directory]` parameter. The response must name that same
+canonical directory. `ReadCatalog` exposes only `Models[].ID` as the
+exact `providerID/id` and every `Models[].Variants[]` ID. Its safe-field
+restriction applies to every returned provider and model, not only to a
+named provider: settings, headers, bodies, credentials, account
+identifiers, and all other raw response fields are discarded for all of
+them and are never copied into diagnostics.
+
+| Touched element | Does its previous behavior still hold? |
+|---|---|
+| OpenCode runtime and npm plugin pins | No. The before-and-after is recorded above: beta 17498 is replaced by beta 18314. |
+| `orch.delivery` plugin ID, setup, guard hooks, and session context | Yes. The same plugin contract remains; unit and live smoke checks still exercise it on the new beta. |
+| Catalog process invocation | New. It is one argument-vector call in the repository directory, with the location URL-encoded rather than shell-interpolated. |
+| Response `location.directory` | New validation. A response for any other directory is rejected. |
+| Response `data[].providerID` and `data[].id` | New projection. They form the exact `provider/id`; neither value is normalized or aliased. |
+| Response `data[].enabled` and `data[].capabilities.{tools,input,output}` | New filtering. Only enabled, tool-capable, text-input/text-output models remain. |
+| Response `data[].variants[].id` | New projection. Every advertised variant ID is preserved in server order, including an empty list. |
+| Provider/model/variant settings, headers, bodies, credentials, account IDs, and raw payload | Previously Orch did not read the catalog; after this change these fields may arrive in command output but are never retained, returned, or included in an error. |
+| Setup detection's existing CLI, git, GitHub, memhub, and instruction facts | Yes. Catalog and catalog-error fields are additive, and a failed read remains explicit data rather than changing Detect's no-error contract. |
+| Doctor's runtime and active-plugin checks | Yes. They still run and the catalog/location check now follows them. |
+| Live smoke's agent discovery, context injection, denied tracked write, and allowed ignored write | Yes. The catalog/location assertions are additive. |
 
 ## Install order
 
@@ -52,12 +81,13 @@ then load its plugin module from an absolute path.
    opencode2 api get /api/plugin | node -e 'let s=""; process.stdin.on("data", d => s += d).on("end", () => { if (JSON.parse(s).data.filter(p => p.id === "orch.delivery").length !== 1) throw new Error("orch.delivery is not active exactly once") })'
    ```
 
-   The first command must print `opencode2 v0.0.0-beta-17498`. The JSON
+   The first command must print `opencode2 v0.0.0-beta-18314`. The JSON
    from the second must contain exactly one `data` entry whose `id` is
    `orch.delivery`; the third command fails otherwise. `orch doctor`
    performs the same runtime and plugin-ID checks for a repository with
-   `hosts.opencode` enabled; it cannot check an OpenCode adapter version
-   because the beta API does not expose one.
+   `hosts.opencode` enabled, then queries that repository's model catalog
+   and verifies its returned location. It cannot check an OpenCode
+   adapter version because the beta API does not expose one.
 
 4. In each repository, run `orch init`, review and merge its bootstrap
    PR, then run `orch render-agents`. It writes the five OpenCode role

--- a/adapters/opencode/README.md
+++ b/adapters/opencode/README.md
@@ -20,8 +20,8 @@ not a claim of compatibility with other V2 builds.
 ## Catalog safety and blast radius
 
 Orch queries `/api/model` with the repository in the URL-encoded
-`location[directory]` parameter. The response must name that same
-canonical directory. `ReadCatalog` exposes only `Models[].ID` as the
+`location[directory]` parameter. The response must resolve to that same
+filesystem directory identity. `ReadCatalog` exposes only `Models[].ID` as the
 exact `providerID/id` and every `Models[].Variants[]` ID. Its safe-field
 restriction applies to every returned provider and model, not only to a
 named provider: settings, headers, bodies, credentials, account
@@ -33,7 +33,7 @@ them and are never copied into diagnostics.
 | OpenCode runtime and npm plugin pins | No. The before-and-after is recorded above: beta 17498 is replaced by beta 18314. |
 | `orch.delivery` plugin ID, setup, guard hooks, and session context | Yes. The same plugin contract remains; unit and live smoke checks still exercise it on the new beta. |
 | Catalog process invocation | New. It is one argument-vector call in the repository directory, with the location URL-encoded rather than shell-interpolated. |
-| Response `location.directory` | New validation. A response for any other directory is rejected. |
+| Response `location.directory` | New validation. The initial implementation inherited platform-wide case folding and could accept distinct case-different directories on a case-sensitive macOS or Windows volume; that behavior no longer holds. Directory identity is now compared by the filesystem, so every different directory is rejected while aliases of the same directory remain valid. |
 | Response `data[].providerID` and `data[].id` | New projection. They form the exact `provider/id`; neither value is normalized or aliased. |
 | Response `data[].enabled` and `data[].capabilities.{tools,input,output}` | New filtering. Only enabled, tool-capable, text-input/text-output models remain. |
 | Response `data[].variants[].id` | New projection. Every advertised variant ID is preserved in server order, including an empty list. |

--- a/adapters/opencode/package-lock.json
+++ b/adapters/opencode/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@kninetimmy/orch-opencode",
       "version": "0.8.0",
       "dependencies": {
-        "@opencode-ai/plugin": "0.0.0-beta-17498"
+        "@opencode-ai/plugin": "0.0.0-beta-18314"
       }
     },
     "node_modules/@ai-sdk/provider": {
@@ -75,12 +75,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.4.tgz",
-      "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -183,58 +183,60 @@
       ]
     },
     "node_modules/@opencode-ai/ai": {
-      "version": "0.0.0-beta-17498",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/ai/-/ai-0.0.0-beta-17498.tgz",
-      "integrity": "sha512-5a67ZrZaoE/za0NHGPpcaduNsF4NFQcn3YuAw09EfjeahhgBujfzIuKyAzxq+l19tvkkIJvnIxLsWHTrdBCWzw==",
+      "version": "0.0.0-beta-18314",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/ai/-/ai-0.0.0-beta-18314.tgz",
+      "integrity": "sha512-0dcd86JMVv3ADsy9XdTJIgN5Bx6kSKYkS80lcxeBUEcWGUi3UAub0dokZVmsqg8TN11sYLRLiEFjHlqPNQnhHw==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/schema": "0.0.0-beta-17498",
+        "@opencode-ai/schema": "0.0.0-beta-18314",
         "@smithy/eventstream-codec": "4.2.14",
         "@smithy/util-utf8": "4.2.2",
         "aws4fetch": "1.0.20",
-        "effect": "4.0.0-beta.101",
+        "effect": "4.0.0-rc.111",
         "google-auth-library": "10.5.0"
       }
     },
     "node_modules/@opencode-ai/client": {
-      "version": "0.0.0-beta-17498",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/client/-/client-0.0.0-beta-17498.tgz",
-      "integrity": "sha512-/FhkRDDrYI5GK7naIb5ibURI712yrsJuYUMK8Nxu5kbHNYoIqIHVeWQNAtnWV/gyGyBHIYIcCWcHE2MdXqs/+g==",
+      "version": "0.0.0-beta-18314",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/client/-/client-0.0.0-beta-18314.tgz",
+      "integrity": "sha512-LpzH20P0BTsoes7ewylQV2cdBg8WlmJMCeBIsYm789mDN0hXXXmCS8WFA7RWbnvoN7yE5l3I/KSMQuBrKx9puw==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/protocol": "0.0.0-beta-17498",
-        "@opencode-ai/schema": "0.0.0-beta-17498"
+        "@opencode-ai/protocol": "0.0.0-beta-18314",
+        "@opencode-ai/schema": "0.0.0-beta-18314"
       },
       "peerDependencies": {
-        "effect": "4.0.0-beta.101"
+        "effect": "4.0.0-rc.111",
+        "solid-js": ">=1.9.0"
       },
       "peerDependenciesMeta": {
         "effect": {
+          "optional": true
+        },
+        "solid-js": {
           "optional": true
         }
       }
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "0.0.0-beta-17498",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-0.0.0-beta-17498.tgz",
-      "integrity": "sha512-aJjL9QFNWvIPeOt8HG2TXGLQ8+XDrdYSl3OhZP3CLM4wgFEtf73zPi7htwlWlrYyErNgDyNnKUgaryaYzIC2nA==",
+      "version": "0.0.0-beta-18314",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-0.0.0-beta-18314.tgz",
+      "integrity": "sha512-CB6fWjiUf69woHn3QRgwH4YimjrpawMEhgh9b8tBfjnRWrc+qP+vgKztkdTGcNqUjrBcJ1BqOYuUFAYlTZdTcA==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/ai": "0.0.0-beta-17498",
-        "@opencode-ai/client": "0.0.0-beta-17498",
-        "@opencode-ai/protocol": "0.0.0-beta-17498",
-        "@opencode-ai/schema": "0.0.0-beta-17498",
-        "@opencode-ai/sdk": "1.18.5",
+        "@opencode-ai/ai": "0.0.0-beta-18314",
+        "@opencode-ai/client": "0.0.0-beta-18314",
+        "@opencode-ai/protocol": "0.0.0-beta-18314",
+        "@opencode-ai/schema": "0.0.0-beta-18314",
         "@standard-schema/spec": "1.1.0",
-        "effect": "4.0.0-beta.101",
+        "effect": "4.0.0-rc.111",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opencode-ai/theme": "0.0.0-beta-17498",
-        "@opentui/core": ">=0.5.3",
-        "@opentui/keymap": ">=0.5.3",
-        "@opentui/solid": ">=0.5.3",
+        "@opencode-ai/theme": "0.0.0-beta-18314",
+        "@opentui/core": ">=0.5.8",
+        "@opentui/solid": ">=0.5.8",
         "solid-js": ">=1.9.0"
       },
       "peerDependenciesMeta": {
@@ -242,9 +244,6 @@
           "optional": true
         },
         "@opentui/core": {
-          "optional": true
-        },
-        "@opentui/keymap": {
           "optional": true
         },
         "@opentui/solid": {
@@ -256,32 +255,23 @@
       }
     },
     "node_modules/@opencode-ai/protocol": {
-      "version": "0.0.0-beta-17498",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/protocol/-/protocol-0.0.0-beta-17498.tgz",
-      "integrity": "sha512-L7N54mZghkFFykTfMuimtmbRgfUBjtwgFekfgy0eDgMTKWN5WK51s6JTp2W2wRcD+1kFYyzplSThut0pAiLXpA==",
+      "version": "0.0.0-beta-18314",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/protocol/-/protocol-0.0.0-beta-18314.tgz",
+      "integrity": "sha512-/85qh6QvznNvl8X/Jd8fFoD9Rr3N+fDgbtDS0sdcegwAEwP8KfmcQ+JSpOB2JHdmr6GiM5N6Qguz3ptfgyqjHA==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/schema": "0.0.0-beta-17498",
-        "effect": "4.0.0-beta.101"
+        "@opencode-ai/schema": "0.0.0-beta-18314",
+        "effect": "4.0.0-rc.111"
       }
     },
     "node_modules/@opencode-ai/schema": {
-      "version": "0.0.0-beta-17498",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/schema/-/schema-0.0.0-beta-17498.tgz",
-      "integrity": "sha512-M5T/o6oVuddBh8EPHm+3nm0gx8OVFcL0jr37dB66aPJDxVlpANlmBWm85UgWiC70Gl5gCbBZo3p/jwANvuA6QA==",
+      "version": "0.0.0-beta-18314",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/schema/-/schema-0.0.0-beta-18314.tgz",
+      "integrity": "sha512-nPXQdQQBLPXOYGYz8n/vYSq1eVHqAZLcWFIvaNHn04WCnW8NwBXjpH0zww2CmaJfcOd9pNChpoiK8MbjnrMU0A==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "1.1.0",
-        "effect": "4.0.0-beta.101"
-      }
-    },
-    "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.5",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.5.tgz",
-      "integrity": "sha512-7KgMvP5/1oxbhHj6kYBtPSTEdFKYpUeEYOzBTKdzSaRpapUpFFdn6Hkus3rr0rljO0kukWZIgRd3DrVBwTULGA==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "7.0.6"
+        "effect": "4.0.0-rc.111"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -295,9 +285,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.33.2",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.2.tgz",
-      "integrity": "sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==",
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.17.2",
@@ -564,21 +554,14 @@
       }
     },
     "node_modules/effect": {
-      "version": "4.0.0-beta.101",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.101.tgz",
-      "integrity": "sha512-HjowumlIo+orthn4jMlEJPuzIYPBV+uq/XiciHWhiedLsXQpWHdNJHO5d59BVDP5s1LPuvERcktwFqRXnJqnhA==",
+      "version": "4.0.0-rc.111",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-rc.111.tgz",
+      "integrity": "sha512-ASd5L58EIR0CUNueZNKKjSsyOCd+2alxOAIaTcHaqkJkPsaYSsw5Cg/cfANk5K4Jr2YsX756xvX11shzqsreWA==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "fast-check": "^4.9.0",
-        "find-my-way-ts": "^0.1.6",
-        "ini": "^7.0.0",
-        "kubernetes-types": "^1.30.0",
-        "msgpackr": "^2.0.4",
-        "multipasta": "^0.2.8",
-        "toml": "^4.1.2",
-        "uuid": "^14.0.1",
-        "yaml": "^2.9.0"
+        "msgpackr": "^2.0.5"
       }
     },
     "node_modules/emoji-regex": {
@@ -637,12 +620,6 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
-    },
-    "node_modules/find-my-way-ts": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
-      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
-      "license": "MIT"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -798,15 +775,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/ini": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
-      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
-      "license": "ISC",
-      "engines": {
-        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
-      }
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -873,12 +841,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/kubernetes-types": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
-      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
-      "license": "Apache-2.0"
-    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -916,9 +878,9 @@
       "license": "MIT"
     },
     "node_modules/msgpackr": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.5.tgz",
-      "integrity": "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.6.tgz",
+      "integrity": "sha512-plGul/tqjt9vqWFR9zyqyLZls6gb5KTLvnsRO2B9+TZ8tNiXiVI/CR8LiDWlAX4IUeVkQ9gsmzKA6voC2QOciw==",
       "license": "MIT",
       "optionalDependencies": {
         "msgpackr-extract": "^3.0.4"
@@ -945,12 +907,6 @@
         "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
         "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
       }
-    },
-    "node_modules/multipasta": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.8.tgz",
-      "integrity": "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==",
-      "license": "MIT"
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -1216,33 +1172,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/toml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-4.3.0.tgz",
-      "integrity": "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
@@ -1357,21 +1291,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zod": {

--- a/adapters/opencode/package.json
+++ b/adapters/opencode/package.json
@@ -8,6 +8,6 @@
     "smoke": "node smoke.mjs"
   },
   "dependencies": {
-    "@opencode-ai/plugin": "0.0.0-beta-17498"
+    "@opencode-ai/plugin": "0.0.0-beta-18314"
   }
 }

--- a/adapters/opencode/plugin_test.go
+++ b/adapters/opencode/plugin_test.go
@@ -22,8 +22,8 @@ func TestPackagePinsOpenCodeV2Contract(t *testing.T) {
 	if manifest.Name != "@kninetimmy/orch-opencode" || manifest.Version == "" {
 		t.Fatalf("manifest = %#v", manifest)
 	}
-	if got := manifest.Dependencies["@opencode-ai/plugin"]; got != "0.0.0-beta-17498" {
-		t.Fatalf("@opencode-ai/plugin = %q, want pinned beta-17498", got)
+	if got := manifest.Dependencies["@opencode-ai/plugin"]; got != "0.0.0-beta-18314" {
+		t.Fatalf("@opencode-ai/plugin = %q, want pinned beta-18314", got)
 	}
 	if len(manifest.Dependencies) != 1 {
 		t.Fatalf("dependencies = %v, want only the V2 plugin API", manifest.Dependencies)

--- a/adapters/opencode/smoke.mjs
+++ b/adapters/opencode/smoke.mjs
@@ -9,9 +9,10 @@ import { fileURLToPath } from "node:url"
 import { Backend } from "@opencode-ai/protocol/simulation"
 import { pluginID } from "./src/index.js"
 
-const pinned = "opencode2 v0.0.0-beta-17498"
+const pinned = "opencode2 v0.0.0-beta-18314"
 const opencode = "opencode2"
 const serverPassword = "orch-smoke"
+process.env.OPENCODE_SERVER_PASSWORD = serverPassword
 const adapter = path.dirname(fileURLToPath(import.meta.url))
 const repo = path.resolve(adapter, "../..")
 
@@ -48,14 +49,18 @@ async function apiList(baseURL, pathname, ready) {
   return data
 }
 
-async function api(baseURL, pathname, options = {}) {
+async function apiEnvelope(baseURL, pathname, options = {}) {
   const authorization = `Basic ${Buffer.from(`opencode:${serverPassword}`).toString("base64")}`
   const response = await fetch(baseURL + pathname, {
     ...options,
     headers: { authorization, "content-type": "application/json", ...options.headers },
   })
   if (!response.ok) throw new Error(`${response.status} ${await response.text()}`)
-  return response.status === 204 ? undefined : (await response.json()).data
+  return response.status === 204 ? undefined : response.json()
+}
+
+async function api(baseURL, pathname, options = {}) {
+  return (await apiEnvelope(baseURL, pathname, options))?.data
 }
 
 async function within(promise, label) {
@@ -166,7 +171,13 @@ try {
       smoke: {
         package: "aisdk:@ai-sdk/openai-compatible",
         settings: { apiKey: "smoke", baseURL: "https://api.openai.com/v1" },
-        models: { smoke: { name: "Smoke" } },
+        models: {
+          smoke: {
+            name: "Smoke",
+            capabilities: { tools: true, input: ["text"], output: ["text"] },
+            variants: [{ id: "low" }, { id: "high" }],
+          },
+        },
       },
     },
   }))
@@ -194,6 +205,14 @@ try {
   for (const id of agentIDs) {
     assert.equal(agents.find((agent) => agent.id === id)?.mode, "subagent", `${id} was not discovered: ${JSON.stringify(agents)}`)
   }
+  const query = new URLSearchParams({ "location[directory]": temp })
+  const endpoint = `/api/model?${query}`
+  const catalog = JSON.parse(command(opencode, ["api", "get", endpoint, "--server", baseURL], temp))
+  assert.equal(path.resolve(catalog.location.directory), path.resolve(temp), "catalog response location drifted")
+  const smokeModel = catalog.data.find((model) => model.providerID === "smoke" && model.id === "smoke")
+  assert(smokeModel?.enabled, "project model was not enabled in the live catalog")
+  assert(smokeModel.capabilities.tools && smokeModel.capabilities.input.includes("text") && smokeModel.capabilities.output.includes("text"), "project model was not agent-capable")
+  assert.deepEqual(smokeModel.variants.map((variant) => variant.id), ["low", "high"], "live catalog variants drifted")
 
   controller = await simulation(`ws://127.0.0.1:${backendPort}`)
   const tracked = path.join(temp, "tracked.txt")

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -80,25 +80,28 @@ func testEnv(t *testing.T) (Env, *bytes.Buffer, *bytes.Buffer) {
 // fakeRunner answers the doctor probes: git and gh with scripted exits,
 // plus each host's plugin listing (zero values report healthy).
 type fakeRunner struct {
-	toplevel           string
-	gitExit            int
-	gitStderr          string
-	authExit           int
-	repoExit           int
-	repoJSON           string
-	beforeRun          func(execx.Cmd)
-	claudePluginJSON   string
-	claudePluginExit   int
-	claudePluginStderr string
-	claudePluginErr    error
-	codexPluginJSON    string
-	codexPluginExit    int
-	codexPluginStderr  string
-	codexPluginErr     error
-	opencodeVersion    string
-	opencodePlugins    string
-	opencodePluginExit int
-	opencodePluginErr  error
+	toplevel            string
+	gitExit             int
+	gitStderr           string
+	authExit            int
+	repoExit            int
+	repoJSON            string
+	beforeRun           func(execx.Cmd)
+	claudePluginJSON    string
+	claudePluginExit    int
+	claudePluginStderr  string
+	claudePluginErr     error
+	codexPluginJSON     string
+	codexPluginExit     int
+	codexPluginStderr   string
+	codexPluginErr      error
+	opencodeVersion     string
+	opencodePlugins     string
+	opencodePluginExit  int
+	opencodePluginErr   error
+	opencodeCatalog     string
+	opencodeCatalogExit int
+	opencodeCatalogErr  error
 	// checkIgnoreExit scripts `git check-ignore`: 0 ignored, 1 not
 	// ignored, anything else an error (the guard ignore probe).
 	checkIgnoreExit    int
@@ -206,6 +209,16 @@ func (f fakeRunner) Run(_ context.Context, c execx.Cmd) (execx.Result, error) {
 				plugins = `{"data":[{"id":"orch.delivery"}]}`
 			}
 			return execx.Result{Stdout: plugins, ExitCode: f.opencodePluginExit}, nil
+		}
+		if len(c.Args) == 3 && c.Args[0] == "api" && c.Args[1] == "get" && strings.HasPrefix(c.Args[2], "/api/model?") {
+			if f.opencodeCatalogErr != nil {
+				return execx.Result{}, f.opencodeCatalogErr
+			}
+			catalog := f.opencodeCatalog
+			if catalog == "" {
+				catalog = fmt.Sprintf(`{"location":{"directory":%q},"data":[]}`, c.Dir)
+			}
+			return execx.Result{Stdout: catalog, ExitCode: f.opencodeCatalogExit}, nil
 		}
 		return execx.Result{}, fmt.Errorf("fakeRunner: unexpected command %s %v", c.Name, c.Args)
 	case "memhub":

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/kninetimmy/orch/adapters/claude"
 	"github.com/kninetimmy/orch/adapters/codex"
-	"github.com/kninetimmy/orch/adapters/opencode"
+	opencodeadapter "github.com/kninetimmy/orch/adapters/opencode"
 	"github.com/kninetimmy/orch/internal/agents"
 	"github.com/kninetimmy/orch/internal/config"
 	"github.com/kninetimmy/orch/internal/execx"
@@ -22,6 +22,7 @@ import (
 	"github.com/kninetimmy/orch/internal/lockfile"
 	"github.com/kninetimmy/orch/internal/memhub"
 	"github.com/kninetimmy/orch/internal/metrics"
+	opencodecatalog "github.com/kninetimmy/orch/internal/opencode"
 	"github.com/kninetimmy/orch/internal/state"
 )
 
@@ -50,9 +51,9 @@ var (
 	}
 	opencodeAdapter = adapterSpec{
 		host:         "opencode",
-		executable:   "opencode2",
+		executable:   opencodecatalog.Executable,
 		pluginID:     "orch.delivery",
-		manifestJSON: opencode.PackageJSON,
+		manifestJSON: opencodeadapter.PackageJSON,
 		repair:       "install the pinned Orch OpenCode adapter, then restart the OpenCode V2 service",
 	}
 )
@@ -370,10 +371,11 @@ func adapterVersion(manifestJSON string) (string, error) {
 	return manifest.Version, nil
 }
 
-const pinnedOpenCodeVersion = "opencode2 v0.0.0-beta-17498"
+const pinnedOpenCodeVersion = opencodecatalog.PinnedVersion
 
-// checkOpenCodeAdapter pins the beta runtime contract and checks the active
-// plugin ID. V2's plugin API does not currently expose adapter versions.
+// checkOpenCodeAdapter pins the beta runtime contract, checks the active
+// plugin ID, then verifies the project-scoped catalog and returned location.
+// V2's plugin API does not currently expose adapter versions.
 func checkOpenCodeAdapter(env Env, spec adapterSpec) error {
 	fail := func(detail string) error { return fmt.Errorf("%s; %s", detail, spec.repair) }
 	if _, err := env.LookPath(spec.executable); err != nil {
@@ -421,6 +423,9 @@ func checkOpenCodeAdapter(env Env, spec adapterSpec) error {
 	}
 	if count != 1 {
 		return fail(fmt.Sprintf("%s appears %d times; exactly one active plugin is required", spec.pluginID, count))
+	}
+	if _, err := opencodecatalog.ReadCatalog(context.Background(), env.Runner, env.RepoRoot); err != nil {
+		return fail(err.Error())
 	}
 	return nil
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -315,6 +315,15 @@ func TestDoctorAdapterFailures(t *testing.T) {
 			},
 			wantDetails: []string{"malformed `opencode2 api get /api/plugin` output"},
 		},
+		{
+			name:   "opencode malformed catalog response",
+			config: validOpenCodeTOML,
+			spec:   opencodeAdapter,
+			configure: func(r *fakeRunner) {
+				r.opencodeCatalog = "{}"
+			},
+			wantDetails: []string{"OpenCode model catalog", "malformed `opencode2 api get /api/model` response", "location.directory is missing"},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/interview/detect.go
+++ b/internal/interview/detect.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kninetimmy/orch/internal/execx"
 	"github.com/kninetimmy/orch/internal/instructions"
 	"github.com/kninetimmy/orch/internal/memhub"
+	"github.com/kninetimmy/orch/internal/opencode"
 )
 
 // Deps carries Detect's injectable surface: LookPath and Runner are
@@ -23,8 +24,8 @@ type Deps struct {
 	// LookPath resolves an executable name; a nil LookPath makes every
 	// host/git/gh/memhub fact false.
 	LookPath func(string) (string, error)
-	// Runner executes git and memhub. Required whenever LookPath finds
-	// git or memhub — Detect never calls a nil Runner.
+	// Runner executes git, memhub, and the OpenCode catalog query. It is
+	// required whenever LookPath finds one of those commands.
 	Runner execx.Runner
 }
 
@@ -40,6 +41,11 @@ type Facts struct {
 	ClaudeCLI   bool
 	CodexCLI    bool
 	OpenCodeCLI bool
+	// OpenCodeCatalog and OpenCodeCatalogError distinguish a successful
+	// (possibly empty) catalog read from a failed one without making
+	// Detect return an error or dropping the failure.
+	OpenCodeCatalog      opencode.Catalog
+	OpenCodeCatalogError string
 
 	Git     bool
 	GitRoot string
@@ -75,7 +81,8 @@ type InstructionFileState struct {
 }
 
 // Detect probes deps for every Facts field. It never returns an
-// error: an unresolvable tool or an unreachable memhub is data (a
+// error: an unresolvable tool, unreachable memhub, or unreadable
+// OpenCode catalog is data (a
 // false/empty Facts field), not a Detect failure — the interview
 // reports what it found and lets the human decide, rather than fail
 // closed on missing tooling before any question has even been asked.
@@ -109,6 +116,14 @@ func Detect(ctx context.Context, deps Deps) Facts {
 	root := f.GitRoot
 	if root == "" {
 		root = deps.RepoRoot
+	}
+	if f.OpenCodeCLI {
+		catalog, err := opencode.ReadCatalog(ctx, deps.Runner, root)
+		if err != nil {
+			f.OpenCodeCatalogError = err.Error()
+		} else {
+			f.OpenCodeCatalog = catalog
+		}
 	}
 	f.Instructions = map[string]InstructionFileState{
 		"claude":   classifyInstructionFile(root, InstructionFile("claude")),

--- a/internal/interview/detect_test.go
+++ b/internal/interview/detect_test.go
@@ -3,9 +3,13 @@ package interview
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/kninetimmy/orch/internal/execx/execxtest"
+	"github.com/kninetimmy/orch/internal/paths"
 )
 
 // fakeLookPath resolves only the names present, returning a stand-in
@@ -24,9 +28,14 @@ func fakeLookPath(present ...string) func(string) (string, error) {
 }
 
 func TestDetectAllPresentAndHealthy(t *testing.T) {
+	root, err := paths.Canonical("/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
 	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
 		{Name: "git", Args: []string{"rev-parse", "--show-toplevel"}, Dir: "/repo", Stdout: "/repo\n", Exit: 0},
 		{Name: "memhub", Args: []string{"status"}, Dir: "/repo", Exit: 0},
+		{Name: "opencode2", Args: []string{"api", "get", "/api/model?" + url.Values{"location[directory]": {root}}.Encode()}, Dir: "/repo", Stdout: fmt.Sprintf(`{"location":{"directory":%q},"data":[]}`, root)},
 	}}
 	deps := Deps{RepoRoot: "/repo", LookPath: fakeLookPath("claude", "codex", "opencode2", "git", "gh", "memhub"), Runner: script}
 
@@ -44,6 +53,30 @@ func TestDetectAllPresentAndHealthy(t *testing.T) {
 	}
 	if facts.MemhubDetail != "" {
 		t.Errorf("MemhubDetail = %q, want empty on success", facts.MemhubDetail)
+	}
+	if facts.OpenCodeCatalogError != "" || facts.OpenCodeCatalog.Models == nil {
+		t.Errorf("OpenCode catalog = %+v / %q, want successful empty catalog", facts.OpenCodeCatalog, facts.OpenCodeCatalogError)
+	}
+}
+
+func TestDetectKeepsOpenCodeCatalogFailureAsSafeData(t *testing.T) {
+	root := t.TempDir()
+	canonical, err := paths.Canonical(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{{
+		Name: "opencode2",
+		Args: []string{"api", "get", "/api/model?" + url.Values{"location[directory]": {canonical}}.Encode()},
+		Dir:  root, Exit: 1, Stderr: "credential-token raw-provider-payload",
+	}}}
+	facts := Detect(context.Background(), Deps{RepoRoot: root, LookPath: fakeLookPath("opencode2"), Runner: script})
+	script.AssertExhausted()
+	if !facts.OpenCodeCLI || !strings.Contains(facts.OpenCodeCatalogError, "exited 1") {
+		t.Fatalf("catalog detection = %+v / %q", facts.OpenCodeCatalog, facts.OpenCodeCatalogError)
+	}
+	if strings.Contains(facts.OpenCodeCatalogError, "credential-token") || strings.Contains(facts.OpenCodeCatalogError, "raw-provider-payload") {
+		t.Fatalf("catalog failure disclosed command output: %s", facts.OpenCodeCatalogError)
 	}
 }
 

--- a/internal/interview/detect_test.go
+++ b/internal/interview/detect_test.go
@@ -28,16 +28,17 @@ func fakeLookPath(present ...string) func(string) (string, error) {
 }
 
 func TestDetectAllPresentAndHealthy(t *testing.T) {
-	root, err := paths.Canonical("/repo")
+	repo := t.TempDir()
+	root, err := paths.Canonical(repo)
 	if err != nil {
 		t.Fatal(err)
 	}
 	script := &execxtest.Script{T: t, Calls: []execxtest.Call{
-		{Name: "git", Args: []string{"rev-parse", "--show-toplevel"}, Dir: "/repo", Stdout: "/repo\n", Exit: 0},
-		{Name: "memhub", Args: []string{"status"}, Dir: "/repo", Exit: 0},
-		{Name: "opencode2", Args: []string{"api", "get", "/api/model?" + url.Values{"location[directory]": {root}}.Encode()}, Dir: "/repo", Stdout: fmt.Sprintf(`{"location":{"directory":%q},"data":[]}`, root)},
+		{Name: "git", Args: []string{"rev-parse", "--show-toplevel"}, Dir: repo, Stdout: repo + "\n", Exit: 0},
+		{Name: "memhub", Args: []string{"status"}, Dir: repo, Exit: 0},
+		{Name: "opencode2", Args: []string{"api", "get", "/api/model?" + url.Values{"location[directory]": {root}}.Encode()}, Dir: repo, Stdout: fmt.Sprintf(`{"location":{"directory":%q},"data":[]}`, root)},
 	}}
-	deps := Deps{RepoRoot: "/repo", LookPath: fakeLookPath("claude", "codex", "opencode2", "git", "gh", "memhub"), Runner: script}
+	deps := Deps{RepoRoot: repo, LookPath: fakeLookPath("claude", "codex", "opencode2", "git", "gh", "memhub"), Runner: script}
 
 	facts := Detect(context.Background(), deps)
 	script.AssertExhausted()
@@ -45,8 +46,8 @@ func TestDetectAllPresentAndHealthy(t *testing.T) {
 	if !facts.ClaudeCLI || !facts.CodexCLI || !facts.OpenCodeCLI || !facts.Gh {
 		t.Fatalf("facts = %+v, want claude/codex/opencode/gh all true", facts)
 	}
-	if !facts.Git || facts.GitRoot != "/repo" {
-		t.Errorf("git facts = %v/%q, want true/\"/repo\"", facts.Git, facts.GitRoot)
+	if !facts.Git || facts.GitRoot != repo {
+		t.Errorf("git facts = %v/%q, want true/%q", facts.Git, facts.GitRoot, repo)
 	}
 	if !facts.MemhubCLI || !facts.MemhubHealthy {
 		t.Errorf("memhub facts = %+v, want cli/healthy both true", facts)

--- a/internal/opencode/catalog.go
+++ b/internal/opencode/catalog.go
@@ -1,0 +1,134 @@
+// Package opencode reads the project-scoped OpenCode V2 model catalog.
+package opencode
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"slices"
+
+	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/paths"
+)
+
+const (
+	Executable    = "opencode2"
+	PinnedVersion = "opencode2 v0.0.0-beta-18314"
+)
+
+// Model is the safe subset of an available OpenCode model. Provider settings,
+// headers, credentials, account identifiers, and request bodies are never
+// retained.
+type Model struct {
+	ID       string
+	Variants []string
+}
+
+// Catalog is the currently enabled, agent-capable model catalog for one
+// repository.
+type Catalog struct {
+	Models []Model
+}
+
+// ReadCatalog returns enabled models that accept text, emit text, and support
+// tools. It verifies that OpenCode answered for directory and never includes
+// raw command output in an error.
+func ReadCatalog(ctx context.Context, runner execx.Runner, directory string) (Catalog, error) {
+	if runner == nil {
+		return Catalog{}, fmt.Errorf("read OpenCode model catalog: command runner is unavailable; retry through an initialized Orch command")
+	}
+	root, err := paths.Canonical(directory)
+	if err != nil {
+		return Catalog{}, fmt.Errorf("read OpenCode model catalog: repository location cannot be verified")
+	}
+	query := url.Values{"location[directory]": {root}}
+	res, err := runner.Run(ctx, execx.Cmd{
+		Name: Executable,
+		Args: []string{"api", "get", "/api/model?" + query.Encode()},
+		Dir:  directory,
+	})
+	if err != nil {
+		return Catalog{}, fmt.Errorf("read OpenCode model catalog: `%s api get /api/model` could not start; check `%s service status` and retry", Executable, Executable)
+	}
+	if res.ExitCode != 0 {
+		return Catalog{}, fmt.Errorf("read OpenCode model catalog: `%s api get /api/model` exited %d; check `%s service status`, restart the service if needed, and retry", Executable, res.ExitCode, Executable)
+	}
+
+	var response catalogResponse
+	if err := json.Unmarshal([]byte(res.Stdout), &response); err != nil {
+		return Catalog{}, malformed("response is not valid JSON")
+	}
+	if response.Location.Directory == "" {
+		return Catalog{}, malformed("location.directory is missing")
+	}
+	same, err := sameDirectory(root, response.Location.Directory)
+	if err != nil {
+		return Catalog{}, malformed("location.directory cannot be verified")
+	}
+	if !same {
+		return Catalog{}, fmt.Errorf("read OpenCode model catalog: response is scoped to a different directory; restart the OpenCode V2 service and retry")
+	}
+	if response.Data == nil {
+		return Catalog{}, malformed("data is not an array")
+	}
+
+	catalog := Catalog{Models: make([]Model, 0, len(response.Data))}
+	for i, model := range response.Data {
+		if model.ID == "" || model.ProviderID == "" {
+			return Catalog{}, malformed(fmt.Sprintf("data[%d] has no provider/model identifier", i))
+		}
+		if model.Enabled == nil {
+			return Catalog{}, malformed(fmt.Sprintf("data[%d].enabled is missing", i))
+		}
+		if model.Capabilities.Tools == nil || model.Capabilities.Input == nil || model.Capabilities.Output == nil {
+			return Catalog{}, malformed(fmt.Sprintf("data[%d].capabilities is incomplete", i))
+		}
+		if model.Variants == nil {
+			return Catalog{}, malformed(fmt.Sprintf("data[%d].variants is not an array", i))
+		}
+		variants := make([]string, len(model.Variants))
+		for j, variant := range model.Variants {
+			if variant.ID == "" {
+				return Catalog{}, malformed(fmt.Sprintf("data[%d].variants[%d].id is missing", i, j))
+			}
+			variants[j] = variant.ID
+		}
+		if *model.Enabled && *model.Capabilities.Tools && slices.Contains(model.Capabilities.Input, "text") && slices.Contains(model.Capabilities.Output, "text") {
+			catalog.Models = append(catalog.Models, Model{ID: model.ProviderID + "/" + model.ID, Variants: variants})
+		}
+	}
+	return catalog, nil
+}
+
+type catalogResponse struct {
+	Location struct {
+		Directory string `json:"directory"`
+	} `json:"location"`
+	Data []struct {
+		ID           string `json:"id"`
+		ProviderID   string `json:"providerID"`
+		Enabled      *bool  `json:"enabled"`
+		Capabilities struct {
+			Tools  *bool    `json:"tools"`
+			Input  []string `json:"input"`
+			Output []string `json:"output"`
+		} `json:"capabilities"`
+		Variants []struct {
+			ID string `json:"id"`
+		} `json:"variants"`
+	} `json:"data"`
+}
+
+func sameDirectory(want, got string) (bool, error) {
+	forward, err := paths.Inside(want, got)
+	if err != nil {
+		return false, err
+	}
+	back, err := paths.Inside(got, want)
+	return forward && back, err
+}
+
+func malformed(detail string) error {
+	return fmt.Errorf("read OpenCode model catalog: malformed `%s api get /api/model` response (%s); update to %s and retry", Executable, detail, PinnedVersion)
+}

--- a/internal/opencode/catalog.go
+++ b/internal/opencode/catalog.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"slices"
 
 	"github.com/kninetimmy/orch/internal/execx"
@@ -121,12 +122,18 @@ type catalogResponse struct {
 }
 
 func sameDirectory(want, got string) (bool, error) {
-	forward, err := paths.Inside(want, got)
+	wantInfo, err := os.Stat(want)
 	if err != nil {
 		return false, err
 	}
-	back, err := paths.Inside(got, want)
-	return forward && back, err
+	gotInfo, err := os.Stat(got)
+	if err != nil {
+		return false, err
+	}
+	if !wantInfo.IsDir() || !gotInfo.IsDir() {
+		return false, fmt.Errorf("catalog locations must be directories")
+	}
+	return os.SameFile(wantInfo, gotInfo), nil
 }
 
 func malformed(detail string) error {

--- a/internal/opencode/catalog_test.go
+++ b/internal/opencode/catalog_test.go
@@ -76,6 +76,27 @@ func TestReadCatalogRejectsAnotherLocation(t *testing.T) {
 	}
 }
 
+func TestReadCatalogRejectsCaseDifferentLocationOnCaseSensitiveVolume(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "Repo")
+	other := filepath.Join(parent, "repo")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(other, 0o755); os.IsExist(err) {
+		t.Skip("test volume is case-insensitive")
+	} else if err != nil {
+		t.Fatal(err)
+	}
+	runner := catalogRunner(func(execx.Cmd) (execx.Result, error) {
+		return execx.Result{Stdout: fmt.Sprintf(`{"location":{"directory":%q},"data":[]}`, other)}, nil
+	})
+	_, err := ReadCatalog(context.Background(), runner, root)
+	if err == nil || !strings.Contains(err.Error(), "different directory") {
+		t.Fatalf("error = %v, want rejection of case-distinct directory", err)
+	}
+}
+
 func TestReadCatalogDiagnosticsDoNotDiscloseCommandOutput(t *testing.T) {
 	const sensitive = "credential-token account-identifier raw-api-payload"
 	tests := []struct {

--- a/internal/opencode/catalog_test.go
+++ b/internal/opencode/catalog_test.go
@@ -1,0 +1,128 @@
+package opencode
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/paths"
+)
+
+type catalogRunner func(execx.Cmd) (execx.Result, error)
+
+func (f catalogRunner) Run(_ context.Context, cmd execx.Cmd) (execx.Result, error) {
+	return f(cmd)
+}
+
+func TestReadCatalogFiltersAndRetainsOnlySafeFields(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "repo & project")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	root, err := paths.Canonical(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantEndpoint := "/api/model?" + url.Values{"location[directory]": {root}}.Encode()
+	response := fmt.Sprintf(`{
+		"location":{"directory":%q},
+		"data":[
+			{"id":"agent","providerID":"safe-provider","enabled":true,"capabilities":{"tools":true,"input":["text","image"],"output":["text"]},"variants":[{"id":"low","settings":{"secret":"variant-secret"}},{"id":"high","headers":{"authorization":"variant-token"}}],"settings":{"apiKey":"model-secret"},"headers":{"account-id":"account-secret"}},
+			{"id":"disabled","providerID":"safe-provider","enabled":false,"capabilities":{"tools":true,"input":["text"],"output":["text"]},"variants":[]},
+			{"id":"no-input","providerID":"safe-provider","enabled":true,"capabilities":{"tools":true,"input":["image"],"output":["text"]},"variants":[]},
+			{"id":"no-output","providerID":"safe-provider","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["image"]},"variants":[]},
+			{"id":"no-tools","providerID":"safe-provider","enabled":true,"capabilities":{"tools":false,"input":["text"],"output":["text"]},"variants":[]}
+		]
+	}`, root)
+	runner := catalogRunner(func(cmd execx.Cmd) (execx.Result, error) {
+		if cmd.Name != Executable || len(cmd.Args) != 3 || cmd.Args[0] != "api" || cmd.Args[1] != "get" || cmd.Args[2] != wantEndpoint {
+			t.Fatalf("command = %s %q, want %s api get %q", cmd.Name, cmd.Args, Executable, wantEndpoint)
+		}
+		if cmd.Dir != root {
+			t.Fatalf("command dir = %q, want %q", cmd.Dir, root)
+		}
+		return execx.Result{Stdout: response}, nil
+	})
+
+	catalog, err := ReadCatalog(context.Background(), runner, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(catalog.Models) != 1 || catalog.Models[0].ID != "safe-provider/agent" {
+		t.Fatalf("models = %+v, want only safe-provider/agent", catalog.Models)
+	}
+	if got := strings.Join(catalog.Models[0].Variants, ","); got != "low,high" {
+		t.Fatalf("variants = %q, want low,high", got)
+	}
+	if got := fmt.Sprintf("%+v", catalog); strings.Contains(got, "secret") || strings.Contains(got, "account") || strings.Contains(got, "authorization") {
+		t.Fatalf("catalog retained provider-sensitive fields: %s", got)
+	}
+}
+
+func TestReadCatalogRejectsAnotherLocation(t *testing.T) {
+	root := t.TempDir()
+	other := t.TempDir()
+	runner := catalogRunner(func(execx.Cmd) (execx.Result, error) {
+		return execx.Result{Stdout: fmt.Sprintf(`{"location":{"directory":%q},"data":[]}`, other)}, nil
+	})
+	_, err := ReadCatalog(context.Background(), runner, root)
+	if err == nil || !strings.Contains(err.Error(), "different directory") {
+		t.Fatalf("error = %v, want different-directory rejection", err)
+	}
+}
+
+func TestReadCatalogDiagnosticsDoNotDiscloseCommandOutput(t *testing.T) {
+	const sensitive = "credential-token account-identifier raw-api-payload"
+	tests := []struct {
+		name   string
+		result execx.Result
+		err    error
+	}{
+		{name: "cannot start", err: fmt.Errorf("spawn failed: %s", sensitive)},
+		{name: "nonzero", result: execx.Result{Stdout: sensitive, Stderr: sensitive, ExitCode: 7}},
+		{name: "malformed", result: execx.Result{Stdout: `{"headers":{"authorization":"credential-token"},"data":"raw-api-payload account-identifier"}`}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := catalogRunner(func(execx.Cmd) (execx.Result, error) { return tc.result, tc.err })
+			_, err := ReadCatalog(context.Background(), runner, t.TempDir())
+			if err == nil {
+				t.Fatal("ReadCatalog succeeded")
+			}
+			for _, forbidden := range strings.Fields(sensitive) {
+				if strings.Contains(err.Error(), forbidden) {
+					t.Fatalf("diagnostic disclosed %q: %v", forbidden, err)
+				}
+			}
+			if !strings.Contains(err.Error(), "OpenCode model catalog") || !strings.Contains(err.Error(), "retry") {
+				t.Fatalf("diagnostic is not actionable: %v", err)
+			}
+		})
+	}
+}
+
+func TestReadCatalogRejectsMalformedSafeShape(t *testing.T) {
+	root, err := paths.Canonical(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []string{
+		fmt.Sprintf(`{"location":{"directory":%q}}`, root),
+		fmt.Sprintf(`{"location":{"directory":%q},"data":[{"id":"m","providerID":"p","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["text"]}}]}`, root),
+		fmt.Sprintf(`{"location":{"directory":%q},"data":[{"id":"m","providerID":"p","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["text"]},"variants":[{}]}]}`, root),
+	}
+	for i, response := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			runner := catalogRunner(func(execx.Cmd) (execx.Result, error) { return execx.Result{Stdout: response}, nil })
+			_, err := ReadCatalog(context.Background(), runner, root)
+			if err == nil || !strings.Contains(err.Error(), "malformed") {
+				t.Fatalf("error = %v, want malformed response", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Delivers issue #240: Add safe project-scoped OpenCode catalog discovery

Closes #240

**Plan digest:** `sha256:c08d80a09544194d02b5ce92d7fedff47b09897811fbfdb3887633ee668661b7`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Pin a current OpenCode V2 beta and expose its project-scoped available model catalog to Orch without retaining or disclosing provider-sensitive fields.

**Acceptance criteria:**
- A catalog query for a repository returns only currently enabled models that accept text, emit text, and support tools, with each exact provider/model identifier and every advertised variant; a response scoped to another directory is rejected.
- Command failures and malformed catalog responses produce actionable diagnostics without provider settings, request headers, credentials, account identifiers, or raw API payloads.
- The adapter package, doctor, documentation, and live smoke agree on one pinned OpenCode V2 beta whose plugin, catalog, and location contracts pass on this machine.
- Blast radius (contributed by Orch because this issue declares a risk domain, not by the plan document): name every element of the structure this change touches and state, for each, whether the behavior it had before this change still holds; record a behavior this change removes as a before-and-after in the same document that stated the old behavior, rather than deleting that statement; and where a restriction is attributed to one named symbol, establish whether it holds for that symbol alone or for every symbol of its kind, and say which.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`
- `npm test --prefix adapters/opencode`
- `npm run smoke --prefix adapters/opencode` — CI does not run this test

| Field | Value |
| --- | --- |
| Role | `specialist` |
| Executor | `openai/gpt-5.6-sol` — effort `xhigh` |
| Reviewer | `openai/gpt-5.6-sol` — effort `xhigh` |
| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
| Config revision | `sha256:308e4942b411` |

**Routing rationale:** Routed to a specialist with a strong reviewer because risk domains (secrets).

**Escalations:** _none_

**Verification:**
- **branch-scope:live-base-diff** — passed: clean, pushed, two commits touching 14 files — `git diff --name-status df14686cc6d367b9190ce5fe3cc0ed1c73830fa2...3abb767069a7796ebdec047f9fefae7742252dc4` — Live base df14686cc6d367b9190ce5fe3cc0ed1c73830fa2 to head 3abb767069a7796ebdec047f9fefae7742252dc4. Full scope remains the recorded 14 files. Cycle 2 re-touched adapters/opencode/README.md, internal/interview/detect_test.go, internal/opencode/catalog.go, and internal/opencode/catalog_test.go (42 insertions, 13 deletions). sameDirectory changed from platform-wide case folding to filesystem identity; distinct case-different repositories are rejected on case-sensitive volumes while aliases to the same directory remain valid. Catalog filtering, safe projection, diagnostics, beta pin, plugin behavior, doctor sequence, and smoke contracts remain unchanged. Detection runtime behavior remains unchanged; its fixture now uses an existing directory. Documentation records both removed case-folding behavior and the corrected identity rule. — commit `3abb767069a7796ebdec047f9fefae7742252dc4` (2026-08-26T22:56:57Z)
- **go-test** — passed — `go test ./...` — Final full run passed all packages after the filesystem-identity fix. — commit `3abb767069a7796ebdec047f9fefae7742252dc4` (2026-08-26T22:56:57Z)
- **go-vet** — passed — `go vet ./...` — Passed with no output. — commit `3abb767069a7796ebdec047f9fefae7742252dc4` (2026-08-26T22:56:57Z)
- **gofmt** — passed — `gofmt -l .` — No unformatted files. — commit `3abb767069a7796ebdec047f9fefae7742252dc4` (2026-08-26T22:56:57Z)
- **opencode-npm-tests** — passed — `npm test --prefix adapters/opencode` — 5 of 5 tests passed. — commit `3abb767069a7796ebdec047f9fefae7742252dc4` (2026-08-26T22:56:57Z)
- **opencode-live-smoke** — passed — `npm run smoke --prefix adapters/opencode` — Local-only required gate passed on final head. CI does not run this command. Node emitted non-fatal DEP0190 warning. — commit `3abb767069a7796ebdec047f9fefae7742252dc4` (2026-08-26T22:56:57Z)
- **opencode-npm-install** — passed — `npm ci --prefix adapters/opencode` — Install completed with 0 vulnerabilities. — commit `4c48371ee2246ec57561d49aa1046e02debb529a` (2026-08-26T22:36:31Z)
- **diff-check** — passed — `git diff --check && git show --check` — No whitespace errors on final head; word diff inspected. — commit `3abb767069a7796ebdec047f9fefae7742252dc4` (2026-08-26T22:56:57Z)
- **acceptance-criterion-1** — satisfied — Catalog query URL-encodes project scope, verifies returned filesystem identity, safely projects exact provider/model and variants, filters enabled text/tool-capable models, and tests different plus case-distinct directories. — commit `3abb767069a7796ebdec047f9fefae7742252dc4` (2026-08-26T22:56:58Z)
- **acceptance-criterion-2** — satisfied — Catalog diagnostics discard command output and underlying errors while retaining only safe fields; focused tests exercise sensitive output and malformed payloads without disclosure. — commit `3abb767069a7796ebdec047f9fefae7742252dc4` (2026-08-26T22:56:58Z)
- **acceptance-criterion-3** — satisfied — Beta 18314 agrees across catalog reader, package pin, plugin test, doctor, live smoke, and documentation; final local smoke and all six CI jobs passed. — commit `3abb767069a7796ebdec047f9fefae7742252dc4` (2026-08-26T22:56:58Z)
- **acceptance-criterion-4** — satisfied — The audit enumerates the complete 14-file scope, refreshed four-file cycle delta, filesystem-identity before/after, pin history, and preserved catalog, plugin, detection, doctor, diagnostics, and smoke behavior. — commit `3abb767069a7796ebdec047f9fefae7742252dc4` (2026-08-26T22:56:58Z)
- **review-cycle-1** — request-changes — One blocking defect: sameDirectory relies on paths.Inside case folding, so distinct case-different repositories can compare equal on supported case-sensitive macOS or Windows volumes. The location-boundary claim and blast-radius record are therefore inaccurate. Filtering, safe diagnostics, beta pin alignment, scope, and required local verification evidence otherwise check out. GitHub had no CI runs for this head at review time. — commit `4c48371ee2246ec57561d49aa1046e02debb529a` (2026-08-26T22:43:52Z)
- **opencode-catalog-focused** — passed — `go test -v ./internal/opencode` — Focused package passed; case-distinct test skipped because this machine temp volume is case-insensitive. — commit `3abb767069a7796ebdec047f9fefae7742252dc4` (2026-08-26T22:56:57Z)
- **review-cycle-2** — approve — No findings. The cycle-1 case-sensitive repository-boundary defect is fixed with filesystem identity and a focused regression check. Scope, required tests, security, routing, manifest evidence, and all four acceptance criteria are satisfied. All six required CI jobs passed. — commit `3abb767069a7796ebdec047f9fefae7742252dc4` (2026-08-26T22:56:58Z)
- **required-ci** — passing — test (macos-latest)=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (windows-latest)=pass — commit `3abb767069a7796ebdec047f9fefae7742252dc4` (2026-08-26T22:57:12Z)

<!-- orch:manifest:data
{
  "schema_version": 4,
  "objective": "Pin a current OpenCode V2 beta and expose its project-scoped available model catalog to Orch without retaining or disclosing provider-sensitive fields.",
  "acceptance_criteria": [
    "A catalog query for a repository returns only currently enabled models that accept text, emit text, and support tools, with each exact provider/model identifier and every advertised variant; a response scoped to another directory is rejected.",
    "Command failures and malformed catalog responses produce actionable diagnostics without provider settings, request headers, credentials, account identifiers, or raw API payloads.",
    "The adapter package, doctor, documentation, and live smoke agree on one pinned OpenCode V2 beta whose plugin, catalog, and location contracts pass on this machine.",
    "Blast radius (contributed by Orch because this issue declares a risk domain, not by the plan document): name every element of the structure this change touches and state, for each, whether the behavior it had before this change still holds; record a behavior this change removes as a before-and-after in the same document that stated the old behavior, rather than deleting that statement; and where a restriction is attributed to one named symbol, establish whether it holds for that symbol alone or for every symbol of its kind, and say which."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l .",
    "npm test --prefix adapters/opencode",
    "npm run smoke --prefix adapters/opencode"
  ],
  "tests_ci_does_not_run": [
    "npm run smoke --prefix adapters/opencode"
  ],
  "role": "specialist",
  "executor": {
    "model": "openai/gpt-5.6-sol",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to a specialist with a strong reviewer because risk domains (secrets).",
  "reviewer": {
    "model": "openai/gpt-5.6-sol",
    "effort": "xhigh"
  },
  "effort_delivery": "parameter",
  "config_revision": "sha256:308e4942b411",
  "verifications": [
    {
      "name": "branch-scope:live-base-diff",
      "command": "git diff --name-status df14686cc6d367b9190ce5fe3cc0ed1c73830fa2...3abb767069a7796ebdec047f9fefae7742252dc4",
      "result": "passed: clean, pushed, two commits touching 14 files",
      "detail": "Live base df14686cc6d367b9190ce5fe3cc0ed1c73830fa2 to head 3abb767069a7796ebdec047f9fefae7742252dc4. Full scope remains the recorded 14 files. Cycle 2 re-touched adapters/opencode/README.md, internal/interview/detect_test.go, internal/opencode/catalog.go, and internal/opencode/catalog_test.go (42 insertions, 13 deletions). sameDirectory changed from platform-wide case folding to filesystem identity; distinct case-different repositories are rejected on case-sensitive volumes while aliases to the same directory remain valid. Catalog filtering, safe projection, diagnostics, beta pin, plugin behavior, doctor sequence, and smoke contracts remain unchanged. Detection runtime behavior remains unchanged; its fixture now uses an existing directory. Documentation records both removed case-folding behavior and the corrected identity rule.",
      "commit_oid": "3abb767069a7796ebdec047f9fefae7742252dc4",
      "at": "2026-08-26T22:56:57Z"
    },
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "passed",
      "detail": "Final full run passed all packages after the filesystem-identity fix.",
      "commit_oid": "3abb767069a7796ebdec047f9fefae7742252dc4",
      "at": "2026-08-26T22:56:57Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "passed",
      "detail": "Passed with no output.",
      "commit_oid": "3abb767069a7796ebdec047f9fefae7742252dc4",
      "at": "2026-08-26T22:56:57Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "passed",
      "detail": "No unformatted files.",
      "commit_oid": "3abb767069a7796ebdec047f9fefae7742252dc4",
      "at": "2026-08-26T22:56:57Z"
    },
    {
      "name": "opencode-npm-tests",
      "command": "npm test --prefix adapters/opencode",
      "result": "passed",
      "detail": "5 of 5 tests passed.",
      "commit_oid": "3abb767069a7796ebdec047f9fefae7742252dc4",
      "at": "2026-08-26T22:56:57Z"
    },
    {
      "name": "opencode-live-smoke",
      "command": "npm run smoke --prefix adapters/opencode",
      "result": "passed",
      "detail": "Local-only required gate passed on final head. CI does not run this command. Node emitted non-fatal DEP0190 warning.",
      "commit_oid": "3abb767069a7796ebdec047f9fefae7742252dc4",
      "at": "2026-08-26T22:56:57Z"
    },
    {
      "name": "opencode-npm-install",
      "command": "npm ci --prefix adapters/opencode",
      "result": "passed",
      "detail": "Install completed with 0 vulnerabilities.",
      "commit_oid": "4c48371ee2246ec57561d49aa1046e02debb529a",
      "at": "2026-08-26T22:36:31Z"
    },
    {
      "name": "diff-check",
      "command": "git diff --check \u0026\u0026 git show --check",
      "result": "passed",
      "detail": "No whitespace errors on final head; word diff inspected.",
      "commit_oid": "3abb767069a7796ebdec047f9fefae7742252dc4",
      "at": "2026-08-26T22:56:57Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "Catalog query URL-encodes project scope, verifies returned filesystem identity, safely projects exact provider/model and variants, filters enabled text/tool-capable models, and tests different plus case-distinct directories.",
      "commit_oid": "3abb767069a7796ebdec047f9fefae7742252dc4",
      "at": "2026-08-26T22:56:58Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "Catalog diagnostics discard command output and underlying errors while retaining only safe fields; focused tests exercise sensitive output and malformed payloads without disclosure.",
      "commit_oid": "3abb767069a7796ebdec047f9fefae7742252dc4",
      "at": "2026-08-26T22:56:58Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "Beta 18314 agrees across catalog reader, package pin, plugin test, doctor, live smoke, and documentation; final local smoke and all six CI jobs passed.",
      "commit_oid": "3abb767069a7796ebdec047f9fefae7742252dc4",
      "at": "2026-08-26T22:56:58Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "The audit enumerates the complete 14-file scope, refreshed four-file cycle delta, filesystem-identity before/after, pin history, and preserved catalog, plugin, detection, doctor, diagnostics, and smoke behavior.",
      "commit_oid": "3abb767069a7796ebdec047f9fefae7742252dc4",
      "at": "2026-08-26T22:56:58Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "One blocking defect: sameDirectory relies on paths.Inside case folding, so distinct case-different repositories can compare equal on supported case-sensitive macOS or Windows volumes. The location-boundary claim and blast-radius record are therefore inaccurate. Filtering, safe diagnostics, beta pin alignment, scope, and required local verification evidence otherwise check out. GitHub had no CI runs for this head at review time.",
      "commit_oid": "4c48371ee2246ec57561d49aa1046e02debb529a",
      "at": "2026-08-26T22:43:52Z"
    },
    {
      "name": "opencode-catalog-focused",
      "command": "go test -v ./internal/opencode",
      "result": "passed",
      "detail": "Focused package passed; case-distinct test skipped because this machine temp volume is case-insensitive.",
      "commit_oid": "3abb767069a7796ebdec047f9fefae7742252dc4",
      "at": "2026-08-26T22:56:57Z"
    },
    {
      "name": "review-cycle-2",
      "result": "approve",
      "detail": "No findings. The cycle-1 case-sensitive repository-boundary defect is fixed with filesystem identity and a focused regression check. Scope, required tests, security, routing, manifest evidence, and all four acceptance criteria are satisfied. All six required CI jobs passed.",
      "commit_oid": "3abb767069a7796ebdec047f9fefae7742252dc4",
      "at": "2026-08-26T22:56:58Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (macos-latest)=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (windows-latest)=pass",
      "commit_oid": "3abb767069a7796ebdec047f9fefae7742252dc4",
      "at": "2026-08-26T22:57:12Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->