### PR TITLE
Serialize concurrent Delivery mutations

### DIFF
--- a/ORCH-PRD.md
+++ b/ORCH-PRD.md
@@ -383,6 +383,9 @@ Models do not become GitHub labels.
 - Default maximum: three concurrent subagents.
 - Initialization may configure another cap.
 - Potentially conflicting writes serialize.
+- Every mutating Delivery command invocation holds that serialization through its final persisted
+  state and metrics update; process exit releases it automatically.
+- Read-only plan and status commands do not acquire mutation serialization.
 - Read-only Scouts may run concurrently within the cap.
 - Review begins only after the reviewed PR stops changing.
 - Unaffected issues continue while another issue is blocked.

--- a/README.md
+++ b/README.md
@@ -607,9 +607,11 @@ one control on this path that does not depend on the agent.
 
 **A crashed run leaves the Delivery lock held; there is no automatic
 takeover.** `.orchestrator/delivery.lock` is created with `O_EXCL` and
-Orch never steals it on a staleness guess. Symptom: the next run
-refuses to start, and `orch doctor` notes that the acquiring process
-is no longer running. Workaround: `orch resume` to reconcile and
+Orch never steals it on a staleness guess. This remains true for that
+run-spanning lock; the separate per-command mutation serializer is
+OS-owned and is released automatically when its process exits. Symptom:
+the next run refuses to start, and `orch doctor` notes that the acquiring
+process is no longer running. Workaround: `orch resume` to reconcile and
 continue, or `orch abort` to end it.
 
 </details>
@@ -882,7 +884,13 @@ and there is no automatic staleness takeover — recovery is always an
 explicit `orch abort` or `orch resume`. Run state is schema-versioned
 JSON at `.orchestrator/state.json` (machine-local, atomic writes,
 fail-closed loads), persisted after every sub-step, so a crash at any
-point is recoverable.
+point is recoverable. Separately, every mutating Delivery command — all
+mutating `orch run` verbs, `orch resume`, and `orch abort` — holds an
+OS-owned repository serializer through its final state and metrics write.
+Before that command-level serializer, the run-spanning lock excluded a
+second run but let two invocations in the same run load and replace the
+same documents concurrently. `orch run plan` and status commands remain
+outside this serialization, and process exit releases it automatically.
 
 ### The Delivery pipeline
 

--- a/internal/cli/abort.go
+++ b/internal/cli/abort.go
@@ -12,28 +12,30 @@ import (
 // abort is the explicit human takeover, and the released owner is
 // printed so the takeover is visible.
 func runAbort(env Env) error {
-	if _, err := config.Load(env.RepoRoot); err != nil {
-		return err
-	}
-	res, err := state.Abort(env.RepoRoot)
-	if err != nil {
-		return err
-	}
+	return withDeliveryMutation(env.RepoRoot, func() error {
+		if _, err := config.Load(env.RepoRoot); err != nil {
+			return err
+		}
+		res, err := state.Abort(env.RepoRoot)
+		if err != nil {
+			return err
+		}
 
-	if res.LockOwner != nil {
-		fmt.Fprintf(env.Stdout, "released delivery lock held by %s on %s (pid %d)\n",
-			res.LockOwner.Host, res.LockOwner.Hostname, res.LockOwner.PID)
-	} else if res.LockCleared {
-		fmt.Fprintln(env.Stdout, "cleared unreadable delivery lock")
-	}
+		if res.LockOwner != nil {
+			fmt.Fprintf(env.Stdout, "released delivery lock held by %s on %s (pid %d)\n",
+				res.LockOwner.Host, res.LockOwner.Hostname, res.LockOwner.PID)
+		} else if res.LockCleared {
+			fmt.Fprintln(env.Stdout, "cleared unreadable delivery lock")
+		}
 
-	switch {
-	case res.PriorRun != nil:
-		fmt.Fprintf(env.Stdout, "aborted delivery run %s; returned to assist (branches and worktrees preserved)\n", res.PriorRun.ID)
-	case res.StateReset:
-		fmt.Fprintln(env.Stdout, "reset unreadable state file to assist")
-	case !res.LockCleared:
-		fmt.Fprintln(env.Stdout, "already in assist; nothing to abort")
-	}
-	return nil
+		switch {
+		case res.PriorRun != nil:
+			fmt.Fprintf(env.Stdout, "aborted delivery run %s; returned to assist (branches and worktrees preserved)\n", res.PriorRun.ID)
+		case res.StateReset:
+			fmt.Fprintln(env.Stdout, "reset unreadable state file to assist")
+		case !res.LockCleared:
+			fmt.Fprintln(env.Stdout, "already in assist; nothing to abort")
+		}
+		return nil
+	})
 }

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -41,21 +41,23 @@ func runResume(env Env, args []string) error {
 		req.Statement = run.ResumeStoppedRunStatement
 	}
 
-	runEnv := run.Env{RepoRoot: env.RepoRoot, Runner: env.Runner, Now: time.Now}
-	doc, err := run.Resume(context.Background(), runEnv, req)
-	if err != nil {
-		return err
-	}
-
-	if asJSON {
-		data, err := json.MarshalIndent(doc, "", "  ")
+	return withDeliveryMutation(env.RepoRoot, func() error {
+		runEnv := run.Env{RepoRoot: env.RepoRoot, Runner: env.Runner, Now: time.Now}
+		doc, err := run.Resume(context.Background(), runEnv, req)
 		if err != nil {
-			return fmt.Errorf("encode resume result: %w", err)
+			return err
 		}
-		_, err = fmt.Fprintf(env.Stdout, "%s\n", data)
-		return err
-	}
-	return renderResume(env, doc)
+
+		if asJSON {
+			data, err := json.MarshalIndent(doc, "", "  ")
+			if err != nil {
+				return fmt.Errorf("encode resume result: %w", err)
+			}
+			_, err = fmt.Fprintf(env.Stdout, "%s\n", data)
+			return err
+		}
+		return renderResume(env, doc)
+	})
 }
 
 // renderResume prints the human report the resume example in PRD §23

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kninetimmy/orch/internal/lockfile"
 	"github.com/kninetimmy/orch/internal/run"
 )
 
@@ -76,9 +77,36 @@ func runRunVerb(env Env, args []string) error {
 		return fmt.Errorf("read stdin: %w", err)
 	}
 
-	return emitRunResult(env, args[0], func(ctx context.Context, runEnv run.Env) (any, error) {
-		return handler(ctx, runEnv, input)
-	})
+	invoke := func() error {
+		return emitRunResult(env, args[0], func(ctx context.Context, runEnv run.Env) (any, error) {
+			return handler(ctx, runEnv, input)
+		})
+	}
+	// Plan is the only document-taking read-only run verb. Status was
+	// handled above; every other runVerbs entry is a mutating Delivery
+	// command and holds one repository serializer through its final state
+	// and metrics write. This is a command-class rule, not a Dispatch-only
+	// restriction.
+	if args[0] == "plan" {
+		return invoke()
+	}
+	return withDeliveryMutation(env.RepoRoot, invoke)
+}
+
+// withDeliveryMutation holds the process-scoped, cross-process serializer for
+// one complete mutating command invocation. Besides runRunVerb's mutators,
+// resume and abort use this same boundary.
+func withDeliveryMutation(repoRoot string, fn func() error) (err error) {
+	lock, err := lockfile.AcquireMutation(repoRoot)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if releaseErr := lock.Release(); err == nil && releaseErr != nil {
+			err = releaseErr
+		}
+	}()
+	return fn()
 }
 
 // emitRunResult runs one verb and writes its JSON result to stdout.

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -2,8 +2,18 @@ package cli
 
 import (
 	"bytes"
+	"context"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/kninetimmy/orch/internal/execx"
+	"github.com/kninetimmy/orch/internal/lockfile"
+	"github.com/kninetimmy/orch/internal/manifest"
+	"github.com/kninetimmy/orch/internal/metrics"
+	"github.com/kninetimmy/orch/internal/state"
 )
 
 // TestNoArgCommandsRejectTrailingArgs proves noArgs still rejects a
@@ -113,6 +123,172 @@ func TestRunStatusNeverReadsStdin(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), `"mode": "assist"`) {
 		t.Errorf("stdout = %s", stdout.String())
+	}
+}
+
+func TestRunPlanAndStatusDoNotWaitForMutationSerialization(t *testing.T) {
+	env, _, _ := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML)
+	lock, err := lockfile.AcquireMutation(env.RepoRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := lock.Release(); err != nil {
+			t.Errorf("Release: %v", err)
+		}
+	}()
+
+	for name, args := range map[string][]string{
+		"plan":   {"run", "plan"},
+		"status": {"run", "status", "--json"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			callEnv := env
+			var stdout, callStderr bytes.Buffer
+			callEnv.Stdout = &stdout
+			callEnv.Stderr = &callStderr
+			if name == "plan" {
+				callEnv.Stdin = strings.NewReader(minimalPlanJSON)
+			}
+			done := make(chan int, 1)
+			go func() { done <- Run(args, callEnv) }()
+			select {
+			case code := <-done:
+				if code != ExitOK {
+					t.Fatalf("exit = %d, want %d; stderr = %s", code, ExitOK, callStderr.String())
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("%s waited for mutation serialization", name)
+			}
+		})
+	}
+}
+
+type firstCallGateRunner struct {
+	inner   execx.Runner
+	entered chan struct{}
+	release <-chan struct{}
+	once    sync.Once
+}
+
+func (r *firstCallGateRunner) Run(ctx context.Context, cmd execx.Cmd) (execx.Result, error) {
+	r.once.Do(func() {
+		close(r.entered)
+		<-r.release
+	})
+	return r.inner.Run(ctx, cmd)
+}
+
+type dispatchRunner struct{ fakeRunner }
+
+func (r dispatchRunner) Run(ctx context.Context, cmd execx.Cmd) (execx.Result, error) {
+	if cmd.Name == "gh" && len(cmd.Args) > 1 && cmd.Args[0] == "issue" && cmd.Args[1] == "edit" {
+		return execx.Result{}, nil
+	}
+	return r.fakeRunner.Run(ctx, cmd)
+}
+
+func TestConcurrentDispatchesPreserveBothStateAndMetrics(t *testing.T) {
+	env, stdout1, stderr1 := testEnv(t)
+	writeConfig(t, env.RepoRoot, validTOML+"\n[metrics]\nenabled = true\n")
+	planned := []state.Issue{
+		{PlanID: "a", Phase: state.PhasePlanned},
+		{PlanID: "b", Phase: state.PhasePlanned},
+	}
+	st, err := state.EnterDelivery(env.RepoRoot, "claude", testPlanRef(), planned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selection := manifest.Selection{Model: "claude-sonnet-5", Effort: "xhigh"}
+	for i, number := range []int{240, 241} {
+		st.Run.Issues[i] = state.Issue{
+			PlanID:             string(rune('a' + i)),
+			Title:              fmt.Sprintf("Issue %d", number),
+			Phase:              state.PhaseWorktreeReady,
+			Number:             number,
+			Branch:             fmt.Sprintf("orch/issue-%d", number),
+			Worktree:           fmt.Sprintf(".orchestrator/worktrees/issue-%d", number),
+			Objective:          "preserve this transition",
+			AcceptanceCriteria: []string{"state remains recorded"},
+			RequiredTests:      []string{"go test ./..."},
+			Decision: &state.Decision{
+				Role:      manifest.RoleImplementer,
+				Executor:  selection,
+				Reviewer:  selection,
+				Rationale: "test",
+			},
+		}
+	}
+	if err := state.Save(env.RepoRoot, st); err != nil {
+		t.Fatal(err)
+	}
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	env.Runner = &firstCallGateRunner{
+		inner:   dispatchRunner{fakeRunner{toplevel: env.RepoRoot}},
+		entered: entered,
+		release: release,
+	}
+	env.Stdin = strings.NewReader(`{"schema_version":4,"issue_number":240}`)
+	done1 := make(chan int, 1)
+	go func() { done1 <- Run([]string{"run", "dispatch"}, env) }()
+	<-entered // issue #240 loaded state and is now paused before mutation
+
+	var stdout2, stderr2 bytes.Buffer
+	env2 := env
+	env2.Stdout = &stdout2
+	env2.Stderr = &stderr2
+	env2.Runner = dispatchRunner{fakeRunner{toplevel: env.RepoRoot}}
+	env2.Stdin = strings.NewReader(`{"schema_version":4,"issue_number":241}`)
+	done2 := make(chan int, 1)
+	go func() { done2 <- Run([]string{"run", "dispatch"}, env2) }()
+
+	var code2 int
+	secondFinishedEarly := false
+	select {
+	case code2 = <-done2:
+		// Without command serialization #241 saves its independently loaded
+		// state first; releasing #240 below then reproduces the lost update.
+		secondFinishedEarly = true
+	case <-time.After(200 * time.Millisecond):
+		// Serialized: #241 is waiting before its state load.
+	}
+	close(release)
+	code1 := <-done1
+	if !secondFinishedEarly {
+		code2 = <-done2
+	}
+	if code1 != ExitOK || code2 != ExitOK {
+		t.Fatalf("dispatch exits = (%d, %d), want (%d, %d); stderr #240 %q; stderr #241 %q; stdout #240 %q; stdout #241 %q",
+			code1, code2, ExitOK, ExitOK, stderr1.String(), stderr2.String(), stdout1.String(), stdout2.String())
+	}
+
+	got, err := state.Load(env.RepoRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, issue := range got.Run.Issues {
+		if issue.Phase != state.PhaseDispatched {
+			t.Errorf("issue #%d phase = %s, want %s", issue.Number, issue.Phase, state.PhaseDispatched)
+		}
+	}
+	docs, err := metrics.LoadAll(env.RepoRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(docs) != 1 || len(docs[0].Events) != 2 {
+		t.Fatalf("metrics documents = %+v, want one document with two events", docs)
+	}
+	seen := map[int]bool{}
+	for _, event := range docs[0].Events {
+		seen[event.IssueNumber] = true
+	}
+	for _, number := range []int{240, 241} {
+		if !seen[number] {
+			t.Errorf("metrics missing dispatch for issue #%d: %+v", number, docs[0].Events)
+		}
 	}
 }
 

--- a/internal/ghops/ghops.go
+++ b/internal/ghops/ghops.go
@@ -14,9 +14,10 @@
 // merge.
 //
 // Operations that pre-check and then act (for example
-// EnsureLabelTaxonomy) are not atomic; the run engine serializes
-// potentially conflicting writes (PRD §14), so the gap is not raced
-// in practice.
+// EnsureLabelTaxonomy) are not atomic, and this package adds no locking.
+// For Delivery commands, internal/cli serializes potentially conflicting
+// writes at the full-command boundary (PRD §14); callers outside that path
+// must provide any coordination they require.
 package ghops
 
 import (

--- a/internal/ghops/labels.go
+++ b/internal/ghops/labels.go
@@ -248,7 +248,8 @@ func (g *GH) MissingLabels(ctx context.Context, names []string) ([]string, error
 // existing labels are never modified (no --force: repository
 // customizations survive). Idempotent; returns the names it created,
 // in taxonomy order, for the audit trail. The list-then-create gap is
-// not atomic; the run engine serializes conflicting writes (PRD §14).
+// not atomic. The Delivery path is serialized by internal/cli at the
+// full-command boundary (PRD §14); this method itself adds no locking.
 func (g *GH) EnsureLabelTaxonomy(ctx context.Context) ([]string, error) {
 	present, err := g.existingLabelNames(ctx)
 	if err != nil {

--- a/internal/gitops/gitops.go
+++ b/internal/gitops/gitops.go
@@ -14,9 +14,11 @@
 // refuses any worktree that is not detached, so neither can reach a
 // branch or the commits on it.
 //
-// Operations that pre-check and then act (for example AddWorktree)
-// are not atomic; the run engine serializes potentially conflicting
-// writes (PRD §14), so the gap is not raced in practice.
+// Operations that pre-check and then act (for example AddWorktree) are not
+// atomic, and this package adds no locking. For Delivery commands,
+// internal/cli serializes potentially conflicting writes at the full-command
+// boundary (PRD §14); callers outside that path must provide any coordination
+// they require.
 package gitops
 
 import (

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -1,9 +1,9 @@
-// Package lockfile implements the exclusive cross-host Delivery lock
-// (PRD §14): one active Delivery coordinator per repository across both
-// hosts. The lock is the existence of .orchestrator/delivery.lock,
-// created with O_EXCL so acquisition is atomic on every supported OS.
+// Package lockfile implements both Delivery locks from PRD §14: the
+// run-spanning Delivery lock and the process-scoped mutation serializer.
+// The run lock is the existence of .orchestrator/delivery.lock, created
+// with O_EXCL so acquisition is atomic on every supported OS.
 //
-// The lock deliberately outlives the acquiring process: a Delivery run
+// The run lock deliberately outlives the acquiring process: a Delivery run
 // spans many short-lived orch invocations plus a host agent session, so
 // the recorded PID is advisory and its death is never treated as
 // staleness. There is no automatic takeover; recovery is always the

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -1,10 +1,14 @@
 package lockfile
 
 import (
+	"bufio"
+	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -143,6 +147,93 @@ func TestAcquireExactlyOneWinner(t *testing.T) {
 	if wins != 1 {
 		t.Errorf("%d goroutines acquired the lock, want exactly 1", wins)
 	}
+}
+
+func TestMutationSerializationReleasedWhenProcessExits(t *testing.T) {
+	root := lockDir(t)
+	cmd := exec.Command(os.Args[0], "-test.run=^TestMutationSerializationHelper$")
+	cmd.Env = append(os.Environ(), "ORCH_MUTATION_HELPER_ROOT="+root)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	waited := false
+	t.Cleanup(func() {
+		if !waited {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+
+	scanner := bufio.NewScanner(stdout)
+	if !scanner.Scan() || scanner.Text() != "locked" {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		waited = true
+		t.Fatalf("helper did not acquire mutation serialization: stdout %q, stderr %q", scanner.Text(), stderr.String())
+	}
+
+	type result struct {
+		lock *Mutation
+		err  error
+	}
+	acquired := make(chan result, 1)
+	go func() {
+		lock, err := AcquireMutation(root)
+		acquired <- result{lock: lock, err: err}
+	}()
+	select {
+	case got := <-acquired:
+		if got.lock != nil {
+			_ = got.lock.Release()
+		}
+		t.Fatalf("AcquireMutation returned while helper still held it: %v", got.err)
+	case <-time.After(200 * time.Millisecond):
+		// Still blocked by the helper, as required.
+	}
+
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Wait(); err == nil {
+		t.Fatal("killed mutation helper exited successfully")
+	}
+	waited = true
+
+	select {
+	case got := <-acquired:
+		if got.err != nil {
+			t.Fatalf("AcquireMutation after holder exit: %v", got.err)
+		}
+		if err := got.lock.Release(); err != nil {
+			t.Fatalf("Release: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("mutation serialization remained held after holder process exited")
+	}
+}
+
+// TestMutationSerializationHelper is re-executed by
+// TestMutationSerializationReleasedWhenProcessExits. It deliberately exits
+// without Release so the parent proves the OS, rather than cleanup code,
+// recovers the serializer.
+func TestMutationSerializationHelper(t *testing.T) {
+	root := os.Getenv("ORCH_MUTATION_HELPER_ROOT")
+	if root == "" {
+		return
+	}
+	lock, err := AcquireMutation(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println("locked")
+	time.Sleep(time.Hour)
+	runtime.KeepAlive(lock)
 }
 
 func TestPIDAlive(t *testing.T) {

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -178,21 +178,25 @@ func TestMutationSerializationReleasedWhenProcessExits(t *testing.T) {
 		t.Fatalf("helper did not acquire mutation serialization: stdout %q, stderr %q", scanner.Text(), stderr.String())
 	}
 
-	type result struct {
-		lock *Mutation
-		err  error
-	}
-	acquired := make(chan result, 1)
+	acquired := make(chan error, 1)
+	release := make(chan struct{})
+	released := make(chan error, 1)
 	go func() {
 		lock, err := AcquireMutation(root)
-		acquired <- result{lock: lock, err: err}
+		acquired <- err
+		if err != nil {
+			return
+		}
+		<-release
+		released <- lock.Release()
 	}()
 	select {
-	case got := <-acquired:
-		if got.lock != nil {
-			_ = got.lock.Release()
+	case err := <-acquired:
+		if err == nil {
+			close(release)
+			_ = <-released
 		}
-		t.Fatalf("AcquireMutation returned while helper still held it: %v", got.err)
+		t.Fatalf("AcquireMutation returned while helper still held it: %v", err)
 	case <-time.After(200 * time.Millisecond):
 		// Still blocked by the helper, as required.
 	}
@@ -206,11 +210,12 @@ func TestMutationSerializationReleasedWhenProcessExits(t *testing.T) {
 	waited = true
 
 	select {
-	case got := <-acquired:
-		if got.err != nil {
-			t.Fatalf("AcquireMutation after holder exit: %v", got.err)
+	case err := <-acquired:
+		if err != nil {
+			t.Fatalf("AcquireMutation after holder exit: %v", err)
 		}
-		if err := got.lock.Release(); err != nil {
+		close(release)
+		if err := <-released; err != nil {
 			t.Fatalf("Release: %v", err)
 		}
 	case <-time.After(5 * time.Second):

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -194,7 +194,7 @@ func TestMutationSerializationReleasedWhenProcessExits(t *testing.T) {
 	case err := <-acquired:
 		if err == nil {
 			close(release)
-			_ = <-released
+			<-released
 		}
 		t.Fatalf("AcquireMutation returned while helper still held it: %v", err)
 	case <-time.After(200 * time.Millisecond):

--- a/internal/lockfile/mutation.go
+++ b/internal/lockfile/mutation.go
@@ -1,0 +1,43 @@
+package lockfile
+
+import "sync"
+
+// Mutation holds the process-scoped lock that serializes one repository's
+// mutating Delivery commands. Release must be deferred immediately after a
+// successful AcquireMutation.
+type Mutation struct {
+	once    sync.Once
+	release func() error
+	err     error
+}
+
+// processMutation covers same-process callers because OS advisory locks may
+// be process-owned rather than descriptor-owned on a supported platform.
+// ponytail: this serializes different repositories only inside one process;
+// key it by canonical root if Orch ever runs multiple repositories in-process.
+var processMutation sync.Mutex
+
+// AcquireMutation blocks until no other process is running a mutating
+// Delivery command for repoRoot. The operating system owns the underlying
+// lock, so process exit releases it without staleness detection or takeover.
+func AcquireMutation(repoRoot string) (*Mutation, error) {
+	processMutation.Lock()
+	release, err := acquireMutationOS(repoRoot)
+	if err != nil {
+		processMutation.Unlock()
+		return nil, err
+	}
+	return &Mutation{release: release}, nil
+}
+
+// Release gives the mutation serializer to the next waiter. It is idempotent.
+func (m *Mutation) Release() error {
+	if m == nil {
+		return nil
+	}
+	m.once.Do(func() {
+		m.err = m.release()
+		processMutation.Unlock()
+	})
+	return m.err
+}

--- a/internal/lockfile/mutation.go
+++ b/internal/lockfile/mutation.go
@@ -2,9 +2,10 @@ package lockfile
 
 import "sync"
 
-// Mutation holds the process-scoped lock that serializes one repository's
-// mutating Delivery commands. Release must be deferred immediately after a
-// successful AcquireMutation.
+// Mutation holds the process-scoped lock that serializes mutating Delivery
+// commands. Release must be deferred immediately after a successful
+// AcquireMutation and called from the acquiring goroutine. On Windows that
+// goroutine stays pinned to the owning OS thread until Release.
 type Mutation struct {
 	once    sync.Once
 	release func() error
@@ -12,14 +13,17 @@ type Mutation struct {
 }
 
 // processMutation covers same-process callers because OS advisory locks may
-// be process-owned rather than descriptor-owned on a supported platform.
-// ponytail: this serializes different repositories only inside one process;
-// key it by canonical root if Orch ever runs multiple repositories in-process.
+// be process-owned rather than descriptor-owned on a supported platform. It
+// also serializes different repositories inside one process; cross-process
+// serialization remains repository-scoped.
+// ponytail: key it by canonical root if Orch ever runs multiple repositories
+// in-process.
 var processMutation sync.Mutex
 
 // AcquireMutation blocks until no other process is running a mutating
-// Delivery command for repoRoot. The operating system owns the underlying
-// lock, so process exit releases it without staleness detection or takeover.
+// Delivery command for repoRoot and no other same-process acquisition is
+// held. The operating system owns the underlying repository-scoped lock, so
+// process exit releases it without staleness detection or takeover.
 func AcquireMutation(repoRoot string) (*Mutation, error) {
 	processMutation.Lock()
 	release, err := acquireMutationOS(repoRoot)
@@ -30,7 +34,9 @@ func AcquireMutation(repoRoot string) (*Mutation, error) {
 	return &Mutation{release: release}, nil
 }
 
-// Release gives the mutation serializer to the next waiter. It is idempotent.
+// Release gives the mutation serializer to the next waiter. It is idempotent
+// and must run in the goroutine that called AcquireMutation because Windows
+// mutex ownership belongs to that goroutine's pinned OS thread.
 func (m *Mutation) Release() error {
 	if m == nil {
 		return nil

--- a/internal/lockfile/mutation_unix.go
+++ b/internal/lockfile/mutation_unix.go
@@ -1,0 +1,28 @@
+//go:build unix
+
+package lockfile
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// acquireMutationOS locks the stable repository directory itself, avoiding a
+// second persistent lock file whose mere existence could dirty older repos.
+func acquireMutationOS(repoRoot string) (func() error, error) {
+	f, err := os.Open(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("open repository for Delivery mutation serialization: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("lock repository for Delivery mutation serialization: %w", err)
+	}
+	return func() error {
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("release Delivery mutation serialization: %w", err)
+		}
+		return nil
+	}, nil
+}

--- a/internal/lockfile/mutation_windows.go
+++ b/internal/lockfile/mutation_windows.go
@@ -1,0 +1,67 @@
+//go:build windows
+
+package lockfile
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32     = syscall.NewLazyDLL("kernel32.dll")
+	createMutexW = kernel32.NewProc("CreateMutexW")
+	releaseMutex = kernel32.NewProc("ReleaseMutex")
+)
+
+// acquireMutationOS uses a named Windows mutex because mutex ownership is
+// automatically abandoned when a process exits. Mutex ownership is tied to an
+// OS thread, so that thread stays pinned until Release.
+func acquireMutationOS(repoRoot string) (func() error, error) {
+	abs, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve repository for Delivery mutation serialization: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return nil, fmt.Errorf("resolve repository for Delivery mutation serialization: %w", err)
+	}
+	sum := sha256.Sum256([]byte(strings.ToLower(filepath.Clean(resolved))))
+	name, err := syscall.UTF16PtrFromString(fmt.Sprintf("Global\\OrchDeliveryMutation-%x", sum))
+	if err != nil {
+		return nil, fmt.Errorf("name Delivery mutation serialization: %w", err)
+	}
+
+	runtime.LockOSThread()
+	h, _, callErr := createMutexW.Call(0, 0, uintptr(unsafe.Pointer(name)))
+	if h == 0 {
+		runtime.UnlockOSThread()
+		return nil, fmt.Errorf("create Delivery mutation serialization: %w", callErr)
+	}
+	event, waitErr := syscall.WaitForSingleObject(syscall.Handle(h), syscall.INFINITE)
+	if waitErr != nil || (event != syscall.WAIT_OBJECT_0 && event != syscall.WAIT_ABANDONED) {
+		_ = syscall.CloseHandle(syscall.Handle(h))
+		runtime.UnlockOSThread()
+		if waitErr != nil {
+			return nil, fmt.Errorf("wait for Delivery mutation serialization: %w", waitErr)
+		}
+		return nil, fmt.Errorf("wait for Delivery mutation serialization: unexpected result %d", event)
+	}
+
+	return func() error {
+		ok, _, releaseErr := releaseMutex.Call(h)
+		closeErr := syscall.CloseHandle(syscall.Handle(h))
+		runtime.UnlockOSThread()
+		if ok == 0 {
+			return fmt.Errorf("release Delivery mutation serialization: %w", releaseErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("close Delivery mutation serialization: %w", closeErr)
+		}
+		return nil
+	}, nil
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -10,10 +10,12 @@
 // gains no storage from merely reading (PRD §23: disabled metrics
 // create no storage).
 //
-// Exactly one Delivery run owns a repository at a time (the Delivery
-// lock, internal/lockfile), so writes to any one run's document are
-// serialized by construction — this package needs no locking of its
-// own.
+// Before command-level mutation serialization, exactly one Delivery run
+// owned a repository but multiple command invocations inside it could still
+// overlap Append's read-modify-write and lose an event. Now the production
+// CLI's process-scoped Delivery mutation lock covers each final Append. This
+// package remains policy-free and has no lock of its own; direct callers must
+// provide the same serialization.
 //
 // PRD §21 mapping: first-pass review outcome is the first "review"
 // event recorded for an issue; retries show up as ReviewCycles and

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -17,15 +17,19 @@
 // complete. Each reads a schema-versioned request document on stdin and
 // writes a schema-versioned result on stdout.
 //
-// Concurrency invariant: plan and status are read-only. Every mutating
-// verb acquires or re-verifies the cross-host Delivery lock: activate
-// enters Delivery via state.EnterDelivery, and each lifecycle verb runs
-// the shared preconditions in loadVerb (state.Load + lockfile.Inspect +
-// state.CheckConsistent with st.Run.ID == owner.RunID, plus config-drift
-// and stopped-run gates) before touching anything. Within one invocation
-// writes are sequential, so PRD §14's serialization requirement holds
-// trivially. Failure semantics are pure: a verb never mutates phase,
-// state, GitHub, or git as a side effect of failing.
+// Concurrency invariant: plan and status are read-only and never enter
+// mutation serialization. Every mutating verb acquires or re-verifies the
+// run-spanning cross-host Delivery lock: activate enters Delivery via
+// state.EnterDelivery, and each lifecycle verb runs the shared preconditions
+// in loadVerb (state.Load + lockfile.Inspect + state.CheckConsistent with
+// st.Run.ID == owner.RunID, plus config-drift and stopped-run gates) before
+// touching anything. Before process-scoped mutation serialization, those
+// checks excluded a second run but did not stop two invocations in the same
+// run from loading and replacing state concurrently. Now the production CLI
+// serializes every mutating run verb, resume, and abort for the full command;
+// the OS releases that serializer on process exit. Failure semantics are
+// pure: a verb never mutates phase, state, GitHub, or git as a side effect of
+// failing.
 //
 // All documents this package accepts are schema-versioned
 // (exact-match, fail closed) and decoded with DisallowUnknownFields:


### PR DESCRIPTION
Delivers issue #267: Serialize concurrent Delivery mutations

Closes #267

**Plan digest:** `sha256:260520be94aad7f08b8284634865c4a313a2dc842c8c653830a17d01ab9546e5`

The approved objective and acceptance criteria are in the audit record below.

<!-- orch:manifest:begin -->
### Orch audit record

**Objective:** Prevent concurrent mutating Delivery command invocations from losing another invocation's persisted run state or metrics, with automatic recovery when a process exits.

**Acceptance criteria:**
- Potentially conflicting Delivery mutations serialize for their full persisted update, so successful concurrent transitions on different issues and their metrics remain recorded.
- A process exit while serialization is held cannot permanently block a later Delivery mutation.
- Read-only plan and status commands remain outside mutation serialization.
- Blast radius (contributed by Orch because this issue declares a risk domain, not by the plan document): name every element of the structure this change touches and state, for each, whether the behavior it had before this change still holds; record a behavior this change removes as a before-and-after in the same document that stated the old behavior, rather than deleting that statement; and where a restriction is attributed to one named symbol, establish whether it holds for that symbol alone or for every symbol of its kind, and say which.

**Required tests:**
- `gofmt -l .`
- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/run ./internal/cli ./internal/lockfile` — CI does not run this test

| Field | Value |
| --- | --- |
| Role | `specialist` |
| Executor | `openai/gpt-5.6-sol#xhigh` — variant `xhigh` |
| Reviewer | `openai/gpt-5.6-sol#xhigh` — variant `xhigh` |
| Profile delivery | `model-variant` — OpenCode applies a selected variant as #variant and leaves a no-variant model reference bare |
| Config revision | `sha256:308e4942b411` |

**Routing rationale:** Routed to a specialist with a strong reviewer because risk domains (concurrency) and the task is unusually difficult.

**Escalations:** _none_

**Verification:**
- **format** — pass — `gofmt -l .` — No output at 0045909efe577f694c878ad653898caffa86e082. — commit `0045909efe577f694c878ad653898caffa86e082` (2026-08-28T16:11:44Z)
- **tests** — pass — `go test ./...` — All packages passed at 0045909efe577f694c878ad653898caffa86e082. — commit `0045909efe577f694c878ad653898caffa86e082` (2026-08-28T16:11:44Z)
- **vet** — pass — `go vet ./...` — No output at 0045909efe577f694c878ad653898caffa86e082. — commit `0045909efe577f694c878ad653898caffa86e082` (2026-08-28T16:11:44Z)
- **race** — pass — `go test -race ./internal/run ./internal/cli ./internal/lockfile` — Passed locally at 0045909efe577f694c878ad653898caffa86e082; CI does not run this required command. internal/run and internal/cli cached; internal/lockfile 2.531s. — commit `0045909efe577f694c878ad653898caffa86e082` (2026-08-28T16:11:44Z)
- **cross-build** — pass — `GOOS=linux go build ./...; GOOS=darwin go build ./...` — Both cross-builds passed on commit 05bf83528b978bfa7912e889ebf21ff51ec8e5bf. — commit `05bf83528b978bfa7912e889ebf21ff51ec8e5bf` (2026-08-28T15:35:27Z)
- **branch-scope:blast-radius** — pass — `git diff --name-status origin/main...HEAD` — At 0045909e, all 16 files: ORCH-PRD.md keeps concurrency policy and now covers final state/metrics plus process-exit recovery; README.md preserves persistent delivery.lock and records same-run lost updates before/after; cli/run.go preserves JSON dispatch/output while serializing all 13 mutating run verbs, not plan/status; cli/abort.go preserves takeover/output under serialization; cli/resume.go preserves flags, dry-run, reconciliation, and rendering under serialization; cli/run_test.go adds non-waiting and concurrent state/metrics checks; lockfile/lockfile.go preserves persistent-lock schema/behavior and distinguishes lock kinds; lockfile/mutation.go adds repository-scoped cross-process plus process-wide same-process serialization, including across repositories, with idempotent same-goroutine release on Windows; mutation_unix.go adds artifact-free directory flock released on close/exit; mutation_windows.go adds repository-keyed named mutex, abandoned-owner recovery, and thread pinning; lockfile_test.go preserves old tests and adds blocking/exit recovery with same-thread release; metrics.go preserves Append/LoadAll/schema and records CLI coordination versus direct callers; run/run.go preserves engine behavior and records CLI ownership versus unserialized direct calls; ghops.go preserves all mechanics and states every pre-check/act call has no lock outside CLI coordination; ghops/labels.go preserves idempotent non-atomic taxonomy behavior and states the CLI boundary; gitops.go preserves fail-closed mechanics/confirmations and states every pre-check/act call lacks internal locking. No dependency, schema, config, gitignore, persistent artifact, state/metrics format, bootstrap, init, or configure behavior changed. — commit `0045909efe577f694c878ad653898caffa86e082` (2026-08-28T16:11:44Z)
- **branch-scope:review-diff** — pass — `GitHub comparison for PR #268 at 0045909efe577f694c878ad653898caffa86e082` — Three commits and 16 changed files against aa4a0417cf3717793991e50c595f9cce3b49491c. — commit `0045909efe577f694c878ad653898caffa86e082` (2026-08-28T16:11:44Z)
- **review-ci** — pass — `GitHub required-check rollup run 33187822703` — All six required jobs passed at 0045909efe577f694c878ad653898caffa86e082, including Windows tests and lint. — commit `0045909efe577f694c878ad653898caffa86e082` (2026-08-28T16:11:44Z)
- **acceptance-criterion-1** — satisfied — All 13 mutating run verbs, resume, and abort use the full-command serializer; the concurrent-dispatch regression preserves both state transitions and metrics on all three CI operating systems. — commit `0045909efe577f694c878ad653898caffa86e082` (2026-08-28T16:22:50Z)
- **acceptance-criterion-2** — satisfied — Unix process-owned flock and Windows abandoned named-mutex handling release after exit, and the real holder-process recovery test proves subsequent acquisition succeeds. — commit `0045909efe577f694c878ad653898caffa86e082` (2026-08-28T16:22:50Z)
- **acceptance-criterion-3** — satisfied — Plan and status bypass serialization, with focused coverage while the serializer is held. — commit `0045909efe577f694c878ad653898caffa86e082` (2026-08-28T16:22:50Z)
- **acceptance-criterion-4** — satisfied — The live PR body enumerates all 16 changed files, preserved and changed behavior, and command/package-wide locking scope. — commit `0045909efe577f694c878ad653898caffa86e082` (2026-08-28T16:22:50Z)
- **review-cycle-1** — request-changes — Request changes: the Windows mutation-lock recovery test releases a thread-owned mutex from a different goroutine and required Windows CI fails; the blast-radius record also omits process-wide cross-repository serialization, Windows thread affinity, and remaining ghops/gitops claims that serialization lives in the run engine. — commit `05bf83528b978bfa7912e889ebf21ff51ec8e5bf` (2026-08-28T15:44:10Z)
- **recovery-repeat** — pass — `go test ./internal/lockfile -run '^TestMutationSerializationReleasedWhenProcessExits$' -count=10` — The exact child-process recovery test passed ten repetitions in 2.606s at 0045909efe577f694c878ad653898caffa86e082. — commit `0045909efe577f694c878ad653898caffa86e082` (2026-08-28T16:17:38Z)
- **review-cycle-2** — request-changes — Implementation approved in substance, but request changes because the live PR body still lacks the revised current-head blast-radius enumeration and verification records. This review call records that evidence for a fresh evidence-only review. — commit `0045909efe577f694c878ad653898caffa86e082` (2026-08-28T16:11:45Z)
- **review-cycle-3** — request-changes — The implementation and all criteria are satisfied, but the recovery-repeat audit entry named a test pattern that matched no test. This review call replaces it with the exact test name and observed ten-run result for final evidence review. — commit `0045909efe577f694c878ad653898caffa86e082` (2026-08-28T16:17:40Z)
- **review-cycle-4** — approve — Approved with no findings: implementation, cross-platform recovery, read-only bypass, current audit evidence, and the complete blast-radius record satisfy all four criteria; all six protected checks pass at the pinned head. — commit `0045909efe577f694c878ad653898caffa86e082` (2026-08-28T16:22:50Z)
- **required-ci** — passing — test (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass — commit `0045909efe577f694c878ad653898caffa86e082` (2026-08-28T16:23:08Z)

<!-- orch:manifest:data
{
  "schema_version": 5,
  "objective": "Prevent concurrent mutating Delivery command invocations from losing another invocation's persisted run state or metrics, with automatic recovery when a process exits.",
  "acceptance_criteria": [
    "Potentially conflicting Delivery mutations serialize for their full persisted update, so successful concurrent transitions on different issues and their metrics remain recorded.",
    "A process exit while serialization is held cannot permanently block a later Delivery mutation.",
    "Read-only plan and status commands remain outside mutation serialization.",
    "Blast radius (contributed by Orch because this issue declares a risk domain, not by the plan document): name every element of the structure this change touches and state, for each, whether the behavior it had before this change still holds; record a behavior this change removes as a before-and-after in the same document that stated the old behavior, rather than deleting that statement; and where a restriction is attributed to one named symbol, establish whether it holds for that symbol alone or for every symbol of its kind, and say which."
  ],
  "required_tests": [
    "gofmt -l .",
    "go test ./...",
    "go vet ./...",
    "go test -race ./internal/run ./internal/cli ./internal/lockfile"
  ],
  "tests_ci_does_not_run": [
    "go test -race ./internal/run ./internal/cli ./internal/lockfile"
  ],
  "role": "specialist",
  "executor": {
    "model": "openai/gpt-5.6-sol",
    "variant": "xhigh"
  },
  "routing_rationale": "Routed to a specialist with a strong reviewer because risk domains (concurrency) and the task is unusually difficult.",
  "reviewer": {
    "model": "openai/gpt-5.6-sol",
    "variant": "xhigh"
  },
  "effort_delivery": "model-variant",
  "config_revision": "sha256:308e4942b411",
  "verifications": [
    {
      "name": "format",
      "command": "gofmt -l .",
      "result": "pass",
      "detail": "No output at 0045909efe577f694c878ad653898caffa86e082.",
      "commit_oid": "0045909efe577f694c878ad653898caffa86e082",
      "at": "2026-08-28T16:11:44Z"
    },
    {
      "name": "tests",
      "command": "go test ./...",
      "result": "pass",
      "detail": "All packages passed at 0045909efe577f694c878ad653898caffa86e082.",
      "commit_oid": "0045909efe577f694c878ad653898caffa86e082",
      "at": "2026-08-28T16:11:44Z"
    },
    {
      "name": "vet",
      "command": "go vet ./...",
      "result": "pass",
      "detail": "No output at 0045909efe577f694c878ad653898caffa86e082.",
      "commit_oid": "0045909efe577f694c878ad653898caffa86e082",
      "at": "2026-08-28T16:11:44Z"
    },
    {
      "name": "race",
      "command": "go test -race ./internal/run ./internal/cli ./internal/lockfile",
      "result": "pass",
      "detail": "Passed locally at 0045909efe577f694c878ad653898caffa86e082; CI does not run this required command. internal/run and internal/cli cached; internal/lockfile 2.531s.",
      "commit_oid": "0045909efe577f694c878ad653898caffa86e082",
      "at": "2026-08-28T16:11:44Z"
    },
    {
      "name": "cross-build",
      "command": "GOOS=linux go build ./...; GOOS=darwin go build ./...",
      "result": "pass",
      "detail": "Both cross-builds passed on commit 05bf83528b978bfa7912e889ebf21ff51ec8e5bf.",
      "commit_oid": "05bf83528b978bfa7912e889ebf21ff51ec8e5bf",
      "at": "2026-08-28T15:35:27Z"
    },
    {
      "name": "branch-scope:blast-radius",
      "command": "git diff --name-status origin/main...HEAD",
      "result": "pass",
      "detail": "At 0045909e, all 16 files: ORCH-PRD.md keeps concurrency policy and now covers final state/metrics plus process-exit recovery; README.md preserves persistent delivery.lock and records same-run lost updates before/after; cli/run.go preserves JSON dispatch/output while serializing all 13 mutating run verbs, not plan/status; cli/abort.go preserves takeover/output under serialization; cli/resume.go preserves flags, dry-run, reconciliation, and rendering under serialization; cli/run_test.go adds non-waiting and concurrent state/metrics checks; lockfile/lockfile.go preserves persistent-lock schema/behavior and distinguishes lock kinds; lockfile/mutation.go adds repository-scoped cross-process plus process-wide same-process serialization, including across repositories, with idempotent same-goroutine release on Windows; mutation_unix.go adds artifact-free directory flock released on close/exit; mutation_windows.go adds repository-keyed named mutex, abandoned-owner recovery, and thread pinning; lockfile_test.go preserves old tests and adds blocking/exit recovery with same-thread release; metrics.go preserves Append/LoadAll/schema and records CLI coordination versus direct callers; run/run.go preserves engine behavior and records CLI ownership versus unserialized direct calls; ghops.go preserves all mechanics and states every pre-check/act call has no lock outside CLI coordination; ghops/labels.go preserves idempotent non-atomic taxonomy behavior and states the CLI boundary; gitops.go preserves fail-closed mechanics/confirmations and states every pre-check/act call lacks internal locking. No dependency, schema, config, gitignore, persistent artifact, state/metrics format, bootstrap, init, or configure behavior changed.",
      "commit_oid": "0045909efe577f694c878ad653898caffa86e082",
      "at": "2026-08-28T16:11:44Z"
    },
    {
      "name": "branch-scope:review-diff",
      "command": "GitHub comparison for PR #268 at 0045909efe577f694c878ad653898caffa86e082",
      "result": "pass",
      "detail": "Three commits and 16 changed files against aa4a0417cf3717793991e50c595f9cce3b49491c.",
      "commit_oid": "0045909efe577f694c878ad653898caffa86e082",
      "at": "2026-08-28T16:11:44Z"
    },
    {
      "name": "review-ci",
      "command": "GitHub required-check rollup run 33187822703",
      "result": "pass",
      "detail": "All six required jobs passed at 0045909efe577f694c878ad653898caffa86e082, including Windows tests and lint.",
      "commit_oid": "0045909efe577f694c878ad653898caffa86e082",
      "at": "2026-08-28T16:11:44Z"
    },
    {
      "name": "acceptance-criterion-1",
      "result": "satisfied",
      "detail": "All 13 mutating run verbs, resume, and abort use the full-command serializer; the concurrent-dispatch regression preserves both state transitions and metrics on all three CI operating systems.",
      "commit_oid": "0045909efe577f694c878ad653898caffa86e082",
      "at": "2026-08-28T16:22:50Z"
    },
    {
      "name": "acceptance-criterion-2",
      "result": "satisfied",
      "detail": "Unix process-owned flock and Windows abandoned named-mutex handling release after exit, and the real holder-process recovery test proves subsequent acquisition succeeds.",
      "commit_oid": "0045909efe577f694c878ad653898caffa86e082",
      "at": "2026-08-28T16:22:50Z"
    },
    {
      "name": "acceptance-criterion-3",
      "result": "satisfied",
      "detail": "Plan and status bypass serialization, with focused coverage while the serializer is held.",
      "commit_oid": "0045909efe577f694c878ad653898caffa86e082",
      "at": "2026-08-28T16:22:50Z"
    },
    {
      "name": "acceptance-criterion-4",
      "result": "satisfied",
      "detail": "The live PR body enumerates all 16 changed files, preserved and changed behavior, and command/package-wide locking scope.",
      "commit_oid": "0045909efe577f694c878ad653898caffa86e082",
      "at": "2026-08-28T16:22:50Z"
    },
    {
      "name": "review-cycle-1",
      "result": "request-changes",
      "detail": "Request changes: the Windows mutation-lock recovery test releases a thread-owned mutex from a different goroutine and required Windows CI fails; the blast-radius record also omits process-wide cross-repository serialization, Windows thread affinity, and remaining ghops/gitops claims that serialization lives in the run engine.",
      "commit_oid": "05bf83528b978bfa7912e889ebf21ff51ec8e5bf",
      "at": "2026-08-28T15:44:10Z"
    },
    {
      "name": "recovery-repeat",
      "command": "go test ./internal/lockfile -run '^TestMutationSerializationReleasedWhenProcessExits$' -count=10",
      "result": "pass",
      "detail": "The exact child-process recovery test passed ten repetitions in 2.606s at 0045909efe577f694c878ad653898caffa86e082.",
      "commit_oid": "0045909efe577f694c878ad653898caffa86e082",
      "at": "2026-08-28T16:17:38Z"
    },
    {
      "name": "review-cycle-2",
      "result": "request-changes",
      "detail": "Implementation approved in substance, but request changes because the live PR body still lacks the revised current-head blast-radius enumeration and verification records. This review call records that evidence for a fresh evidence-only review.",
      "commit_oid": "0045909efe577f694c878ad653898caffa86e082",
      "at": "2026-08-28T16:11:45Z"
    },
    {
      "name": "review-cycle-3",
      "result": "request-changes",
      "detail": "The implementation and all criteria are satisfied, but the recovery-repeat audit entry named a test pattern that matched no test. This review call replaces it with the exact test name and observed ten-run result for final evidence review.",
      "commit_oid": "0045909efe577f694c878ad653898caffa86e082",
      "at": "2026-08-28T16:17:40Z"
    },
    {
      "name": "review-cycle-4",
      "result": "approve",
      "detail": "Approved with no findings: implementation, cross-platform recovery, read-only bypass, current audit evidence, and the complete blast-radius record satisfy all four criteria; all six protected checks pass at the pinned head.",
      "commit_oid": "0045909efe577f694c878ad653898caffa86e082",
      "at": "2026-08-28T16:22:50Z"
    },
    {
      "name": "required-ci",
      "result": "passing",
      "detail": "test (windows-latest)=pass, test (ubuntu-latest)=pass, test (macos-latest)=pass, lint=pass, scripts (ubuntu-latest)=pass, scripts (windows-latest)=pass",
      "commit_oid": "0045909efe577f694c878ad653898caffa86e082",
      "at": "2026-08-28T16:23:08Z"
    }
  ]
}
-->
<!-- orch:manifest:end -->