### PR TITLE
Accept OpenCode runtimes at or above beta-18314

### DIFF
--- a/ORCH-PRD.md
+++ b/ORCH-PRD.md
@@ -66,8 +66,12 @@ Orch must:
 - Claude Code CLI.
 - OpenCode V2 beta API. Before project-scoped catalog discovery it was pinned to
   `opencode2 v0.0.0-beta-17498` without a model/location contract; that behavior no longer
-  holds. It is now pinned to `opencode2 v0.0.0-beta-18314`, with project-scoped model and
-  returned-location validation.
+  holds. The minimum runtime is now `opencode2 v0.0.0-beta-18314`; newer numeric beta
+  builds are supported only while exactly one `orch.delivery` plugin and the
+  repository-scoped, returned-location-validated model catalog contract pass doctor.
+  The npm SDK remains exactly pinned to `@opencode-ai/plugin`
+  `0.0.0-beta-18314`, and the live smoke to `opencode2 v0.0.0-beta-18314`, to prove
+  that floor.
 - Windows, macOS, and Linux.
 - GitHub through authenticated `gh`.
 - Git repositories with isolated worktree support.
@@ -263,11 +267,12 @@ alias with the same effective selection and revision meaning. This change is
 restricted to OpenCode roles: every Claude Code and Codex role retains its
 required `model` plus `effort` shape and its existing rendering and routing.
 
-On the pinned `opencode2 v0.0.0-beta-18314` contract, initialization,
-configuration, and local configuration derive each OpenCode role's choices from
-the repository's live, returned-location-validated catalog. Every role may select
-a different enabled, tool-capable text `provider/model`; only that model's
-advertised variants are offered, and a model with none uses the bare reference.
+On the minimum `opencode2 v0.0.0-beta-18314` contract, and on newer numeric beta
+builds that preserve it, initialization, configuration, and local configuration
+derive each OpenCode role's choices from the repository's live,
+returned-location-validated catalog. Every role may select a different enabled,
+tool-capable text `provider/model`; only that model's advertised variants are
+offered, and a model with none uses the bare reference.
 Catalog model and variant domains are emitted as deterministic native pages of
 two or three mutually exclusive choices with explicit previous/next navigation,
 each answer appearing exactly once; a one-answer domain adds cancel. Discovery
@@ -592,7 +597,7 @@ V1 is acceptable when:
 - Disabled metrics create no metrics storage.
 - Successful merge leaves the primary checkout current and no stale worktree behind.
 - Behavior is validated on Windows, macOS, and Linux.
-- Codex and Claude adapters retain their shared parity tests; OpenCode passes its native adapter tests and pinned-beta smoke check.
+- Codex and Claude adapters retain their shared parity tests; OpenCode passes its native adapter tests and exact beta-18314 smoke check.
 
 ## 24. Deferred implementation decisions
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ on this machine. Work in a scratch directory, not in one of my projects.
         the absolute path to `$HOME/orch/adapters/opencode/src/index.js`
         to the `plugins` array in `opencode.json`. Restart OpenCode V2,
         then run `opencode2 --version` and
-        `opencode2 api get /api/plugin`; require exactly one
-        `orch.delivery` plugin entry before relying on enforcement.
+        `opencode2 api get /api/plugin`; require beta 18314 or a newer
+        numeric beta runtime and exactly one `orch.delivery` plugin entry
+        before relying on enforcement.
 
 4. Codex CLI only. Skip this entire step on Claude Code and OpenCode V2:
    a. Add both of these stanzas to ~/.codex/config.toml, leaving any
@@ -377,7 +378,8 @@ schema-v1 `effort` values from v0.8.0 still load with the same
 effective selection and configuration revision. This exception is OpenCode-only;
 Claude Code and Codex keep their existing model/effort configuration and routing.
 
-On the supported `opencode2 v0.0.0-beta-18314` contract, OpenCode setup reads the
+On the minimum supported `opencode2 v0.0.0-beta-18314` runtime, or a newer
+numeric beta that passes the same contract checks, OpenCode setup reads the
 repository's live, location-validated catalog. Each of the six roles independently
 chooses any enabled, tool-capable text model, so one profile may mix providers and
 models. A second question offers only the selected model's advertised variants;
@@ -516,8 +518,9 @@ configuration names, and fails when that host's CLI is missing from
 `PATH` or its adapter check fails. Claude and Codex adapter checks also
 report absent, duplicate, disabled, missing-version, and version-
 mismatch states (plus Codex's not-installed state). OpenCode instead
-checks its exact beta runtime and active plugin ID because its beta API
-does not expose adapter versions. Host enablement is a committed-only key
+checks for at least the beta 18314 runtime and exactly one active plugin
+with ID `orch.delivery` because its beta API does not expose adapter
+versions. Host enablement is a committed-only key
 — the Settings table above marks `hosts.claude` / `hosts.codex` /
 `hosts.opencode` as
 `no (committed)` — so machine-local configuration cannot switch a
@@ -570,22 +573,24 @@ envelope and denies the write. That is deliberate — an unparsed write
 must never be allowed — but it means a host upgrade can produce
 spurious denials. Workaround: update `orch`.
 
-**OpenCode V2 support is pinned to a beta API.** Before project-scoped
+**OpenCode V2 support has a beta runtime floor.** Before project-scoped
 catalog discovery, the live smoke check exercised exactly `opencode2
 v0.0.0-beta-17498` and `@opencode-ai/plugin`
 `0.0.0-beta-17498`, while doctor checked only that runtime and the active
 plugin ID. That old compatibility behavior no longer holds. The current
-package and live smoke instead exercise exactly `opencode2
-v0.0.0-beta-18314` and `@opencode-ai/plugin`
-`0.0.0-beta-18314`; no other V2 build is a supported compatibility floor.
-`orch doctor` checks that exact runtime, plugin ID `orch.delivery`, and a
-URL-location-scoped model catalog response for the repository. It retains
-only enabled text-input/text-output tool-capable `provider/model` IDs and
-their variant IDs; provider settings, headers, credentials, account IDs,
-and raw API payloads never enter the returned catalog or its diagnostics.
-The V2 API still does not expose an adapter version. After an OpenCode
-upgrade, restart the service and rerun doctor before relying on
-enforcement.
+minimum runtime is `opencode2 v0.0.0-beta-18314`. Newer numeric V2 beta
+builds are accepted only when `orch doctor` also finds exactly one active
+`orch.delivery` plugin and a URL-location-scoped model catalog response for
+the repository. It retains only enabled text-input/text-output tool-capable
+`provider/model` IDs and their variant IDs; provider settings, headers,
+credentials, account IDs, and raw API payloads never enter the returned
+catalog or its diagnostics. The npm SDK dependency and live smoke remain
+exactly pinned to `@opencode-ai/plugin` `0.0.0-beta-18314` and `opencode2
+v0.0.0-beta-18314`, respectively, to prove the oldest supported contract;
+they do not cap runtime support. The V2 API still does not expose an adapter
+version. After an OpenCode upgrade, restart the service and rerun doctor
+before relying on enforcement; upstream contract drift may require an Orch
+update.
 
 **The merge gate cannot tell a human's approval from an agent's.** The
 engine requires an approval carrying the exact literal `approve-merge`,

--- a/adapters/opencode/README.md
+++ b/adapters/opencode/README.md
@@ -12,10 +12,15 @@ contract landed, the live smoke check exercised exactly `opencode2
 v0.0.0-beta-17498` with `@opencode-ai/plugin`
 `0.0.0-beta-17498` and did not check the model or returned-location
 APIs. That old compatibility behavior no longer holds. After the
-catalog change, the package, doctor, documentation, and live smoke pin
-exactly `opencode2 v0.0.0-beta-18314` with `@opencode-ai/plugin`
-`0.0.0-beta-18314`; that exact beta is the current compatibility floor,
-not a claim of compatibility with other V2 builds.
+catalog change, `opencode2 v0.0.0-beta-18314` is the minimum supported
+runtime. Doctor accepts newer numeric V2 beta builds only when exactly
+one `orch.delivery` plugin is active and the repository-scoped model
+catalog preserves the returned-location contract. Upstream drift in a
+newer build can therefore still require an Orch update. The npm SDK and
+live smoke remain exactly pinned to `@opencode-ai/plugin`
+`0.0.0-beta-18314` and `opencode2 v0.0.0-beta-18314`, respectively, to
+prove the oldest supported contract; those test pins do not cap runtime
+support.
 
 ## Catalog safety and blast radius
 
@@ -30,7 +35,7 @@ them and are never copied into diagnostics.
 
 | Touched element | Does its previous behavior still hold? |
 |---|---|
-| OpenCode runtime and npm plugin pins | No. The before-and-after is recorded above: beta 17498 is replaced by beta 18314. |
+| OpenCode runtime floor and npm SDK/smoke pins | No. The before-and-after is recorded above: beta 17498 is replaced by a beta 18314 runtime floor, while the SDK and smoke stay exactly pinned to beta 18314. |
 | `orch.delivery` plugin ID, setup, guard hooks, and session context | Yes. The same plugin contract remains; unit and live smoke checks still exercise it on the new beta. |
 | Catalog process invocation | New. It is one argument-vector call in the repository directory, with the location URL-encoded rather than shell-interpolated. |
 | Response `location.directory` | New validation. The initial implementation inherited platform-wide case folding and could accept distinct case-different directories on a case-sensitive macOS or Windows volume; that behavior no longer holds. Directory identity is now compared by the filesystem, so every different directory is rejected while aliases of the same directory remain valid. |
@@ -39,7 +44,7 @@ them and are never copied into diagnostics.
 | Response `data[].variants[].id` | New projection. Every advertised variant ID is preserved in server order, including an empty list. |
 | Provider/model/variant settings, headers, bodies, credentials, account IDs, and raw payload | Previously Orch did not read the catalog; after this change these fields may arrive in command output but are never retained, returned, or included in an error. |
 | Setup detection's existing CLI, git, GitHub, memhub, and instruction facts | Yes. Catalog and catalog-error fields are additive, and a failed read remains explicit data rather than changing Detect's no-error contract. |
-| Doctor's runtime and active-plugin checks | Yes. They still run and the catalog/location check now follows them. |
+| Doctor's runtime and active-plugin checks | Yes. The runtime check now accepts beta 18314 or a newer numeric beta, then still requires exactly one active plugin before the catalog/location check follows. |
 | Live smoke's agent discovery, context injection, denied tracked write, and allowed ignored write | Yes. The catalog/location assertions are additive, and the smoke now renders a mixed-provider fixture and checks every discovered dispatched agent's exact model reference. |
 | Interview `profile`, `roleVariantID`, and `openCodeVariantQuestion` | Before, committed interviews represented every execution value as host-wide effort and suggested host-wide variant names. After, the shared profile carries a host-native execution value and each OpenCode variant question contains only no-variant plus the selected catalog model's advertised variants. This applies to every OpenCode role; Claude/Codex keep effort IDs and options. |
 | Committed question writer `openCodeRoleDocSpecs` | Before, OpenCode shared the static `roleDocSpecs` model/effort path. After, all six roles ask a catalog-backed model question followed, only when applicable, by that model's dependent variant question. Claude/Codex retain their model+effort documents. |
@@ -60,8 +65,9 @@ them and are never copied into diagnostics.
 ## Role selection and sessions
 
 `orch init`, `orch configure`, and `orch configure-local` discover models from
-the current repository's live catalog on the pinned
-`opencode2 v0.0.0-beta-18314` runtime. All six role selections are independent:
+the current repository's live catalog on the minimum
+`opencode2 v0.0.0-beta-18314` runtime or a newer runtime that passes doctor's
+contract checks. All six role selections are independent:
 one profile can mix providers and models, and model IDs after the first slash are
 opaque. After each model choice, setup offers only that model's advertised
 variants; a model with no variants produces a bare `provider/model` selection.
@@ -117,7 +123,7 @@ then load its plugin module from an absolute path.
    @kninetimmy/orch-opencode` is not an installation path because that
    package is not published.
 
-3. Restart the OpenCode V2 service, then verify both the pinned runtime
+3. Restart the OpenCode V2 service, then verify both the supported runtime
    and the active plugin ID before relying on enforcement:
 
    ```sh
@@ -126,13 +132,14 @@ then load its plugin module from an absolute path.
    opencode2 api get /api/plugin | node -e 'let s=""; process.stdin.on("data", d => s += d).on("end", () => { if (JSON.parse(s).data.filter(p => p.id === "orch.delivery").length !== 1) throw new Error("orch.delivery is not active exactly once") })'
    ```
 
-   The first command must print `opencode2 v0.0.0-beta-18314`. The JSON
-   from the second must contain exactly one `data` entry whose `id` is
-   `orch.delivery`; the third command fails otherwise. `orch doctor`
-   performs the same runtime and plugin-ID checks for a repository with
-   `hosts.opencode` enabled, then queries that repository's model catalog
-   and verifies its returned location. It cannot check an OpenCode
-   adapter version because the beta API does not expose one.
+   The first command must print `opencode2 v0.0.0-beta-18314` or a newer
+   numeric beta build. The JSON from the second must contain exactly one
+   `data` entry whose `id` is `orch.delivery`; the third command fails
+   otherwise. `orch doctor` enforces that runtime floor and the same
+   plugin-ID requirement for a repository with `hosts.opencode` enabled,
+   then queries that repository's model catalog and verifies its returned
+   location. It cannot check an OpenCode adapter version because the beta
+   API does not expose one.
 
 4. In each repository, run `orch init`, review and merge its bootstrap
    PR, then run `orch render-agents`. It writes the five OpenCode role

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -196,7 +196,7 @@ func (f fakeRunner) Run(_ context.Context, c execx.Cmd) (execx.Result, error) {
 		if len(c.Args) == 1 && c.Args[0] == "--version" {
 			version := f.opencodeVersion
 			if version == "" {
-				version = pinnedOpenCodeVersion
+				version = minimumOpenCodeVersion
 			}
 			return execx.Result{Stdout: version + "\n"}, nil
 		}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/kninetimmy/orch/adapters/claude"
@@ -377,11 +378,11 @@ func adapterVersion(manifestJSON string) (string, error) {
 	return manifest.Version, nil
 }
 
-const pinnedOpenCodeVersion = opencodecatalog.PinnedVersion
+const minimumOpenCodeVersion = opencodecatalog.MinimumVersion
 
-// checkOpenCodeAdapter pins the beta runtime contract, checks the active
-// plugin ID, then returns the verified project-scoped catalog for role
-// selection checks. V2's plugin API does not currently expose adapter versions.
+// checkOpenCodeAdapter enforces the beta runtime floor, checks the active plugin
+// ID, then returns the verified project-scoped catalog for role selection
+// checks. V2's plugin API does not currently expose adapter versions.
 func checkOpenCodeAdapter(env Env, spec adapterSpec) (opencodecatalog.Catalog, error) {
 	fail := func(detail string) (opencodecatalog.Catalog, error) {
 		return opencodecatalog.Catalog{}, fmt.Errorf("%s; %s", detail, spec.repair)
@@ -400,8 +401,8 @@ func checkOpenCodeAdapter(env Env, spec adapterSpec) (opencodecatalog.Catalog, e
 		}
 		return fail(fmt.Sprintf("`%s --version` exited %d: %s", spec.executable, version.ExitCode, detail))
 	}
-	if got := strings.TrimSpace(version.Stdout); got != pinnedOpenCodeVersion {
-		return fail(fmt.Sprintf("OpenCode V2 contract drift: got %q, want %q", got, pinnedOpenCodeVersion))
+	if err := checkOpenCodeRuntimeVersion(strings.TrimSpace(version.Stdout)); err != nil {
+		return fail(err.Error())
 	}
 	listing, err := env.Runner.Run(context.Background(), execx.Cmd{Name: spec.executable, Args: []string{"api", "get", "/api/plugin"}, Dir: env.RepoRoot})
 	command := spec.executable + " api get /api/plugin"
@@ -437,6 +438,21 @@ func checkOpenCodeAdapter(env Env, spec adapterSpec) (opencodecatalog.Catalog, e
 		return fail(err.Error())
 	}
 	return catalog, nil
+}
+
+func checkOpenCodeRuntimeVersion(version string) error {
+	buildText, ok := strings.CutPrefix(version, opencodecatalog.RuntimeVersionPrefix)
+	if !ok || buildText == "" || strings.Trim(buildText, "0123456789") != "" {
+		return fmt.Errorf("OpenCode V2 runtime version output %q is malformed; minimum supported runtime is %q, or use a newer numeric beta build", version, minimumOpenCodeVersion)
+	}
+	build, err := strconv.ParseUint(buildText, 10, 64)
+	if err != nil {
+		return fmt.Errorf("OpenCode V2 runtime version output %q is malformed; minimum supported runtime is %q, or use a newer numeric beta build", version, minimumOpenCodeVersion)
+	}
+	if build < opencodecatalog.MinimumBetaBuild {
+		return fmt.Errorf("OpenCode V2 runtime %q is too old; minimum supported runtime is %q; update OpenCode V2 and retry", version, minimumOpenCodeVersion)
+	}
+	return nil
 }
 
 func decodeAdapterPlugins(host string, data []byte) ([]adapterPlugin, error) {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -295,9 +295,30 @@ func TestDoctorAcceptsAvailableMixedProviderOpenCodeProfile(t *testing.T) {
 	}
 }
 
+func TestDoctorAcceptsOpenCodeRuntimeFloorAndNewerBuilds(t *testing.T) {
+	for _, version := range []string{"opencode2 v0.0.0-beta-18314", "opencode2 v0.0.0-beta-18414"} {
+		t.Run(version, func(t *testing.T) {
+			env, stdout, _ := testEnv(t)
+			writeConfig(t, env.RepoRoot, validOpenCodeTOML)
+			if code := Run([]string{"render-agents"}, env); code != ExitOK {
+				t.Fatalf("render-agents exit = %d\n%s", code, stdout.String())
+			}
+			stdout.Reset()
+			env.Runner = fakeRunner{toplevel: env.RepoRoot, opencodeVersion: version}
+			if code := Run([]string{"doctor"}, env); code != ExitOK {
+				t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+			}
+			if !strings.Contains(stdout.String(), "ok    opencode adapter") {
+				t.Errorf("stdout missing passing adapter check:\n%s", stdout.String())
+			}
+		})
+	}
+}
+
 func TestDoctorAdapterFailures(t *testing.T) {
 	claudeVersion := mustAdapterVersion(t, claudeAdapter)
 	codexVersion := mustAdapterVersion(t, codexAdapter)
+	otherCatalogRoot := t.TempDir()
 	tests := []struct {
 		name        string
 		config      string
@@ -417,13 +438,42 @@ func TestDoctorAdapterFailures(t *testing.T) {
 			wantDetails: []string{"orch@orch version mismatch", fmt.Sprintf(`installed "0.5.0", expected %q`, codexVersion)},
 		},
 		{
-			name:   "opencode runtime mismatch",
+			name:   "opencode runtime below minimum",
+			config: validOpenCodeTOML,
+			spec:   opencodeAdapter,
+			configure: func(r *fakeRunner) {
+				r.opencodeVersion = "opencode2 v0.0.0-beta-18313"
+			},
+			wantDetails: []string{"too old", "minimum supported runtime", minimumOpenCodeVersion},
+		},
+		{
+			name:   "opencode malformed runtime",
 			config: validOpenCodeTOML,
 			spec:   opencodeAdapter,
 			configure: func(r *fakeRunner) {
 				r.opencodeVersion = "opencode2 v0.0.0-beta-newer"
 			},
-			wantDetails: []string{"OpenCode V2 contract drift", pinnedOpenCodeVersion},
+			wantDetails: []string{"runtime version output", "malformed", "minimum supported runtime", minimumOpenCodeVersion},
+		},
+		{
+			name:   "opencode newer runtime still requires one active plugin",
+			config: validOpenCodeTOML,
+			spec:   opencodeAdapter,
+			configure: func(r *fakeRunner) {
+				r.opencodeVersion = "opencode2 v0.0.0-beta-18414"
+				r.opencodePlugins = `{"data":[{"id":"orch.delivery"},{"id":"orch.delivery"}]}`
+			},
+			wantDetails: []string{"orch.delivery appears 2 times", "exactly one active plugin is required"},
+		},
+		{
+			name:   "opencode newer runtime still requires repository catalog location",
+			config: validOpenCodeTOML,
+			spec:   opencodeAdapter,
+			configure: func(r *fakeRunner) {
+				r.opencodeVersion = "opencode2 v0.0.0-beta-18414"
+				r.opencodeCatalog = openCodeCatalogResponse(otherCatalogRoot, "")
+			},
+			wantDetails: []string{"OpenCode model catalog", "different directory"},
 		},
 		{
 			name:   "opencode malformed plugin response",

--- a/internal/opencode/catalog.go
+++ b/internal/opencode/catalog.go
@@ -14,8 +14,10 @@ import (
 )
 
 const (
-	Executable    = "opencode2"
-	PinnedVersion = "opencode2 v0.0.0-beta-18314"
+	Executable           = "opencode2"
+	RuntimeVersionPrefix = Executable + " v0.0.0-beta-"
+	MinimumBetaBuild     = 18314
+	MinimumVersion       = RuntimeVersionPrefix + "18314"
 )
 
 // Model is the safe subset of an available OpenCode model. Provider settings,
@@ -137,5 +139,5 @@ func sameDirectory(want, got string) (bool, error) {
 }
 
 func malformed(detail string) error {
-	return fmt.Errorf("read OpenCode model catalog: malformed `%s api get /api/model` response (%s); update to %s and retry", Executable, detail, PinnedVersion)
+	return fmt.Errorf("read OpenCode model catalog: malformed `%s api get /api/model` response (%s); %s or newer must preserve this catalog contract, so update Orch or OpenCode and retry", Executable, detail, MinimumVersion)
 }


### PR DESCRIPTION
Delivers issue #255: Accept OpenCode runtimes at or above beta-18314

Closes #255

**Plan digest:** `sha256:40d02334ec21315accba54eb002716ce3e069cce681fb7b573917f6c3ea5891f`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Make doctor accept supported newer OpenCode V2 beta runtimes without weakening the active-plugin or repository-scoped catalog checks, and document the runtime floor separately from the exact SDK and smoke pins.

**Acceptance criteria:**
- orch doctor accepts the beta-18314 floor and newer numeric OpenCode V2 beta builds, including beta-18414, while rejecting older and malformed version output with an actionable diagnostic that names the minimum.
- After a supported runtime passes the floor check, doctor still requires exactly one active orch.delivery plugin and a repository-scoped, returned-location-validated model catalog; failures in either contract remain fatal.
- README, ORCH-PRD, and OpenCode adapter documentation describe beta-18314 as the minimum runtime, allow newer runtimes with contract validation, and distinguish that policy from the npm SDK and live smoke remaining exactly pinned to beta-18314.

**Required tests:**
- `gofmt -l .`
- `go build ./...`
- `go vet ./...`
- `go test ./...`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `openai/gpt-5.6-sol#xhigh` — variant `xhigh` |
| Reviewer | `openai/gpt-5.6-sol#xhigh` — variant `xhigh` |
| Profile delivery | `model-variant` — OpenCode applies a selected variant as #variant and leaves a no-variant model reference bare |
| Config revision | `sha256:308e4942b411` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.

**Escalations:** _none_

**Verification:**
- **format** — passed — `gofmt -l .` — No output; all Go files are formatted. — commit `7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb` (2026-08-28T01:46:29Z)
- **build** — passed — `go build ./...` — All packages built successfully. — commit `7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb` (2026-08-28T01:46:29Z)
- **vet** — passed — `go vet ./...` — Go vet completed successfully. — commit `7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb` (2026-08-28T01:46:29Z)
- **tests** — passed — `go test ./...` — All Go package tests passed. — commit `7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb` (2026-08-28T01:46:29Z)
- **diff-check** — passed — `git diff --check origin/main...HEAD` — No whitespace errors. — commit `7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb` (2026-08-28T01:46:29Z)
- **acceptance-criterion-1** — satisfied — The implementation strictly parses the numeric beta suffix, enforces build 18314, names the minimum in malformed and old-version diagnostics, and tests beta-18314, beta-18414, beta-18313, and malformed output. — commit `7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb` (2026-08-28T01:50:57Z)
- **acceptance-criterion-2** — satisfied — Doctor still performs the exactly-one-plugin check before the project catalog read, catalog location validation is preserved, and focused tests prove newer runtimes still fail on duplicate plugins and a wrong catalog location. — commit `7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb` (2026-08-28T01:50:57Z)
- **acceptance-criterion-3** — satisfied — README.md, ORCH-PRD.md, and adapters/opencode/README.md describe the runtime floor and newer-build contract while package.json and smoke.mjs remain exactly pinned to beta-18314. — commit `7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb` (2026-08-28T01:50:57Z)
- **review-cycle-1** — approve — Approve: all acceptance criteria are satisfied, required checks and all six CI jobs pass, scope and audit evidence match the reviewed head, and no security issue was found. Non-blocking backlog finding: adapters/opencode/README.md's blast-radius table should split the changed runtime-floor behavior from the preserved active-plugin behavior instead of labeling the combined row as unchanged. — commit `7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb` (2026-08-28T01:50:57Z)
- **required-ci** — passing — test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb` (2026-08-28T01:51:20Z)

<!-- orch:manifest:data
{
  "schema_version": 5,
  "objective": "Make doctor accept supported newer OpenCode V2 beta runtimes without weakening the active-plugin or repository-scoped catalog checks, and document the runtime floor separately from the exact SDK and smoke pins.",
  "acceptance_criteria": [
    "orch doctor accepts the beta-18314 floor and newer numeric OpenCode V2 beta builds, including beta-18414, while rejecting older and malformed version output with an actionable diagnostic that names the minimum.",
    "After a supported runtime passes the floor check, doctor still requires exactly one active orch.delivery plugin and a repository-scoped, returned-location-validated model catalog; failures in either contract remain fatal.",
    "README, ORCH-PRD, and OpenCode adapter documentation describe beta-18314 as the minimum runtime, allow newer runtimes with contract validation, and distinguish that policy from the npm SDK and live smoke remaining exactly pinned to beta-18314."
  ],
  "required_tests": [
    "gofmt -l .",
    "go build ./...",
    "go vet ./...",
    "go test ./..."
  ],
  "role": "implementer",
  "executor": {
    "model": "openai/gpt-5.6-sol",
    "variant": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.",
  "reviewer": {
    "model": "openai/gpt-5.6-sol",
    "variant": "xhigh"
  },
  "effort_delivery": "model-variant",
  "config_revision": "sha256:308e4942b411",
  "verifications": [
    {
      "name": "format",
      "command": "gofmt -l .",
      "result": "passed",
      "detail": "No output; all Go files are formatted.",
      "commit_oid": "7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb",
      "at": "2026-08-28T01:46:29Z"
    },
    {
      "name": "build",
      "command": "go build ./...",
      "result": "passed",
      "detail": "All packages built successfully.",
      "commit_oid": "7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb",
      "at": "2026-08-28T01:46:29Z"
    },
    {
      "name": "vet",
      "command": "go vet ./...",
      "result": "passed",
      "detail": "Go vet completed successfully.",
      "commit_oid": "7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb",
      "at": "2026-08-28T01:46:29Z"
    },
    {
      "name": "tests",
      "command": "go test ./...",
      "result": "passed",
      "detail": "All Go package tests passed.",
      "commit_oid": "7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb",
      "at": "2026-08-28T01:46:29Z"
    },
    {
      "name": "diff-check",
      "command": "git diff --check origin/main...HEAD",
      "result": "passed",
      "detail": "No whitespace errors.",
      "commit_oid": "7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb",
      "at": "2026-08-28T01:46:29Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "The implementation strictly parses the numeric beta suffix, enforces build 18314, names the minimum in malformed and old-version diagnostics, and tests beta-18314, beta-18414, beta-18313, and malformed output.",
      "commit_oid": "7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb",
      "at": "2026-08-28T01:50:57Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "Doctor still performs the exactly-one-plugin check before the project catalog read, catalog location validation is preserved, and focused tests prove newer runtimes still fail on duplicate plugins and a wrong catalog location.",
      "commit_oid": "7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb",
      "at": "2026-08-28T01:50:57Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "README.md, ORCH-PRD.md, and adapters/opencode/README.md describe the runtime floor and newer-build contract while package.json and smoke.mjs remain exactly pinned to beta-18314.",
      "commit_oid": "7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb",
      "at": "2026-08-28T01:50:57Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approve: all acceptance criteria are satisfied, required checks and all six CI jobs pass, scope and audit evidence match the reviewed head, and no security issue was found. Non-blocking backlog finding: adapters/opencode/README.md's blast-radius table should split the changed runtime-floor behavior from the preserved active-plugin behavior instead of labeling the combined row as unchanged.",
      "commit_oid": "7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb",
      "at": "2026-08-28T01:50:57Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (ubuntu-latest)=pass, test (windows-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "7f7d21a9eac77ceb6b0563ff1b2c4c7bc8a7d2bb",
      "at": "2026-08-28T01:51:20Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->