### PR TITLE
Keep installed OpenCode Orch skills current

### DIFF
--- a/adapters/opencode/README.md
+++ b/adapters/opencode/README.md
@@ -100,7 +100,7 @@ simulation backend, so the smoke never requires a paid model request.
 The adapter is not published to npm and releases do not publish an npm
 artifact. Install the checked-out `adapters/opencode/` package — the
 same directory CI installs with `npm ci --prefix adapters/opencode` —
-then load its plugin module from an absolute path.
+then load its plugin module and canonical skills directory from absolute paths.
 
 1. Install the `orch` binary first, then clone the repository somewhere
    persistent (not into a project it will orchestrate):
@@ -111,14 +111,20 @@ then load its plugin module from an absolute path.
    npm ci --prefix adapters/opencode
    ```
 
-2. Add the absolute plugin module path to OpenCode V2's `opencode.json`.
-   Keep any existing configuration and plugins:
+2. Append the absolute plugin module path and canonical skill source to the
+   existing `plugins` and `skills` arrays in OpenCode V2's `opencode.json`.
+   Keep all unrelated configuration, plugin entries, and skill-source entries:
 
    ```json
    {
-     "plugins": ["/absolute/path/to/orch/adapters/opencode/src/index.js"]
+     "plugins": ["/absolute/path/to/orch/adapters/opencode/src/index.js"],
+     "skills": ["/absolute/path/to/orch/adapters/opencode/skills"]
    }
    ```
+
+   These are entries to add, not replacement arrays. The checkout-backed skill
+   source makes updates available after a service restart without copying skill
+   files into OpenCode's global skill directory.
 
    The module is supplied by the local
    `@kninetimmy/orch-opencode` package; `npm install
@@ -138,10 +144,11 @@ then load its plugin module from an absolute path.
    numeric beta build. The JSON from the second must contain exactly one
    `data` entry whose `id` is `orch.delivery`; the third command fails
    otherwise. `orch doctor` enforces that runtime floor and the same
-   plugin-ID requirement for a repository with `hosts.opencode` enabled,
-   then queries that repository's model catalog and verifies its returned
-   location. It cannot check an OpenCode adapter version because the beta
-   API does not expose one.
+   plugin-ID requirement for a repository with `hosts.opencode` enabled. It
+   also queries that repository's live skill and model catalogs, verifies their
+   returned locations, and requires compatible `orch-architect`,
+   `orch-delivery`, and `orch-setup` wire contracts. It cannot check an
+   OpenCode adapter version because the beta API does not expose one.
 
 4. In each repository, run `orch init`, review and merge its bootstrap
    PR, then run `orch render-agents`. It writes the five OpenCode role
@@ -172,9 +179,10 @@ opencode2 api get /api/plugin
 opencode2 api get /api/plugin | node -e 'let s=""; process.stdin.on("data", d => s += d).on("end", () => { if (JSON.parse(s).data.filter(p => p.id === "orch.delivery").length !== 1) throw new Error("orch.delivery is not active exactly once") })'
 ```
 
-The configured absolute module path stays the same. If the checkout
-path changes, update `opencode.json` to the new absolute
-`adapters/opencode/src/index.js` path before restarting.
+The configured absolute module and skill-source paths stay the same. If the
+checkout path changes, update `opencode.json` to the new absolute
+`adapters/opencode/src/index.js` and `adapters/opencode/skills` paths before
+restarting.
 
 ## Limitations
 

--- a/adapters/opencode/plugin_test.go
+++ b/adapters/opencode/plugin_test.go
@@ -2,6 +2,7 @@ package opencode_test
 
 import (
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -27,6 +28,23 @@ func TestPackagePinsOpenCodeV2Contract(t *testing.T) {
 	}
 	if len(manifest.Dependencies) != 1 {
 		t.Fatalf("dependencies = %v, want only the V2 plugin API", manifest.Dependencies)
+	}
+}
+
+func TestInstallGuideAddsCheckoutPluginAndSkillSources(t *testing.T) {
+	data, err := os.ReadFile("README.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		`"plugins": ["/absolute/path/to/orch/adapters/opencode/src/index.js"]`,
+		`"skills": ["/absolute/path/to/orch/adapters/opencode/skills"]`,
+		"entries to add, not replacement arrays",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("README.md missing additive installation guidance %q", want)
+		}
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -99,6 +99,9 @@ type fakeRunner struct {
 	opencodePlugins     string
 	opencodePluginExit  int
 	opencodePluginErr   error
+	opencodeSkills      string
+	opencodeSkillExit   int
+	opencodeSkillErr    error
 	opencodeCatalog     string
 	opencodeCatalogExit int
 	opencodeCatalogErr  error
@@ -210,6 +213,16 @@ func (f fakeRunner) Run(_ context.Context, c execx.Cmd) (execx.Result, error) {
 			}
 			return execx.Result{Stdout: plugins, ExitCode: f.opencodePluginExit}, nil
 		}
+		if len(c.Args) == 3 && c.Args[0] == "api" && c.Args[1] == "get" && strings.HasPrefix(c.Args[2], "/api/skill?") {
+			if f.opencodeSkillErr != nil {
+				return execx.Result{}, f.opencodeSkillErr
+			}
+			skills := f.opencodeSkills
+			if skills == "" {
+				skills = healthyOpenCodeSkillResponse(c.Dir)
+			}
+			return execx.Result{Stdout: skills, ExitCode: f.opencodeSkillExit}, nil
+		}
 		if len(c.Args) == 3 && c.Args[0] == "api" && c.Args[1] == "get" && strings.HasPrefix(c.Args[2], "/api/model?") {
 			if f.opencodeCatalogErr != nil {
 				return execx.Result{}, f.opencodeCatalogErr
@@ -237,6 +250,21 @@ func (f fakeRunner) Run(_ context.Context, c execx.Cmd) (execx.Result, error) {
 		}
 	}
 	return execx.Result{}, fmt.Errorf("fakeRunner: unexpected command %s %v", c.Name, c.Args)
+}
+
+func healthyOpenCodeSkillResponse(root string) string {
+	return openCodeSkillResponse(root, func(contract openCodeSkillContract) string {
+		return strings.Join(contract.markers, "\n")
+	})
+}
+
+func openCodeSkillResponse(root string, content func(openCodeSkillContract) string) string {
+	var skills []string
+	for _, contract := range openCodeSkillContracts() {
+		skills = append(skills, fmt.Sprintf(`{"id":%q,"location":%q,"content":%q}`,
+			contract.id, "/compatible/custom/"+contract.id+"/SKILL.md", content(contract)))
+	}
+	return fmt.Sprintf(`{"location":{"directory":%q},"data":[%s]}`, root, strings.Join(skills, ","))
 }
 
 func writeConfig(t *testing.T, root, content string) {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -24,6 +24,8 @@ import (
 	"github.com/kninetimmy/orch/internal/memhub"
 	"github.com/kninetimmy/orch/internal/metrics"
 	opencodecatalog "github.com/kninetimmy/orch/internal/opencode"
+	"github.com/kninetimmy/orch/internal/question"
+	"github.com/kninetimmy/orch/internal/run"
 	"github.com/kninetimmy/orch/internal/state"
 )
 
@@ -381,8 +383,9 @@ func adapterVersion(manifestJSON string) (string, error) {
 const minimumOpenCodeVersion = opencodecatalog.MinimumVersion
 
 // checkOpenCodeAdapter enforces the beta runtime floor, checks the active plugin
-// ID, then returns the verified project-scoped catalog for role selection
-// checks. V2's plugin API does not currently expose adapter versions.
+// ID and live skill contracts, then returns the verified project-scoped model
+// catalog for role selection checks. V2's plugin API does not currently expose
+// adapter versions.
 func checkOpenCodeAdapter(env Env, spec adapterSpec) (opencodecatalog.Catalog, error) {
 	fail := func(detail string) (opencodecatalog.Catalog, error) {
 		return opencodecatalog.Catalog{}, fmt.Errorf("%s; %s", detail, spec.repair)
@@ -433,11 +436,78 @@ func checkOpenCodeAdapter(env Env, spec adapterSpec) (opencodecatalog.Catalog, e
 	if count != 1 {
 		return fail(fmt.Sprintf("%s appears %d times; exactly one active plugin is required", spec.pluginID, count))
 	}
+	skills, err := opencodecatalog.ReadSkillCatalog(context.Background(), env.Runner, env.RepoRoot)
+	if err != nil {
+		return failOpenCodeSkills(err.Error())
+	}
+	if err := checkOpenCodeSkillContracts(skills); err != nil {
+		return failOpenCodeSkills(err.Error())
+	}
 	catalog, err := opencodecatalog.ReadCatalog(context.Background(), env.Runner, env.RepoRoot)
 	if err != nil {
 		return fail(err.Error())
 	}
 	return catalog, nil
+}
+
+const canonicalOpenCodeSkillSource = "adapters/opencode/skills"
+
+type openCodeSkillContract struct {
+	id      string
+	markers []string
+}
+
+func openCodeSkillContracts() []openCodeSkillContract {
+	return []openCodeSkillContract{
+		{
+			id: "orch-setup",
+			markers: []string{
+				fmt.Sprintf(`{"schema_version": %d, "answers": {}}`, question.SchemaVersion),
+				fmt.Sprintf("Question wire `schema_version` is closed at `%d` for both `AnswerSet` and `Document`", question.SchemaVersion),
+			},
+		},
+		{
+			id: "orch-delivery",
+			markers: []string{
+				fmt.Sprintf("Selection-bearing wire versions are closed: StatusDoc `%d`, GateDoc `%d`, Dispatch `%d`, Escalate `%d`, Review `%d`.",
+					run.StatusSchemaVersion, run.GateSchemaVersion, run.DispatchSchemaVersion, run.EscalateSchemaVersion, run.ReviewSchemaVersion),
+				"Reject any other `schema_version` before reading or submitting a `Selection`.",
+				fmt.Sprintf("`GateDoc` (`schema_version: %d`)", run.GateSchemaVersion),
+				fmt.Sprintf("`{\"schema_version\": %d, \"issue_number\": N}`. Result (`DispatchResult`)", run.DispatchSchemaVersion),
+				fmt.Sprintf("{\"schema_version\": %d, \"issue_number\": N, \"reviewed_head_oid\": \"...\"", run.ReviewSchemaVersion),
+				fmt.Sprintf("{\"schema_version\": %d, \"issue_number\": N, \"trigger\": \"...\", \"detail\": \"...\"}", run.EscalateSchemaVersion),
+			},
+		},
+		{
+			id: "orch-architect",
+			markers: []string{
+				fmt.Sprintf("`orch run status --json` returns `StatusDoc` schema_version `%d`; reject any other before reading its Selection-bearing run state.", run.StatusSchemaVersion),
+			},
+		},
+	}
+}
+
+func checkOpenCodeSkillContracts(catalog opencodecatalog.SkillCatalog) error {
+	contents := make(map[string]string, len(catalog.Skills))
+	for _, skill := range catalog.Skills {
+		contents[skill.ID] = strings.Join(strings.Fields(skill.Content), " ")
+	}
+	for _, contract := range openCodeSkillContracts() {
+		content, ok := contents[contract.id]
+		if !ok {
+			return fmt.Errorf("live OpenCode skill %q is absent", contract.id)
+		}
+		for _, marker := range contract.markers {
+			if !strings.Contains(content, strings.Join(strings.Fields(marker), " ")) {
+				return fmt.Errorf("live OpenCode skill %q lacks this Orch build's wire contract", contract.id)
+			}
+		}
+	}
+	return nil
+}
+
+func failOpenCodeSkills(detail string) (opencodecatalog.Catalog, error) {
+	return opencodecatalog.Catalog{}, fmt.Errorf("%s; configure the checked-out `%s` directory as an additive OpenCode skill source, then restart the OpenCode V2 service", detail, canonicalOpenCodeSkillSource)
 }
 
 func checkOpenCodeRuntimeVersion(version string) error {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -315,6 +315,86 @@ func TestDoctorAcceptsOpenCodeRuntimeFloorAndNewerBuilds(t *testing.T) {
 	}
 }
 
+func TestDoctorAcceptsCompatibleCustomizedOpenCodeSkills(t *testing.T) {
+	env, stdout, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validOpenCodeTOML)
+	if code := Run([]string{"render-agents"}, env); code != ExitOK {
+		t.Fatalf("render-agents exit = %d\n%s", code, stdout.String())
+	}
+	stdout.Reset()
+	response := healthyOpenCodeSkillResponse(env.RepoRoot)
+	response = strings.ReplaceAll(response, `"content":"`, `"content":"customized preface `)
+	env.Runner = fakeRunner{toplevel: env.RepoRoot, opencodeSkills: response}
+	if code := Run([]string{"doctor"}, env); code != ExitOK {
+		t.Fatalf("exit = %d, want %d\n%s", code, ExitOK, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "ok    opencode adapter") {
+		t.Errorf("stdout missing passing adapter check:\n%s", stdout.String())
+	}
+}
+
+func TestDoctorRejectsMissingOrIncompatibleOpenCodeSkillsWithoutDisclosingContent(t *testing.T) {
+	contracts := openCodeSkillContracts()
+	tests := []struct {
+		name     string
+		skillID  string
+		response func(string) string
+	}{
+		{
+			name:    "missing shipped skill",
+			skillID: contracts[0].id,
+			response: func(root string) string {
+				return strings.Replace(healthyOpenCodeSkillResponse(root), fmt.Sprintf(`{"id":%q`, contracts[0].id), `{"id":"unrelated-skill"`, 1)
+			},
+		},
+	}
+	for _, contract := range contracts {
+		contract := contract
+		tests = append(tests, struct {
+			name     string
+			skillID  string
+			response func(string) string
+		}{
+			name:    "incompatible " + contract.id,
+			skillID: contract.id,
+			response: func(root string) string {
+				return openCodeSkillResponse(root, func(candidate openCodeSkillContract) string {
+					if candidate.id == contract.id {
+						return "raw-skill-secret"
+					}
+					return strings.Join(candidate.markers, "\n")
+				})
+			},
+		})
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env, stdout, _ := testEnv(t)
+			writeConfig(t, env.RepoRoot, validOpenCodeTOML)
+			if code := Run([]string{"render-agents"}, env); code != ExitOK {
+				t.Fatalf("render-agents exit = %d\n%s", code, stdout.String())
+			}
+			stdout.Reset()
+			env.Runner = fakeRunner{toplevel: env.RepoRoot, opencodeSkills: tc.response(env.RepoRoot)}
+			if code := Run([]string{"doctor"}, env); code != ExitError {
+				t.Fatalf("exit = %d, want %d\n%s", code, ExitError, stdout.String())
+			}
+			out := stdout.String()
+			for _, want := range []string{"FAIL  opencode adapter", tc.skillID, canonicalOpenCodeSkillSource, "restart the OpenCode V2 service"} {
+				if !strings.Contains(out, want) {
+					t.Errorf("stdout missing %q:\n%s", want, out)
+				}
+			}
+			for _, forbidden := range []string{"raw-skill-secret", "/compatible/custom/"} {
+				if strings.Contains(out, forbidden) {
+					t.Errorf("doctor disclosed live skill data %q:\n%s", forbidden, out)
+				}
+			}
+		})
+	}
+}
+
 func TestDoctorAdapterFailures(t *testing.T) {
 	claudeVersion := mustAdapterVersion(t, claudeAdapter)
 	codexVersion := mustAdapterVersion(t, codexAdapter)

--- a/internal/opencode/skills.go
+++ b/internal/opencode/skills.go
@@ -1,0 +1,98 @@
+package opencode
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/paths"
+)
+
+// LoadedSkill is the safe subset of one live OpenCode skill. Its source
+// location is deliberately not retained: compatibility depends on content, not
+// where OpenCode loaded it from.
+type LoadedSkill struct {
+	ID      string
+	Content string
+}
+
+// SkillCatalog is OpenCode's winning live skill set for one repository.
+type SkillCatalog struct {
+	Skills []LoadedSkill
+}
+
+// ReadSkillCatalog returns the repository-scoped live OpenCode skill catalog.
+// It verifies that OpenCode answered for directory and never includes command
+// output or loaded skill content in an error.
+func ReadSkillCatalog(ctx context.Context, runner execx.Runner, directory string) (SkillCatalog, error) {
+	if runner == nil {
+		return SkillCatalog{}, fmt.Errorf("read OpenCode skill catalog: command runner is unavailable; retry through an initialized Orch command")
+	}
+	root, err := paths.Canonical(directory)
+	if err != nil {
+		return SkillCatalog{}, fmt.Errorf("read OpenCode skill catalog: repository location cannot be verified")
+	}
+	query := url.Values{"location[directory]": {root}}
+	res, err := runner.Run(ctx, execx.Cmd{
+		Name: Executable,
+		Args: []string{"api", "get", "/api/skill?" + query.Encode()},
+		Dir:  directory,
+	})
+	if err != nil {
+		return SkillCatalog{}, fmt.Errorf("read OpenCode skill catalog: `%s api get /api/skill` could not start; check `%s service status` and retry", Executable, Executable)
+	}
+	if res.ExitCode != 0 {
+		return SkillCatalog{}, fmt.Errorf("read OpenCode skill catalog: `%s api get /api/skill` exited %d; check `%s service status`, restart the service if needed, and retry", Executable, res.ExitCode, Executable)
+	}
+
+	var response skillCatalogResponse
+	if err := json.Unmarshal([]byte(res.Stdout), &response); err != nil {
+		return SkillCatalog{}, malformedSkills("response is not valid JSON")
+	}
+	if response.Location.Directory == "" {
+		return SkillCatalog{}, malformedSkills("location.directory is missing")
+	}
+	same, err := sameDirectory(root, response.Location.Directory)
+	if err != nil {
+		return SkillCatalog{}, malformedSkills("location.directory cannot be verified")
+	}
+	if !same {
+		return SkillCatalog{}, fmt.Errorf("read OpenCode skill catalog: response is scoped to a different directory; restart the OpenCode V2 service and retry")
+	}
+	if response.Data == nil {
+		return SkillCatalog{}, malformedSkills("data is not an array")
+	}
+
+	catalog := SkillCatalog{Skills: make([]LoadedSkill, len(response.Data))}
+	seen := make(map[string]struct{}, len(response.Data))
+	for i, skill := range response.Data {
+		if skill.ID == "" {
+			return SkillCatalog{}, malformedSkills(fmt.Sprintf("data[%d].id is missing", i))
+		}
+		if skill.Content == nil {
+			return SkillCatalog{}, malformedSkills(fmt.Sprintf("data[%d].content is missing", i))
+		}
+		if _, ok := seen[skill.ID]; ok {
+			return SkillCatalog{}, malformedSkills(fmt.Sprintf("data[%d].id is duplicated", i))
+		}
+		seen[skill.ID] = struct{}{}
+		catalog.Skills[i] = LoadedSkill{ID: skill.ID, Content: *skill.Content}
+	}
+	return catalog, nil
+}
+
+type skillCatalogResponse struct {
+	Location struct {
+		Directory string `json:"directory"`
+	} `json:"location"`
+	Data []struct {
+		ID      string  `json:"id"`
+		Content *string `json:"content"`
+	} `json:"data"`
+}
+
+func malformedSkills(detail string) error {
+	return fmt.Errorf("read OpenCode skill catalog: malformed `%s api get /api/skill` response (%s); %s or newer must preserve this catalog contract, so update Orch or OpenCode and retry", Executable, detail, MinimumVersion)
+}

--- a/internal/opencode/skills_test.go
+++ b/internal/opencode/skills_test.go
@@ -1,0 +1,83 @@
+package opencode
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/paths"
+)
+
+func TestReadSkillCatalogRetainsOnlyIDAndContent(t *testing.T) {
+	root, err := paths.Canonical(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantEndpoint := "/api/skill?" + url.Values{"location[directory]": {root}}.Encode()
+	response := fmt.Sprintf(`{"location":{"directory":%q},"data":[{"id":"orch-setup","location":"C:/custom/SKILL.md","content":"compatible custom prose"}]}`, root)
+	runner := catalogRunner(func(cmd execx.Cmd) (execx.Result, error) {
+		if cmd.Name != Executable || len(cmd.Args) != 3 || cmd.Args[0] != "api" || cmd.Args[1] != "get" || cmd.Args[2] != wantEndpoint {
+			t.Fatalf("command = %s %q, want %s api get %q", cmd.Name, cmd.Args, Executable, wantEndpoint)
+		}
+		if cmd.Dir != root {
+			t.Fatalf("command dir = %q, want %q", cmd.Dir, root)
+		}
+		return execx.Result{Stdout: response}, nil
+	})
+
+	catalog, err := ReadSkillCatalog(context.Background(), runner, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(catalog.Skills) != 1 || catalog.Skills[0].ID != "orch-setup" || catalog.Skills[0].Content != "compatible custom prose" {
+		t.Fatalf("skills = %+v", catalog.Skills)
+	}
+	if strings.Contains(fmt.Sprintf("%+v", catalog), "custom/SKILL.md") {
+		t.Fatalf("catalog retained installation location: %+v", catalog)
+	}
+}
+
+func TestReadSkillCatalogRejectsAnotherLocation(t *testing.T) {
+	root := t.TempDir()
+	other := t.TempDir()
+	runner := catalogRunner(func(execx.Cmd) (execx.Result, error) {
+		return execx.Result{Stdout: fmt.Sprintf(`{"location":{"directory":%q},"data":[]}`, other)}, nil
+	})
+	_, err := ReadSkillCatalog(context.Background(), runner, root)
+	if err == nil || !strings.Contains(err.Error(), "different directory") {
+		t.Fatalf("error = %v, want different-directory rejection", err)
+	}
+}
+
+func TestReadSkillCatalogDiagnosticsDoNotDiscloseOutput(t *testing.T) {
+	const sensitive = "credential-token raw-skill-content copied-skill-location"
+	tests := []struct {
+		name   string
+		result execx.Result
+		err    error
+	}{
+		{name: "cannot start", err: fmt.Errorf("spawn failed: %s", sensitive)},
+		{name: "nonzero", result: execx.Result{Stdout: sensitive, Stderr: sensitive, ExitCode: 7}},
+		{name: "malformed", result: execx.Result{Stdout: `{"data":[{"id":"orch-setup","content":"raw-skill-content"}]}`}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := catalogRunner(func(execx.Cmd) (execx.Result, error) { return tc.result, tc.err })
+			_, err := ReadSkillCatalog(context.Background(), runner, t.TempDir())
+			if err == nil {
+				t.Fatal("ReadSkillCatalog succeeded")
+			}
+			for _, forbidden := range strings.Fields(sensitive) {
+				if strings.Contains(err.Error(), forbidden) {
+					t.Fatalf("diagnostic disclosed %q: %v", forbidden, err)
+				}
+			}
+			if !strings.Contains(err.Error(), "OpenCode skill catalog") || !strings.Contains(err.Error(), "retry") {
+				t.Fatalf("diagnostic is not actionable: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Delivers issue #263: Keep installed OpenCode Orch skills current

Closes #263

**Plan digest:** `sha256:43d33d72a036e3ce4275fc4d5e0e8501c0011f1aff742b28d23e5042c311e8e9`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Replace undocumented copied-skill drift with a checkout-backed OpenCode skill source and a doctor check that validates the live setup and Delivery wire contracts.

**Acceptance criteria:**
- The OpenCode adapter installation guide configures the checked-out adapter's canonical skills directory as an additive skill source alongside its plugin module, without replacing unrelated plugin or skill entries.
- For an enabled OpenCode host, doctor queries the repository-scoped live skill catalog and fails when any shipped Orch skill is absent or its loaded content lacks this build's question or Selection wire contract, with remediation that names the canonical skill source and service restart.
- The live-skill compatibility check does not require byte-equal skill files or a specific installation location, so compatible customized or newer prose remains accepted.
- Existing OpenCode runtime-floor, exactly-one-plugin, returned-location catalog, configured-selection, and generated-agent doctor checks retain their prior behavior.

**Required tests:**
- `gofmt -l .`
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `npm test --prefix adapters/opencode`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `openai/gpt-5.6-sol#xhigh` — variant `xhigh` |
| Reviewer | `openai/gpt-5.6-sol#xhigh` — variant `xhigh` |
| Profile delivery | `model-variant` — OpenCode applies a selected variant as #variant and leaves a no-variant model reference bare |
| Config revision | `sha256:308e4942b411` |

**Routing rationale:** Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.

**Escalations:** _none_

**Verification:**
- **format** — passed — `gofmt -l .` — No output. — commit `613b5734484aec1dae3088305aa6c8a2e80e7b9f` (2026-08-28T13:42:24Z)
- **build** — passed — `go build ./...` — commit `613b5734484aec1dae3088305aa6c8a2e80e7b9f` (2026-08-28T13:42:24Z)
- **vet** — passed — `go vet ./...` — commit `613b5734484aec1dae3088305aa6c8a2e80e7b9f` (2026-08-28T13:42:24Z)
- **go-tests** — passed — `go test ./...` — commit `613b5734484aec1dae3088305aa6c8a2e80e7b9f` (2026-08-28T13:42:24Z)
- **opencode-tests** — passed — `npm test --prefix adapters/opencode` — 6/6 tests passed after npm ci installed the lockfile-pinned dependencies. — commit `613b5734484aec1dae3088305aa6c8a2e80e7b9f` (2026-08-28T13:42:24Z)
- **live-stale-skill-detection** — passed — `go run ./cmd/orch doctor` — Expected exit 1: the source doctor identified live orch-setup as wire-incompatible and named the canonical additive skill source plus OpenCode V2 service restart remediation. — commit `613b5734484aec1dae3088305aa6c8a2e80e7b9f` (2026-08-28T13:42:24Z)
- **acceptance-criterion-1** — satisfied — The installation guide tells users to append the absolute plugin and canonical skill source while preserving unrelated entries, and the guidance is test-pinned. — commit `613b5734484aec1dae3088305aa6c8a2e80e7b9f` (2026-08-28T13:47:33Z)
- **acceptance-criterion-2** — satisfied — Doctor reads the repository-scoped live skill catalog, checks every shipped skill against build-derived wire markers, and names the canonical source plus service restart when missing or incompatible. — commit `613b5734484aec1dae3088305aa6c8a2e80e7b9f` (2026-08-28T13:47:33Z)
- **acceptance-criterion-3** — satisfied — Validation ignores installation location and file identity, using whitespace-normalized required markers; tests prove compatible customized prose passes. — commit `613b5734484aec1dae3088305aa6c8a2e80e7b9f` (2026-08-28T13:47:33Z)
- **acceptance-criterion-4** — satisfied — Runtime, exactly-one-plugin, catalog location, configured-selection, and generated-agent checks remain in their prior order and retain regression coverage. — commit `613b5734484aec1dae3088305aa6c8a2e80e7b9f` (2026-08-28T13:47:33Z)
- **review-cycle-1** — approve — All four acceptance criteria are satisfied. The live skill API shape and location scope are handled safely, compatibility is marker-based, existing doctor checks are preserved, required CI is green, and no correctness, scope, security, dependency, test, or manifest defect was found. — commit `613b5734484aec1dae3088305aa6c8a2e80e7b9f` (2026-08-28T13:47:33Z)
- **required-ci** — passing — test (macos-latest)=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (windows-latest)=pass — commit `613b5734484aec1dae3088305aa6c8a2e80e7b9f` (2026-08-28T13:47:54Z)

<!-- orch:manifest:data
{
  "schema_version": 5,
  "objective": "Replace undocumented copied-skill drift with a checkout-backed OpenCode skill source and a doctor check that validates the live setup and Delivery wire contracts.",
  "acceptance_criteria": [
    "The OpenCode adapter installation guide configures the checked-out adapter's canonical skills directory as an additive skill source alongside its plugin module, without replacing unrelated plugin or skill entries.",
    "For an enabled OpenCode host, doctor queries the repository-scoped live skill catalog and fails when any shipped Orch skill is absent or its loaded content lacks this build's question or Selection wire contract, with remediation that names the canonical skill source and service restart.",
    "The live-skill compatibility check does not require byte-equal skill files or a specific installation location, so compatible customized or newer prose remains accepted.",
    "Existing OpenCode runtime-floor, exactly-one-plugin, returned-location catalog, configured-selection, and generated-agent doctor checks retain their prior behavior."
  ],
  "required_tests": [
    "gofmt -l .",
    "go build ./...",
    "go vet ./...",
    "go test ./...",
    "npm test --prefix adapters/opencode"
  ],
  "role": "implementer",
  "executor": {
    "model": "openai/gpt-5.6-sol",
    "variant": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a strong reviewer, declining the reviewer downgrade because the change is not affirmatively mechanical.",
  "reviewer": {
    "model": "openai/gpt-5.6-sol",
    "variant": "xhigh"
  },
  "effort_delivery": "model-variant",
  "config_revision": "sha256:308e4942b411",
  "verifications": [
    {
      "name": "format",
      "command": "gofmt -l .",
      "result": "passed",
      "detail": "No output.",
      "commit_oid": "613b5734484aec1dae3088305aa6c8a2e80e7b9f",
      "at": "2026-08-28T13:42:24Z"
    },
    {
      "name": "build",
      "command": "go build ./...",
      "result": "passed",
      "commit_oid": "613b5734484aec1dae3088305aa6c8a2e80e7b9f",
      "at": "2026-08-28T13:42:24Z"
    },
    {
      "name": "vet",
      "command": "go vet ./...",
      "result": "passed",
      "commit_oid": "613b5734484aec1dae3088305aa6c8a2e80e7b9f",
      "at": "2026-08-28T13:42:24Z"
    },
    {
      "name": "go-tests",
      "command": "go test ./...",
      "result": "passed",
      "commit_oid": "613b5734484aec1dae3088305aa6c8a2e80e7b9f",
      "at": "2026-08-28T13:42:24Z"
    },
    {
      "name": "opencode-tests",
      "command": "npm test --prefix adapters/opencode",
      "result": "passed",
      "detail": "6/6 tests passed after npm ci installed the lockfile-pinned dependencies.",
      "commit_oid": "613b5734484aec1dae3088305aa6c8a2e80e7b9f",
      "at": "2026-08-28T13:42:24Z"
    },
    {
      "name": "live-stale-skill-detection",
      "command": "go run ./cmd/orch doctor",
      "result": "passed",
      "detail": "Expected exit 1: the source doctor identified live orch-setup as wire-incompatible and named the canonical additive skill source plus OpenCode V2 service restart remediation.",
      "commit_oid": "613b5734484aec1dae3088305aa6c8a2e80e7b9f",
      "at": "2026-08-28T13:42:24Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "The installation guide tells users to append the absolute plugin and canonical skill source while preserving unrelated entries, and the guidance is test-pinned.",
      "commit_oid": "613b5734484aec1dae3088305aa6c8a2e80e7b9f",
      "at": "2026-08-28T13:47:33Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "Doctor reads the repository-scoped live skill catalog, checks every shipped skill against build-derived wire markers, and names the canonical source plus service restart when missing or incompatible.",
      "commit_oid": "613b5734484aec1dae3088305aa6c8a2e80e7b9f",
      "at": "2026-08-28T13:47:33Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "Validation ignores installation location and file identity, using whitespace-normalized required markers; tests prove compatible customized prose passes.",
      "commit_oid": "613b5734484aec1dae3088305aa6c8a2e80e7b9f",
      "at": "2026-08-28T13:47:33Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "Runtime, exactly-one-plugin, catalog location, configured-selection, and generated-agent checks remain in their prior order and retain regression coverage.",
      "commit_oid": "613b5734484aec1dae3088305aa6c8a2e80e7b9f",
      "at": "2026-08-28T13:47:33Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "All four acceptance criteria are satisfied. The live skill API shape and location scope are handled safely, compatibility is marker-based, existing doctor checks are preserved, required CI is green, and no correctness, scope, security, dependency, test, or manifest defect was found.",
      "commit_oid": "613b5734484aec1dae3088305aa6c8a2e80e7b9f",
      "at": "2026-08-28T13:47:33Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (macos-latest)=pass, scripts (ubuntu-latest)=pass, test (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (windows-latest)=pass",
      "commit_oid": "613b5734484aec1dae3088305aa6c8a2e80e7b9f",
      "at": "2026-08-28T13:47:54Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->