### PR TITLE
Bump release identities for v0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/License-MIT-2E7D32?style=flat&logo=opensourceinitiative&logoColor=white" alt="License: MIT"/>
   <img src="https://img.shields.io/badge/Go-1.26%2B-00ADD8?style=flat&logo=go&logoColor=white" alt="Go 1.26+"/>
-  <img src="https://img.shields.io/badge/Release-v0.9.0-24292F?style=flat&logo=github&logoColor=white" alt="Release: v0.9.0"/>
+  <img src="https://img.shields.io/badge/Release-v0.10.0-24292F?style=flat&logo=github&logoColor=white" alt="Release: v0.10.0"/>
   <br/>
   <img src="https://img.shields.io/badge/Platform-Linux%20%C2%B7%20macOS%20%C2%B7%20Windows-607D8B?style=flat" alt="Platform: Linux, macOS, Windows"/>
   <img src="https://img.shields.io/badge/Hosts-Claude%20Code%20%C2%B7%20Codex%20CLI%20%C2%B7%20OpenCode%20V2-6E56CF?style=flat" alt="Hosts: Claude Code, Codex CLI, and OpenCode V2"/>
@@ -437,7 +437,7 @@ receive a copy of the memhub database.
 
 ## Status
 
-Early software. What can be stated as fact: 21 tagged releases, v0.1.0 through v0.9.0, and every pull request merged since PR #40 carries an Orch audit record in its body — apart from the configuration deliveries, which `orch configure` writes in its own body format. Since PR #40, this repository has been built through the pipeline described above: a plan gate, an isolated worktree per issue, a review dispatched separately from the work, CI, and a merge that fails closed unless it carries an approval pinned to the commit `merge-report` recorded.
+Early software. What can be stated as fact: 22 tagged releases, v0.1.0 through v0.10.0, and every pull request merged since PR #40 carries an Orch audit record in its body — apart from the configuration deliveries, which `orch configure` writes in its own body format. Since PR #40, this repository has been built through the pipeline described above: a plan gate, an isolated worktree per issue, a review dispatched separately from the work, CI, and a merge that fails closed unless it carries an approval pinned to the commit `merge-report` recorded.
 
 All of that evidence comes from one repository: this one.
 
@@ -619,7 +619,7 @@ continue, or `orch abort` to end it.
 <details>
 <summary>Defects already corrected, newest first</summary>
 
-Everything here is merged on `main` and shipped in v0.9.0, the latest
+Everything here is merged on `main` and shipped in v0.10.0, the latest
 tagged release.
 
 - The wrong-criterion guidance in the standard and safe reviewer

--- a/adapters/opencode/README.md
+++ b/adapters/opencode/README.md
@@ -1,7 +1,7 @@
 # OpenCode V2 adapter
 
 This directory is Orch's npm-native OpenCode V2 adapter. Its package ID
-is `@kninetimmy/orch-opencode` (version `0.9.0`) and its running plugin
+is `@kninetimmy/orch-opencode` (version `0.10.0`) and its running plugin
 ID is `orch.delivery`. It is not the Codex marketplace adapter: that is
 `adapters/codex/`, installed as `orch@orch` from the shared marketplace.
 

--- a/adapters/opencode/package-lock.json
+++ b/adapters/opencode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kninetimmy/orch-opencode",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kninetimmy/orch-opencode",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "@opencode-ai/plugin": "0.0.0-beta-18314"
       }

--- a/adapters/opencode/package.json
+++ b/adapters/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kninetimmy/orch-opencode",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "module",
   "exports": "./src/index.js",
   "scripts": {


### PR DESCRIPTION
Delivers issue #265: Bump release identities for v0.10.0

Closes #265

**Plan digest:** `sha256:0ade16ac378fb1c8187ee286e9e9cd2d36236cce0ee038375be0efe8583c583f`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Prepare the tracked identities for the v0.10.0 release by updating the OpenCode adapter package and README identities plus the root README release badge, tagged-release count, and latest-release prose. Keep historical release references and unchanged Claude/Codex adapter identities intact; the binary version remains tag-injected.

**Acceptance criteria:**
- The OpenCode adapter package.json, both root package-lock version fields, and adapter README package-version mention read 0.10.0.
- README.md's Release badge reads v0.10.0, and its latest-release and tagged-release-count prose identifies 22 tagged releases through v0.10.0.
- The marketplace manifest and Claude/Codex plugin manifests remain at 0.7.0, historical release references remain unchanged, and the binary version remains tag-injected by the release workflow.

**Required tests:**
- `go test ./...`
- `gofmt -l .`

| Field | Value |
| --- | --- |
| Role | `implementer` |
| Executor | `openai/gpt-5.6-sol#xhigh` — variant `xhigh` |
| Reviewer | `openai/gpt-5.6-sol#high` — variant `high` |
| Profile delivery | `model-variant` — OpenCode applies a selected variant as #variant and leaves a no-variant model reference bare |
| Config revision | `sha256:308e4942b411` |

**Routing rationale:** Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.

**Escalations:** _none_

**Verification:**
- **go-test-all** — passed — `go test ./...` — All Go packages passed at commit 2b211008b065004cc994de30755f902c50911f45. — commit `2b211008b065004cc994de30755f902c50911f45` (2026-08-28T14:14:54Z)
- **gofmt-clean** — passed — `gofmt -l .` — No unformatted files were reported at commit 2b211008b065004cc994de30755f902c50911f45. — commit `2b211008b065004cc994de30755f902c50911f45` (2026-08-28T14:14:54Z)
- **branch-scope:diff-check** — passed — `git diff --check origin/main...HEAD` — No whitespace errors; the clean pushed branch changes only the four established release-identity files with seven substitutions. — commit `2b211008b065004cc994de30755f902c50911f45` (2026-08-28T14:14:54Z)
- **acceptance-criterion-1** — satisfied — adapters/opencode/package.json:3, package-lock.json:3 and :9, and adapters/opencode/README.md:4 all read 0.10.0. — commit `2b211008b065004cc994de30755f902c50911f45` (2026-08-28T14:18:04Z)
- **acceptance-criterion-2** — satisfied — README.md:8 shows v0.10.0, README.md:440 states 22 tagged releases through v0.10.0, and README.md:622-623 names it as the latest tagged release. — commit `2b211008b065004cc994de30755f902c50911f45` (2026-08-28T14:18:04Z)
- **acceptance-criterion-3** — satisfied — Marketplace and Claude/Codex plugin identities remain 0.7.0, the comparison changes only current release identities, and the binary remains dev in source with GITHUB_REF_NAME tag injection in the release workflow. — commit `2b211008b065004cc994de30755f902c50911f45` (2026-08-28T14:18:04Z)
- **review-cycle-1** — approve — Approve: all three criteria are satisfied, the four-file seven-substitution scope and audit record match the reviewed head, required local checks passed, and no correctness or security defect was found. Five of six CI checks had passed at final review while test (windows-latest) remained in progress and was not treated as passing. — commit `2b211008b065004cc994de30755f902c50911f45` (2026-08-28T14:18:04Z)
- **required-ci** — passing — test (macos-latest)=pass, test (ubuntu-latest)=pass, scripts (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (windows-latest)=pass — commit `2b211008b065004cc994de30755f902c50911f45` (2026-08-28T14:19:21Z)

<!-- orch:manifest:data
{
  "schema_version": 5,
  "objective": "Prepare the tracked identities for the v0.10.0 release by updating the OpenCode adapter package and README identities plus the root README release badge, tagged-release count, and latest-release prose. Keep historical release references and unchanged Claude/Codex adapter identities intact; the binary version remains tag-injected.",
  "acceptance_criteria": [
    "The OpenCode adapter package.json, both root package-lock version fields, and adapter README package-version mention read 0.10.0.",
    "README.md's Release badge reads v0.10.0, and its latest-release and tagged-release-count prose identifies 22 tagged releases through v0.10.0.",
    "The marketplace manifest and Claude/Codex plugin manifests remain at 0.7.0, historical release references remain unchanged, and the binary version remains tag-injected by the release workflow."
  ],
  "required_tests": [
    "go test ./...",
    "gofmt -l ."
  ],
  "role": "implementer",
  "executor": {
    "model": "openai/gpt-5.6-sol",
    "variant": "xhigh"
  },
  "routing_rationale": "Routed to an implementer with a downgraded reviewer because the change is affirmatively mechanical, low-risk, fully specified, and unsurprising.",
  "reviewer": {
    "model": "openai/gpt-5.6-sol",
    "variant": "high"
  },
  "effort_delivery": "model-variant",
  "config_revision": "sha256:308e4942b411",
  "verifications": [
    {
      "name": "go-test-all",
      "command": "go test ./...",
      "result": "passed",
      "detail": "All Go packages passed at commit 2b211008b065004cc994de30755f902c50911f45.",
      "commit_oid": "2b211008b065004cc994de30755f902c50911f45",
      "at": "2026-08-28T14:14:54Z"
    },
    {
      "name": "gofmt-clean",
      "command": "gofmt -l .",
      "result": "passed",
      "detail": "No unformatted files were reported at commit 2b211008b065004cc994de30755f902c50911f45.",
      "commit_oid": "2b211008b065004cc994de30755f902c50911f45",
      "at": "2026-08-28T14:14:54Z"
    },
    {
      "name": "branch-scope:diff-check",
      "command": "git diff --check origin/main...HEAD",
      "result": "passed",
      "detail": "No whitespace errors; the clean pushed branch changes only the four established release-identity files with seven substitutions.",
      "commit_oid": "2b211008b065004cc994de30755f902c50911f45",
      "at": "2026-08-28T14:14:54Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "adapters/opencode/package.json:3, package-lock.json:3 and :9, and adapters/opencode/README.md:4 all read 0.10.0.",
      "commit_oid": "2b211008b065004cc994de30755f902c50911f45",
      "at": "2026-08-28T14:18:04Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "README.md:8 shows v0.10.0, README.md:440 states 22 tagged releases through v0.10.0, and README.md:622-623 names it as the latest tagged release.",
      "commit_oid": "2b211008b065004cc994de30755f902c50911f45",
      "at": "2026-08-28T14:18:04Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "Marketplace and Claude/Codex plugin identities remain 0.7.0, the comparison changes only current release identities, and the binary remains dev in source with GITHUB_REF_NAME tag injection in the release workflow.",
      "commit_oid": "2b211008b065004cc994de30755f902c50911f45",
      "at": "2026-08-28T14:18:04Z"
    },
    {
      "name": "review-cycle-1",
      "result": "approve",
      "detail": "Approve: all three criteria are satisfied, the four-file seven-substitution scope and audit record match the reviewed head, required local checks passed, and no correctness or security defect was found. Five of six CI checks had passed at final review while test (windows-latest) remained in progress and was not treated as passing.",
      "commit_oid": "2b211008b065004cc994de30755f902c50911f45",
      "at": "2026-08-28T14:18:04Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (macos-latest)=pass, test (ubuntu-latest)=pass, scripts (ubuntu-latest)=pass, test (windows-latest)=pass, lint=pass, scripts (windows-latest)=pass",
      "commit_oid": "2b211008b065004cc994de30755f902c50911f45",
      "at": "2026-08-28T14:19:21Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->