### PR TITLE
Prove mixed-provider OpenCode roles and document the workflow

### DIFF
--- a/ORCH-PRD.md
+++ b/ORCH-PRD.md
@@ -263,6 +263,24 @@ alias with the same effective selection and revision meaning. This change is
 restricted to OpenCode roles: every Claude Code and Codex role retains its
 required `model` plus `effort` shape and its existing rendering and routing.
 
+On the pinned `opencode2 v0.0.0-beta-18314` contract, initialization,
+configuration, and local configuration derive each OpenCode role's choices from
+the repository's live, returned-location-validated catalog. Every role may select
+a different enabled, tool-capable text `provider/model`; only that model's
+advertised variants are offered, and a model with none uses the bare reference.
+Catalog model and variant domains are emitted as deterministic native pages of
+two or three mutually exclusive choices with explicit previous/next navigation,
+each answer appearing exactly once; a one-answer domain adds cancel. Discovery
+failure or an empty agent-capable catalog blocks initialization and OpenCode role
+edits while unrelated configuration edits preserve existing role values.
+Activation re-discovers the catalog and fails before mutation if any of the six
+configured provider, model, or variant selections is unavailable.
+
+The OpenCode session-context hook compares the selected model only for a root
+main session against `hosts.opencode.roles.architect`, including its optional
+variant. It reports a mismatch in context but never changes the session model;
+child sessions are not compared to the Architect selection.
+
 ### Claude Code
 
 | Role | Model | Effort |

--- a/README.md
+++ b/README.md
@@ -377,6 +377,23 @@ schema-v1 `effort` values from v0.8.0 still load with the same
 effective selection and configuration revision. This exception is OpenCode-only;
 Claude Code and Codex keep their existing model/effort configuration and routing.
 
+On the supported `opencode2 v0.0.0-beta-18314` contract, OpenCode setup reads the
+repository's live, location-validated catalog. Each of the six roles independently
+chooses any enabled, tool-capable text model, so one profile may mix providers and
+models. A second question offers only the selected model's advertised variants;
+models with none remain bare. Catalog choices use deterministic two- or
+three-choice native pages with explicit previous/next navigation, and every model
+appears exactly once. A one-model page adds cancel rather than emitting a
+host-invalid one-choice dialog.
+
+If catalog discovery fails or returns no agent-capable model, initialization and
+OpenCode role edits stop with the discovery error; unrelated configuration edits
+preserve the existing OpenCode roles. Delivery activation rechecks all six exact
+selections and fails before mutation when a provider, model, or variant is no
+longer available. The plugin compares only the main session's selected model to
+the configured Architect reference: a mismatch adds a warning but never switches
+the session automatically, and child sessions are not compared to the Architect.
+
 Typical tuning: point a role at a bigger or smaller model on one
 machine with `configure-local` (run the Architect on a frontier model
 only where you have the subscription), raise `max_subagents` on a

--- a/adapters/opencode/README.md
+++ b/adapters/opencode/README.md
@@ -40,7 +40,7 @@ them and are never copied into diagnostics.
 | Provider/model/variant settings, headers, bodies, credentials, account IDs, and raw payload | Previously Orch did not read the catalog; after this change these fields may arrive in command output but are never retained, returned, or included in an error. |
 | Setup detection's existing CLI, git, GitHub, memhub, and instruction facts | Yes. Catalog and catalog-error fields are additive, and a failed read remains explicit data rather than changing Detect's no-error contract. |
 | Doctor's runtime and active-plugin checks | Yes. They still run and the catalog/location check now follows them. |
-| Live smoke's agent discovery, context injection, denied tracked write, and allowed ignored write | Yes. The catalog/location assertions are additive. |
+| Live smoke's agent discovery, context injection, denied tracked write, and allowed ignored write | Yes. The catalog/location assertions are additive, and the smoke now renders a mixed-provider fixture and checks every discovered dispatched agent's exact model reference. |
 | Interview `profile`, `roleVariantID`, and `openCodeVariantQuestion` | Before, committed interviews represented every execution value as host-wide effort and suggested host-wide variant names. After, the shared profile carries a host-native execution value and each OpenCode variant question contains only no-variant plus the selected catalog model's advertised variants. This applies to every OpenCode role; Claude/Codex keep effort IDs and options. |
 | Committed question writer `openCodeRoleDocSpecs` | Before, OpenCode shared the static `roleDocSpecs` model/effort path. After, all six roles ask a catalog-backed model question followed, only when applicable, by that model's dependent variant question. Claude/Codex retain their model+effort documents. |
 | Committed config writer `materializeHost` | Before, every host answer was written to `RoleProfile.Effort`. After, a selected available/new OpenCode model writes `Variant` (empty for no variant). The preservation exception is an unchanged committed model absent from the live catalog: it keeps its prior `Effort`/`Variant` fields exactly so legacy configuration remains loadable. Every Claude/Codex role still writes `Effort`. |
@@ -56,6 +56,36 @@ them and are never copied into diagnostics.
 | `StatusDoc` wire | Before, it remained schema v1 while transitive state decisions gained the new Selection shape. After, schema v2 exposes all three exact shapes and adapters reject any other result version before reading run state. |
 | Adapter protocol pins | The Claude, Codex, and OpenCode Architect/Delivery skills now state the same closed versions. Shared `adaptertest.CheckSelectionWireVersions` derives every expected literal from the engine constants, so no host keeps an unpinned hand-synced Selection schema. |
 | Legacy local `effort` validation | Before, raw `effort = ""` bypassed the named legacy-effort domain and silently cleared a committed variant into a bare-model selection. After, every OpenCode role rejects an explicitly empty legacy effort with `variant = ""` as the remediation. Named v0.8.0 efforts remain compatible; only native `variant = ""` selects no variant. Claude/Codex effort behavior is unchanged. |
+
+## Role selection and sessions
+
+`orch init`, `orch configure`, and `orch configure-local` discover models from
+the current repository's live catalog on the pinned
+`opencode2 v0.0.0-beta-18314` runtime. All six role selections are independent:
+one profile can mix providers and models, and model IDs after the first slash are
+opaque. After each model choice, setup offers only that model's advertised
+variants; a model with no variants produces a bare `provider/model` selection.
+
+Model and variant choices use the shared deterministic setup pagination contract.
+Every native page contains two or three mutually exclusive choices, every answer
+appears on exactly one page, larger domains use explicit previous/next actions,
+and a one-answer domain adds cancel. Setup does not accept a free-text model that
+the project catalog did not report.
+
+Catalog discovery failure or an empty agent-capable catalog blocks initialization
+and OpenCode role edits with an actionable error. Unrelated configuration edits
+remain available and preserve existing OpenCode selections. Delivery activation
+re-discovers the catalog and fails before mutation if any configured role names an
+unavailable provider, model, or variant. It also fails if generated agent files do
+not match the effective configuration, with `orch render-agents` as remediation.
+
+The plugin passes the selected model of a root main session to Orch's context
+hook. When it differs from the configured Architect model and optional variant,
+Orch adds a warning but does not switch models; child sessions skip this Architect
+comparison. `npm run smoke` renders the shared mixed-provider fixture, starts the
+pinned runtime, and checks `/api/agent` for every dispatched role's exact
+provider/model/variant reference. Its later tool-path generation uses the runtime's
+simulation backend, so the smoke never requires a paid model request.
 
 ## Install order
 

--- a/adapters/opencode/smoke.mjs
+++ b/adapters/opencode/smoke.mjs
@@ -15,6 +15,13 @@ const serverPassword = "orch-smoke"
 process.env.OPENCODE_SERVER_PASSWORD = serverPassword
 const adapter = path.dirname(fileURLToPath(import.meta.url))
 const repo = path.resolve(adapter, "../..")
+const agentModels = {
+  "orch-scout": { providerID: "smoke-alpha", id: "scout", variant: "fast" },
+  "orch-implementer": { providerID: "smoke-beta", id: "implementer" },
+  "orch-specialist": { providerID: "smoke-alpha", id: "team/specialist", variant: "deep" },
+  "orch-reviewer": { providerID: "smoke-beta", id: "reviewer" },
+  "orch-reviewer-safe": { providerID: "smoke-beta", id: "reviewer-safe", variant: "careful" },
+}
 
 function command(name, args, cwd) {
   const result = spawnSync(name, args, {
@@ -145,15 +152,14 @@ try {
   const orchBinary = path.join(temp, process.platform === "win32" ? "orch.exe" : "orch")
   command("go", ["build", "-o", orchBinary, "./cmd/orch"], repo)
   process.env.PATH = `${temp}${delimiter}${process.env.PATH}`
-  await mkdir(path.join(temp, ".opencode", "agents"), { recursive: true })
   await mkdir(path.join(temp, ".orchestrator"), { recursive: true })
-  await cp(path.join(adapter, "agents"), path.join(temp, ".opencode", "agents"), { recursive: true })
-  await cp(path.join(repo, ".orchestrator", "config.toml"), path.join(temp, ".orchestrator", "config.toml"))
-  await writeFile(path.join(temp, ".gitignore"), ".scratch/\n")
+  await cp(path.join(repo, "internal", "agents", "testdata", "opencode-mixed-provider.toml"), path.join(temp, ".orchestrator", "config.toml"))
+  await writeFile(path.join(temp, ".gitignore"), ".opencode/agents/\n.scratch/\n")
   await writeFile(path.join(temp, "tracked.txt"), "before\n")
   command("git", ["init"], temp)
   command("git", ["add", ".gitignore", "tracked.txt", ".orchestrator/config.toml"], temp)
   command("git", ["-c", "user.name=Orch Smoke", "-c", "user.email=orch-smoke@example.invalid", "commit", "-m", "smoke fixture"], temp)
+  command(orchBinary, ["render-agents"], temp)
   const backendPort = await availablePort()
   const uiPort = await availablePort()
   const state = path.join(temp, "state")
@@ -163,19 +169,48 @@ try {
     endpoints: { ui: `ws://127.0.0.1:${uiPort}`, backend: `ws://127.0.0.1:${backendPort}` },
   }))
   await writeFile(path.join(temp, "opencode.json"), JSON.stringify({
-    model: "smoke/smoke",
+    model: "smoke-alpha/architect#steady",
     permissions: [{ action: "write", resource: "*", effect: "allow" }],
     plugins: [path.join(adapter, "src", "index.js")],
     snapshots: false,
     providers: {
-      smoke: {
+      "smoke-alpha": {
         package: "aisdk:@ai-sdk/openai-compatible",
         settings: { apiKey: "smoke", baseURL: "https://api.openai.com/v1" },
         models: {
-          smoke: {
-            name: "Smoke",
+          architect: {
+            name: "Architect",
             capabilities: { tools: true, input: ["text"], output: ["text"] },
-            variants: [{ id: "low" }, { id: "high" }],
+            variants: [{ id: "steady" }],
+          },
+          scout: {
+            name: "Scout",
+            capabilities: { tools: true, input: ["text"], output: ["text"] },
+            variants: [{ id: "fast" }],
+          },
+          "team/specialist": {
+            name: "Specialist",
+            capabilities: { tools: true, input: ["text"], output: ["text"] },
+            variants: [{ id: "deep" }],
+          },
+        },
+      },
+      "smoke-beta": {
+        package: "aisdk:@ai-sdk/openai-compatible",
+        settings: { apiKey: "smoke", baseURL: "https://api.openai.com/v1" },
+        models: {
+          implementer: {
+            name: "Implementer",
+            capabilities: { tools: true, input: ["text"], output: ["text"] },
+          },
+          reviewer: {
+            name: "Reviewer",
+            capabilities: { tools: true, input: ["text"], output: ["text"] },
+          },
+          "reviewer-safe": {
+            name: "Safe reviewer",
+            capabilities: { tools: true, input: ["text"], output: ["text"] },
+            variants: [{ id: "careful" }],
           },
         },
       },
@@ -200,19 +235,23 @@ try {
   })
   const plugins = await apiList(baseURL, "/api/plugin", (entries) => entries.some((entry) => entry.id === pluginID))
   assert.equal(plugins.filter((entry) => entry.id === pluginID).length, 1, `native plugin was not discovered exactly once: ${JSON.stringify(plugins)}`)
-  const agentIDs = ["orch-scout", "orch-implementer", "orch-specialist", "orch-reviewer", "orch-reviewer-safe"]
+  const agentIDs = Object.keys(agentModels)
   const agents = await apiList(baseURL, "/api/agent", (entries) => agentIDs.every((id) => entries.some((entry) => entry.id === id)))
   for (const id of agentIDs) {
-    assert.equal(agents.find((agent) => agent.id === id)?.mode, "subagent", `${id} was not discovered: ${JSON.stringify(agents)}`)
+    const agent = agents.find((entry) => entry.id === id)
+    assert.equal(agent?.mode, "subagent", `${id} was not discovered: ${JSON.stringify(agents)}`)
+    assert.deepEqual(agent.model, agentModels[id], `${id} model reference drifted`)
   }
   const query = new URLSearchParams({ "location[directory]": temp })
   const endpoint = `/api/model?${query}`
   const catalog = JSON.parse(command(opencode, ["api", "get", endpoint, "--server", baseURL], temp))
   assert.equal(path.resolve(catalog.location.directory), path.resolve(temp), "catalog response location drifted")
-  const smokeModel = catalog.data.find((model) => model.providerID === "smoke" && model.id === "smoke")
-  assert(smokeModel?.enabled, "project model was not enabled in the live catalog")
-  assert(smokeModel.capabilities.tools && smokeModel.capabilities.input.includes("text") && smokeModel.capabilities.output.includes("text"), "project model was not agent-capable")
-  assert.deepEqual(smokeModel.variants.map((variant) => variant.id), ["low", "high"], "live catalog variants drifted")
+  for (const expected of [{ providerID: "smoke-alpha", id: "architect", variant: "steady" }, ...Object.values(agentModels)]) {
+    const model = catalog.data.find((entry) => entry.providerID === expected.providerID && entry.id === expected.id)
+    assert(model?.enabled, `${expected.providerID}/${expected.id} was not enabled in the live catalog`)
+    assert(model.capabilities.tools && model.capabilities.input.includes("text") && model.capabilities.output.includes("text"), `${expected.providerID}/${expected.id} was not agent-capable`)
+    if (expected.variant) assert(model.variants.some((variant) => variant.id === expected.variant), `${expected.providerID}/${expected.id} omitted variant ${expected.variant}`)
+  }
 
   controller = await simulation(`ws://127.0.0.1:${backendPort}`)
   const tracked = path.join(temp, "tracked.txt")
@@ -220,7 +259,7 @@ try {
   const scratch = path.join(temp, ".scratch", "opencode-smoke.tmp")
   const session = await api(baseURL, "/api/session", {
     method: "POST",
-    body: JSON.stringify({ location: { directory: temp }, model: { providerID: "smoke", id: "smoke" } }),
+    body: JSON.stringify({ location: { directory: temp }, model: { providerID: "smoke-alpha", id: "architect", variant: "steady" } }),
   })
   await api(baseURL, `/api/session/${session.id}/prompt`, {
     method: "POST",

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -5,6 +5,7 @@ package agents_test
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -115,6 +116,41 @@ func TestRenderOpenCodeNativeAgents(t *testing.T) {
 		}
 		if !strings.Contains(text, "mode: subagent") || !strings.Contains(text, "model: openai/") || !strings.Contains(text, "#") {
 			t.Errorf("%s is not a native V2 model/variant agent", file.Path)
+		}
+	}
+}
+
+func TestRenderOpenCodeMixedProviderFixture(t *testing.T) {
+	data, err := os.ReadFile("testdata/opencode-mixed-provider.toml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files, err := agents.Render("opencode", cfg.Hosts.OpenCode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{
+		"orch-scout":         "smoke-alpha/scout#fast",
+		"orch-implementer":   "smoke-beta/implementer",
+		"orch-specialist":    "smoke-alpha/team/specialist#deep",
+		"orch-reviewer":      "smoke-beta/reviewer",
+		"orch-reviewer-safe": "smoke-beta/reviewer-safe#careful",
+	}
+	if len(files) != len(want) {
+		t.Fatalf("Render returned %d files, want %d", len(files), len(want))
+	}
+	for _, file := range files {
+		model, ok := want[stem(file)]
+		if !ok {
+			t.Errorf("unexpected rendered agent %s", file.Path)
+			continue
+		}
+		if line := "model: " + strconv.Quote(model) + "\n"; !strings.Contains(string(file.Content), line) {
+			t.Errorf("%s does not pin exact model reference %q", file.Path, model)
 		}
 	}
 }

--- a/internal/agents/testdata/opencode-mixed-provider.toml
+++ b/internal/agents/testdata/opencode-mixed-provider.toml
@@ -1,0 +1,27 @@
+schema_version  = 1
+config_revision = "mixed-provider-fixture"
+
+[memhub]
+mode = "off"
+
+[hosts.opencode.roles.architect]
+model   = "smoke-alpha/architect"
+variant = "steady"
+
+[hosts.opencode.roles.scout]
+model   = "smoke-alpha/scout"
+variant = "fast"
+
+[hosts.opencode.roles.implementer]
+model = "smoke-beta/implementer"
+
+[hosts.opencode.roles.specialist]
+model   = "smoke-alpha/team/specialist"
+variant = "deep"
+
+[hosts.opencode.roles.reviewer]
+model = "smoke-beta/reviewer"
+
+[hosts.opencode.roles.review_downgrade]
+model   = "smoke-beta/reviewer-safe"
+variant = "careful"


### PR DESCRIPTION
Delivers issue #250: Prove mixed-provider OpenCode roles and document the workflow

Closes #250

**Plan digest:** `sha256:d8babfc1e20fb1e2c3342c5872abab9e0d869ecd9b5f034f73f9a35e5c6efab0`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Provide deterministic and live evidence that one OpenCode-host profile can use different providers and models by role, then document the supported configuration and limits.

**Acceptance criteria:**
- A mixed-provider fixture renders every dispatched OpenCode role with its configured exact model reference, including both variant and no-variant selections.
- The pinned live smoke discovers the mixed-provider agent definitions and confirms their exact model references without requiring a paid model generation.
- The README, product requirements, and OpenCode adapter guide describe live catalog discovery, per-model variants, main-session handling, failure behavior, deterministic setup pagination, and the pinned compatibility version consistently.
- All repository build, test, vet, formatting, npm, and pinned OpenCode smoke gates pass.

**Required tests:**
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`
- `npm test --prefix adapters/opencode`
- `npm run smoke --prefix adapters/opencode` — CI does not run this test

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `openai/gpt-5.6-sol` — effort `xhigh` |
| Reviewer | `openai/gpt-5.6-sol` — effort `xhigh` |
| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
| Config revision | `sha256:308e4942b411` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.

**Escalations:** _none_

**Verification:**
- **go-build** — passed — `go build ./...` — Executor ran the full repository Go build at d07b057c1d8503035d519498a7558f1c8ddbd139. — commit `d07b057c1d8503035d519498a7558f1c8ddbd139` (2026-08-27T23:14:22Z)
- **go-test** — passed — `go test ./...` — Executor ran the full Go test suite at d07b057c1d8503035d519498a7558f1c8ddbd139. — commit `d07b057c1d8503035d519498a7558f1c8ddbd139` (2026-08-27T23:14:22Z)
- **go-vet** — passed — `go vet ./...` — Executor ran go vet across all packages at d07b057c1d8503035d519498a7558f1c8ddbd139. — commit `d07b057c1d8503035d519498a7558f1c8ddbd139` (2026-08-27T23:14:22Z)
- **gofmt** — passed — `gofmt -l .` — No output; all Go files are formatted. — commit `d07b057c1d8503035d519498a7558f1c8ddbd139` (2026-08-27T23:14:22Z)
- **opencode-tests** — passed — `npm test --prefix adapters/opencode` — All 6 OpenCode adapter tests passed. — commit `d07b057c1d8503035d519498a7558f1c8ddbd139` (2026-08-27T23:14:22Z)
- **opencode-pinned-smoke** — passed — `npm run smoke --prefix adapters/opencode` — Required local-only gate passed with 'OpenCode V2 smoke passed'. The globally installed runtime was beta-18414, so the smoke used a temporary integrity-verified beta-18314 runtime; CI does not repeat this check. — commit `d07b057c1d8503035d519498a7558f1c8ddbd139` (2026-08-27T23:14:22Z)
- **branch-scope:issue-250-diff** — passed — `git diff --name-status origin/main...HEAD; git diff --stat origin/main...HEAD; git log --oneline origin/main..HEAD` — One pushed commit d07b057c1d8503035d519498a7558f1c8ddbd139 changes six approved-scope files: ORCH-PRD.md, README.md, adapters/opencode/README.md, adapters/opencode/smoke.mjs, internal/agents/agents_test.go, and internal/agents/testdata/opencode-mixed-provider.toml; 184 insertions and 17 deletions. Worktree is clean and remote branch resolves to the same full OID. — commit `d07b057c1d8503035d519498a7558f1c8ddbd139` (2026-08-27T23:14:22Z)
- **acceptance-criterion-1** — satisfied — The shared mixed-provider fixture configures all six roles across two providers with variant and no-variant selections, and the deterministic renderer test asserts exact references for all five dispatched roles while correctly excluding the Architect main session. — commit `d07b057c1d8503035d519498a7558f1c8ddbd139` (2026-08-27T23:19:40Z)
- **acceptance-criterion-2** — satisfied — The beta-18314 smoke renders the shared fixture, discovers every dispatched agent through the live agent API, deep-compares exact model objects, and routes generation through the simulation backend so no paid generation is required. — commit `d07b057c1d8503035d519498a7558f1c8ddbd139` (2026-08-27T23:19:40Z)
- **acceptance-criterion-3** — satisfied — README.md, ORCH-PRD.md, and adapters/opencode/README.md consistently document live catalog discovery, model-specific variants, deterministic pagination, failure behavior, main-session comparison without switching, child-session exclusion, and beta-18314 compatibility. — commit `d07b057c1d8503035d519498a7558f1c8ddbd139` (2026-08-27T23:19:40Z)
- **acceptance-criterion-4** — satisfied — The audit record pins all six required commands to the reviewed head as passing, including the local-only pinned smoke; GitHub independently showed five required checks successful and the remaining Windows job pending rather than failed during review. — commit `d07b057c1d8503035d519498a7558f1c8ddbd139` (2026-08-27T23:19:40Z)
- **review-cycle-1** — approve — Approved with no correctness, security, scope, or test-quality defects. All four acceptance criteria are satisfied at the pinned head; required GitHub CI was still settling during review and must pass before merge. — commit `d07b057c1d8503035d519498a7558f1c8ddbd139` (2026-08-27T23:19:40Z)
- **required-ci** — passing — test (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `d07b057c1d8503035d519498a7558f1c8ddbd139` (2026-08-27T23:20:19Z)

<!-- orch:manifest:data
{
  "schema_version": 4,
  "objective": "Provide deterministic and live evidence that one OpenCode-host profile can use different providers and models by role, then document the supported configuration and limits.",
  "acceptance_criteria": [
    "A mixed-provider fixture renders every dispatched OpenCode role with its configured exact model reference, including both variant and no-variant selections.",
    "The pinned live smoke discovers the mixed-provider agent definitions and confirms their exact model references without requiring a paid model generation.",
    "The README, product requirements, and OpenCode adapter guide describe live catalog discovery, per-model variants, main-session handling, failure behavior, deterministic setup pagination, and the pinned compatibility version consistently.",
    "All repository build, test, vet, formatting, npm, and pinned OpenCode smoke gates pass."
  ],
  "required_tests": [
    "go build ./...",
    "go test ./...",
    "go vet ./...",
    "gofmt -l .",
    "npm test --prefix adapters/opencode",
    "npm run smoke --prefix adapters/opencode"
  ],
  "tests_ci_does_not_run": [
    "npm run smoke --prefix adapters/opencode"
  ],
  "role": "implementer",
  "executor": {
    "model": "openai/gpt-5.6-sol",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.",
  "reviewer": {
    "model": "openai/gpt-5.6-sol",
    "effort": "xhigh"
  },
  "effort_delivery": "parameter",
  "config_revision": "sha256:308e4942b411",
  "verifications": [
    {
      "name": "go-build",
      "command": "go build ./...",
      "result": "passed",
      "detail": "Executor ran the full repository Go build at d07b057c1d8503035d519498a7558f1c8ddbd139.",
      "commit_oid": "d07b057c1d8503035d519498a7558f1c8ddbd139",
      "at": "2026-08-27T23:14:22Z"
    },
    {
      "name": "go-test",
      "command": "go test ./...",
      "result": "passed",
      "detail": "Executor ran the full Go test suite at d07b057c1d8503035d519498a7558f1c8ddbd139.",
      "commit_oid": "d07b057c1d8503035d519498a7558f1c8ddbd139",
      "at": "2026-08-27T23:14:22Z"
    },
    {
      "name": "go-vet",
      "command": "go vet ./...",
      "result": "passed",
      "detail": "Executor ran go vet across all packages at d07b057c1d8503035d519498a7558f1c8ddbd139.",
      "commit_oid": "d07b057c1d8503035d519498a7558f1c8ddbd139",
      "at": "2026-08-27T23:14:22Z"
    },
    {
      "name": "gofmt",
      "command": "gofmt -l .",
      "result": "passed",
      "detail": "No output; all Go files are formatted.",
      "commit_oid": "d07b057c1d8503035d519498a7558f1c8ddbd139",
      "at": "2026-08-27T23:14:22Z"
    },
    {
      "name": "opencode-tests",
      "command": "npm test --prefix adapters/opencode",
      "result": "passed",
      "detail": "All 6 OpenCode adapter tests passed.",
      "commit_oid": "d07b057c1d8503035d519498a7558f1c8ddbd139",
      "at": "2026-08-27T23:14:22Z"
    },
    {
      "name": "opencode-pinned-smoke",
      "command": "npm run smoke --prefix adapters/opencode",
      "result": "passed",
      "detail": "Required local-only gate passed with 'OpenCode V2 smoke passed'. The globally installed runtime was beta-18414, so the smoke used a temporary integrity-verified beta-18314 runtime; CI does not repeat this check.",
      "commit_oid": "d07b057c1d8503035d519498a7558f1c8ddbd139",
      "at": "2026-08-27T23:14:22Z"
    },
    {
      "name": "branch-scope:issue-250-diff",
      "command": "git diff --name-status origin/main...HEAD; git diff --stat origin/main...HEAD; git log --oneline origin/main..HEAD",
      "result": "passed",
      "detail": "One pushed commit d07b057c1d8503035d519498a7558f1c8ddbd139 changes six approved-scope files: ORCH-PRD.md, README.md, adapters/opencode/README.md, adapters/opencode/smoke.mjs, internal/agents/agents_test.go, and internal/agents/testdata/opencode-mixed-provider.toml; 184 insertions and 17 deletions. Worktree is clean and remote branch resolves to the same full OID.",
      "commit_oid": "d07b057c1d8503035d519498a7558f1c8ddbd139",
      "at": "2026-08-27T23:14:22Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "The shared mixed-provider fixture configures all six roles across two providers with variant and no-variant selections, and the deterministic renderer test asserts exact references for all five dispatched roles while correctly excluding the Architect main session.",
      "commit_oid": "d07b057c1d8503035d519498a7558f1c8ddbd139",
      "at": "2026-08-27T23:19:40Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "The beta-18314 smoke renders the shared fixture, discovers every dispatched agent through the live agent API, deep-compares exact model objects, and routes generation through the simulation backend so no paid generation is required.",
      "commit_oid": "d07b057c1d8503035d519498a7558f1c8ddbd139",
      "at": "2026-08-27T23:19:40Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "README.md, ORCH-PRD.md, and adapters/opencode/README.md consistently document live catalog discovery, model-specific variants, deterministic pagination, failure behavior, main-session comparison without switching, child-session exclusion, and beta-18314 compatibility.",
      "commit_oid": "d07b057c1d8503035d519498a7558f1c8ddbd139",
      "at": "2026-08-27T23:19:40Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "The audit record pins all six required commands to the reviewed head as passing, including the local-only pinned smoke; GitHub independently showed five required checks successful and the remaining Windows job pending rather than failed during review.",
      "commit_oid": "d07b057c1d8503035d519498a7558f1c8ddbd139",
      "at": "2026-08-27T23:19:40Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approved with no correctness, security, scope, or test-quality defects. All four acceptance criteria are satisfied at the pinned head; required GitHub CI was still settling during review and must pass before merge.",
      "commit_oid": "d07b057c1d8503035d519498a7558f1c8ddbd139",
      "at": "2026-08-27T23:19:40Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, test (macos-latest)=pass, test (ubuntu-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "d07b057c1d8503035d519498a7558f1c8ddbd139",
      "at": "2026-08-27T23:20:19Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->