### PR TITLE
Validate OpenCode role selections before Delivery

### DIFF
--- a/adapters/opencode/src/index.js
+++ b/adapters/opencode/src/index.js
@@ -47,7 +47,12 @@ export function definePlugin(run = runOrch) {
       })
       await ctx.session.hook("context", async (event) => {
         const session = await ctx.session.get({ sessionID: event.sessionID })
-        const text = run(["hook", "opencode", "session-start"], session.location.directory)
+        const args = ["hook", "opencode", "session-start"]
+        if (!session.parentID) {
+          const model = `${event.model.providerID}/${event.model.id}${event.model.variant ? `#${event.model.variant}` : ""}`
+          args.push("--model", model)
+        }
+        const text = run(args, session.location.directory)
         if (text) event.system.push({ type: "text", text })
       })
     },

--- a/adapters/opencode/test/plugin.test.js
+++ b/adapters/opencode/test/plugin.test.js
@@ -32,6 +32,7 @@ test("fails closed on malformed mutation inputs", () => {
 test("registers pre-execution guard and session context hooks", async () => {
   const hooks = []
   const calls = []
+  let switched = false
   await definePlugin((args, cwd) => {
     calls.push([args, cwd])
     return args[0] === "hook" ? "context" : ""
@@ -40,6 +41,7 @@ test("registers pre-execution guard and session context hooks", async () => {
     session: {
       get: async () => ({ location: { directory: "/repo" } }),
       hook: async (name, callback) => hooks.push(["session", name, callback]),
+      switchModel: async () => (switched = true),
     },
   })
   assert.deepEqual(
@@ -47,13 +49,32 @@ test("registers pre-execution guard and session context hooks", async () => {
     [["tool", "execute.before"], ["session", "context"]],
   )
   await hooks[0][2]({ sessionID: "session", agent: "build", tool: "write", input: { path: "a.txt", content: "x" } })
-  const event = { sessionID: "session", system: [] }
+  const event = { sessionID: "session", model: { providerID: "openai", id: "gpt", variant: "high" }, system: [] }
   await hooks[1][2](event)
   assert.deepEqual(calls, [
     [["guard", "check", "--", "a.txt"], "/repo"],
-    [["hook", "opencode", "session-start"], "/repo"],
+    [["hook", "opencode", "session-start", "--model", "openai/gpt#high"], "/repo"],
   ])
   assert.deepEqual(event.system, [{ type: "text", text: "context" }])
+  assert.equal(switched, false)
+})
+
+test("does not compare a child session model to the Architect", async () => {
+  let hook
+  let call
+  await definePlugin((args, cwd) => {
+    call = [args, cwd]
+    return "context"
+  }).setup({
+    tool: { hook: async () => {} },
+    session: {
+      get: async () => ({ parentID: "parent", location: { directory: "/repo" } }),
+      hook: async (_, callback) => (hook = callback),
+    },
+  })
+  const event = { sessionID: "child", model: { providerID: "other", id: "model" }, system: [] }
+  await hook(event)
+  assert.deepEqual(call, [["hook", "opencode", "session-start"], "/repo"])
 })
 
 test("a denied guard stops before OpenCode can continue", async () => {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -216,7 +216,11 @@ func (f fakeRunner) Run(_ context.Context, c execx.Cmd) (execx.Result, error) {
 			}
 			catalog := f.opencodeCatalog
 			if catalog == "" {
-				catalog = fmt.Sprintf(`{"location":{"directory":%q},"data":[]}`, c.Dir)
+				catalog = fmt.Sprintf(`{"location":{"directory":%q},"data":[
+					{"id":"gpt-5.6-sol","providerID":"openai","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["text"]},"variants":[{"id":"high"},{"id":"xhigh"},{"id":"max"}]},
+					{"id":"gpt-5.6-luna","providerID":"openai","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["text"]},"variants":[{"id":"max"}]},
+					{"id":"gpt-5.6-terra","providerID":"openai","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["text"]},"variants":[{"id":"max"}]}
+				]}`, c.Dir)
 			}
 			return execx.Result{Stdout: catalog, ExitCode: f.opencodeCatalogExit}, nil
 		}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -137,7 +137,13 @@ func runDoctor(env Env) error {
 			check("codex adapter", checkAdapter(env, codexAdapter))
 		}
 		if cfg.Hosts.OpenCode != nil {
-			check("opencode adapter", checkOpenCodeAdapter(env, opencodeAdapter))
+			catalog, err := checkOpenCodeAdapter(env, opencodeAdapter)
+			check("opencode adapter", err)
+			if err == nil {
+				for _, selection := range opencodecatalog.CheckSelections(cfg.Hosts.OpenCode.Roles, catalog) {
+					check("opencode "+selection.Role+" selection", selection.Err)
+				}
+			}
 		}
 	}
 
@@ -374,10 +380,12 @@ func adapterVersion(manifestJSON string) (string, error) {
 const pinnedOpenCodeVersion = opencodecatalog.PinnedVersion
 
 // checkOpenCodeAdapter pins the beta runtime contract, checks the active
-// plugin ID, then verifies the project-scoped catalog and returned location.
-// V2's plugin API does not currently expose adapter versions.
-func checkOpenCodeAdapter(env Env, spec adapterSpec) error {
-	fail := func(detail string) error { return fmt.Errorf("%s; %s", detail, spec.repair) }
+// plugin ID, then returns the verified project-scoped catalog for role
+// selection checks. V2's plugin API does not currently expose adapter versions.
+func checkOpenCodeAdapter(env Env, spec adapterSpec) (opencodecatalog.Catalog, error) {
+	fail := func(detail string) (opencodecatalog.Catalog, error) {
+		return opencodecatalog.Catalog{}, fmt.Errorf("%s; %s", detail, spec.repair)
+	}
 	if _, err := env.LookPath(spec.executable); err != nil {
 		return fail(fmt.Sprintf("%s not found on PATH: %v", spec.executable, err))
 	}
@@ -424,10 +432,11 @@ func checkOpenCodeAdapter(env Env, spec adapterSpec) error {
 	if count != 1 {
 		return fail(fmt.Sprintf("%s appears %d times; exactly one active plugin is required", spec.pluginID, count))
 	}
-	if _, err := opencodecatalog.ReadCatalog(context.Background(), env.Runner, env.RepoRoot); err != nil {
+	catalog, err := opencodecatalog.ReadCatalog(context.Background(), env.Runner, env.RepoRoot)
+	if err != nil {
 		return fail(err.Error())
 	}
-	return nil
+	return catalog, nil
 }
 
 func decodeAdapterPlugins(host string, data []byte) ([]adapterPlugin, error) {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -17,6 +17,39 @@ import (
 	"github.com/kninetimmy/orch/internal/state"
 )
 
+const mixedOpenCodeTOML = `
+schema_version  = 1
+config_revision = "r1"
+
+[memhub]
+mode = "off"
+
+[hosts.opencode.roles.architect]
+model   = "openai/architect"
+variant = "deep"
+
+[hosts.opencode.roles.scout]
+model = "copilot/scout"
+
+[hosts.opencode.roles.implementer]
+model   = "local/team/implementer"
+variant = "fast"
+
+[hosts.opencode.roles.specialist]
+model = "openai/specialist"
+
+[hosts.opencode.roles.reviewer]
+model   = "copilot/reviewer"
+variant = "thorough"
+
+[hosts.opencode.roles.review_downgrade]
+model = "local/reviewer-lite"
+`
+
+func openCodeCatalogResponse(root, models string) string {
+	return fmt.Sprintf(`{"location":{"directory":%q},"data":[%s]}`, root, models)
+}
+
 func TestDoctorAllChecksPass(t *testing.T) {
 	env, stdout, _ := testEnv(t)
 	writeConfig(t, env.RepoRoot, validTOML)
@@ -173,6 +206,92 @@ func TestDoctorConfiguredAdaptersPassCurrentListings(t *testing.T) {
 				t.Errorf("stdout missing passing adapter check:\n%s", stdout.String())
 			}
 		})
+	}
+}
+
+func TestDoctorReportsEveryUnavailableOpenCodeRole(t *testing.T) {
+	const unavailable = `
+schema_version  = 1
+config_revision = "r1"
+
+[memhub]
+mode = "off"
+
+[hosts.opencode.roles.architect]
+model   = "missing/architect"
+variant = "deep"
+
+[hosts.opencode.roles.scout]
+model = "available/missing-scout"
+
+[hosts.opencode.roles.implementer]
+model   = "available/agent"
+variant = "missing-implementer"
+
+[hosts.opencode.roles.specialist]
+model = "missing/specialist"
+
+[hosts.opencode.roles.reviewer]
+model = "available/missing-reviewer"
+
+[hosts.opencode.roles.review_downgrade]
+model   = "available/agent"
+variant = "missing-safe"
+`
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, unavailable)
+	if code := Run([]string{"render-agents"}, env); code != ExitOK {
+		t.Fatalf("render-agents exit = %d\n%s", code, stdout.String())
+	}
+	stdout.Reset()
+	env.Runner = fakeRunner{
+		toplevel: env.RepoRoot,
+		opencodeCatalog: openCodeCatalogResponse(env.RepoRoot,
+			`{"id":"agent","providerID":"available","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["text"]},"variants":[{"id":"fast","settings":{"token":"catalog-secret"}}]}`),
+	}
+	if code := Run([]string{"doctor"}, env); code != ExitError {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitError, stdout.String())
+	}
+	out := stdout.String()
+	for _, role := range []string{"architect", "scout", "implementer", "specialist", "reviewer", "review_downgrade"} {
+		for _, want := range []string{"FAIL  opencode " + role + " selection", "hosts.opencode.roles." + role, "choose an available OpenCode selection for this role"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("output missing %q:\n%s", want, out)
+			}
+		}
+	}
+	if strings.Contains(out, "catalog-secret") || strings.Contains(out, `"fast"`) {
+		t.Errorf("doctor disclosed catalog-only data:\n%s", out)
+	}
+}
+
+func TestDoctorAcceptsAvailableMixedProviderOpenCodeProfile(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, mixedOpenCodeTOML)
+	if code := Run([]string{"render-agents"}, env); code != ExitOK {
+		t.Fatalf("render-agents exit = %d\n%s", code, stdout.String())
+	}
+	stdout.Reset()
+	models := strings.Join([]string{
+		`{"id":"architect","providerID":"openai","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["text"]},"variants":[{"id":"deep"}]}`,
+		`{"id":"scout","providerID":"copilot","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["text"]},"variants":[]}`,
+		`{"id":"team/implementer","providerID":"local","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["text"]},"variants":[{"id":"fast"}]}`,
+		`{"id":"specialist","providerID":"openai","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["text"]},"variants":[]}`,
+		`{"id":"reviewer","providerID":"copilot","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["text"]},"variants":[{"id":"thorough"}]}`,
+		`{"id":"reviewer-lite","providerID":"local","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["text"]},"variants":[]}`,
+	}, ",")
+	env.Runner = fakeRunner{toplevel: env.RepoRoot, opencodeCatalog: openCodeCatalogResponse(env.RepoRoot, models)}
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	out := stdout.String()
+	for _, role := range []string{"architect", "scout", "implementer", "specialist", "reviewer", "review_downgrade"} {
+		if !strings.Contains(out, "ok    opencode "+role+" selection") {
+			t.Errorf("output missing passing %s selection:\n%s", role, out)
+		}
+	}
+	if !strings.Contains(out, "ok    opencode agent files") {
+		t.Errorf("mixed-provider generated agents are not fresh:\n%s", out)
 	}
 }
 

--- a/internal/cli/hook.go
+++ b/internal/cli/hook.go
@@ -11,31 +11,23 @@ import (
 
 // hookUsage is the one-line usage for the adapter plumbing surface,
 // mirroring guardUsage.
-const hookUsage = "orch hook: usage: orch hook <claude|codex|opencode> session-start | orch hook codex subagent-usage (JSON document on stdin)"
+const hookUsage = "orch hook: usage: orch hook <claude|codex> session-start | orch hook opencode session-start [--model provider/model[#variant]] | orch hook codex subagent-usage (JSON document on stdin)"
 
 // runHook dispatches host adapter-plumbing verbs (PRD §23). Host adapters call
 // it instead of reimplementing their host-specific behavior; it is never
 // invoked by a human directly.
 func runHook(env Env, args []string) error {
-	if len(args) != 2 {
-		return usageError(hookUsage)
-	}
-	switch args[0] {
-	case "claude":
-		if args[1] == "session-start" {
-			return hookSessionStart(env, args[0])
-		}
-	case "codex":
-		switch args[1] {
-		case "session-start":
-			return hookSessionStart(env, args[0])
-		case "subagent-usage":
-			return runCodexSubagentUsage(env)
-		}
-	case "opencode":
-		if args[1] == "session-start" {
-			return hookSessionStart(env, args[0])
-		}
+	switch {
+	case len(args) == 2 && args[0] == "claude" && args[1] == "session-start":
+		return hookSessionStart(env, args[0], "")
+	case len(args) == 2 && args[0] == "codex" && args[1] == "session-start":
+		return hookSessionStart(env, args[0], "")
+	case len(args) == 2 && args[0] == "codex" && args[1] == "subagent-usage":
+		return runCodexSubagentUsage(env)
+	case len(args) == 2 && args[0] == "opencode" && args[1] == "session-start":
+		return hookSessionStart(env, args[0], "")
+	case len(args) == 4 && args[0] == "opencode" && args[1] == "session-start" && args[2] == "--model" && args[3] != "":
+		return hookSessionStart(env, args[0], args[3])
 	}
 	return usageError(hookUsage)
 }
@@ -49,7 +41,7 @@ func runHook(env Env, args []string) error {
 // discovery, config, or state failure degrades to silent output, not an
 // error. The architect skill's own `orch run status --json` call surfaces
 // a broken repo loudly later, once a session is actually underway.
-func hookSessionStart(env Env, host string) error {
+func hookSessionStart(env Env, host, selectedModel string) error {
 	root, err := paths.FindOutermostRoot(env.RepoRoot)
 	if err != nil {
 		return nil // no .orchestrator ancestor (or an unwalkable one): silent
@@ -62,7 +54,7 @@ func hookSessionStart(env Env, host string) error {
 	if err != nil {
 		return nil // unreadable/invalid state: silent
 	}
-	fmt.Fprint(env.Stdout, sessionStartContext(cfg, st, host))
+	fmt.Fprint(env.Stdout, sessionStartContext(cfg, st, host, selectedModel))
 	return nil
 }
 
@@ -89,10 +81,10 @@ var sessionStartClosing = map[string]string{
 }
 
 // sessionStartContext renders the compact plain-text context block the
-// SessionStart hook injects: both hosts take a hook's raw stdout as
+// SessionStart hook injects: all hosts take a hook's raw stdout as
 // context text, not a JSON envelope, so this is deliberately prose, not a
 // document.
-func sessionStartContext(cfg *config.Config, st *state.State, host string) string {
+func sessionStartContext(cfg *config.Config, st *state.State, host, selectedModel string) string {
 	var b strings.Builder
 	if st.Mode == state.ModeDelivery {
 		fmt.Fprintln(&b, "This repository is managed by Orch (mode: delivery).")
@@ -101,6 +93,15 @@ func sessionStartContext(cfg *config.Config, st *state.State, host string) strin
 		fmt.Fprintln(&b, "This repository is managed by Orch (mode: assist).")
 	}
 	fmt.Fprintf(&b, "Memhub mode: %s.\n", cfg.Memhub.Mode)
+	if host == "opencode" && selectedModel != "" && cfg.Hosts.OpenCode != nil {
+		architect := cfg.Hosts.OpenCode.Roles.Architect.Model
+		if variant := cfg.Hosts.OpenCode.Roles.Architect.EffectiveOpenCodeVariant(); variant != "" {
+			architect += "#" + variant
+		}
+		if selectedModel != architect {
+			fmt.Fprintf(&b, "Warning: this main session selected %q, but hosts.opencode.roles.architect configures %q. Orch will not switch the session model automatically; select the configured Architect manually if you want them to match.\n", selectedModel, architect)
+		}
+	}
 	fmt.Fprintln(&b, sessionStartClosing[host])
 	return b.String()
 }

--- a/internal/cli/hook_test.go
+++ b/internal/cli/hook_test.go
@@ -320,3 +320,35 @@ func TestHookSessionStartSharedLinesAcrossHosts(t *testing.T) {
 		t.Errorf("shared lines differ:\nclaude: %q\nopencode: %q", claudeShared, openCodeShared)
 	}
 }
+
+func TestHookOpenCodeWarnsOnArchitectModelMismatch(t *testing.T) {
+	env, stdout, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validOpenCodeTOML)
+	args := []string{"hook", "opencode", "session-start", "--model", "github-copilot/gpt-5-mini"}
+	if code := Run(args, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr %q)", code, ExitOK, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		`Warning: this main session selected "github-copilot/gpt-5-mini"`,
+		`hosts.opencode.roles.architect configures "openai/gpt-5.6-sol#xhigh"`,
+		"will not switch the session model automatically",
+		"select the configured Architect manually",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestHookOpenCodeMatchingArchitectHasNoWarning(t *testing.T) {
+	env, stdout, stderr := testEnv(t)
+	writeConfig(t, env.RepoRoot, validOpenCodeTOML)
+	args := []string{"hook", "opencode", "session-start", "--model", "openai/gpt-5.6-sol#xhigh"}
+	if code := Run(args, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr %q)", code, ExitOK, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Warning:") {
+		t.Errorf("matching model received warning:\n%s", stdout.String())
+	}
+}

--- a/internal/cli/renderagents_test.go
+++ b/internal/cli/renderagents_test.go
@@ -54,7 +54,37 @@ effort = "high"
 
 var validBothHostsTOML = validTOML + validCodexTOML[strings.Index(validCodexTOML, "[hosts.codex"):]
 
-var validOpenCodeTOML = strings.ReplaceAll(validCodexTOML, "hosts.codex", "hosts.opencode")
+const validOpenCodeTOML = `
+schema_version  = 1
+config_revision = "r1"
+
+[memhub]
+mode = "off"
+
+[hosts.opencode.roles.architect]
+model   = "openai/gpt-5.6-sol"
+variant = "xhigh"
+
+[hosts.opencode.roles.scout]
+model   = "openai/gpt-5.6-luna"
+variant = "max"
+
+[hosts.opencode.roles.implementer]
+model   = "openai/gpt-5.6-terra"
+variant = "max"
+
+[hosts.opencode.roles.specialist]
+model   = "openai/gpt-5.6-sol"
+variant = "max"
+
+[hosts.opencode.roles.reviewer]
+model   = "openai/gpt-5.6-sol"
+variant = "xhigh"
+
+[hosts.opencode.roles.review_downgrade]
+model   = "openai/gpt-5.6-sol"
+variant = "high"
+`
 
 const validClaudeDefaultTOML = `
 schema_version  = 1

--- a/internal/opencode/selection.go
+++ b/internal/opencode/selection.go
@@ -1,0 +1,67 @@
+package opencode
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/kninetimmy/orch/internal/config"
+)
+
+// SelectionCheck reports whether one configured OpenCode role is present in
+// the project-scoped live catalog.
+type SelectionCheck struct {
+	Role string
+	Err  error
+}
+
+// CheckSelections checks all six configured roles in configuration order. It
+// never includes other catalog entries in diagnostics.
+func CheckSelections(roles config.Roles, catalog Catalog) []SelectionCheck {
+	profiles := []struct {
+		role    string
+		profile config.RoleProfile
+	}{
+		{"architect", roles.Architect},
+		{"scout", roles.Scout},
+		{"implementer", roles.Implementer},
+		{"specialist", roles.Specialist},
+		{"reviewer", roles.Reviewer},
+		{"review_downgrade", roles.ReviewDowngrade},
+	}
+	checks := make([]SelectionCheck, len(profiles))
+	for i, item := range profiles {
+		checks[i] = SelectionCheck{Role: item.role, Err: checkSelection(item.role, item.profile, catalog)}
+	}
+	return checks
+}
+
+func checkSelection(role string, profile config.RoleProfile, catalog Catalog) error {
+	path := "hosts.opencode.roles." + role
+	variant := profile.EffectiveOpenCodeVariant()
+	provider, _, exact := strings.Cut(profile.Model, "/")
+	providerFound := false
+	var found *Model
+	for i := range catalog.Models {
+		modelProvider, _, _ := strings.Cut(catalog.Models[i].ID, "/")
+		if exact && modelProvider == provider {
+			providerFound = true
+		}
+		if catalog.Models[i].ID == profile.Model {
+			found = &catalog.Models[i]
+			break
+		}
+	}
+
+	repair := "run `orch configure` or `orch configure-local` to choose an available OpenCode selection for this role"
+	switch {
+	case found == nil && exact && !providerFound:
+		return fmt.Errorf("%s selects unavailable provider %q for model %q; %s", path, provider, profile.Model, repair)
+	case found == nil:
+		return fmt.Errorf("%s selects unavailable model %q; %s", path, profile.Model, repair)
+	case variant != "" && !slices.Contains(found.Variants, variant):
+		return fmt.Errorf("%s selects unavailable variant %q for model %q; %s", path, variant, profile.Model, repair)
+	default:
+		return nil
+	}
+}

--- a/internal/opencode/selection_test.go
+++ b/internal/opencode/selection_test.go
@@ -1,0 +1,60 @@
+package opencode
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/config"
+)
+
+func TestCheckSelectionsReportsEveryUnavailableRole(t *testing.T) {
+	roles := config.Roles{
+		Architect:       config.RoleProfile{Model: "missing/architect", Variant: "deep"},
+		Scout:           config.RoleProfile{Model: "available/missing"},
+		Implementer:     config.RoleProfile{Model: "available/agent", Variant: "missing"},
+		Specialist:      config.RoleProfile{Model: "available/agent", Variant: "fast"},
+		Reviewer:        config.RoleProfile{Model: "available/agent"},
+		ReviewDowngrade: config.RoleProfile{Model: "legacy-bare-model", Effort: "high"},
+	}
+	catalog := Catalog{Models: []Model{{ID: "available/agent", Variants: []string{"fast"}}}}
+	checks := CheckSelections(roles, catalog)
+	if len(checks) != 6 {
+		t.Fatalf("checks = %d, want 6", len(checks))
+	}
+	wants := []string{"unavailable provider", "unavailable model", "unavailable variant", "", "", "unavailable model"}
+	for i, want := range wants {
+		if want == "" {
+			if checks[i].Err != nil {
+				t.Errorf("%s error = %v, want nil", checks[i].Role, checks[i].Err)
+			}
+			continue
+		}
+		if checks[i].Err == nil || !strings.Contains(checks[i].Err.Error(), want) || !strings.Contains(checks[i].Err.Error(), "this role") {
+			t.Errorf("%s error = %v, want %q and role-specific repair", checks[i].Role, checks[i].Err, want)
+		}
+	}
+}
+
+func TestCheckSelectionsAcceptsMixedProvidersAndNoVariant(t *testing.T) {
+	roles := config.Roles{
+		Architect:       config.RoleProfile{Model: "openai/architect", Variant: "deep"},
+		Scout:           config.RoleProfile{Model: "copilot/scout"},
+		Implementer:     config.RoleProfile{Model: "local/team/implementer", Variant: "fast"},
+		Specialist:      config.RoleProfile{Model: "openai/specialist"},
+		Reviewer:        config.RoleProfile{Model: "copilot/reviewer", Variant: "thorough"},
+		ReviewDowngrade: config.RoleProfile{Model: "local/reviewer-lite"},
+	}
+	catalog := Catalog{Models: []Model{
+		{ID: "openai/architect", Variants: []string{"deep"}},
+		{ID: "copilot/scout"},
+		{ID: "local/team/implementer", Variants: []string{"fast"}},
+		{ID: "openai/specialist"},
+		{ID: "copilot/reviewer", Variants: []string{"thorough"}},
+		{ID: "local/reviewer-lite"},
+	}}
+	for _, check := range CheckSelections(roles, catalog) {
+		if check.Err != nil {
+			t.Errorf("%s error = %v", check.Role, check.Err)
+		}
+	}
+}

--- a/internal/run/activate.go
+++ b/internal/run/activate.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kninetimmy/orch/internal/manifest"
 	"github.com/kninetimmy/orch/internal/memhub"
 	"github.com/kninetimmy/orch/internal/metrics"
+	opencodecatalog "github.com/kninetimmy/orch/internal/opencode"
 	"github.com/kninetimmy/orch/internal/routing"
 	"github.com/kninetimmy/orch/internal/state"
 )
@@ -116,7 +117,8 @@ func wrapAfterEnter(err error) error {
 //
 //   - Phase 1 (pure validation): decode/validate the plan and its
 //     approval, derive routing and labels for every issue.
-//   - Phase 2 (read-only preflights): Assist+no-lock, current rendered
+//   - Phase 2 (read-only preflights): Assist+no-lock, configured OpenCode
+//     selections present in the project-scoped live catalog, current rendered
 //     project agent files for the plan's host, clean primary
 //     checkout, authenticated GitHub remote, primary on the default
 //     branch (F4), every plan-declared area label existing in the
@@ -183,6 +185,21 @@ func Activate(ctx context.Context, env Env, reqJSON []byte) (*ActivationResult, 
 	// Phase 2: read-only preflights.
 	if err := requireAssistNoLock(env.RepoRoot); err != nil {
 		return nil, err
+	}
+	if plan.Host == "opencode" {
+		catalog, err := opencodecatalog.ReadCatalog(ctx, env.Runner, env.RepoRoot)
+		if err != nil {
+			return nil, err
+		}
+		var unavailable []string
+		for _, check := range opencodecatalog.CheckSelections(cfg.Hosts.OpenCode.Roles, catalog) {
+			if check.Err != nil {
+				unavailable = append(unavailable, check.Err.Error())
+			}
+		}
+		if len(unavailable) > 0 {
+			return nil, fmt.Errorf("%w:\n  - %s", ErrOpenCodeSelectionUnavailable, strings.Join(unavailable, "\n  - "))
+		}
 	}
 	agentHost := cfg.Host(plan.Host)
 	stale, staleErr := agents.Stale(env.RepoRoot, plan.Host, agentHost)

--- a/internal/run/activate_test.go
+++ b/internal/run/activate_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,6 +21,7 @@ import (
 	"github.com/kninetimmy/orch/internal/lockfile"
 	"github.com/kninetimmy/orch/internal/manifest"
 	"github.com/kninetimmy/orch/internal/metrics"
+	opencodecatalog "github.com/kninetimmy/orch/internal/opencode"
 	"github.com/kninetimmy/orch/internal/paths"
 	"github.com/kninetimmy/orch/internal/state"
 )
@@ -69,7 +71,7 @@ func newActivateRepoWithConfigAndIgnore(t *testing.T, tomlContent, gitignore str
 	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("hi\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	gitignore += ".claude/agents/\n.codex/agents/\n"
+	gitignore += ".claude/agents/\n.codex/agents/\n.opencode/agents/\n"
 	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(gitignore), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -87,10 +89,7 @@ func newActivateRepoWithConfigAndIgnore(t *testing.T, tomlContent, gitignore str
 	}
 	var files []agents.File
 	for _, host := range cfg.EnabledHosts() {
-		h := cfg.Hosts.Claude
-		if host == "codex" {
-			h = cfg.Hosts.Codex
-		}
+		h := cfg.Host(host)
 		rendered, err := agents.Render(host, h)
 		if err != nil {
 			t.Fatal(err)
@@ -890,4 +889,105 @@ func TestActivateClaudeAbsentAgentsLeavesNothing(t *testing.T) {
 	}
 	script.AssertExhausted()
 	assertNoActivationArtifacts(t, root)
+}
+
+const mixedOpenCodeConfigTOML = `
+schema_version  = 1
+config_revision = "r1"
+
+[memhub]
+mode = "off"
+
+[hosts.opencode.roles.architect]
+model   = "openai/architect"
+variant = "deep"
+
+[hosts.opencode.roles.scout]
+model = "copilot/scout"
+
+[hosts.opencode.roles.implementer]
+model   = "local/team/implementer"
+variant = "fast"
+
+[hosts.opencode.roles.specialist]
+model = "openai/specialist"
+
+[hosts.opencode.roles.reviewer]
+model   = "copilot/reviewer"
+variant = "thorough"
+
+[hosts.opencode.roles.review_downgrade]
+model = "local/reviewer-lite"
+`
+
+func openCodePlanJSON() string {
+	return strings.Replace(codexPlanJSON(), `"host": "codex"`, `"host": "opencode"`, 1)
+}
+
+func openCodeCatalogCall(root, models string) execxtest.Call {
+	endpoint := "/api/model?" + url.Values{"location[directory]": {root}}.Encode()
+	return execxtest.Call{
+		Name:   opencodecatalog.Executable,
+		Args:   []string{"api", "get", endpoint},
+		Stdout: fmt.Sprintf(`{"location":{"directory":%q},"data":[%s]}`, root, models),
+	}
+}
+
+func availableMixedOpenCodeModels() string {
+	return strings.Join([]string{
+		`{"id":"architect","providerID":"openai","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["text"]},"variants":[{"id":"deep"}]}`,
+		`{"id":"scout","providerID":"copilot","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["text"]},"variants":[]}`,
+		`{"id":"team/implementer","providerID":"local","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["text"]},"variants":[{"id":"fast"}]}`,
+		`{"id":"specialist","providerID":"openai","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["text"]},"variants":[]}`,
+		`{"id":"reviewer","providerID":"copilot","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["text"]},"variants":[{"id":"thorough"}]}`,
+		`{"id":"reviewer-lite","providerID":"local","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["text"]},"variants":[]}`,
+	}, ",")
+}
+
+func TestActivateOpenCodeUnavailableSelectionsLeaveNothing(t *testing.T) {
+	root := newActivateRepoWithConfigAndIgnore(t, mixedOpenCodeConfigTOML, fullGitignore)
+	models := `{"id":"unrelated","providerID":"catalog","enabled":true,"capabilities":{"tools":true,"input":["text"],"output":["text"]},"variants":[{"id":"secret-variant","settings":{"token":"catalog-secret"}}]}`
+	script := &execxtest.Script{T: t, Calls: []execxtest.Call{openCodeCatalogCall(root, models)}}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	_, err := Activate(context.Background(), env, activationJSON(t, openCodePlanJSON()))
+	if !errors.Is(err, ErrOpenCodeSelectionUnavailable) {
+		t.Fatalf("err = %v, want ErrOpenCodeSelectionUnavailable", err)
+	}
+	for _, role := range []string{"architect", "scout", "implementer", "specialist", "reviewer", "review_downgrade"} {
+		if !strings.Contains(err.Error(), "hosts.opencode.roles."+role) {
+			t.Errorf("err does not name %s: %v", role, err)
+		}
+	}
+	if strings.Contains(err.Error(), "catalog-secret") || strings.Contains(err.Error(), "secret-variant") {
+		t.Errorf("error disclosed catalog-only data: %v", err)
+	}
+	script.AssertExhausted()
+	assertNoActivationArtifacts(t, root)
+}
+
+func TestActivateOpenCodeAvailableMixedProfileProceedsWithFreshAgents(t *testing.T) {
+	root := newActivateRepoWithConfigAndIgnore(t, mixedOpenCodeConfigTOML, fullGitignore)
+	cfg, err := config.Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale, staleErr := agents.Stale(root, "opencode", cfg.Hosts.OpenCode)
+	if len(stale) > 0 || staleErr != nil {
+		t.Fatalf("OpenCode agents stale = %v, err = %v", stale, staleErr)
+	}
+	calls := []execxtest.Call{openCodeCatalogCall(root, availableMixedOpenCodeModels())}
+	calls = append(calls, fullTaxonomyScript()...)
+	calls = append(calls, ghIssueCreateCall("Issue A", []string{"ready", "feature", "implementer", "standard"}, 1))
+	script := &execxtest.Script{T: t, Calls: calls}
+	env := Env{RepoRoot: root, Runner: muxRunner{git: execx.Local{}, gh: script}, Now: fixedNow}
+
+	result, err := Activate(context.Background(), env, activationJSON(t, openCodePlanJSON()))
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	script.AssertExhausted()
+	if len(result.Issues) != 1 || result.Issues[0].Number != 1 {
+		t.Errorf("Issues = %+v, want one issue #1", result.Issues)
+	}
 }

--- a/internal/run/errors.go
+++ b/internal/run/errors.go
@@ -28,6 +28,9 @@ var (
 	// project-local agent definitions absent, unreadable, or different
 	// from the current build and effective role configuration.
 	ErrAgentsStale = errors.New("rendered agent files are absent or out of date")
+	// ErrOpenCodeSelectionUnavailable reports one or more configured OpenCode
+	// role selections missing from the project-scoped live catalog.
+	ErrOpenCodeSelectionUnavailable = errors.New("configured OpenCode role selection is unavailable")
 	// ErrMemhubRequired reports that config.Memhub.Mode is "required"
 	// and the memhub probe failed or could not run (PRD §20: fail
 	// closed rather than proceed without memory).


### PR DESCRIPTION
Delivers issue #243: Validate OpenCode role selections before Delivery

Closes #243

**Plan digest:** `sha256:c08d80a09544194d02b5ce92d7fedff47b09897811fbfdb3887633ee668661b7`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Fail before repository mutation when configured OpenCode role models are unavailable, and surface main-session Architect mismatches without changing the user's session model.

**Acceptance criteria:**
- Doctor identifies every configured OpenCode role whose provider, model, or variant is unavailable and gives role-specific remediation.
- OpenCode-host activation rejects unavailable configured selections before creating an issue, branch, worktree, or Delivery lock.
- A session whose selected main model differs from the configured OpenCode Architect receives a clear context warning, and Orch never switches the session model automatically.
- A fully available mixed-provider profile passes doctor, activation preflight, and generated-agent freshness checks, while Claude Code and Codex behavior remains unchanged.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`
- `npm test --prefix adapters/opencode`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `openai/gpt-5.6-sol` — effort `xhigh` |
| Reviewer | `openai/gpt-5.6-sol` — effort `xhigh` |
| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
| Config revision | `sha256:308e4942b411` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.

**Escalations:** _none_

**Verification:**
- **branch-scope:live-base-diff** — passed: clean, pushed, one commit touching 13 files — `git diff --name-status 3812e05ad7c78e26d28fd330e88465ab579dad1f...2012dcadc82963cd9739e3a80e1e23b41f681993` — Live main 3812e05ad7c78e26d28fd330e88465ab579dad1f to head 2012dcadc82963cd9739e3a80e1e23b41f681993: adapters/opencode/src/index.js, test/plugin.test.js; internal/cli/cli_test.go, doctor.go, doctor_test.go, hook.go, hook_test.go, renderagents_test.go; new internal/opencode/selection.go and selection_test.go; internal/run/activate.go, activate_test.go, errors.go. 510 insertions, 42 deletions. — commit `2012dcadc82963cd9739e3a80e1e23b41f681993` (2026-08-27T01:29:06Z)
- **branch-scope:validation-boundaries** — passed — `review implementation and focused boundary tests` — Shared validation checks provider/model/variant for all six OpenCode roles with role-specific remediation and redacted diagnostics. OpenCode activation validates the project-scoped catalog before GitHub, Delivery lock, issue, branch, or worktree mutation. Root OpenCode sessions warn when the selected main model differs from configured Architect and never switch it. Mixed-provider available profiles pass doctor, activation preflight, and generated-agent freshness; Claude/Codex remain unchanged. — commit `2012dcadc82963cd9739e3a80e1e23b41f681993` (2026-08-27T01:29:06Z)
- **go-test** — passed — `go test ./...` — All packages passed. — commit `2012dcadc82963cd9739e3a80e1e23b41f681993` (2026-08-27T01:29:06Z)
- **go-vet** — passed — `go vet ./...` — Passed with no output. — commit `2012dcadc82963cd9739e3a80e1e23b41f681993` (2026-08-27T01:29:06Z)
- **gofmt** — passed — `gofmt -l .` — No unformatted files. — commit `2012dcadc82963cd9739e3a80e1e23b41f681993` (2026-08-27T01:29:06Z)
- **opencode-npm-tests** — passed — `npm test --prefix adapters/opencode` — 6 of 6 tests passed. — commit `2012dcadc82963cd9739e3a80e1e23b41f681993` (2026-08-27T01:29:06Z)
- **doctor-hook-focused** — passed — `focused doctor and hook tests` — 5 of 5 focused checks passed, including diagnostics redaction and root-session warning behavior. — commit `2012dcadc82963cd9739e3a80e1e23b41f681993` (2026-08-27T01:29:06Z)
- **activation-host-parity-focused** — passed — `focused activation and Claude/Codex parity tests` — 4 of 4 focused checks passed. An initial combined command timed out after two packages passed; each remaining check was rerun separately and passed. — commit `2012dcadc82963cd9739e3a80e1e23b41f681993` (2026-08-27T01:29:06Z)
- **diff-check** — passed — `git diff --check && git show --check` — No whitespace errors; prose word diff inspected with no unintended removals. — commit `2012dcadc82963cd9739e3a80e1e23b41f681993` (2026-08-27T01:29:06Z)
- **acceptance-criterion-1** — satisfied — Shared validation checks all six roles and distinguishes unavailable provider, model, and variant with role-path remediation; doctor tests cover every role and secret redaction. — commit `2012dcadc82963cd9739e3a80e1e23b41f681993` (2026-08-27T01:35:54Z)
- **acceptance-criterion-2** — satisfied — Activation catalog validation runs before label, lock/state, issue, branch, worktree, or other GitHub mutation, with a test proving no mutation on failure. — commit `2012dcadc82963cd9739e3a80e1e23b41f681993` (2026-08-27T01:35:54Z)
- **acceptance-criterion-3** — satisfied — Root sessions pass effective provider/model/variant to the hook, mismatches inject an explicit warning, child sessions omit comparison, and no model-switch action exists. — commit `2012dcadc82963cd9739e3a80e1e23b41f681993` (2026-08-27T01:35:54Z)
- **acceptance-criterion-4** — satisfied — Mixed-provider doctor, activation, and generated-agent freshness checks pass; existing Claude/Codex activation and session parity remain green. — commit `2012dcadc82963cd9739e3a80e1e23b41f681993` (2026-08-27T01:35:54Z)
- **review-cycle-1** — approve — No findings. All four criteria are satisfied: role-specific doctor validation covers all six roles with redacted diagnostics; OpenCode activation rejects unavailable selections before every mutation; root-session mismatch warning never auto-switches; mixed-provider doctor/activation/freshness and Claude/Codex parity pass. Scope and audit match, and all six required CI jobs are green. — commit `2012dcadc82963cd9739e3a80e1e23b41f681993` (2026-08-27T01:35:54Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `2012dcadc82963cd9739e3a80e1e23b41f681993` (2026-08-27T01:36:21Z)

<!-- orch:manifest:data
{
  "schema_version": 4,
  "objective": "Fail before repository mutation when configured OpenCode role models are unavailable, and surface main-session Architect mismatches without changing the user's session model.",
  "acceptance_criteria": [
    "Doctor identifies every configured OpenCode role whose provider, model, or variant is unavailable and gives role-specific remediation.",
    "OpenCode-host activation rejects unavailable configured selections before creating an issue, branch, worktree, or Delivery lock.",
    "A session whose selected main model differs from the configured OpenCode Architect receives a clear context warning, and Orch never switches the session model automatically.",
    "A fully available mixed-provider profile passes doctor, activation preflight, and generated-agent freshness checks, while Claude Code and Codex behavior remains unchanged."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l .",
    "npm test --prefix adapters/opencode"
  ],
  "role": "implementer",
  "executor": {
    "model": "openai/gpt-5.6-sol",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.",
  "reviewer": {
    "model": "openai/gpt-5.6-sol",
    "effort": "xhigh"
  },
  "effort_delivery": "parameter",
  "config_revision": "sha256:308e4942b411",
  "verifications": [
    {
      "name": "branch-scope:live-base-diff",
      "command": "git diff --name-status 3812e05ad7c78e26d28fd330e88465ab579dad1f...2012dcadc82963cd9739e3a80e1e23b41f681993",
      "result": "passed: clean, pushed, one commit touching 13 files",
      "detail": "Live main 3812e05ad7c78e26d28fd330e88465ab579dad1f to head 2012dcadc82963cd9739e3a80e1e23b41f681993: adapters/opencode/src/index.js, test/plugin.test.js; internal/cli/cli_test.go, doctor.go, doctor_test.go, hook.go, hook_test.go, renderagents_test.go; new internal/opencode/selection.go and selection_test.go; internal/run/activate.go, activate_test.go, errors.go. 510 insertions, 42 deletions.",
      "commit_oid": "2012dcadc82963cd9739e3a80e1e23b41f681993",
      "at": "2026-08-27T01:29:06Z"
    },
    {
      "name": "branch-scope:validation-boundaries",
      "command": "review implementation and focused boundary tests",
      "result": "passed",
      "detail": "Shared validation checks provider/model/variant for all six OpenCode roles with role-specific remediation and redacted diagnostics. OpenCode activation validates the project-scoped catalog before GitHub, Delivery lock, issue, branch, or worktree mutation. Root OpenCode sessions warn when the selected main model differs from configured Architect and never switch it. Mixed-provider available profiles pass doctor, activation preflight, and generated-agent freshness; Claude/Codex remain unchanged.",
      "commit_oid": "2012dcadc82963cd9739e3a80e1e23b41f681993",
      "at": "2026-08-27T01:29:06Z"
    },
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "passed",
      "detail": "All packages passed.",
      "commit_oid": "2012dcadc82963cd9739e3a80e1e23b41f681993",
      "at": "2026-08-27T01:29:06Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "passed",
      "detail": "Passed with no output.",
      "commit_oid": "2012dcadc82963cd9739e3a80e1e23b41f681993",
      "at": "2026-08-27T01:29:06Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "passed",
      "detail": "No unformatted files.",
      "commit_oid": "2012dcadc82963cd9739e3a80e1e23b41f681993",
      "at": "2026-08-27T01:29:06Z"
    },
    {
      "name": "opencode-npm-tests",
      "command": "npm test --prefix adapters/opencode",
      "result": "passed",
      "detail": "6 of 6 tests passed.",
      "commit_oid": "2012dcadc82963cd9739e3a80e1e23b41f681993",
      "at": "2026-08-27T01:29:06Z"
    },
    {
      "name": "doctor-hook-focused",
      "command": "focused doctor and hook tests",
      "result": "passed",
      "detail": "5 of 5 focused checks passed, including diagnostics redaction and root-session warning behavior.",
      "commit_oid": "2012dcadc82963cd9739e3a80e1e23b41f681993",
      "at": "2026-08-27T01:29:06Z"
    },
    {
      "name": "activation-host-parity-focused",
      "command": "focused activation and Claude/Codex parity tests",
      "result": "passed",
      "detail": "4 of 4 focused checks passed. An initial combined command timed out after two packages passed; each remaining check was rerun separately and passed.",
      "commit_oid": "2012dcadc82963cd9739e3a80e1e23b41f681993",
      "at": "2026-08-27T01:29:06Z"
    },
    {
      "name": "diff-check",
      "command": "git diff --check \u0026\u0026 git show --check",
      "result": "passed",
      "detail": "No whitespace errors; prose word diff inspected with no unintended removals.",
      "commit_oid": "2012dcadc82963cd9739e3a80e1e23b41f681993",
      "at": "2026-08-27T01:29:06Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "Shared validation checks all six roles and distinguishes unavailable provider, model, and variant with role-path remediation; doctor tests cover every role and secret redaction.",
      "commit_oid": "2012dcadc82963cd9739e3a80e1e23b41f681993",
      "at": "2026-08-27T01:35:54Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "Activation catalog validation runs before label, lock/state, issue, branch, worktree, or other GitHub mutation, with a test proving no mutation on failure.",
      "commit_oid": "2012dcadc82963cd9739e3a80e1e23b41f681993",
      "at": "2026-08-27T01:35:54Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "Root sessions pass effective provider/model/variant to the hook, mismatches inject an explicit warning, child sessions omit comparison, and no model-switch action exists.",
      "commit_oid": "2012dcadc82963cd9739e3a80e1e23b41f681993",
      "at": "2026-08-27T01:35:54Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "Mixed-provider doctor, activation, and generated-agent freshness checks pass; existing Claude/Codex activation and session parity remain green.",
      "commit_oid": "2012dcadc82963cd9739e3a80e1e23b41f681993",
      "at": "2026-08-27T01:35:54Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "No findings. All four criteria are satisfied: role-specific doctor validation covers all six roles with redacted diagnostics; OpenCode activation rejects unavailable selections before every mutation; root-session mismatch warning never auto-switches; mixed-provider doctor/activation/freshness and Claude/Codex parity pass. Scope and audit match, and all six required CI jobs are green.",
      "commit_oid": "2012dcadc82963cd9739e3a80e1e23b41f681993",
      "at": "2026-08-27T01:35:54Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "2012dcadc82963cd9739e3a80e1e23b41f681993",
      "at": "2026-08-27T01:36:21Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->