### PR TITLE
Bump release identities for v0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/License-MIT-2E7D32?style=flat&logo=opensourceinitiative&logoColor=white" alt="License: MIT"/>
   <img src="https://img.shields.io/badge/Go-1.26%2B-00ADD8?style=flat&logo=go&logoColor=white" alt="Go 1.26+"/>
-  <img src="https://img.shields.io/badge/Release-v0.8.0-24292F?style=flat&logo=github&logoColor=white" alt="Release: v0.8.0"/>
+  <img src="https://img.shields.io/badge/Release-v0.9.0-24292F?style=flat&logo=github&logoColor=white" alt="Release: v0.9.0"/>
   <br/>
   <img src="https://img.shields.io/badge/Platform-Linux%20%C2%B7%20macOS%20%C2%B7%20Windows-607D8B?style=flat" alt="Platform: Linux, macOS, Windows"/>
   <img src="https://img.shields.io/badge/Hosts-Claude%20Code%20%C2%B7%20Codex%20CLI%20%C2%B7%20OpenCode%20V2-6E56CF?style=flat" alt="Hosts: Claude Code, Codex CLI, and OpenCode V2"/>
@@ -435,7 +435,7 @@ receive a copy of the memhub database.
 
 ## Status
 
-Early software. What can be stated as fact: 20 tagged releases, v0.1.0 through v0.8.0, and every pull request merged since PR #40 carries an Orch audit record in its body — apart from the configuration deliveries, which `orch configure` writes in its own body format. Since PR #40, this repository has been built through the pipeline described above: a plan gate, an isolated worktree per issue, a review dispatched separately from the work, CI, and a merge that fails closed unless it carries an approval pinned to the commit `merge-report` recorded.
+Early software. What can be stated as fact: 21 tagged releases, v0.1.0 through v0.9.0, and every pull request merged since PR #40 carries an Orch audit record in its body — apart from the configuration deliveries, which `orch configure` writes in its own body format. Since PR #40, this repository has been built through the pipeline described above: a plan gate, an isolated worktree per issue, a review dispatched separately from the work, CI, and a merge that fails closed unless it carries an approval pinned to the commit `merge-report` recorded.
 
 All of that evidence comes from one repository: this one.
 
@@ -614,7 +614,7 @@ continue, or `orch abort` to end it.
 <details>
 <summary>Defects already corrected, newest first</summary>
 
-Everything here is merged on `main` and shipped in v0.8.0, the latest
+Everything here is merged on `main` and shipped in v0.9.0, the latest
 tagged release.
 
 - The wrong-criterion guidance in the standard and safe reviewer

--- a/adapters/opencode/README.md
+++ b/adapters/opencode/README.md
@@ -1,7 +1,7 @@
 # OpenCode V2 adapter
 
 This directory is Orch's npm-native OpenCode V2 adapter. Its package ID
-is `@kninetimmy/orch-opencode` (version `0.8.0`) and its running plugin
+is `@kninetimmy/orch-opencode` (version `0.9.0`) and its running plugin
 ID is `orch.delivery`. It is not the Codex marketplace adapter: that is
 `adapters/codex/`, installed as `orch@orch` from the shared marketplace.
 

--- a/adapters/opencode/package-lock.json
+++ b/adapters/opencode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kninetimmy/orch-opencode",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kninetimmy/orch-opencode",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@opencode-ai/plugin": "0.0.0-beta-18314"
       }

--- a/adapters/opencode/package.json
+++ b/adapters/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kninetimmy/orch-opencode",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "exports": "./src/index.js",
   "scripts": {


### PR DESCRIPTION
Delivers issue #253: Bump release identities for v0.9.0

Closes #253

**Plan digest:** `sha256:f1ae198783db559b382a8465d381e9648fbef47e9b50e24b265273f408c53e96`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Prepare identity bumps for the v0.9.0 release. Update the OpenCode adapter package and README identities plus the root README release badge, tagged-release count, and latest-release prose. Keep historical v0.8.0 compatibility references and unchanged Claude/Codex adapter identities intact; the binary version remains tag-injected.

**Acceptance criteria:**
- The OpenCode adapter package.json, both root package-lock version fields, and adapter README package-version mention read 0.9.0.
- The marketplace manifest and Claude/Codex plugin manifests remain at 0.7.0, and historical v0.8.0 compatibility references remain unchanged.
- README.md's Release badge reads v0.9.0, and its latest-release and tagged-release-count prose identifies 21 tagged releases through v0.9.0.
- go test ./... passes and gofmt -l . is clean.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `openai/gpt-5.6-sol` — effort `xhigh` |
| Reviewer | `openai/gpt-5.6-sol` — effort `high` |
| Effort delivery | `parameter` — the host applied the routed effort as a real model parameter |
| Config revision | `sha256:308e4942b411` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **branch-scope:release-identity-diff** — passed — `git diff --name-status origin/main...HEAD && git diff --stat origin/main...HEAD && git rev-parse HEAD && git rev-parse origin/orch/issue-253-bump-release-identities-for-v0-9-0` — Clean pushed branch at e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3 changes only README.md, adapters/opencode/README.md, adapters/opencode/package.json, and adapters/opencode/package-lock.json: 7 insertions and 7 deletions. Remote and local heads match. — commit `e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3` (2026-08-28T00:18:41Z)
- **go-test-all** — passed — `go test ./...` — All Go packages passed at e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3. — commit `e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3` (2026-08-28T00:18:41Z)
- **gofmt-clean** — passed — `gofmt -l .` — No unformatted files were reported at e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3. — commit `e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3` (2026-08-28T00:18:41Z)
- **identity-spread-check** — passed — `git grep -n "0.9.0" -- README.md adapters/opencode/README.md adapters/opencode/package.json adapters/opencode/package-lock.json; git grep -n "v0.8.0\|0.7.0" -- README.md adapters/opencode/README.md .claude-plugin adapters/claude adapters/codex` — Seven intended v0.9.0 identity sites are present; historical v0.8.0 compatibility prose remains; marketplace and Claude/Codex manifests remain 0.7.0; installer example pins remain unchanged. — commit `e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3` (2026-08-28T00:22:36Z)
- **acceptance-criterion-1** — satisfied — adapters/opencode/package.json:3, package-lock.json:3 and :9, and adapters/opencode/README.md:4 all read 0.9.0. — commit `e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3` (2026-08-28T00:22:37Z)
- **acceptance-criterion-2** — satisfied — .claude-plugin/marketplace.json:6 and the Claude/Codex plugin manifests remain 0.7.0; the complete diff does not modify the historical v0.8.0 compatibility passages. — commit `e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3` (2026-08-28T00:22:37Z)
- **acceptance-criterion-3** — satisfied — README.md:8 carries the v0.9.0 badge, line 438 identifies 21 tagged releases through v0.9.0, and lines 617-618 name v0.9.0 as latest. — commit `e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3` (2026-08-28T00:22:37Z)
- **acceptance-criterion-4** — satisfied — The audit evidence records go test ./... passing and gofmt -l . returning no files at the reviewed head; CI independently confirmed both on completed jobs while the Windows test job remained pending. — commit `e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3` (2026-08-28T00:22:37Z)
- **review-cycle-1** — approve — Approved at frozen head e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3. One commit changes only the four requested files with 7 additions and 7 deletions; OpenCode and root README release identities are correct, historical compatibility text and Claude/Codex identities remain intact, and no functional or security surface changed. Five of six CI checks had passed during review while test (windows-latest) remained in progress and was not treated as passing. The reviewer noted that identity-spread-check's command field was descriptive prose; this review replaces it with the exact commands actually run. — commit `e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3` (2026-08-28T00:22:37Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3` (2026-08-28T00:22:58Z)

<!-- orch:manifest:data
{
  "schema_version": 4,
  "objective": "Prepare identity bumps for the v0.9.0 release. Update the OpenCode adapter package and README identities plus the root README release badge, tagged-release count, and latest-release prose. Keep historical v0.8.0 compatibility references and unchanged Claude/Codex adapter identities intact; the binary version remains tag-injected.",
  "acceptance_criteria": [
    "The OpenCode adapter package.json, both root package-lock version fields, and adapter README package-version mention read 0.9.0.",
    "The marketplace manifest and Claude/Codex plugin manifests remain at 0.7.0, and historical v0.8.0 compatibility references remain unchanged.",
    "README.md's Release badge reads v0.9.0, and its latest-release and tagged-release-count prose identifies 21 tagged releases through v0.9.0.",
    "go test ./... passes and gofmt -l . is clean."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "openai/gpt-5.6-sol",
    "effort": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "openai/gpt-5.6-sol",
    "effort": "high"
  },
  "effort_delivery": "parameter",
  "config_revision": "sha256:308e4942b411",
  "verifications": [
    {
      "name": "branch-scope:release-identity-diff",
      "command": "git diff --name-status origin/main...HEAD \u0026\u0026 git diff --stat origin/main...HEAD \u0026\u0026 git rev-parse HEAD \u0026\u0026 git rev-parse origin/orch/issue-253-bump-release-identities-for-v0-9-0",
      "result": "passed",
      "detail": "Clean pushed branch at e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3 changes only README.md, adapters/opencode/README.md, adapters/opencode/package.json, and adapters/opencode/package-lock.json: 7 insertions and 7 deletions. Remote and local heads match.",
      "commit_oid": "e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3",
      "at": "2026-08-28T00:18:41Z"
    },
    {
      "name": "go-test-all",
      "command": "go test ./...",
      "result": "passed",
      "detail": "All Go packages passed at e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3.",
      "commit_oid": "e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3",
      "at": "2026-08-28T00:18:41Z"
    },
    {
      "name": "gofmt-clean",
      "command": "gofmt -l .",
      "result": "passed",
      "detail": "No unformatted files were reported at e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3.",
      "commit_oid": "e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3",
      "at": "2026-08-28T00:18:41Z"
    },
    {
      "name": "identity-spread-check",
      "command": "git grep -n \"0.9.0\" -- README.md adapters/opencode/README.md adapters/opencode/package.json adapters/opencode/package-lock.json; git grep -n \"v0.8.0\\|0.7.0\" -- README.md adapters/opencode/README.md .claude-plugin adapters/claude adapters/codex",
      "result": "passed",
      "detail": "Seven intended v0.9.0 identity sites are present; historical v0.8.0 compatibility prose remains; marketplace and Claude/Codex manifests remain 0.7.0; installer example pins remain unchanged.",
      "commit_oid": "e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3",
      "at": "2026-08-28T00:22:36Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "adapters/opencode/package.json:3, package-lock.json:3 and :9, and adapters/opencode/README.md:4 all read 0.9.0.",
      "commit_oid": "e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3",
      "at": "2026-08-28T00:22:37Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": ".claude-plugin/marketplace.json:6 and the Claude/Codex plugin manifests remain 0.7.0; the complete diff does not modify the historical v0.8.0 compatibility passages.",
      "commit_oid": "e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3",
      "at": "2026-08-28T00:22:37Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "README.md:8 carries the v0.9.0 badge, line 438 identifies 21 tagged releases through v0.9.0, and lines 617-618 name v0.9.0 as latest.",
      "commit_oid": "e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3",
      "at": "2026-08-28T00:22:37Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "The audit evidence records go test ./... passing and gofmt -l . returning no files at the reviewed head; CI independently confirmed both on completed jobs while the Windows test job remained pending.",
      "commit_oid": "e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3",
      "at": "2026-08-28T00:22:37Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approved at frozen head e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3. One commit changes only the four requested files with 7 additions and 7 deletions; OpenCode and root README release identities are correct, historical compatibility text and Claude/Codex identities remain intact, and no functional or security surface changed. Five of six CI checks had passed during review while test (windows-latest) remained in progress and was not treated as passing. The reviewer noted that identity-spread-check's command field was descriptive prose; this review replaces it with the exact commands actually run.",
      "commit_oid": "e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3",
      "at": "2026-08-28T00:22:37Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "e3ce2e58c7821a4ad9d8cd143ece9959708a9dd3",
      "at": "2026-08-28T00:22:58Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->