### PR TITLE
Drive setup interviews from detected OpenCode models

### DIFF
--- a/adapters/claude/plugin_test.go
+++ b/adapters/claude/plugin_test.go
@@ -383,6 +383,10 @@ func TestSetupSkillHasTerminalForms(t *testing.T) {
 	adaptertest.CheckSetupTerminalForms(t, setupSkillPath)
 }
 
+func TestSetupSkillPagesLargeOptionSets(t *testing.T) {
+	adaptertest.CheckSetupOptionPagination(t, setupSkillPath)
+}
+
 func TestDeliverySkillHasRoutedSelectionCue(t *testing.T) {
 	adaptertest.CheckRoutedSelectionCue(t, deliverySkillPath)
 }

--- a/adapters/claude/skills/orch-setup/SKILL.md
+++ b/adapters/claude/skills/orch-setup/SKILL.md
@@ -37,9 +37,10 @@ its own. Never send a partial or incremental update.
 
 ### `kind: "questions"`
 
-`Document.questions` carries 1–4 independent `Question`s. Present them
-as **one** batched `AskUserQuestion` call — the schema guarantees at
-most 4, so a single call always fits.
+`Document.questions` carries 1–4 independent `Question`s. When every question
+has at most four options, present them as **one** batched `AskUserQuestion`
+call. If any question has more than four options, handle the document in order
+with one-question calls and page that oversized question as described below.
 
 For each question, use its `header` and `prompt` as the
 `AskUserQuestion` header/prompt, and list its `options[]` with each
@@ -52,6 +53,15 @@ of the matching option too.
 When the human answers, record `answers[question.id] = option.value`
 — **the option's `value`, never its `label`**. The label is display
 text only; the value is what the core expects back.
+
+For a question with more than four options, keep every option selectable through
+`AskUserQuestion`: show up to three real options plus `Next choices` on the first
+page; on middle pages show `Previous choices`, up to two real options, and `Next
+choices`; on the final page show `Previous choices` plus up to three real
+options. Navigation choices only move between pages — never record a navigation
+choice in the `AnswerSet`. Record an answer only when the human picks a real
+option, using its original `value`. Never replace catalog options with an
+instruction to type or copy an identifier manually.
 
 If a question has `kind: "text"`, or `free_text: true` on a `select`
 question, it never carries meaningful options for that path:

--- a/adapters/codex/plugin_test.go
+++ b/adapters/codex/plugin_test.go
@@ -276,6 +276,10 @@ func TestSetupSkillHasTerminalForms(t *testing.T) {
 	adaptertest.CheckSetupTerminalForms(t, setupSkillPath)
 }
 
+func TestSetupSkillPagesLargeOptionSets(t *testing.T) {
+	adaptertest.CheckSetupOptionPagination(t, setupSkillPath)
+}
+
 func TestDeliverySkillHasRoutedSelectionCue(t *testing.T) {
 	adaptertest.CheckRoutedSelectionCue(t, deliverySkillPath)
 }

--- a/adapters/codex/skills/orch-setup/SKILL.md
+++ b/adapters/codex/skills/orch-setup/SKILL.md
@@ -57,6 +57,15 @@ When the human answers, record `answers[question.id] = option.value`
 — **the option's `value`, never its `label`**. The label is display
 text only; the value is what the core expects back.
 
+For a question with more than four options, keep every option selectable through
+`request_user_input`: show up to three real options plus `Next choices` on the
+first page; on middle pages show `Previous choices`, up to two real options, and
+`Next choices`; on the final page show `Previous choices` plus up to three real
+options. Navigation choices only move between pages — never record a navigation
+choice in the `AnswerSet`. Record an answer only when the human picks a real
+option, using its original `value`. Never replace catalog options with an
+instruction to type or copy an identifier manually.
+
 If a `select` question has `free_text: true`, it still carries real
 options — present them through `request_user_input` exactly as above,
 and append one extra option, label `Other — enter a custom value`, as

--- a/adapters/opencode/plugin_test.go
+++ b/adapters/opencode/plugin_test.go
@@ -103,6 +103,10 @@ func TestSetupSkillHasTerminalForms(t *testing.T) {
 	adaptertest.CheckSetupTerminalForms(t, setupSkillPath)
 }
 
+func TestSetupSkillPagesLargeOptionSets(t *testing.T) {
+	adaptertest.CheckSetupOptionPagination(t, setupSkillPath)
+}
+
 func TestDeliverySkillHasRoutedSelectionCue(t *testing.T) {
 	adaptertest.CheckOpenCodeRoutedSelectionCue(t, deliverySkillPath)
 }

--- a/adapters/opencode/skills/orch-setup/SKILL.md
+++ b/adapters/opencode/skills/orch-setup/SKILL.md
@@ -50,6 +50,15 @@ When the human answers, record `answers[question.id] = option.value`
 — **the option's `value`, never its `label`**. The label is display
 text only; the value is what the core expects back.
 
+For a question with more than four options, keep every option selectable through
+the `question` tool: show up to three real options plus `Next choices` on the
+first page; on middle pages show `Previous choices`, up to two real options, and
+`Next choices`; on the final page show `Previous choices` plus up to three real
+options. Navigation choices only move between pages — never record a navigation
+choice in the `AnswerSet`. Record an answer only when the human picks a real
+option, using its original `value`. Never replace catalog options with an
+instruction to type or copy an identifier manually.
+
 If a `select` question has `free_text: true`, present its real options exactly
 as above. OpenCode adds its own custom-answer choice; when the human uses it,
 record what they type verbatim as `answers[question.id]` — do not transform or

--- a/internal/adaptertest/adaptertest.go
+++ b/internal/adaptertest/adaptertest.go
@@ -284,6 +284,24 @@ func CheckSetupTerminalForms(t *testing.T, setupSkillPath string) {
 	}
 }
 
+// CheckSetupOptionPagination pins the native-dialog paging contract that keeps
+// catalog-backed questions with more than four options fully selectable.
+func CheckSetupOptionPagination(t *testing.T, setupSkillPath string) {
+	t.Helper()
+	content := normalizeWhitespace(readFile(t, setupSkillPath))
+	for _, phrase := range []string{
+		"more than four options",
+		"Next choices",
+		"Previous choices",
+		"never record a navigation choice",
+		"Never replace catalog options with an instruction to type or copy an identifier manually",
+	} {
+		if !strings.Contains(content, normalizeWhitespace(phrase)) {
+			t.Errorf("%s does not contain setup option-pagination guidance %q", setupSkillPath, phrase)
+		}
+	}
+}
+
 // portabilityForbidden are shell metacharacters a bare-argv hook command
 // must never contain: hook commands run directly as argv on every OS,
 // no shell interposed, so a shell-syntax command would work nowhere.

--- a/internal/cli/configurelocal.go
+++ b/internal/cli/configurelocal.go
@@ -142,7 +142,8 @@ func runConfigureLocalStep(env Env) error {
 		return err
 	}
 
-	doc, err := interview.NextConfigureLocal(answers.Answers, env.RepoRoot)
+	facts := initDetect(env)
+	doc, err := interview.NextConfigureLocalWithFacts(facts, answers.Answers, env.RepoRoot)
 	if err != nil {
 		return err
 	}
@@ -177,7 +178,8 @@ func runConfigureLocalApply(env Env) error {
 		return err
 	}
 
-	doc, err := interview.NextConfigureLocal(answers.Answers, env.RepoRoot)
+	facts := initDetect(env)
+	doc, err := interview.NextConfigureLocalWithFacts(facts, answers.Answers, env.RepoRoot)
 	if err != nil {
 		return err
 	}

--- a/internal/interview/configure.go
+++ b/internal/interview/configure.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kninetimmy/orch/internal/config"
 	"github.com/kninetimmy/orch/internal/instructions"
+	"github.com/kninetimmy/orch/internal/opencode"
 	"github.com/kninetimmy/orch/internal/question"
 )
 
@@ -81,7 +82,7 @@ func NextConfigure(facts Facts, answers map[string]string, repoRoot string) (que
 // nextAfterSequenceConfigure handles NextConfigure's tail, mirroring
 // nextAfterSequence's approval/summary/complete shape.
 func nextAfterSequenceConfigure(facts Facts, committed *config.Config, committedRaw []byte, answers map[string]string, repoRoot string) (question.Document, error) {
-	cfg, err := materializeConfigure(committed, answers)
+	cfg, err := materializeConfigure(committed, answers, facts.OpenCodeCatalog)
 	if err != nil {
 		return question.Document{}, err
 	}
@@ -230,9 +231,17 @@ func buildSequenceConfigure(facts Facts, committed *config.Config, answers map[s
 		showExplain := !claudeEnabled && !codexEnabled
 		switch {
 		case !openCommitted:
-			docs = append(docs, roleDocSpecs("opencode", showExplain, defaultProfileFor("opencode"))...)
+			openDocs, err := openCodeRoleDocSpecs(facts, showExplain, defaultProfileFor("opencode"), answers, false)
+			if err != nil {
+				return nil, err
+			}
+			docs = append(docs, openDocs...)
 		case answers[idPickRolesOpenCode] == "yes":
-			docs = append(docs, roleDocSpecs("opencode", showExplain, committedRoleDefaults("opencode", committedHostConfig(committed, "opencode")))...)
+			openDocs, err := openCodeRoleDocSpecs(facts, showExplain, committedRoleDefaults("opencode", committedHostConfig(committed, "opencode")), answers, true)
+			if err != nil {
+				return nil, err
+			}
+			docs = append(docs, openDocs...)
 		}
 	}
 
@@ -408,7 +417,7 @@ func deepCopyConfig(committed *config.Config) *config.Config {
 // (setRoleProfile/validateModelFreeText) init's own materializeHost
 // already owns; otherwise host's already-deep-copied value (nil or the
 // committed profile) is left untouched.
-func applyHostConfigure(cfg *config.Config, host string, answers map[string]string) error {
+func applyHostConfigure(cfg *config.Config, host string, answers map[string]string, catalog opencode.Catalog) error {
 	toggleVal, toggleKnown := answers[hostEnabledID(host)]
 	_, hasRoleAnswers := answers[roleModelID(host, "architect")]
 
@@ -416,7 +425,7 @@ func applyHostConfigure(cfg *config.Config, host string, answers map[string]stri
 	case toggleKnown && toggleVal == "no":
 		setConfigHost(cfg, host, nil)
 	case hasRoleAnswers:
-		h, err := materializeHost(host, answers, committedHostConfig(cfg, host))
+		h, err := materializeHost(host, answers, committedHostConfig(cfg, host), catalog)
 		if err != nil {
 			return err
 		}
@@ -431,11 +440,11 @@ func applyHostConfigure(cfg *config.Config, host string, answers map[string]stri
 // settings), a recomputed Revision, and a Render/Parse round-trip
 // self-check — the same discipline materialize applies to a fresh
 // init configuration.
-func materializeConfigure(committed *config.Config, answers map[string]string) (*config.Config, error) {
+func materializeConfigure(committed *config.Config, answers map[string]string, catalog opencode.Catalog) (*config.Config, error) {
 	cfg := deepCopyConfig(committed)
 
 	for _, host := range []string{"claude", "codex", "opencode"} {
-		if err := applyHostConfigure(cfg, host, answers); err != nil {
+		if err := applyHostConfigure(cfg, host, answers, catalog); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/interview/configure_test.go
+++ b/internal/interview/configure_test.go
@@ -222,7 +222,7 @@ func TestGoldenTranscriptConfigureMergeAndModel(t *testing.T) {
 func TestGoldenTranscriptConfigureOpenCodeRoleModels(t *testing.T) {
 	root := t.TempDir()
 	writeCommittedConfigOpenCodeOnly(t, root)
-	doc, err := NextConfigure(configureFacts(), map[string]string{
+	doc, err := NextConfigure(withOpenCodeTestCatalog(configureFacts()), map[string]string{
 		idPickHosts:         "no",
 		idPickRolesOpenCode: "yes",
 		idPickSettings:      "no",
@@ -241,7 +241,7 @@ func openCodeConfigureSummary(t *testing.T, root string, overrides map[string]st
 		idPickSettings:      "no",
 	}
 	for i := 0; i < 100; i++ {
-		doc, err := NextConfigure(configureFacts(), answers, root)
+		doc, err := NextConfigure(withOpenCodeTestCatalog(configureFacts()), answers, root)
 		if err != nil {
 			t.Fatalf("NextConfigure: %v", err)
 		}

--- a/internal/interview/configurelocal.go
+++ b/internal/interview/configurelocal.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/kninetimmy/orch/internal/config"
 	"github.com/kninetimmy/orch/internal/instructions"
 	"github.com/kninetimmy/orch/internal/metrics"
+	"github.com/kninetimmy/orch/internal/opencode"
 	"github.com/kninetimmy/orch/internal/question"
 )
 
@@ -78,13 +80,10 @@ func buildPreferenceKeySet() map[string]bool {
 	return set
 }
 
-// NextConfigureLocal derives the next document for the `orch
-// configure-local` interview (PRD §17). Unlike Next it carries no
-// Facts: every default comes from the committed configuration and the
-// current config.local.toml on disk, never the environment, so both
-// are read up front — before any question is asked, not only once the
-// sequence completes the way Next's own repoRoot use is scoped
-// (documented deviation from the init precedent).
+// NextConfigureLocal derives the next document without detected host facts.
+// It remains the compatibility entry point for callers that edit only
+// non-OpenCode areas; OpenCode role edits fail with the same actionable catalog
+// error as a real detection failure. CLI callers use NextConfigureLocalWithFacts.
 //
 // Question IDs equal the exact current writer keys config.EditablePreferenceKeys
 // enumerates (the picker's own pick.* ids aside), so an adapter's
@@ -94,6 +93,13 @@ func buildPreferenceKeySet() map[string]bool {
 // committed configuration exists yet — configure-local overlays onto
 // it and has nothing to seed from otherwise.
 func NextConfigureLocal(answers map[string]string, repoRoot string) (question.Document, error) {
+	return NextConfigureLocalWithFacts(Facts{}, answers, repoRoot)
+}
+
+// NextConfigureLocalWithFacts derives the configure-local document using the
+// live OpenCode catalog while keeping all ordinary defaults sourced from the
+// committed configuration and config.local.toml.
+func NextConfigureLocalWithFacts(facts Facts, answers map[string]string, repoRoot string) (question.Document, error) {
 	if answers == nil {
 		answers = map[string]string{}
 	}
@@ -108,7 +114,10 @@ func NextConfigureLocal(answers map[string]string, repoRoot string) (question.Do
 	}
 	seeded := seedOverrides(committed, localRaw)
 
-	seq := buildSequenceLocal(committed, seeded, answers)
+	seq, err := buildSequenceLocal(facts, committed, seeded, answers)
+	if err != nil {
+		return question.Document{}, err
+	}
 	complete := allDocsAnswered(seq, answers)
 
 	applicable := applicableQuestions(seq, complete)
@@ -127,13 +136,13 @@ func NextConfigureLocal(answers map[string]string, repoRoot string) (question.Do
 		}
 	}
 
-	return nextAfterSequenceLocal(committed, seeded, answers, repoRoot)
+	return nextAfterSequenceLocal(committed, seeded, answers, repoRoot, facts.OpenCodeCatalog)
 }
 
 // nextAfterSequenceLocal handles NextConfigureLocal's tail, mirroring
 // nextAfterSequence's approval/summary/complete shape.
-func nextAfterSequenceLocal(committed *config.Config, seeded map[string]string, answers map[string]string, repoRoot string) (question.Document, error) {
-	overrides, err := materializeLocal(committed, seeded, answers)
+func nextAfterSequenceLocal(committed *config.Config, seeded map[string]string, answers map[string]string, repoRoot string, catalog opencode.Catalog) (question.Document, error) {
+	overrides, err := materializeLocal(committed, seeded, answers, catalog)
 	if err != nil {
 		return question.Document{}, err
 	}
@@ -409,10 +418,10 @@ func pickIDForHost(host string) string {
 // buildSequenceLocal derives the ordered list of "questions"-kind
 // documents for the current answers: the picker (doc 1, always
 // present), then each picked host's six role docs (roleSpecs order),
-// then the settings doc when picked. Unlike buildSequence there is no
-// error case here — configure-local never disables a host, so no
-// "at least one host enabled" rule is ever at risk.
-func buildSequenceLocal(committed *config.Config, seeded map[string]string, answers map[string]string) []docSpec {
+// then the settings doc when picked. It can fail only when an OpenCode role
+// edit needs an unavailable catalog; configure-local never disables a host, so
+// no "at least one host enabled" rule is at risk.
+func buildSequenceLocal(facts Facts, committed *config.Config, seeded map[string]string, answers map[string]string) ([]docSpec, error) {
 	docs := []docSpec{pickerDocLocal(committed, seeded)}
 
 	if committed.Hosts.Claude != nil && answers[idPickClaude] == "yes" {
@@ -422,12 +431,16 @@ func buildSequenceLocal(committed *config.Config, seeded map[string]string, answ
 		docs = append(docs, localRoleDocSpecs("codex", committed, seeded)...)
 	}
 	if committed.Hosts.OpenCode != nil && answers[idPickOpenCode] == "yes" {
-		docs = append(docs, localRoleDocSpecs("opencode", committed, seeded)...)
+		openDocs, err := localOpenCodeRoleDocSpecs(facts, committed, seeded, answers)
+		if err != nil {
+			return nil, err
+		}
+		docs = append(docs, openDocs...)
 	}
 	if answers[idPickSettings] == "yes" {
 		docs = append(docs, localSettingsDoc(committed, seeded))
 	}
-	return docs
+	return docs, nil
 }
 
 // pickerDocLocal is doc 1: whether to review/change each
@@ -506,9 +519,10 @@ func effectiveValue(seeded map[string]string, key, committedValue string) string
 	return committedValue
 }
 
-// localRoleDocSpecs builds host's six per-role documents (model plus effort
-// for Claude/Codex, or model plus optional variant for OpenCode), paired in
-// roleSpecs order for the configure-local interview. Question
+// localRoleDocSpecs builds Claude or Codex's six per-role model-plus-effort
+// documents, paired in roleSpecs order for the configure-local interview.
+// OpenCode uses localOpenCodeRoleDocSpecs so variants follow the selected
+// catalog model. Question
 // IDs are the true overlay dotted keys, options mark the committed
 // value's option "(committed)" in its Label and the effective-current
 // value Recommended, and Default is always the effective-current value
@@ -532,49 +546,71 @@ func localRoleDocSpecs(host string, committed *config.Config, seeded map[string]
 			FreeText: true,
 			Default:  effectiveModel,
 		}
-		profileQ := localProfileQuestion(host, rs, cp, seeded)
+		effortKey := localRoleEffortID(host, rs.key)
+		effectiveEffort := effectiveValue(seeded, effortKey, cp.Effort)
+		profileQ := question.Question{
+			ID: effortKey, Header: rs.header, Prompt: fmt.Sprintf("%s reasoning effort (%s)", rs.label, hostLabels[host]),
+			Kind: question.KindSelect, Options: effortOptionsLocal(host, cp.Effort, effectiveEffort), FreeText: true, Default: effectiveEffort,
+		}
 		docs = append(docs, docSpec{questions: []question.Question{modelQ, profileQ}})
 	}
 	return docs
 }
 
-func localProfileQuestion(host string, rs roleSpec, committed config.RoleProfile, seeded map[string]string) question.Question {
-	if host != "opencode" {
-		key := localRoleEffortID(host, rs.key)
-		effective := effectiveValue(seeded, key, committed.Effort)
-		return question.Question{
-			ID: key, Header: rs.header, Prompt: fmt.Sprintf("%s reasoning effort (%s)", rs.label, hostLabels[host]),
-			Kind: question.KindSelect, Options: effortOptionsLocal(host, committed.Effort, effective), FreeText: true, Default: effective,
+func localOpenCodeRoleDocSpecs(facts Facts, committed *config.Config, seeded, answers map[string]string) ([]docSpec, error) {
+	if err := requireOpenCodeCatalog(facts); err != nil {
+		return nil, err
+	}
+	h := committed.Hosts.OpenCode
+	docs := make([]docSpec, 0, len(roleSpecs)*2)
+	for _, rs := range roleSpecs {
+		cp := committedProfile(h, rs.key)
+		modelKey := localRoleModelID("opencode", rs.key)
+		effectiveModel := effectiveValue(seeded, modelKey, cp.Model)
+		defModel := effectiveModel
+		if _, advertised := openCodeCatalogModel(facts.OpenCodeCatalog, defModel); !advertised && defModel != cp.Model {
+			defModel = cp.Model
 		}
-	}
-	key := localRoleVariantID(rs.key)
-	committedVariant := committed.EffectiveOpenCodeVariant()
-	effective := committedVariant
-	if legacy, ok := seeded[localRoleEffortID(host, rs.key)]; ok {
-		effective = legacy
-	}
-	if variant, ok := seeded[key]; ok {
-		effective = variant
-	}
-	return question.Question{
-		ID: key, Header: rs.header, Prompt: fmt.Sprintf("%s model variant (%s)", rs.label, hostLabels[host]),
-		Kind: question.KindSelect, Options: variantOptionsLocal(committedVariant, effective), FreeText: true, Default: variantAnswer(effective),
-	}
-}
+		modelOpts := openCodeModelOptions(facts.OpenCodeCatalog, defModel, cp.Model)
+		for i := range modelOpts {
+			if modelOpts[i].Value == cp.Model {
+				modelOpts[i].Label += " (committed)"
+			}
+		}
+		modelQ := question.Question{
+			ID: modelKey, Header: rs.header, Prompt: fmt.Sprintf("%s model (%s)", rs.label, hostLabels["opencode"]),
+			Kind: question.KindSelect, Options: modelOpts, Default: defModel,
+		}
+		docs = append(docs, docSpec{questions: []question.Question{modelQ}})
 
-func variantOptionsLocal(committed, effective string) []question.Option {
-	values := variantOptionValues(committed, effective)
-	effective = variantAnswer(effective)
-	committed = variantAnswer(committed)
-	opts := make([]question.Option, len(values))
-	for i, value := range values {
-		label := value
-		if value == committed {
-			label += " (committed)"
+		selected, answered := answers[modelKey]
+		model, advertised := openCodeCatalogModel(facts.OpenCodeCatalog, selected)
+		if !answered || !advertised || len(model.Variants) == 0 {
+			continue
 		}
-		opts[i] = question.Option{Value: value, Label: label, Recommended: value == effective}
+		effectiveVariant := cp.EffectiveOpenCodeVariant()
+		if legacy, ok := seeded[localRoleEffortID("opencode", rs.key)]; ok {
+			effectiveVariant = legacy
+		}
+		if variant, ok := seeded[localRoleVariantID(rs.key)]; ok {
+			effectiveVariant = variant
+		}
+		preferredVariant := cp.EffectiveOpenCodeVariant()
+		if defModel == effectiveModel {
+			preferredVariant = effectiveVariant
+		}
+		defVariant := ""
+		if selected == defModel && slices.Contains(model.Variants, preferredVariant) {
+			defVariant = preferredVariant
+		}
+		committedVariant := ""
+		if selected == cp.Model && slices.Contains(model.Variants, cp.EffectiveOpenCodeVariant()) {
+			committedVariant = cp.EffectiveOpenCodeVariant()
+		}
+		variantQ := openCodeVariantQuestion(localRoleVariantID(rs.key), rs, model.Variants, defVariant, committedVariant)
+		docs = append(docs, docSpec{questions: []question.Question{variantQ}})
 	}
-	return opts
+	return docs, nil
 }
 
 // modelOptionsLocal lists host's local-override-selectable models,
@@ -695,7 +731,7 @@ func yesNoLabelLocal(label, value, committedVal string) string {
 // result round-trips through config.RenderLocal and config.MergeLocal
 // as a fail-closed self-check — the same anti-forgery discipline
 // materialize's Render/Parse round trip applies to init.
-func materializeLocal(committed *config.Config, seeded map[string]string, answers map[string]string) (map[string]string, error) {
+func materializeLocal(committed *config.Config, seeded map[string]string, answers map[string]string, catalog opencode.Catalog) (map[string]string, error) {
 	overrides := make(map[string]string, len(seeded))
 	for k, v := range seeded {
 		overrides[k] = v
@@ -705,7 +741,7 @@ func materializeLocal(committed *config.Config, seeded map[string]string, answer
 		if answers[pickIDForHost(host)] != "yes" {
 			continue
 		}
-		if err := applyRoleAnswers(committed, host, answers, overrides); err != nil {
+		if err := applyRoleAnswers(committed, host, answers, overrides, catalog); err != nil {
 			return nil, err
 		}
 	}
@@ -735,7 +771,7 @@ func materializeLocal(committed *config.Config, seeded map[string]string, answer
 // question defaulted to — the override overrides already carries for
 // that key, or the committed value when it carries none — so leaving a
 // near-miss default alone is not treated as newly typing it.
-func applyRoleAnswers(committed *config.Config, host string, answers, overrides map[string]string) error {
+func applyRoleAnswers(committed *config.Config, host string, answers, overrides map[string]string, catalog opencode.Catalog) error {
 	h := committedHostConfig(committed, host)
 	for _, rs := range roleSpecs {
 		modelKey := localRoleModelID(host, rs.key)
@@ -752,7 +788,12 @@ func applyRoleAnswers(committed *config.Config, host string, answers, overrides 
 		if host == "opencode" {
 			effortKey := localRoleEffortID(host, rs.key)
 			variantKey := localRoleVariantID(rs.key)
-			variant := answers[variantKey]
+			variant, answered := answers[variantKey]
+			if !answered {
+				if _, advertised := openCodeCatalogModel(catalog, modelVal); !advertised && modelVal == current {
+					continue
+				}
+			}
 			if variant == noVariantAnswer {
 				variant = ""
 			}

--- a/internal/interview/configurelocal_test.go
+++ b/internal/interview/configurelocal_test.go
@@ -204,7 +204,7 @@ func TestGoldenTranscriptLocalFlagship(t *testing.T) {
 func TestGoldenTranscriptLocalOpenCodeRoleModels(t *testing.T) {
 	root := t.TempDir()
 	writeCommittedConfigOpenCodeOnly(t, root)
-	doc, err := NextConfigureLocal(map[string]string{
+	doc, err := NextConfigureLocalWithFacts(withOpenCodeTestCatalog(Facts{}), map[string]string{
 		idPickOpenCode: "yes",
 		idPickSettings: "no",
 	}, root)
@@ -474,8 +474,11 @@ func TestConfigureLocalLeafIDsMatchEditablePreferenceKeys(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	openCode := *committed.Hosts.Codex
-	committed.Hosts.OpenCode = &openCode
+	openCode, err := materialize(openCodeOnlyAnswers())
+	if err != nil {
+		t.Fatal(err)
+	}
+	committed.Hosts.OpenCode = openCode.Hosts.OpenCode
 	committed.ConfigRevision, err = config.Revision(committed)
 	if err != nil {
 		t.Fatal(err)
@@ -491,7 +494,7 @@ func TestConfigureLocalLeafIDsMatchEditablePreferenceKeys(t *testing.T) {
 	answers := map[string]string{}
 	seen := map[string]bool{}
 	for i := 0; i < 100; i++ {
-		doc, err := NextConfigureLocal(answers, root)
+		doc, err := NextConfigureLocalWithFacts(withOpenCodeTestCatalog(Facts{}), answers, root)
 		if err != nil {
 			t.Fatalf("NextConfigureLocal: %v", err)
 		}
@@ -528,7 +531,7 @@ func TestConfigureLocalLeafIDsMatchEditablePreferenceKeys(t *testing.T) {
 }
 
 func TestVariantOptionsKeepCommittedAndEffectiveValues(t *testing.T) {
-	opts := variantOptionsLocal("high", "machine-choice")
+	opts := openCodeVariantQuestion(localRoleVariantID("architect"), roleSpecs[0], []string{"high", "machine-choice"}, "machine-choice", "high").Options
 	seen := map[string]bool{}
 	recommended := ""
 	committedLabel := ""

--- a/internal/interview/errors.go
+++ b/internal/interview/errors.go
@@ -26,4 +26,8 @@ var (
 	// containing whitespace or shortening a known model id, or a
 	// concurrency value that is not an integer >= 1.
 	ErrBadAnswer = errors.New("answer fails its semantic validation")
+	// ErrOpenCodeCatalogUnavailable reports an attempt to edit OpenCode role
+	// selections without a usable project-scoped model catalog. Unrelated
+	// configuration areas remain editable because they never need the catalog.
+	ErrOpenCodeCatalogUnavailable = errors.New("OpenCode model catalog is unavailable")
 )

--- a/internal/interview/interview.go
+++ b/internal/interview/interview.go
@@ -98,7 +98,7 @@ func Next(facts Facts, answers map[string]string, repoRoot string) (question.Doc
 // (seedFiles over initSeedScope, seed.go) are the same ones
 // buildSequence derived from the host toggles.
 func nextAfterSequence(facts Facts, answers map[string]string, repoRoot string) (question.Document, error) {
-	cfg, err := materialize(answers)
+	cfg, err := materializeWithCatalog(answers, facts.OpenCodeCatalog)
 	if err != nil {
 		return question.Document{}, err
 	}

--- a/internal/interview/interview_test.go
+++ b/internal/interview/interview_test.go
@@ -97,7 +97,7 @@ func TestGoldenTranscriptBothHosts(t *testing.T) {
 }
 
 func TestGoldenTranscriptOpenCodeRoleModels(t *testing.T) {
-	doc, err := Next(Facts{OpenCodeCLI: true}, map[string]string{
+	doc, err := Next(withOpenCodeTestCatalog(Facts{}), map[string]string{
 		idHostClaudeEnabled:   "no",
 		idHostCodexEnabled:    "no",
 		idHostOpenCodeEnabled: "yes",

--- a/internal/interview/materialize.go
+++ b/internal/interview/materialize.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/opencode"
 )
 
 // materialize turns a complete answer set into a validated, revisioned
@@ -26,24 +27,28 @@ import (
 // config deliberately does not export) are enforced this way rather
 // than duplicated here.
 func materialize(answers map[string]string) (*config.Config, error) {
+	return materializeWithCatalog(answers, opencode.Catalog{})
+}
+
+func materializeWithCatalog(answers map[string]string, catalog opencode.Catalog) (*config.Config, error) {
 	cfg := &config.Config{SchemaVersion: 1}
 
 	if answers[idHostClaudeEnabled] == "yes" {
-		host, err := materializeHost("claude", answers, nil)
+		host, err := materializeHost("claude", answers, nil, catalog)
 		if err != nil {
 			return nil, err
 		}
 		cfg.Hosts.Claude = host
 	}
 	if answers[idHostCodexEnabled] == "yes" {
-		host, err := materializeHost("codex", answers, nil)
+		host, err := materializeHost("codex", answers, nil, catalog)
 		if err != nil {
 			return nil, err
 		}
 		cfg.Hosts.Codex = host
 	}
 	if answers[idHostOpenCodeEnabled] == "yes" {
-		host, err := materializeHost("opencode", answers, nil)
+		host, err := materializeHost("opencode", answers, nil, catalog)
 		if err != nil {
 			return nil, err
 		}
@@ -84,7 +89,7 @@ func materialize(answers map[string]string) (*config.Config, error) {
 // committed near-miss model still round-trips (validateModelAnswer);
 // it is nil for init and for any host a session newly enables, neither
 // of which has a committed profile to leave alone.
-func materializeHost(host string, answers map[string]string, current *config.Host) (*config.Host, error) {
+func materializeHost(host string, answers map[string]string, current *config.Host, catalog opencode.Catalog) (*config.Host, error) {
 	var roles config.Roles
 	for _, rs := range roleSpecs {
 		modelID := roleModelID(host, rs.key)
@@ -94,9 +99,21 @@ func materializeHost(host string, answers map[string]string, current *config.Hos
 		}
 		profile := config.RoleProfile{Model: model}
 		if host == "opencode" {
-			profile.Variant = answers[roleVariantID(host, rs.key)]
-			if profile.Variant == noVariantAnswer {
-				profile.Variant = ""
+			variant, answered := answers[roleVariantID(host, rs.key)]
+			switch {
+			case answered:
+				profile.Variant = variant
+				if profile.Variant == noVariantAnswer {
+					profile.Variant = ""
+				}
+			case current != nil:
+				previous := committedProfile(current, rs.key)
+				if previous.Model == model {
+					if _, advertised := openCodeCatalogModel(catalog, model); !advertised {
+						profile.Effort = previous.Effort
+						profile.Variant = previous.Variant
+					}
+				}
 			}
 		} else {
 			profile.Effort = answers[roleEffortID(host, rs.key)]

--- a/internal/interview/opencode_catalog_test.go
+++ b/internal/interview/opencode_catalog_test.go
@@ -1,0 +1,281 @@
+package interview
+
+import (
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/config"
+	"github.com/kninetimmy/orch/internal/question"
+)
+
+func questionByID(t *testing.T, doc question.Document, id string) question.Question {
+	t.Helper()
+	for _, q := range doc.Questions {
+		if q.ID == id {
+			return q
+		}
+	}
+	t.Fatalf("question %s not found in %+v", id, doc.Questions)
+	return question.Question{}
+}
+
+func optionValuesOf(q question.Question) []string {
+	values := make([]string, len(q.Options))
+	for i, option := range q.Options {
+		values[i] = option.Value
+	}
+	return values
+}
+
+func TestOpenCodeInitOffersEveryCatalogModelWithoutStaticFallbacks(t *testing.T) {
+	facts := withOpenCodeTestCatalog(Facts{})
+	doc, err := Next(facts, map[string]string{
+		idHostClaudeEnabled: "no", idHostCodexEnabled: "no", idHostOpenCodeEnabled: "yes",
+	}, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := questionByID(t, doc, roleModelID("opencode", "architect"))
+	got := optionValuesOf(q)
+	for _, model := range facts.OpenCodeCatalog.Models {
+		if !slices.Contains(got, model.ID) {
+			t.Errorf("model options %v omit catalog model %q", got, model.ID)
+		}
+	}
+	if len(got) != len(facts.OpenCodeCatalog.Models) {
+		t.Errorf("model options = %v, want exactly the %d catalog models", got, len(facts.OpenCodeCatalog.Models))
+	}
+	if slices.Contains(got, "opencode/x-preview-f-free") || q.FreeText {
+		t.Errorf("catalog model question retained stale/manual choices: %+v", q)
+	}
+	if len(q.Options) <= 4 {
+		t.Fatalf("fixture has %d options, want a catalog large enough to exercise native pagination", len(q.Options))
+	}
+	if err := question.SpecCheck(q); err != nil {
+		t.Fatalf("large catalog question failed SpecCheck: %v", err)
+	}
+}
+
+func TestOpenCodeVariantsFollowTheSelectedModel(t *testing.T) {
+	facts := withOpenCodeTestCatalog(Facts{})
+	answers := map[string]string{
+		idHostClaudeEnabled: "no", idHostCodexEnabled: "no", idHostOpenCodeEnabled: "yes",
+		roleModelID("opencode", "architect"): "anthropic/claude-sonnet-5",
+	}
+	doc, err := Next(facts, answers, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := questionByID(t, doc, roleVariantID("opencode", "architect"))
+	if got, want := optionValuesOf(q), []string{noVariantAnswer, "fast", "max"}; !slices.Equal(got, want) {
+		t.Errorf("variant options = %v, want %v", got, want)
+	}
+	if q.FreeText {
+		t.Error("variant question admits an unadvertised free-text value")
+	}
+
+	answers[q.ID] = "xhigh"
+	if _, err := Next(facts, answers, t.TempDir()); err == nil || !strings.Contains(err.Error(), "not one of") {
+		t.Fatalf("unadvertised variant error = %v", err)
+	}
+}
+
+func TestOpenCodeModelWithoutVariantsNeedsNoSuffixQuestion(t *testing.T) {
+	facts := withOpenCodeTestCatalog(Facts{})
+	root := t.TempDir()
+	answers := map[string]string{
+		idHostClaudeEnabled: "no", idHostCodexEnabled: "no", idHostOpenCodeEnabled: "yes",
+	}
+	for i := 0; i < 100; i++ {
+		doc, err := Next(facts, answers, root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if doc.Kind == question.DocSummary {
+			cfg, err := config.Parse([]byte(doc.Summary.ConfigTOML))
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, rs := range roleSpecs {
+				profile := committedProfile(cfg.Hosts.OpenCode, rs.key)
+				if profile.Model != "github-copilot/gpt-5-mini" || profile.EffectiveOpenCodeVariant() != "" {
+					t.Errorf("%s profile = %+v, want bare github-copilot/gpt-5-mini", rs.key, profile)
+				}
+			}
+			return
+		}
+		if doc.Kind != question.DocQuestions {
+			t.Fatalf("unexpected document kind %q", doc.Kind)
+		}
+		for _, q := range doc.Questions {
+			if strings.Contains(q.ID, "host.opencode.role") && strings.HasSuffix(q.ID, ".model") {
+				if len(q.Options) != len(facts.OpenCodeCatalog.Models) {
+					t.Errorf("%s offers %d models, want all %d", q.ID, len(q.Options), len(facts.OpenCodeCatalog.Models))
+				}
+				answers[q.ID] = "github-copilot/gpt-5-mini"
+				continue
+			}
+			if strings.Contains(q.ID, "host.opencode.role") && strings.HasSuffix(q.ID, ".variant") {
+				t.Fatalf("no-variant model unexpectedly produced question %s", q.ID)
+			}
+			answers[q.ID] = q.Default
+		}
+	}
+	t.Fatal("OpenCode no-variant interview did not reach summary")
+}
+
+func TestConfigurePreservesOpenCodeRolesWithoutCatalogForUnrelatedEdit(t *testing.T) {
+	root := t.TempDir()
+	committed := writeCommittedConfigOpenCodeOnly(t, root)
+	answers := map[string]string{}
+	for i := 0; i < 100; i++ {
+		doc, err := NextConfigure(Facts{}, answers, root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if doc.Kind == question.DocSummary {
+			got, err := config.Parse([]byte(doc.Summary.ConfigTOML))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Hosts.OpenCode == nil || got.Hosts.OpenCode.Roles != committed.Hosts.OpenCode.Roles {
+				t.Errorf("OpenCode roles changed without catalog: got %+v want %+v", got.Hosts.OpenCode, committed.Hosts.OpenCode)
+			}
+			if got.Merge.Strategy != "rebase" {
+				t.Errorf("merge strategy = %q, want unrelated edit to land", got.Merge.Strategy)
+			}
+			return
+		}
+		for _, q := range doc.Questions {
+			switch q.ID {
+			case idPickSettings:
+				answers[q.ID] = "yes"
+			case idMergeStrategy:
+				answers[q.ID] = "rebase"
+			default:
+				answers[q.ID] = q.Default
+			}
+		}
+	}
+	t.Fatal("configure did not reach summary")
+}
+
+func TestOpenCodeRoleEditsFailClearlyWithoutCatalog(t *testing.T) {
+	root := t.TempDir()
+	writeCommittedConfigOpenCodeOnly(t, root)
+	facts := Facts{OpenCodeCLI: true, OpenCodeCatalogError: "safe discovery failure; retry"}
+	_, err := Next(facts, map[string]string{
+		idHostClaudeEnabled: "no", idHostCodexEnabled: "no", idHostOpenCodeEnabled: "yes",
+	}, root)
+	if !errors.Is(err, ErrOpenCodeCatalogUnavailable) || !strings.Contains(err.Error(), "safe discovery failure") {
+		t.Fatalf("init catalog error = %v", err)
+	}
+
+	configureAnswers := map[string]string{idPickHosts: "no", idPickRolesOpenCode: "yes", idPickSettings: "no"}
+	_, err = NextConfigure(facts, configureAnswers, root)
+	if !errors.Is(err, ErrOpenCodeCatalogUnavailable) || !strings.Contains(err.Error(), "safe discovery failure") || !strings.Contains(err.Error(), "cannot be edited") {
+		t.Fatalf("configure catalog error = %v", err)
+	}
+
+	_, err = NextConfigureLocal(map[string]string{idPickOpenCode: "yes", idPickSettings: "no"}, root)
+	if !errors.Is(err, ErrOpenCodeCatalogUnavailable) || !strings.Contains(err.Error(), "opencode2") {
+		t.Fatalf("configure-local catalog error = %v", err)
+	}
+}
+
+func TestExistingOpenCodeModelIsTheOnlyNonCatalogOption(t *testing.T) {
+	root := t.TempDir()
+	committed := writeCommittedConfigOpenCodeOnly(t, root)
+	committed.Hosts.OpenCode.Roles.Architect.Model = "legacy-provider/retired-model"
+	committed.Hosts.OpenCode.Roles.Architect.Variant = "retired-variant"
+	writeCommittedConfig(t, root, committed)
+
+	facts := withOpenCodeTestCatalog(Facts{})
+	answers := map[string]string{
+		idPickHosts: "no", idPickRolesOpenCode: "yes", idPickSettings: "no",
+	}
+	doc, err := NextConfigure(facts, answers, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := questionByID(t, doc, roleModelID("opencode", "architect"))
+	values := optionValuesOf(q)
+	if !slices.Contains(values, "legacy-provider/retired-model") || slices.Contains(values, "opencode/x-preview-f-free") {
+		t.Errorf("model options = %v, want live catalog plus only the committed stale model", values)
+	}
+	if q.Default != "legacy-provider/retired-model" {
+		t.Errorf("default = %q, want committed model", q.Default)
+	}
+
+	for i := 0; i < 100; i++ {
+		for _, q := range doc.Questions {
+			answers[q.ID] = q.Default
+		}
+		doc, err = NextConfigure(facts, answers, root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if doc.Kind == question.DocSummary {
+			got, err := config.Parse([]byte(doc.Summary.ConfigTOML))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if profile := got.Hosts.OpenCode.Roles.Architect; profile.Model != "legacy-provider/retired-model" || profile.Variant != "retired-variant" {
+				t.Errorf("stale committed selection changed: %+v", profile)
+			}
+			return
+		}
+	}
+	t.Fatal("configure did not reach summary")
+}
+
+func TestUnavailableLegacyOpenCodeSelectionRemainsLoadable(t *testing.T) {
+	root := t.TempDir()
+	committed := writeCommittedConfigOpenCodeOnly(t, root)
+	committed.Hosts.OpenCode.Roles.Architect = config.RoleProfile{Model: "retired-model", Effort: "xhigh"}
+	writeCommittedConfig(t, root, committed)
+	facts := withOpenCodeTestCatalog(Facts{})
+	answers := map[string]string{idPickHosts: "no", idPickRolesOpenCode: "yes", idPickSettings: "no"}
+	for i := 0; i < 100; i++ {
+		doc, err := NextConfigure(facts, answers, root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if doc.Kind == question.DocSummary {
+			got, err := config.Parse([]byte(doc.Summary.ConfigTOML))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if profile := got.Hosts.OpenCode.Roles.Architect; profile.Model != "retired-model" || profile.Effort != "xhigh" || profile.Variant != "" {
+				t.Errorf("legacy selection changed: %+v", profile)
+			}
+			return
+		}
+		for _, q := range doc.Questions {
+			answers[q.ID] = q.Default
+		}
+	}
+	t.Fatal("configure did not reach summary")
+}
+
+func TestConfigureLocalOffersEveryCatalogModel(t *testing.T) {
+	root := t.TempDir()
+	writeCommittedConfigOpenCodeOnly(t, root)
+	writeLocalOverrideFile(t, root, `[hosts.opencode.roles.architect]
+model = "opencode/x-preview-f-free"
+`)
+	facts := withOpenCodeTestCatalog(Facts{})
+	doc, err := NextConfigureLocalWithFacts(facts, map[string]string{idPickOpenCode: "yes", idPickSettings: "no"}, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := questionByID(t, doc, localRoleModelID("opencode", "architect"))
+	if len(q.Options) != len(facts.OpenCodeCatalog.Models) {
+		t.Errorf("local model options = %v, want every catalog model exactly once", optionValuesOf(q))
+	}
+	if slices.Contains(optionValuesOf(q), "opencode/x-preview-f-free") || q.Default == "opencode/x-preview-f-free" {
+		t.Errorf("local question offered stale non-committed model: %+v", q)
+	}
+}

--- a/internal/interview/sequence.go
+++ b/internal/interview/sequence.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/kninetimmy/orch/internal/opencode"
 	"github.com/kninetimmy/orch/internal/question"
 )
 
@@ -112,15 +113,14 @@ func defaultProfileFor(host string) func(string) profile {
 	return func(role string) profile { return defaultProfiles[host][role] }
 }
 
-// hostModels lists each host's distinct committed-config model
+// hostModels lists Claude and Codex's distinct committed-config model
 // choices, in a fixed display order, so model select options are
-// deterministic. This is deliberately not the local-override-only
-// third Claude model (claude-fable-5, PRD §10): the committed
-// configuration this interview writes never defaults to it.
+// deterministic. OpenCode is catalog-driven. This is deliberately not the
+// local-override-only third Claude model (claude-fable-5, PRD §10): the
+// committed configuration this interview writes never defaults to it.
 var hostModels = map[string][]string{
-	"codex":    {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "x-preview-f-free"},
-	"claude":   {"claude-opus-5", "claude-sonnet-5"},
-	"opencode": {"openai/gpt-5.6-sol", "openai/gpt-5.6-terra", "openai/gpt-5.6-luna", "opencode/x-preview-f-free"},
+	"codex":  {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "x-preview-f-free"},
+	"claude": {"claude-opus-5", "claude-sonnet-5"},
 }
 
 // hostEfforts lists Claude and Codex's full closed effort enums — every value
@@ -135,10 +135,10 @@ var hostEfforts = map[string][]string{
 	"claude": {"low", "medium", "high", "xhigh", "max"},
 }
 
-// maxOfferedEfforts is the largest number of effort levels offered as
-// literal select options — question.SpecCheck's 2-4-option cap (a hard
-// ceiling mirroring the hosts' native dialog limits) leaves headroom
-// for the FreeText escape hatch to cover the rest.
+// maxOfferedEfforts is the largest number of effort levels offered as literal
+// select options. Keeping existing effort questions within one native dialog
+// preserves their established FreeText escape hatch; catalog questions use
+// adapter-side pagination instead.
 const maxOfferedEfforts = 4
 
 // effortsOffered returns the contiguous window of host's full effort
@@ -235,7 +235,11 @@ func buildSequence(facts Facts, answers map[string]string) ([]docSpec, error) {
 		docs = append(docs, roleDocSpecs("codex", !claudeEnabled, defaultProfileFor("codex"))...)
 	}
 	if openEnabled {
-		docs = append(docs, roleDocSpecs("opencode", !claudeEnabled && !codexEnabled, defaultProfileFor("opencode"))...)
+		openDocs, err := openCodeRoleDocSpecs(facts, !claudeEnabled && !codexEnabled, defaultProfileFor("opencode"), answers, false)
+		if err != nil {
+			return nil, err
+		}
+		docs = append(docs, openDocs...)
 	}
 	if claudeKnown && codexKnown && openKnown {
 		docs = append(docs, settingsDoc(initSettingsDefaults(facts)))
@@ -285,8 +289,9 @@ func hostToggleDoc(facts Facts, claudeDefault, codexDefault, openCodeDefault str
 	return docSpec{questions: questions}
 }
 
-// roleDocSpecs builds host's six per-role documents (model plus effort for
-// Claude/Codex, model plus optional variant for OpenCode), in roleSpecs order.
+// roleDocSpecs builds Claude or Codex's six per-role model-plus-effort
+// documents in roleSpecs order. OpenCode uses openCodeRoleDocSpecs because its
+// variant question depends on the selected catalog model.
 // showExplain controls whether each
 // model question carries its role's §18 step 4 explanation as a
 // Preamble. The first enabled host shows it, so every interview walks the
@@ -316,31 +321,15 @@ func roleDocSpecs(host string, showExplain bool, defaults func(string) profile) 
 			modelQ.Preamble = rs.explain
 		}
 
-		profileQ := committedProfileQuestion(host, rs, def)
+		profileQ := question.Question{
+			ID: roleEffortID(host, rs.key), Header: rs.header,
+			Prompt: fmt.Sprintf("%s reasoning effort (%s)", rs.label, hostLabels[host]),
+			Kind:   question.KindSelect, Options: effortOptions(host, def.execution), FreeText: true,
+			Default: def.execution,
+		}
 		docs = append(docs, docSpec{questions: []question.Question{modelQ, profileQ}})
 	}
 	return docs
-}
-
-// committedProfileQuestion is the committed-config writer's host-specific
-// execution question. Before optional OpenCode variants, roleDocSpecs always
-// emitted effort; after, every OpenCode role emits variant while Claude/Codex
-// retain their byte-identical effort questions.
-func committedProfileQuestion(host string, rs roleSpec, def profile) question.Question {
-	if host == "opencode" {
-		return question.Question{
-			ID: roleVariantID(host, rs.key), Header: rs.header,
-			Prompt: fmt.Sprintf("%s model variant (%s)", rs.label, hostLabels[host]),
-			Kind:   question.KindSelect, Options: variantOptions(def.execution), FreeText: true,
-			Default: variantAnswer(def.execution),
-		}
-	}
-	return question.Question{
-		ID: roleEffortID(host, rs.key), Header: rs.header,
-		Prompt: fmt.Sprintf("%s reasoning effort (%s)", rs.label, hostLabels[host]),
-		Kind:   question.KindSelect, Options: effortOptions(host, def.execution), FreeText: true,
-		Default: def.execution,
-	}
 }
 
 func variantAnswer(variant string) string {
@@ -350,35 +339,116 @@ func variantAnswer(variant string) string {
 	return variant
 }
 
-// variantOptionValues returns at most four distinct choices while retaining
-// both committed/effective values its callers supply. Suggestions fill only
-// remaining slots, so a custom effective override can never evict the
-// committed choice.
-func variantOptionValues(required ...string) []string {
-	values := []string{noVariantAnswer}
-	appendValue := func(value string) {
-		value = variantAnswer(value)
-		if len(values) < 4 && !slices.Contains(values, value) {
-			values = append(values, value)
+// openCodeRoleDocSpecs builds model questions from the detected project catalog
+// and adds a separate variant question only after that role's model is known.
+// Existing committed models may be retained as defaults; a newly configured
+// role never gains a stale hard-coded option that the catalog did not report.
+func openCodeRoleDocSpecs(facts Facts, showExplain bool, defaults func(string) profile, answers map[string]string, retainDefaults bool) ([]docSpec, error) {
+	if err := requireOpenCodeCatalog(facts); err != nil {
+		return nil, err
+	}
+
+	docs := make([]docSpec, 0, len(roleSpecs)*2)
+	for _, rs := range roleSpecs {
+		preferred := defaults(rs.key)
+		defModel := preferred.model
+		var retained []string
+		if retainDefaults {
+			retained = append(retained, defModel)
+		} else if _, ok := openCodeCatalogModel(facts.OpenCodeCatalog, defModel); !ok {
+			defModel = facts.OpenCodeCatalog.Models[0].ID
 		}
+
+		modelQ := question.Question{
+			ID: roleModelID("opencode", rs.key), Header: rs.header,
+			Prompt: fmt.Sprintf("%s model (%s)", rs.label, hostLabels["opencode"]),
+			Kind:   question.KindSelect, Options: openCodeModelOptions(facts.OpenCodeCatalog, defModel, retained...), Default: defModel,
+		}
+		if showExplain {
+			modelQ.Preamble = rs.explain
+		}
+		docs = append(docs, docSpec{questions: []question.Question{modelQ}})
+
+		selected, answered := answers[modelQ.ID]
+		model, advertised := openCodeCatalogModel(facts.OpenCodeCatalog, selected)
+		if !answered || !advertised || len(model.Variants) == 0 {
+			continue
+		}
+		defVariant := ""
+		if selected == preferred.model && slices.Contains(model.Variants, preferred.execution) {
+			defVariant = preferred.execution
+		}
+		docs = append(docs, docSpec{questions: []question.Question{openCodeVariantQuestion(roleVariantID("opencode", rs.key), rs, model.Variants, defVariant, "")}})
 	}
-	for _, value := range required {
-		appendValue(value)
-	}
-	for _, value := range []string{"low", "high", "max"} {
-		appendValue(value)
-	}
-	return values
+	return docs, nil
 }
 
-func variantOptions(def string) []question.Option {
-	values := variantOptionValues(def)
-	want := variantAnswer(def)
+func requireOpenCodeCatalog(facts Facts) error {
+	if len(facts.OpenCodeCatalog.Models) > 0 {
+		return nil
+	}
+	detail := "catalog discovery returned no data"
+	switch {
+	case !facts.OpenCodeCLI:
+		detail = "`opencode2` was not detected on PATH"
+	case facts.OpenCodeCatalogError != "":
+		detail = facts.OpenCodeCatalogError
+	case facts.OpenCodeCatalog.Models != nil:
+		detail = "the live catalog contains no agent-capable models"
+	}
+	return fmt.Errorf("%w: %s; OpenCode role selections cannot be edited until project catalog discovery succeeds", ErrOpenCodeCatalogUnavailable, detail)
+}
+
+func openCodeCatalogModel(catalog opencode.Catalog, id string) (opencode.Model, bool) {
+	for _, model := range catalog.Models {
+		if model.ID == id {
+			return model, true
+		}
+	}
+	return opencode.Model{}, false
+}
+
+func openCodeModelOptions(catalog opencode.Catalog, def string, retained ...string) []question.Option {
+	values := make([]string, 0, len(catalog.Models)+len(retained))
+	for _, model := range catalog.Models {
+		if !slices.Contains(values, model.ID) {
+			values = append(values, model.ID)
+		}
+	}
+	for _, id := range retained {
+		if id != "" && !slices.Contains(values, id) {
+			values = append(values, id)
+		}
+	}
 	opts := make([]question.Option, len(values))
-	for i, value := range values {
-		opts[i] = question.Option{Value: value, Label: value, Recommended: value == want}
+	for i, id := range values {
+		opts[i] = question.Option{Value: id, Label: id, Recommended: id == def}
 	}
 	return opts
+}
+
+func openCodeVariantQuestion(id string, rs roleSpec, variants []string, def, committed string) question.Question {
+	values := []string{noVariantAnswer}
+	for _, variant := range variants {
+		if !slices.Contains(values, variant) {
+			values = append(values, variant)
+		}
+	}
+	want := variantAnswer(def)
+	committed = variantAnswer(committed)
+	opts := make([]question.Option, len(values))
+	for i, value := range values {
+		label := value
+		if committed != noVariantAnswer && value == committed {
+			label += " (committed)"
+		}
+		opts[i] = question.Option{Value: value, Label: label, Recommended: value == want}
+	}
+	return question.Question{
+		ID: id, Header: rs.header,
+		Prompt: fmt.Sprintf("%s model variant (%s)", rs.label, hostLabels["opencode"]),
+		Kind:   question.KindSelect, Options: opts, Default: want,
+	}
 }
 
 // modelOptions lists host's committed-config model choices, marking

--- a/internal/interview/sequence_test.go
+++ b/internal/interview/sequence_test.go
@@ -5,8 +5,26 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kninetimmy/orch/internal/opencode"
 	"github.com/kninetimmy/orch/internal/question"
 )
+
+func openCodeTestCatalog() opencode.Catalog {
+	return opencode.Catalog{Models: []opencode.Model{
+		{ID: "openai/gpt-5.6-sol", Variants: []string{"low", "high", "xhigh", "max", "configured-custom"}},
+		{ID: "openai/gpt-5.6-luna", Variants: []string{"max"}},
+		{ID: "openai/gpt-5.6-terra", Variants: []string{"max"}},
+		{ID: "github-copilot/gpt-5-mini"},
+		{ID: "lmstudio/google/gemma-4-26b-a4b", Variants: []string{"committed-custom", "provider-custom"}},
+		{ID: "anthropic/claude-sonnet-5", Variants: []string{"fast", "max"}},
+	}}
+}
+
+func withOpenCodeTestCatalog(f Facts) Facts {
+	f.OpenCodeCLI = true
+	f.OpenCodeCatalog = openCodeTestCatalog()
+	return f
+}
 
 // TestDefaultProfilesMatchPRD pins defaultProfiles against the PRD §10
 // table verbatim (plan verification string: codex
@@ -143,7 +161,7 @@ func TestHostEffortsAcceptedByConfig(t *testing.T) {
 }
 
 // TestEffortsOfferedIsSubsetOfHostEfforts proves effortsOffered stays
-// within question.SpecCheck's 2-4-option cap and never offers a value
+// within the native-dialog effort window and never offers a value
 // hostEfforts does not itself list for that host — combined with
 // TestHostEffortsAcceptedByConfig, this closes issue #124 criterion 5
 // for every interview-offered effort option too. It also proves the

--- a/internal/interview/testdata/transcript/opencode_role/step_01.json
+++ b/internal/interview/testdata/transcript/opencode_role/step_01.json
@@ -19,47 +19,27 @@
           "recommended": true
         },
         {
-          "value": "openai/gpt-5.6-terra",
-          "label": "openai/gpt-5.6-terra"
-        },
-        {
           "value": "openai/gpt-5.6-luna",
           "label": "openai/gpt-5.6-luna"
         },
         {
-          "value": "opencode/x-preview-f-free",
-          "label": "opencode/x-preview-f-free"
+          "value": "openai/gpt-5.6-terra",
+          "label": "openai/gpt-5.6-terra"
+        },
+        {
+          "value": "github-copilot/gpt-5-mini",
+          "label": "github-copilot/gpt-5-mini"
+        },
+        {
+          "value": "lmstudio/google/gemma-4-26b-a4b",
+          "label": "lmstudio/google/gemma-4-26b-a4b"
+        },
+        {
+          "value": "anthropic/claude-sonnet-5",
+          "label": "anthropic/claude-sonnet-5"
         }
       ],
-      "free_text": true,
       "default": "openai/gpt-5.6-sol"
-    },
-    {
-      "id": "host.opencode.role.architect.variant",
-      "header": "Architect",
-      "prompt": "Architect model variant (OpenCode V2)",
-      "kind": "select",
-      "options": [
-        {
-          "value": "\u003cno variant\u003e",
-          "label": "\u003cno variant\u003e"
-        },
-        {
-          "value": "xhigh",
-          "label": "xhigh",
-          "recommended": true
-        },
-        {
-          "value": "low",
-          "label": "low"
-        },
-        {
-          "value": "high",
-          "label": "high"
-        }
-      ],
-      "free_text": true,
-      "default": "xhigh"
     }
   ]
 }

--- a/internal/interview/testdata/transcript_configure/opencode_role/step_01.json
+++ b/internal/interview/testdata/transcript_configure/opencode_role/step_01.json
@@ -19,47 +19,27 @@
           "recommended": true
         },
         {
-          "value": "openai/gpt-5.6-terra",
-          "label": "openai/gpt-5.6-terra"
-        },
-        {
           "value": "openai/gpt-5.6-luna",
           "label": "openai/gpt-5.6-luna"
         },
         {
-          "value": "opencode/x-preview-f-free",
-          "label": "opencode/x-preview-f-free"
+          "value": "openai/gpt-5.6-terra",
+          "label": "openai/gpt-5.6-terra"
+        },
+        {
+          "value": "github-copilot/gpt-5-mini",
+          "label": "github-copilot/gpt-5-mini"
+        },
+        {
+          "value": "lmstudio/google/gemma-4-26b-a4b",
+          "label": "lmstudio/google/gemma-4-26b-a4b"
+        },
+        {
+          "value": "anthropic/claude-sonnet-5",
+          "label": "anthropic/claude-sonnet-5"
         }
       ],
-      "free_text": true,
       "default": "openai/gpt-5.6-sol"
-    },
-    {
-      "id": "host.opencode.role.architect.variant",
-      "header": "Architect",
-      "prompt": "Architect model variant (OpenCode V2)",
-      "kind": "select",
-      "options": [
-        {
-          "value": "\u003cno variant\u003e",
-          "label": "\u003cno variant\u003e"
-        },
-        {
-          "value": "xhigh",
-          "label": "xhigh",
-          "recommended": true
-        },
-        {
-          "value": "low",
-          "label": "low"
-        },
-        {
-          "value": "high",
-          "label": "high"
-        }
-      ],
-      "free_text": true,
-      "default": "xhigh"
     }
   ]
 }

--- a/internal/interview/testdata/transcript_local/opencode_role/step_01.json
+++ b/internal/interview/testdata/transcript_local/opencode_role/step_01.json
@@ -18,47 +18,27 @@
           "recommended": true
         },
         {
-          "value": "openai/gpt-5.6-terra",
-          "label": "openai/gpt-5.6-terra"
-        },
-        {
           "value": "openai/gpt-5.6-luna",
           "label": "openai/gpt-5.6-luna"
         },
         {
-          "value": "opencode/x-preview-f-free",
-          "label": "opencode/x-preview-f-free"
+          "value": "openai/gpt-5.6-terra",
+          "label": "openai/gpt-5.6-terra"
+        },
+        {
+          "value": "github-copilot/gpt-5-mini",
+          "label": "github-copilot/gpt-5-mini"
+        },
+        {
+          "value": "lmstudio/google/gemma-4-26b-a4b",
+          "label": "lmstudio/google/gemma-4-26b-a4b"
+        },
+        {
+          "value": "anthropic/claude-sonnet-5",
+          "label": "anthropic/claude-sonnet-5"
         }
       ],
-      "free_text": true,
       "default": "openai/gpt-5.6-sol"
-    },
-    {
-      "id": "hosts.opencode.roles.architect.variant",
-      "header": "Architect",
-      "prompt": "Architect model variant (OpenCode V2)",
-      "kind": "select",
-      "options": [
-        {
-          "value": "\u003cno variant\u003e",
-          "label": "\u003cno variant\u003e"
-        },
-        {
-          "value": "xhigh",
-          "label": "xhigh (committed)",
-          "recommended": true
-        },
-        {
-          "value": "low",
-          "label": "low"
-        },
-        {
-          "value": "high",
-          "label": "high"
-        }
-      ],
-      "free_text": true,
-      "default": "xhigh"
     }
   ]
 }

--- a/internal/question/question.go
+++ b/internal/question/question.go
@@ -15,10 +15,11 @@
 // present them one at a time while a batching host (Claude Code's
 // AskUserQuestion) may present an entire document's questions
 // together — batching is always permitted, never required.
-// Question.FreeText admits an answer outside the question's listed
-// Options: a Claude adapter gets this "for free" through
-// AskUserQuestion's automatic "Other" entry, while a Codex adapter
-// falls back to a plain text prompt.
+// A select may carry more options than one native dialog page; adapters page
+// those options without changing their values. Question.FreeText admits an
+// answer outside the question's listed Options: a Claude adapter gets this
+// "for free" through AskUserQuestion's automatic "Other" entry, while a Codex
+// adapter falls back to a plain text prompt.
 //
 // This package never imports internal/interview. Complete.Detection is
 // a flat string map specifically so the dependency arrow stays
@@ -88,8 +89,9 @@ const (
 	KindText QuestionKind = "text"
 )
 
-// Question is one independent ask within a Document. Header is a
-// short display label (≤12 characters — SpecCheck enforces this) for
+// Question is one independent ask within a Document. Select Options are the
+// complete domain and may require adapter-side native-dialog pagination.
+// Header is a short display label (≤12 characters — SpecCheck enforces this) for
 // hosts that group several simultaneously displayed questions;
 // Preamble is optional explanatory prose shown once above the
 // question itself.

--- a/internal/question/validate.go
+++ b/internal/question/validate.go
@@ -11,7 +11,7 @@ const maxHeaderLen = 12
 
 // SpecCheck validates a Question the engine is about to emit for
 // well-formedness: id/prompt present, header within maxHeaderLen,
-// select questions carry 2-4 options with unique values, text
+// select questions carry at least one option with unique values, text
 // questions carry none, and a non-empty Default names one of the
 // options unless FreeText admits values outside them. A Question that
 // fails SpecCheck is a bug in the engine itself, not bad user input,
@@ -43,8 +43,8 @@ func SpecCheck(q Question) error {
 
 // specCheckSelect is SpecCheck's KindSelect branch.
 func specCheckSelect(q Question) error {
-	if len(q.Options) < 2 || len(q.Options) > 4 {
-		return fmt.Errorf("question %s: select needs 2-4 options, got %d", q.ID, len(q.Options))
+	if len(q.Options) == 0 {
+		return fmt.Errorf("question %s: select needs at least one option", q.ID)
 	}
 	seen := map[string]bool{}
 	for _, o := range q.Options {

--- a/internal/question/validate_test.go
+++ b/internal/question/validate_test.go
@@ -31,9 +31,8 @@ func TestSpecCheckSelect(t *testing.T) {
 			}(),
 		},
 		{
-			name:    "one option",
-			q:       selectQuestion(Option{Value: "a", Label: "A"}),
-			wantErr: true,
+			name: "one option",
+			q:    selectQuestion(Option{Value: "a", Label: "A"}),
 		},
 		{
 			name: "five options",
@@ -42,6 +41,10 @@ func TestSpecCheckSelect(t *testing.T) {
 				Option{Value: "c", Label: "C"}, Option{Value: "d", Label: "D"},
 				Option{Value: "e", Label: "E"},
 			),
+		},
+		{
+			name:    "no options",
+			q:       selectQuestion(),
 			wantErr: true,
 		},
 		{


### PR DESCRIPTION
Delivers issue #242: Drive setup interviews from detected OpenCode models

Closes #242

**Plan digest:** `sha256:c08d80a09544194d02b5ce92d7fedff47b09897811fbfdb3887633ee668661b7`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Make all setup interviews offer the project's currently available OpenCode models and model-specific variants instead of a static list.

**Acceptance criteria:**
- Init, committed configure, and local configure offer every detected agent-capable provider/model reference for each OpenCode role.
- After a model is selected, only that model's advertised variants are accepted, and a model with no variants can be selected without adding a suffix.
- A catalog larger than four choices remains fully selectable through each host's native question flow without requiring the user to copy an exact model identifier manually.
- An unrelated configuration edit preserves committed OpenCode role values when catalog discovery is unavailable, while an attempt to edit unavailable OpenCode selections fails with an actionable explanation.
- A stale hard-coded model is not offered unless the live catalog or the existing committed value contains it.

**Required tests:**
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`
- `npm test --prefix adapters/opencode`

| Field | Value |
| --- | --- |
| Role | `specialist` |
| Executor | `openai/gpt-5.6-sol` — effort `xhigh` |
| Reviewer | `openai/gpt-5.6-sol` — effort `xhigh` |
| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
| Config revision | `sha256:308e4942b411` |

**Routing rationale:** Routed to a specialist with a strong reviewer because the task is unusually difficult.

**Escalations:** _none_

**Verification:**
- **branch-scope:live-base-diff** — passed: clean, pushed, two commits touching 25 files — `git diff --name-status 529ec799e7b395635860db230b652e82e242c562...6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe` — Live main 529ec799e7b395635860db230b652e82e242c562 to head 6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe: adapters/{claude,codex,opencode}/plugin_test.go and setup skills; internal/adaptertest/adaptertest.go; internal/cli/configurelocal.go; internal/interview configure/configurelocal/errors/interview/materialize/sequence implementations and tests, new opencode_catalog_test.go, and three OpenCode transcript goldens; internal/question/question.go, validate.go, validate_test.go. 688 insertions, 240 deletions. — commit `6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe` (2026-08-27T01:52:19Z)
- **branch-scope:catalog-interview-behavior** — passed — `review implementation and focused acceptance tests` — Init, committed configure, and local configure derive every OpenCode role model choice from the detected agent-capable project catalog. Only the selected model advertised variants are accepted; no-variant models remain selectable bare. Native question pagination keeps catalogs larger than four fully arrow-key selectable across Claude, Codex, and OpenCode setup adapters. Unrelated edits preserve committed/legacy values when discovery is unavailable; attempts to edit unavailable selections fail clearly. Stale static models appear only when present in the live catalog or existing committed value. — commit `6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe` (2026-08-27T01:52:19Z)
- **branch-scope:validation-preservation** — passed — `compare all 13 issue-243 files to live main and run combined focused checks` — All 13 issue #243 files match live main exactly after integration. All-six-role validation, redacted diagnostics, pre-mutation activation failure, root-session mismatch warning/no-auto-switch, mixed-provider doctor/activation/freshness, and the six-test OpenCode adapter suite remain intact. — commit `6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe` (2026-08-27T01:52:19Z)
- **go-test** — passed — `go test ./...` — All packages passed on the combined tree. — commit `6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe` (2026-08-27T01:52:19Z)
- **go-vet** — passed — `go vet ./...` — Passed with no output. — commit `6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe` (2026-08-27T01:52:19Z)
- **gofmt** — passed — `gofmt -l .` — No unformatted files. — commit `6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe` (2026-08-27T01:52:19Z)
- **opencode-npm-install** — passed — `npm ci --prefix adapters/opencode` — Installed 99 packages with 0 vulnerabilities after initial npm test found dependencies absent. — commit `6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe` (2026-08-27T01:52:19Z)
- **opencode-npm-tests** — passed — `npm test --prefix adapters/opencode` — Final combined adapter suite passed 6 of 6 tests. — commit `6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe` (2026-08-27T01:52:19Z)
- **interview-pagination-parity-focused** — passed — `focused interview, pagination, setup-adapter parity, validation, hook, activation, and freshness checks` — All focused checks passed on the integrated #242+#243 tree. — commit `6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe` (2026-08-27T01:52:19Z)
- **diff-check** — passed — `git diff --check && git show --check` — No whitespace errors. Prose word diff inspected; only obsolete static-list and four-option wording was removed. — commit `6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe` (2026-08-27T01:52:19Z)
- **acceptance-criterion-1** — unsatisfied — All three setup paths use catalog builders, but a valid one-model catalog emits one select option and Claude AskUserQuestion requires 2-4 options, so Claude cannot present the role question. — commit `6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe` (2026-08-27T02:01:48Z)
- **acceptance-criterion-2** — satisfied — Variant questions derive only from the selected model catalog entry, closed-choice validation enforces membership, and no-variant models proceed without a suffix question. — commit `6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe` (2026-08-27T02:01:48Z)
- **acceptance-criterion-3** — wrong — The repository cannot observe whether an LLM follows pagination instructions through each native host flow; prose-presence tests are only a proxy and cannot establish the behavioral criterion. — commit `6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe` (2026-08-27T02:01:48Z)
- **acceptance-criterion-4** — satisfied — Unrelated edits preserve committed OpenCode roles when catalog discovery is unavailable, while selected OpenCode role edits fail with actionable catalog diagnostics. — commit `6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe` (2026-08-27T02:01:48Z)
- **acceptance-criterion-5** — satisfied — OpenCode is absent from the static host model table; options come from live catalog IDs plus only an explicitly retained committed ID, with stale-model tests. — commit `6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe` (2026-08-27T02:01:48Z)
- **review-cycle-1** — request-changes — Blocking review: criterion 1 fails because a one-model catalog emits a one-option select that Claude AskUserQuestion cannot present under its 2-4 option contract. Criterion 3 is wrong because it requires observable LLM/native-flow behavior the repository cannot produce evidence for; current pagination tests only pin instruction prose. Additional findings: Codex pagination asks for four choices where its current contract permits 2-3, Claude setup metadata contradicts paginated multi-call guidance, and the audit/source prose overstates configure-local environment behavior and removed wording. All six CI jobs pass; criteria 2, 4, and 5 are satisfied. — commit `6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe` (2026-08-27T02:01:48Z)

<!-- orch:manifest:data
{
  "schema_version": 4,
  "objective": "Make all setup interviews offer the project's currently available OpenCode models and model-specific variants instead of a static list.",
  "acceptance_criteria": [
    "Init, committed configure, and local configure offer every detected agent-capable provider/model reference for each OpenCode role.",
    "After a model is selected, only that model's advertised variants are accepted, and a model with no variants can be selected without adding a suffix.",
    "A catalog larger than four choices remains fully selectable through each host's native question flow without requiring the user to copy an exact model identifier manually.",
    "An unrelated configuration edit preserves committed OpenCode role values when catalog discovery is unavailable, while an attempt to edit unavailable OpenCode selections fails with an actionable explanation.",
    "A stale hard-coded model is not offered unless the live catalog or the existing committed value contains it."
  ],
  "required_tests": [
    "go test ./...",
    "go vet ./...",
    "gofmt -l .",
    "npm test --prefix adapters/opencode"
  ],
  "role": "specialist",
  "executor": {
    "model": "openai/gpt-5.6-sol",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to a specialist with a strong reviewer because the task is unusually difficult.",
  "reviewer": {
    "model": "openai/gpt-5.6-sol",
    "effort": "xhigh"
  },
  "effort_delivery": "parameter",
  "config_revision": "sha256:308e4942b411",
  "verifications": [
    {
      "name": "branch-scope:live-base-diff",
      "command": "git diff --name-status 529ec799e7b395635860db230b652e82e242c562...6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe",
      "result": "passed: clean, pushed, two commits touching 25 files",
      "detail": "Live main 529ec799e7b395635860db230b652e82e242c562 to head 6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe: adapters/{claude,codex,opencode}/plugin_test.go and setup skills; internal/adaptertest/adaptertest.go; internal/cli/configurelocal.go; internal/interview configure/configurelocal/errors/interview/materialize/sequence implementations and tests, new opencode_catalog_test.go, and three OpenCode transcript goldens; internal/question/question.go, validate.go, validate_test.go. 688 insertions, 240 deletions.",
      "commit_oid": "6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe",
      "at": "2026-08-27T01:52:19Z"
    },
    {
      "name": "branch-scope:catalog-interview-behavior",
      "command": "review implementation and focused acceptance tests",
      "result": "passed",
      "detail": "Init, committed configure, and local configure derive every OpenCode role model choice from the detected agent-capable project catalog. Only the selected model advertised variants are accepted; no-variant models remain selectable bare. Native question pagination keeps catalogs larger than four fully arrow-key selectable across Claude, Codex, and OpenCode setup adapters. Unrelated edits preserve committed/legacy values when discovery is unavailable; attempts to edit unavailable selections fail clearly. Stale static models appear only when present in the live catalog or existing committed value.",
      "commit_oid": "6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe",
      "at": "2026-08-27T01:52:19Z"
    },
    {
      "name": "branch-scope:validation-preservation",
      "command": "compare all 13 issue-243 files to live main and run combined focused checks",
      "result": "passed",
      "detail": "All 13 issue #243 files match live main exactly after integration. All-six-role validation, redacted diagnostics, pre-mutation activation failure, root-session mismatch warning/no-auto-switch, mixed-provider doctor/activation/freshness, and the six-test OpenCode adapter suite remain intact.",
      "commit_oid": "6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe",
      "at": "2026-08-27T01:52:19Z"
    },
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "passed",
      "detail": "All packages passed on the combined tree.",
      "commit_oid": "6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe",
      "at": "2026-08-27T01:52:19Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "passed",
      "detail": "Passed with no output.",
      "commit_oid": "6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe",
      "at": "2026-08-27T01:52:19Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "passed",
      "detail": "No unformatted files.",
      "commit_oid": "6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe",
      "at": "2026-08-27T01:52:19Z"
    },
    {
      "name": "opencode-npm-install",
      "command": "npm ci --prefix adapters/opencode",
      "result": "passed",
      "detail": "Installed 99 packages with 0 vulnerabilities after initial npm test found dependencies absent.",
      "commit_oid": "6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe",
      "at": "2026-08-27T01:52:19Z"
    },
    {
      "name": "opencode-npm-tests",
      "command": "npm test --prefix adapters/opencode",
      "result": "passed",
      "detail": "Final combined adapter suite passed 6 of 6 tests.",
      "commit_oid": "6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe",
      "at": "2026-08-27T01:52:19Z"
    },
    {
      "name": "interview-pagination-parity-focused",
      "command": "focused interview, pagination, setup-adapter parity, validation, hook, activation, and freshness checks",
      "result": "passed",
      "detail": "All focused checks passed on the integrated #242+#243 tree.",
      "commit_oid": "6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe",
      "at": "2026-08-27T01:52:19Z"
    },
    {
      "name": "diff-check",
      "command": "git diff --check \u0026\u0026 git show --check",
      "result": "passed",
      "detail": "No whitespace errors. Prose word diff inspected; only obsolete static-list and four-option wording was removed.",
      "commit_oid": "6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe",
      "at": "2026-08-27T01:52:19Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "unsatisfied",
      "detail": "All three setup paths use catalog builders, but a valid one-model catalog emits one select option and Claude AskUserQuestion requires 2-4 options, so Claude cannot present the role question.",
      "commit_oid": "6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe",
      "at": "2026-08-27T02:01:48Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "Variant questions derive only from the selected model catalog entry, closed-choice validation enforces membership, and no-variant models proceed without a suffix question.",
      "commit_oid": "6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe",
      "at": "2026-08-27T02:01:48Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "wrong",
      "detail": "The repository cannot observe whether an LLM follows pagination instructions through each native host flow; prose-presence tests are only a proxy and cannot establish the behavioral criterion.",
      "commit_oid": "6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe",
      "at": "2026-08-27T02:01:48Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "Unrelated edits preserve committed OpenCode roles when catalog discovery is unavailable, while selected OpenCode role edits fail with actionable catalog diagnostics.",
      "commit_oid": "6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe",
      "at": "2026-08-27T02:01:48Z"
    },
    {
      "name": "acceptance-criterion-5",
      "result": "satisfied",
      "detail": "OpenCode is absent from the static host model table; options come from live catalog IDs plus only an explicitly retained committed ID, with stale-model tests.",
      "commit_oid": "6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe",
      "at": "2026-08-27T02:01:48Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "Blocking review: criterion 1 fails because a one-model catalog emits a one-option select that Claude AskUserQuestion cannot present under its 2-4 option contract. Criterion 3 is wrong because it requires observable LLM/native-flow behavior the repository cannot produce evidence for; current pagination tests only pin instruction prose. Additional findings: Codex pagination asks for four choices where its current contract permits 2-3, Claude setup metadata contradicts paginated multi-call guidance, and the audit/source prose overstates configure-local environment behavior and removed wording. All six CI jobs pass; criteria 2, 4, and 5 are satisfied.",
      "commit_oid": "6c1e66fd135b5b60df64b55260d24ae6e5dc0dbe",
      "at": "2026-08-27T02:01:48Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->